### PR TITLE
Add architecture foundation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,15 @@ For now, Harness should optimize for clarity over automation theater.
 ## Status
 
 This is an early project scaffold. The README currently captures the intent and operating model so the repo has a concrete starting point.
+
+## Architecture Docs
+
+The architecture baseline for Epic 1 lives under `docs/`:
+
+- [System Context](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/system-context.md)
+- [Module Boundaries](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/module-boundaries.md)
+- [Canonical Vocabulary](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/canonical-vocabulary.md)
+- [Repository Layout Proposal](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/repository-layout.md)
+- [ADR 0001](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/adrs/0001-openclaw-as-ingress-harness-as-control-plane.md)
+- [ADR 0002](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/adrs/0002-initial-substrate-choice-and-replacement-strategy.md)
+- [Initial Codex Tickets](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/planning/initial-codex-tickets.md)

--- a/docs/adrs/0001-openclaw-as-ingress-harness-as-control-plane.md
+++ b/docs/adrs/0001-openclaw-as-ingress-harness-as-control-plane.md
@@ -1,0 +1,44 @@
+# OpenClaw As Ingress, Harness As Control Plane
+
+- title: OpenClaw as ingress, Harness as control plane
+- status: accepted
+- date: 2026-03-23
+
+## Context
+
+The project needs a clear boundary between the user-facing agent experience and the system that manages durable work execution. If those concerns are merged too early, the system will blur clarification, planning, assignment, persistence, and execution into one layer.
+
+The desired operating model is:
+
+- OpenClaw handles user interaction and clarification
+- Harness manages decomposition, assignment, monitoring, and reporting
+- Linear stores structured work
+- executors perform assigned tasks
+
+## Decision
+
+Treat OpenClaw as the ingress layer and Harness as the control plane.
+
+This means:
+
+- OpenClaw receives requests and resolves ambiguity before handoff
+- Harness accepts validated requests as input contracts, not free-form conversation state
+- Harness owns orchestration policy and task lifecycle decisions
+- Harness reports status back to OpenClaw, which remains the user-facing surface
+
+## Consequences
+
+- ingress, orchestration, and execution stay separable
+- Harness can evolve independently from the user-facing agent shell
+- executor integrations can change without rewriting ingress behavior
+- the system gains a clearer path to durable orchestration because conversation state is not the primary control plane
+
+## Alternatives Considered
+
+### OpenClaw As Both Ingress And Control Plane
+
+Rejected because it couples user interaction with durable orchestration and makes the system harder to reason about, swap, and test.
+
+### Linear As The Control Plane
+
+Rejected because Linear is the source of truth for structured work, not the component that should own planning and routing policy.

