### PR TITLE
Define artifact and completion evidence model

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The architecture baseline for Epic 1 lives under `docs/`:
 
 - [System Context](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/system-context.md)
 - [TaskEnvelope Contract](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/task-envelope.md)
+- [Artifact And Completion Evidence](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/artifact-and-completion-evidence.md)
 - [Intake To TaskEnvelope Mapping](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/intake-to-task-envelope.md)
 - [Module Boundaries](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/module-boundaries.md)
 - [Canonical Vocabulary](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/canonical-vocabulary.md)

--- a/docs/architecture/artifact-and-completion-evidence.md
+++ b/docs/architecture/artifact-and-completion-evidence.md
@@ -1,0 +1,287 @@
+# Artifact And Completion Evidence
+
+## Purpose
+
+Define the canonical model for execution artifacts and completion evidence in Harness.
+
+Harness is a reliability/control-plane system. Executor-reported success is advisory. Completion is only trustworthy when the task's evidence policy is satisfied by verifiable artifacts.
+
+## Design Goals
+
+- support artifact-backed completion
+- support multiple artifacts per task
+- distinguish evidence from advisory output
+- support reconciliation with GitHub and Linear
+- preserve auditability over time
+
+## Core Model
+
+TaskEnvelope attaches artifacts under `artifacts`.
+
+`artifacts` contains:
+
+- `items`: canonical artifact records
+- `completion_evidence`: the policy and validation state used to decide whether completion may be accepted
+
+## Artifact Types
+
+Supported canonical artifact types:
+
+- `pull_request`
+- `commit`
+- `branch`
+- `changed_file`
+- `log`
+- `output`
+- `review_note`
+
+These artifact types are broad enough to support code-bearing tasks, advisory tasks, and reconciliation across external systems.
+
+## Artifact Record
+
+Each artifact record includes:
+
+- `id`: stable artifact identifier within the task
+- `type`: canonical artifact type
+- `provenance`: how Harness learned about the artifact
+- `verification_status`: whether the artifact is verified, unverified, rejected, or informational
+- `repository`: repository identity when applicable
+- `branch`: branch identity when applicable
+- `changed_files`: changed-file details when applicable
+- `external_refs`: references to external systems such as GitHub or Linear
+
+Optional fields provide type-specific details:
+
+- `location`
+- `external_id`
+- `commit_sha`
+- `pull_request_number`
+- `review_state`
+- `title`
+- `description`
+- `content_type`
+- `captured_at`
+- `metadata`
+
+## Type-Specific Required Fields
+
+### pull_request
+
+Required:
+
+- `pull_request_number`
+- `repository`
+- `branch`
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- verify that work was proposed in a repository
+- connect GitHub PR state back to task completion
+
+### commit
+
+Required:
+
+- `commit_sha`
+- `repository`
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- prove a concrete code change exists
+- support reconciliation between task state and repository history
+
+### branch
+
+Required:
+
+- `repository`
+- `branch`
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- capture working branch context even when completion is not yet satisfied
+
+### changed_file
+
+Required:
+
+- `repository`
+- `branch`
+- `changed_files` with at least one file
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- show file-level evidence without requiring a full PR or commit artifact
+
+### log
+
+Required:
+
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- diagnostic evidence
+- execution traces
+
+Logs are not sufficient for completion on their own unless a task's evidence policy explicitly allows them.
+
+### output
+
+Required:
+
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- advisory or research deliverables
+- generated documents or reports
+
+### review_note
+
+Required:
+
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- approval notes
+- manual verification statements
+- review commentary
+
+## Repository And Branch Identity
+
+Repository identity is represented as:
+
+- `host`
+- `owner`
+- `name`
+- `external_id` optional
+
+Branch identity is represented as:
+
+- `name`
+- `base_branch`
+- `head_commit_sha` optional
+
+This allows Harness to tie task evidence back to an external repository context without embedding Git provider-specific runtime types.
+
+## Changed Files Representation
+
+Changed files are represented as an array of records containing:
+
+- `path`
+- `change_type`
+- `previous_path` optional
+- `additions` optional
+- `deletions` optional
+
+This supports both auditability and later reconciliation with external systems that expose file-level diffs.
+
+## Provenance
+
+Every artifact record must include provenance:
+
+- `source_system`
+- `source_type`
+- `source_id`
+- `captured_by` optional
+
+Provenance is required so Harness can later explain where evidence came from and whether it came directly from an external system, from an executor report, or from a manual verifier.
+
+## Completion Evidence
+
+`artifacts.completion_evidence` is the canonical completion rule state for a task.
+
+It includes:
+
+- `policy`
+- `status`
+- `required_artifact_types`
+- `validated_artifact_ids`
+- `validation_method`
+- `validated_at`
+- `validator`
+- `notes`
+
+### Evidence Policy
+
+`policy` may be:
+
+- `deferred`: evidence requirements have not been decided yet
+- `required`: completion must be backed by artifacts
+- `advisory_only`: outputs may be useful without strong external evidence
+- `not_applicable`: evidence is not relevant for this task type
+
+### Evidence Status
+
+`status` may be:
+
+- `deferred`
+- `pending`
+- `satisfied`
+- `insufficient`
+- `not_applicable`
+
+## Completion Rules
+
+A task may transition to `completed` only when both the task outcome and the evidence state support it.
+
+Canonical rules:
+
+- if `completion_evidence.policy` is `required`, then `completion_evidence.status` must be `satisfied`
+- if `completion_evidence.policy` is `required`, then `validated_artifact_ids` must reference the artifacts used for verification
+- if evidence is required but missing, completion must not be accepted
+- executor-reported success without evidence is not sufficient for `completed`
+- advisory or research tasks may use `advisory_only` or `not_applicable`, but that must be explicit
+
+## Distinguishing Outcome Classes
+
+### Completed With Evidence
+
+- task reaches `completed`
+- `completion_evidence.policy` is `required`
+- `completion_evidence.status` is `satisfied`
+- validating artifacts are recorded
+
+### Work Attempted Without Evidence
+
+- executor may report success or attempted work
+- evidence policy remains unmet
+- `completion_evidence.status` is `insufficient`
+- task should remain non-complete, typically `blocked` or `failed` depending on policy
+
+### Advisory Or Research Output Only
+
+- task may produce useful outputs without code-bearing artifacts
+- `completion_evidence.policy` is `advisory_only` or `not_applicable`
+- completion still requires explicit policy alignment, not implicit trust
+
+## GitHub And Linear Reconciliation
+
+The model supports later reconciliation by:
+
+- representing GitHub-native evidence through repository, branch, PR, commit, review, and changed-file records
+- allowing external references back to GitHub and Linear identifiers
+- separating evidence presence from evidence validation
+- making it possible to compare Harness lifecycle state against both structured work state and artifact state
+
+## TaskEnvelope Alignment
+
+TaskEnvelope uses this model through:
+
+- `artifacts.items` for canonical artifact records
+- `artifacts.completion_evidence` for completion policy and validation state
+
+This keeps completion enforcement inside Harness rather than inside executor reports or workflow runtime state.

--- a/docs/architecture/intake-to-task-envelope.md
+++ b/docs/architecture/intake-to-task-envelope.md
@@ -29,7 +29,7 @@ Intake does not own:
 - executor capability requirements
 - routing priority policy
 - workflow runtime state
-- execution artifacts beyond empty initialization
+- execution artifacts beyond schema-valid empty initialization
 
 ## Inbound Intake Shape
 
@@ -104,12 +104,19 @@ These fields are explicitly deferred at intake time:
 
 ### Artifacts
 
-Artifacts are initialized empty:
+Artifacts are initialized as schema-valid placeholders only:
 
-- `pr_links` -> `[]`
-- `commit_shas` -> `[]`
-- `logs` -> `[]`
-- `outputs` -> `[]`
+- `items` -> `[]`
+- `completion_evidence.policy` -> `deferred`
+- `completion_evidence.status` -> `deferred`
+- `completion_evidence.required_artifact_types` -> `[]`
+- `completion_evidence.validated_artifact_ids` -> `[]`
+- `completion_evidence.validation_method` -> `deferred`
+- `completion_evidence.validated_at` -> `null`
+- `completion_evidence.validator` -> `null`
+- `completion_evidence.notes` -> `null`
+
+These defaults do not claim completion evidence exists. They only keep intake schema-valid while leaving evidence policy and verification to later modules.
 
 ### Observability
 