--- a/docs/adrs/0002-initial-substrate-choice-and-replacement-strategy.md
+++ b/docs/adrs/0002-initial-substrate-choice-and-replacement-strategy.md
@@ -1,0 +1,99 @@
+# Initial Substrate Choice And Replacement Strategy
+
+- title: Initial substrate choice and replacement strategy
+- status: accepted
+- date: 2026-03-23
+
+## Context
+
+Harness needs a workflow substrate that provides persistence and resumability for orchestration. The initial choice should fit an early-stage open-source project with limited operational budget and a strong need to keep business rules understandable.
+
+The current candidate set is:
+
+- LangGraph
+- Temporal
+- build mostly ourselves with minimal framework support
+
+The architecture also needs a credible path to replace the initial substrate later without rewriting the control plane.
+
+## Decision
+
+Start by building the workflow substrate mostly ourselves behind a narrow internal abstraction, using only minimal framework support where it removes obvious boilerplate.
+
+The recommended shape is:
+
+- explicit Harness state machines and contracts live in Harness-owned code
+- substrate interfaces handle checkpoint persistence, resume, and event replay
+- vendor-specific orchestration behavior stays behind adapters
+
+This is the default starting point because it best matches the current stage of the project:
+
+- it keeps the system model legible while core concepts are still changing
+- it avoids early commitment to a graph-oriented or platform-oriented runtime model
+- it reduces operational and conceptual overhead for a non-monetized open-source project
+- it forces the control plane contracts to become explicit before platform lock-in happens
+
+## Consequences
+
+- initial implementation effort is higher than adopting a full orchestration platform immediately
+- the project keeps tighter control over task lifecycle semantics
+- later migration remains possible because business workflow state is defined in Harness terms rather than substrate terms
+- early contributors can reason about the system without learning a large orchestration platform first
+
+## Alternatives Considered
+
+### LangGraph
+
+Not the default starting point.
+
+Reasons:
+
+- its graph-centric model is attractive for persistent agent workflows, but Harness is primarily a control plane, not a graph-authored agent runtime
+- adopting it early risks encoding business orchestration policy into framework-specific graph structures
+- it is more useful after the core Harness state model is stable enough to map intentionally onto graph execution
+
+Potential future use:
+
+- if the system later benefits from graph-native resumability for planner-heavy flows, LangGraph can be introduced behind the substrate adapter for selected workflow classes
+
+### Temporal
+
+Not the default starting point.
+
+Reasons:
+
+- it offers strong durability and long-running workflow primitives, but adds operational weight and platform complexity too early
+- it is a better fit once workflow volume, reliability demands, and team maturity justify the infrastructure cost
+- starting there would optimize for scale and robustness before the Harness domain model is settled
+
+Potential future use:
+
+- if Harness grows into a multi-tenant or high-throughput orchestration service, Temporal is a credible replacement substrate because it is strong at durable execution once contracts are stable
+
+### Build Mostly Ourselves With Minimal Framework Support
+
+Chosen as the starting point.
+
+Reasons:
+
+- lowest operational burden
+- best fit for an architecture that is still being defined
+- easiest way to keep the substrate replaceable by making boundaries explicit now
+
+## Replacement Strategy
+
+The migration path depends on keeping these rules from day one:
+
+- define orchestration state in Harness-owned contracts
+- isolate checkpointing and resume behavior behind substrate interfaces
+- treat Linear identifiers and task states as business-level references, not substrate internals
+- keep executor event handling independent from vendor runtime types
+
+If replacement becomes necessary later:
+
+1. keep task and workflow state contracts stable
+2. implement a new substrate adapter
+3. replay or migrate active workflow state into the new adapter
+4. cut over workflow creation to the new substrate while retiring the old adapter
+
+The key architectural constraint is that Harness business rules must not depend on LangGraph nodes, Temporal workflow classes, or any other substrate-native model.