--- a/docs/architecture/task-envelope.md
+++ b/docs/architecture/task-envelope.md
@@ -65,7 +65,7 @@ At the top level, a TaskEnvelope contains:
 | `assigned_executor` | object or null | yes | current routing decision |
 | `required_capabilities` | array | yes | executor capabilities needed for the task |
 | `priority` | enum | yes | relative scheduling priority |
-| `artifacts` | object | yes | PRs, commits, logs, and outputs |
+| `artifacts` | object | yes | canonical execution artifacts and completion evidence state |
 | `observability` | object | yes | retries, errors, and execution metadata |
 | `extensions` | object | no | explicitly non-canonical extension surface for future modules |
 
@@ -81,7 +81,7 @@ TaskEnvelope uses the following canonical states:
 | `assigned` | task has an executor selected but execution has not yet started |
 | `executing` | executor has started work |
 | `blocked` | task cannot currently proceed because of an unmet dependency, missing input, or external blocker |
-| `completed` | task satisfied its acceptance criteria and is considered done by Harness |
+| `completed` | task satisfied its acceptance criteria and any required completion evidence has been verified by Harness |
 | `failed` | task reached a terminal unsuccessful outcome |
 | `canceled` | task was intentionally stopped and should not continue |
 
@@ -116,6 +116,8 @@ Terminal states:
 - `canceled`
 
 `status_history` should capture all non-initial state changes with timestamps and reasons.
+
+For tasks with required completion evidence, transition to `completed` is only valid after `artifacts.completion_evidence.status` reaches `satisfied`.
 
 ## Field Semantics
 
@@ -205,18 +207,23 @@ Execution routing fields remain abstract so executors can be swapped without cha
 
 ### Artifacts
 
-Artifacts are product-facing outputs attached to the task, not substrate checkpoints.
+Artifacts are product-facing outputs and verification evidence attached to the task, not substrate checkpoints.
 
 `artifacts` contains:
 
-- `pr_links`
-- `commit_shas`
-- `logs`
-- `outputs`
+- `items`: canonical artifact records such as pull requests, commits, changed files, logs, outputs, and review notes
+- `completion_evidence`: the current policy and validation state for deciding whether a task may be treated as complete
 
-`logs` is for execution or diagnostic references that matter at the task level.
+Each artifact record may carry:
 
-`outputs` is for task deliverables or produced references.
+- artifact type
+- repository and branch identity
+- changed-file information
+- provenance
+- external references
+- verification status
+
+Completion is not trusted purely because an executor claims success. `artifacts.completion_evidence` is where Harness records whether the evidence requirement is deferred, required, satisfied, insufficient, or not applicable.
 
 ### Observability
 
@@ -282,6 +289,12 @@ This distinction matters because Linear and Harness business logic should reason
 
 - contribute logs, outputs, and execution observations
 - do not redefine task status semantics outside the canonical lifecycle
+
+### Verification
+
+- evaluates `artifacts.items` and `artifacts.completion_evidence`
+- determines whether a completion transition is evidence-backed
+- rejects terminal completion when required evidence is missing or insufficient
 
 ## Schema Reference
 

--- a/modules/intake/task_envelope.py
+++ b/modules/intake/task_envelope.py
@@ -169,10 +169,17 @@ def create_task_envelope(
         "required_capabilities": [],
         "priority": "normal",
         "artifacts": {
-            "pr_links": [],
-            "commit_shas": [],
-            "logs": [],
-            "outputs": [],
+            "items": [],
+            "completion_evidence": {
+                "policy": "deferred",
+                "status": "deferred",
+                "required_artifact_types": [],
+                "validated_artifact_ids": [],
+                "validation_method": "deferred",
+                "validated_at": None,
+                "validator": None,
+                "notes": None,
+            },
         },
         "observability": {
             "errors": [],
@@ -189,7 +196,8 @@ def create_task_envelope(
                     "assigned_executor",
                     "required_capabilities",
                     "priority",
-                    "artifacts",
+                    "artifacts.items",
+                    "artifacts.completion_evidence",
                     "observability",
                 ]
             },

--- a/schemas/task_envelope.schema.json
+++ b/schemas/task_envelope.schema.json
@@ -408,92 +408,497 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "pr_links",
-        "commit_shas",
-        "logs",
-        "outputs"
+        "items",
+        "completion_evidence"
       ],
       "properties": {
-        "pr_links": {
+        "items": {
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "uri"
+            "$ref": "#/$defs/artifactRecord"
           },
           "default": []
         },
-        "commit_shas": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^[a-fA-F0-9]{7,40}$"
-          },
-          "uniqueItems": true,
-          "default": []
-        },
-        "logs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/logReference"
-          },
-          "default": []
-        },
-        "outputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/outputReference"
-          },
-          "default": []
+        "completion_evidence": {
+          "$ref": "#/$defs/completionEvidence"
         }
       }
     },
-    "logReference": {
+    "artifactRecord": {
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "id",
         "type",
-        "location"
+        "provenance",
+        "verification_status",
+        "repository",
+        "branch",
+        "changed_files",
+        "external_refs"
       ],
       "properties": {
-        "type": {
+        "id": {
           "type": "string",
           "minLength": 1
         },
-        "location": {
+        "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "pull_request",
+            "commit",
+            "branch",
+            "changed_file",
+            "log",
+            "output",
+            "review_note"
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "type": [
             "string",
             "null"
           ]
-        }
-      }
-    },
-    "outputReference": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "location"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "minLength": 1
         },
         "location": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
           "type": [
             "string",
             "null"
           ]
         },
         "content_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commit_sha": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[a-fA-F0-9]{7,40}$"
+        },
+        "pull_request_number": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "review_state": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "approved",
+            "changes_requested",
+            "commented",
+            "dismissed",
+            null
+          ]
+        },
+        "provenance": {
+          "$ref": "#/$defs/artifactProvenance"
+        },
+        "verification_status": {
+          "type": "string",
+          "enum": [
+            "unverified",
+            "verified",
+            "rejected",
+            "informational"
+          ]
+        },
+        "repository": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/repositoryIdentity"
+            }
+          ]
+        },
+        "branch": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/branchIdentity"
+            }
+          ]
+        },
+        "changed_files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/changedFile"
+          },
+          "default": []
+        },
+        "external_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/externalReference"
+          },
+          "default": []
+        },
+        "captured_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pull_request"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "pull_request_number"
+            ],
+            "properties": {
+              "repository": {
+                "$ref": "#/$defs/repositoryIdentity"
+              },
+              "branch": {
+                "$ref": "#/$defs/branchIdentity"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "commit"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "commit_sha"
+            ],
+            "properties": {
+              "repository": {
+                "$ref": "#/$defs/repositoryIdentity"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "branch"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "repository": {
+                "$ref": "#/$defs/repositoryIdentity"
+              },
+              "branch": {
+                "$ref": "#/$defs/branchIdentity"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "changed_file"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "repository": {
+                "$ref": "#/$defs/repositoryIdentity"
+              },
+              "branch": {
+                "$ref": "#/$defs/branchIdentity"
+              },
+              "changed_files": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ]
+    },
+    "artifactProvenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_system",
+        "source_type",
+        "source_id"
+      ],
+      "properties": {
+        "source_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "captured_by": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "repositoryIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "owner",
+        "name"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "external_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "branchIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "base_branch"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "base_branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "head_commit_sha": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[a-fA-F0-9]{7,40}$"
+        }
+      }
+    },
+    "changedFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "change_type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "change_type": {
+          "type": "string",
+          "enum": [
+            "added",
+            "modified",
+            "deleted",
+            "renamed",
+            "copied",
+            "unknown"
+          ]
+        },
+        "previous_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "additions": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "deletions": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "externalReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "system",
+        "id"
+      ],
+      "properties": {
+        "system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        }
+      }
+    },
+    "completionEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy",
+        "status",
+        "required_artifact_types",
+        "validated_artifact_ids",
+        "validation_method",
+        "validated_at",
+        "validator"
+      ],
+      "properties": {
+        "policy": {
+          "type": "string",
+          "enum": [
+            "deferred",
+            "required",
+            "advisory_only",
+            "not_applicable"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "deferred",
+            "pending",
+            "satisfied",
+            "insufficient",
+            "not_applicable"
+          ]
+        },
+        "required_artifact_types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "pull_request",
+              "commit",
+              "branch",
+              "changed_file",
+              "log",
+              "output",
+              "review_note"
+            ]
+          },
+          "uniqueItems": true,
+          "default": []
+        },
+        "validated_artifact_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true,
+          "default": []
+        },
+        "validation_method": {
+          "type": "string",
+          "enum": [
+            "deferred",
+            "artifact_presence",
+            "external_reconciliation",
+            "manual_review",
+            "mixed",
+            "none"
+          ]
+        },
+        "validated_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "validator": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/artifactProvenance"
+            }
+          ]
+        },
+        "notes": {
           "type": [
             "string",
             "null"

--- a/tests/contracts/__init__.py
+++ b/tests/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Contract schema tests."""

--- a/tests/contracts/test_task_envelope_artifacts.py
+++ b/tests/contracts/test_task_envelope_artifacts.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.contracts.task_envelope_validation import validate_task_envelope
+
+
+def _base_task_envelope() -> dict:
+    return {
+        "id": "task-artifacts-1",
+        "title": "Verify code-bearing completion evidence",
+        "description": "Task used to validate artifact-backed completion schema behavior.",
+        "origin": {
+            "source_system": "openclaw",
+            "source_type": "ingress_request",
+            "source_id": "req-artifacts-1",
+            "ingress_id": None,
+            "ingress_name": "OpenClaw",
+            "requested_by": None,
+        },
+        "status": "completed",
+        "timestamps": {
+            "created_at": "2026-03-24T16:00:00Z",
+            "updated_at": "2026-03-24T16:15:00Z",
+            "completed_at": "2026-03-24T16:15:00Z",
+        },
+        "status_history": [],
+        "objective": {
+            "summary": "Validate completion evidence shape.",
+            "deliverable_type": "code_change",
+            "success_signal": "Evidence validates against the canonical schema.",
+        },
+        "constraints": [],
+        "acceptance_criteria": [
+            {
+                "id": "ac-1",
+                "description": "Task completion is supported by a PR and commit artifact.",
+                "required": True,
+            }
+        ],
+        "parent_task_id": None,
+        "child_task_ids": [],
+        "dependencies": [],
+        "assigned_executor": None,
+        "required_capabilities": [],
+        "priority": "normal",
+        "artifacts": {
+            "items": [],
+            "completion_evidence": {
+                "policy": "required",
+                "status": "satisfied",
+                "required_artifact_types": ["pull_request", "commit"],
+                "validated_artifact_ids": ["artifact-pr-1", "artifact-commit-1"],
+                "validation_method": "external_reconciliation",
+                "validated_at": "2026-03-24T16:14:00Z",
+                "validator": {
+                    "source_system": "harness",
+                    "source_type": "verification",
+                    "source_id": "verification-run-1",
+                    "captured_by": "github-sync",
+                },
+                "notes": "PR and commit reconciled against GitHub before completion.",
+            },
+        },
+        "observability": {
+            "errors": [],
+            "retries": {
+                "attempt_count": 0,
+                "max_attempts": 0,
+                "last_retry_at": None,
+            },
+            "execution_metadata": {},
+        },
+    }
+
+
+class TaskEnvelopeArtifactSchemaTests(unittest.TestCase):
+    def test_accepts_valid_pull_request_and_commit_evidence(self) -> None:
+        task_envelope = _base_task_envelope()
+        task_envelope["artifacts"]["items"] = [
+            {
+                "id": "artifact-pr-1",
+                "type": "pull_request",
+                "title": "Implement evidence model",
+                "description": "Pull request opened for the evidence-model change set.",
+                "location": "https://github.com/example/harness/pull/99",
+                "content_type": None,
+                "external_id": "PR-99",
+                "commit_sha": None,
+                "pull_request_number": 99,
+                "review_state": "approved",
+                "provenance": {
+                    "source_system": "github",
+                    "source_type": "api",
+                    "source_id": "pull/99",
+                    "captured_by": "github-sync",
+                },
+                "verification_status": "verified",
+                "repository": {
+                    "host": "github.com",
+                    "owner": "sfayka",
+                    "name": "Harness",
+                    "external_id": "repo-123",
+                },
+                "branch": {
+                    "name": "codex/evidence-model",
+                    "base_branch": "main",
+                    "head_commit_sha": "abcdef1234567890",
+                },
+                "changed_files": [
+                    {
+                        "path": "schemas/task_envelope.schema.json",
+                        "change_type": "modified",
+                        "previous_path": None,
+                        "additions": 42,
+                        "deletions": 3,
+                    }
+                ],
+                "external_refs": [
+                    {
+                        "system": "github",
+                        "id": "pull/99",
+                        "url": "https://github.com/example/harness/pull/99",
+                    }
+                ],
+                "captured_at": "2026-03-24T16:10:00Z",
+                "metadata": {},
+            },
+            {
+                "id": "artifact-commit-1",
+                "type": "commit",
+                "title": None,
+                "description": None,
+                "location": "https://github.com/example/harness/commit/abcdef1234567890",
+                "content_type": None,
+                "external_id": "commit-abcdef1234567890",
+                "commit_sha": "abcdef1234567890",
+                "pull_request_number": None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "github",
+                    "source_type": "api",
+                    "source_id": "commit/abcdef1234567890",
+                    "captured_by": "github-sync",
+                },
+                "verification_status": "verified",
+                "repository": {
+                    "host": "github.com",
+                    "owner": "sfayka",
+                    "name": "Harness",
+                    "external_id": "repo-123",
+                },
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [
+                    {
+                        "system": "github",
+                        "id": "commit/abcdef1234567890",
+                        "url": "https://github.com/example/harness/commit/abcdef1234567890",
+                    }
+                ],
+                "captured_at": "2026-03-24T16:11:00Z",
+                "metadata": {},
+            },
+        ]
+
+        errors = validate_task_envelope(task_envelope)
+        self.assertEqual(errors, [])
+
+    def test_rejects_pull_request_artifact_missing_repository_context(self) -> None:
+        task_envelope = _base_task_envelope()
+        task_envelope["artifacts"]["items"] = [
+            {
+                "id": "artifact-pr-1",
+                "type": "pull_request",
+                "title": None,
+                "description": None,
+                "location": "https://github.com/example/harness/pull/99",
+                "content_type": None,
+                "external_id": "PR-99",
+                "commit_sha": None,
+                "pull_request_number": 99,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "github",
+                    "source_type": "api",
+                    "source_id": "pull/99",
+                    "captured_by": "github-sync",
+                },
+                "verification_status": "verified",
+                "repository": None,
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T16:10:00Z",
+                "metadata": {},
+            }
+        ]
+
+        errors = validate_task_envelope(task_envelope)
+        self.assertTrue(errors)
+        self.assertTrue(any("/artifacts/items/0/repository" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/intake/test_task_envelope.py
+++ b/tests/intake/test_task_envelope.py
@@ -63,7 +63,22 @@ class CreateTaskEnvelopeTests(unittest.TestCase):
         self.assertIsNone(task_envelope["assigned_executor"])
         self.assertEqual(task_envelope["required_capabilities"], [])
         self.assertEqual(task_envelope["priority"], "normal")
-        self.assertEqual(task_envelope["artifacts"], {"pr_links": [], "commit_shas": [], "logs": [], "outputs": []})
+        self.assertEqual(
+            task_envelope["artifacts"],
+            {
+                "items": [],
+                "completion_evidence": {
+                    "policy": "deferred",
+                    "status": "deferred",
+                    "required_artifact_types": [],
+                    "validated_artifact_ids": [],
+                    "validation_method": "deferred",
+                    "validated_at": None,
+                    "validator": None,
+                    "notes": None,
+                },
+            },
+        )
 
         assert_valid_task_envelope(task_envelope)
 
@@ -107,7 +122,8 @@ class CreateTaskEnvelopeTests(unittest.TestCase):
                 "assigned_executor",
                 "required_capabilities",
                 "priority",
-                "artifacts",
+                "artifacts.items",
+                "artifacts.completion_evidence",
                 "observability",
             ],
         )


### PR DESCRIPTION
## Summary
- define the canonical artifact and completion-evidence model for Harness
- update TaskEnvelope schema and contract alignment for verifiable completion evidence
- add contract tests for artifact-backed completion and malformed artifact validation

## Testing
- python3 -m json.tool schemas/task_envelope.schema.json >/dev/null
- .venv/bin/python -m unittest discover -s tests