--- a/docs/architecture/canonical-vocabulary.md
+++ b/docs/architecture/canonical-vocabulary.md
@@ -1,0 +1,88 @@
+# Canonical Vocabulary
+
+## Purpose
+
+Define the words Harness will use consistently so documentation and implementation do not drift.
+
+## Terms
+
+### Ingress
+
+The user-facing entry point that receives requests, asks clarifying questions, and hands validated work into Harness.
+
+For this architecture, OpenClaw is the ingress.
+
+### Harness
+
+The control plane responsible for planning, assignment, monitoring, and reporting across work execution.
+
+### Control Plane
+
+The part of the system that decides what work exists, who owns it, what state it is in, and what should happen next.
+
+### Structured Work
+
+The durable project, epic, task, and dependency records that represent planned or active work.
+
+Linear is the source of truth for structured work.
+
+### Workflow Substrate
+
+The persistence and resumability layer used by Harness to survive restarts, resume long-running orchestration, and track internal execution progress.
+
+### Executor
+
+A worker capable of performing assigned tasks according to a stable contract.
+
+Codex is an initial executor, not the only possible executor.
+
+### Task
+
+The smallest unit of structured work that Harness intends to assign and monitor as a single owned outcome.
+
+### Assignment
+
+The decision that a specific executor type or executor instance owns a task.
+
+### Execution Event
+
+A progress, result, failure, or heartbeat message emitted by an executor and consumed by Harness.
+
+### Decomposition
+
+The transformation of a validated request into smaller, structured tasks with explicit dependencies and ownership boundaries.
+
+### Source Of Truth
+
+The system whose records are authoritative for a particular class of information.
+
+In this architecture:
+
+- Linear is the source of truth for structured work.
+- the workflow substrate is the source of truth for resumable orchestration state
+- executors are the source of truth only for their immediate runtime outputs until Harness applies policy
+
+## Terms To Avoid Or Use Carefully
+
+### Agent
+
+Use only when the distinction does not matter. Prefer `ingress`, `harness`, or `executor` when the specific role matters.
+
+### Workflow
+
+Use for orchestration progress or substrate-managed execution flow, not as a synonym for project or task.
+
+### Job
+
+Avoid as a top-level product term until a specific definition is adopted. Prefer `task` or `execution` depending on meaning.
+
+### Memory
+
+Avoid as a system-wide architecture term. Use `structured work state`, `workflow state`, or `execution output` instead.
+
+## Naming Rules
+
+- Prefer role-based terms over implementation names.
+- Name modules by responsibility, not by vendor.
+- Separate business state from runtime state in naming.
+- Use `executor` as the abstraction and `Codex` as one implementation.

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -1,0 +1,81 @@
+# Module Boundaries
+
+## Objective
+
+Define a single owner for each core module and keep ingress, orchestration, structured work, and execution separate.
+
+## Boundary Model
+
+Each module below has one owner. Ownership here means responsibility for the module's behavior, interfaces, and state transitions.
+
+| Module | Owner | Responsibilities | Must Not Own |
+| --- | --- | --- | --- |
+| Ingress adapter | OpenClaw integration layer | receive validated requests from OpenClaw, return status and results upstream, map clarification outcomes into Harness input contracts | task decomposition, executor selection, durable workflow state |
+| Intake and normalization | Harness core | convert validated requests into canonical Harness work objects, reject malformed inputs, attach metadata needed for planning | UI policy, executor-specific logic |
+| Planning and decomposition | Harness core | create epics, tasks, and dependency edges from normalized requests | direct execution, persistence substrate details |
+| Work registry sync | Linear integration layer | create and update Linear records, reconcile Harness state with Linear task state, enforce Linear as structured work record | decomposition policy, executor runtime control |
+| Assignment and routing | Harness core | choose executor type, assign work, reassign stalled tasks, enforce assignment rules | executor implementation details, user-facing clarification |
+| Execution gateway | Executor integration layer | send tasks to Codex or future workers, collect outputs, normalize execution events | planning, Linear ownership, long-term orchestration policy |
+| Workflow runtime adapter | Workflow substrate layer | persist workflow checkpoints, resume interrupted runs, model orchestration progress through durable state | user-facing ingress, structured work definitions |
+| Reporting and summarization | Harness core | aggregate task outcomes and expose upstream progress summaries | direct executor control, source-of-truth ownership |
+
+## Ownership Rules
+
+- Harness core owns orchestration policy.
+- Linear integration owns synchronization with Linear only.
+- Executor integrations own protocol translation to specific workers only.
+- Workflow substrate owns internal durability only.
+- OpenClaw integration owns ingress and upstream reporting surfaces only.
+
+## Interaction Rules
+
+- OpenClaw may submit work to Harness, but not mutate internal orchestration state directly.
+- Harness core may request persistence from the workflow substrate, but should not couple business rules to a specific substrate API.
+- Harness core may update structured work through the Linear integration layer, but should not treat executor events as the source of truth.
+- Executors may report status and outputs, but they do not decide final work state without Harness applying policy.
+
+## Required Contracts
+
+### Request Contract
+
+Input entering Harness after clarification is complete.
+
+Required fields should eventually include:
+
+- request identifier
+- originating ingress
+- validated objective
+- constraints
+- requested deliverable shape
+
+### Task Contract
+
+Unit of structured work tracked by Harness and represented in Linear.
+
+Required fields should eventually include:
+
+- task identifier
+- parent work item
+- owner executor type
+- status
+- dependencies
+- expected output contract
+
+### Execution Event Contract
+
+Message from an executor back to Harness.
+
+Required fields should eventually include:
+
+- executor identifier
+- task identifier
+- event type
+- timestamp
+- payload
+
+## Anti-Patterns To Avoid
+
+- putting clarification logic into the control plane after work is accepted
+- letting executor implementations define task semantics
+- treating workflow checkpoint state as the product-facing source of truth
+- storing business workflow policy inside a vendor-specific orchestration graph

--- a/docs/architecture/repository-layout.md
+++ b/docs/architecture/repository-layout.md
@@ -1,0 +1,92 @@
+# Repository Layout Proposal
+
+## Objective
+
+Propose a repository layout that mirrors the architecture boundaries without committing to runtime implementation yet.
+
+## Proposed Layout
+
+```text
+docs/
+  architecture/
+  adrs/
+  planning/
+
+src/
+  harness/
+    intake/
+    planning/
+    assignment/
+    reporting/
+  integrations/
+    openclaw/
+    linear/
+    executors/
+      codex/
+  substrate/
+  contracts/
+
+tests/
+  architecture/
+  integrations/
+  substrate/
+```
+
+## Layout Rationale
+
+### docs/
+
+Architecture, ADRs, and planning artifacts stay visible and versioned next to code.
+
+### src/harness/
+
+Owns control-plane behavior only.
+
+Suggested ownership slices:
+
+- `intake/` for normalization after ingress validation
+- `planning/` for decomposition and dependency generation
+- `assignment/` for routing and reassignment policy
+- `reporting/` for status aggregation and upstream summaries
+
+### src/integrations/
+
+Contains boundary adapters to external systems.
+
+- `openclaw/` for ingress-facing contracts
+- `linear/` for structured work synchronization
+- `executors/` for worker-specific transport layers
+
+### src/substrate/
+
+Contains the workflow runtime adapter and substrate-facing abstractions.
+
+This directory should hide substrate implementation details behind stable interfaces used by `src/harness/`.
+
+### src/contracts/
+
+Contains canonical payload and state definitions shared across modules.
+
+Examples:
+
+- request contract
+- task contract
+- execution event contract
+- status enums
+
+### tests/
+
+Keeps architecture tests and adapter tests separate from control-plane tests.
+
+## Layout Rules
+
+- do not put executor-specific behavior into `src/harness/`
+- do not put planning policy into `src/integrations/`
+- do not let substrate APIs leak through module boundaries
+- keep shared contracts independent from vendor adapters
+
+## Near-Term Recommendation
+
+Do not create the runtime directories yet unless implementation starts in those areas.
+
+For Epic 1, the value is in agreeing on the layout and using it to guide future tickets.

--- a/docs/architecture/system-context.md
+++ b/docs/architecture/system-context.md
@@ -1,0 +1,80 @@
+# System Context
+
+## Objective
+
+Define the top-level system model before implementation so future modules do not blur ingress, orchestration, work tracking, and execution.
+
+## System Framing
+
+Harness sits between the user-facing agent layer and the execution layer.
+
+- OpenClaw is the ingress layer.
+- Harness is the control plane.
+- Linear is the source of truth for structured work.
+- Executors such as Codex are workers.
+- The workflow substrate provides persistence, resumability, and coordination state for Harness itself.
+
+## Context Diagram
+
+The Mermaid source for the diagram lives in [system-context.mmd](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/system-context.mmd).
+
+```mermaid
+flowchart LR
+    U["User"] --> O["OpenClaw\nIngress and clarification"]
+    O --> H["Harness\nControl plane"]
+    H --> L["Linear\nStructured work source of truth"]
+    H --> S["Workflow substrate\nPersistence and resumability"]
+    H --> E["Executors\nCodex and future workers"]
+    E --> H
+    H --> O
+```
+
+## Responsibilities By System
+
+### OpenClaw
+
+- collects user intent
+- asks follow-up questions when intent is ambiguous
+- hands validated work into Harness
+- presents progress and results back to the user
+
+### Harness
+
+- translates validated requests into structured work
+- decomposes work into manageable tasks
+- decides assignment and reassignment
+- monitors progress and exceptions
+- aggregates outcomes for upstream reporting
+
+### Linear
+
+- stores epics, projects, tasks, and task state
+- provides the durable structured record of planned and active work
+- serves as the reference point for task ownership and status
+
+### Workflow Substrate
+
+- persists orchestration state that should survive crashes or restarts
+- allows resumable long-running workflows
+- stores execution checkpoints and internal coordination state
+- does not replace Linear as the source of truth for work items
+
+### Executors
+
+- perform assigned work
+- report execution progress and outputs back to Harness
+- remain replaceable behind stable task contracts
+
+## Boundary Rules
+
+- OpenClaw does not become the durable orchestrator.
+- Harness does not become the user interface.
+- Linear owns structured work records, not executor internals.
+- Executors do not own planning, routing, or lifecycle policy.
+- The workflow substrate owns resumability, not product-level work semantics.
+
+## Architectural Implications
+
+- ingress, orchestration, source-of-truth, and execution remain separable
+- executor implementations can change without changing Harness core planning logic
+- workflow technology can change if Harness state transitions are modeled explicitly

--- a/docs/architecture/system-context.mmd
+++ b/docs/architecture/system-context.mmd
@@ -1,0 +1,8 @@
+flowchart LR
+    U["User"] --> O["OpenClaw\nIngress and clarification"]
+    O --> H["Harness\nControl plane"]
+    H --> L["Linear\nStructured work source of truth"]
+    H --> S["Workflow substrate\nPersistence and resumability"]
+    H --> E["Executors\nCodex and future workers"]
+    E --> H
+    H --> O

--- a/docs/planning/initial-codex-tickets.md
+++ b/docs/planning/initial-codex-tickets.md
@@ -1,0 +1,61 @@
+# Initial Codex Tickets
+
+## Purpose
+
+These tickets translate Epic 1 into concrete follow-on implementation work without turning the repository into the task management system.
+
+## Proposed Tickets
+
+### Ticket 1: Define canonical contracts
+
+- create request, task, and execution event contracts
+- define status enums and ownership fields
+- document which contracts are business state versus runtime state
+
+### Ticket 2: Create control-plane skeleton
+
+- scaffold `src/harness/` with intake, planning, assignment, and reporting module boundaries
+- add package-level documentation for each module
+- avoid runtime logic beyond boundary scaffolding
+
+### Ticket 3: Create integration boundaries
+
+- scaffold `src/integrations/openclaw/`, `src/integrations/linear/`, and `src/integrations/executors/codex/`
+- define adapter interfaces without implementation detail leakage
+- document what each integration owns and does not own
+
+### Ticket 4: Define substrate abstraction
+
+- create substrate-facing interfaces for checkpoint persistence, workflow resume, and event replay
+- keep substrate contracts independent from LangGraph or Temporal types
+- add architecture tests for forbidden dependency directions
+
+### Ticket 5: Model structured work synchronization
+
+- define how Harness task state maps to Linear state
+- identify fields that must remain authoritative in Linear
+- specify reconciliation rules for drift and failed updates
+
+### Ticket 6: Define executor task lifecycle
+
+- document assignment, heartbeat, completion, failure, and retry events
+- specify what an executor can report versus what Harness decides
+- make executor replacement an explicit design constraint
+
+### Ticket 7: Add architecture guardrails
+
+- add dependency-direction tests or lint rules
+- enforce separation between `harness`, `integrations`, and `substrate`
+- prevent executor-specific imports from leaking into control-plane modules
+
+## Sequencing
+
+Recommended order:
+
+1. canonical contracts
+2. control-plane skeleton
+3. integration boundaries
+4. substrate abstraction
+5. structured work synchronization
+6. executor lifecycle
+7. architecture guardrails


### PR DESCRIPTION
## Summary
- add the Epic 1 architecture baseline under docs/
- define system context, module boundaries, vocabulary, and repository layout
- add ADRs for control-plane framing and initial substrate choice
- propose the initial Codex ticket list

## Testing
- not run (documentation-only change)