### PR TITLE
Prepare repository for public release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 __pycache__/
+*.py[cod]
 .pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+.python-version
 .venv/
+venv/
 node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Harness is still early. The most useful contributions right now are the ones that make contracts, verification rules, and control-plane boundaries clearer.
+
+## Before Opening A Change
+
+- read the README for project positioning
+- read the docs in `docs/architecture/`
+- check accepted ADRs in `docs/adrs/`
+- prefer opening focused changes rather than broad mixed refactors
+
+## Contribution Guidelines
+
+- keep Harness positioned as a control plane and reliability layer
+- do not treat executor-reported success as sufficient completion evidence
+- preserve the boundary between ingress, control plane, systems of record, and executors
+- avoid introducing runtime or framework choices that conflict with accepted ADRs
+- update docs when contracts or architectural assumptions change
+
+## Development Notes
+
+- Python is the primary implementation runtime
+- machine-readable contracts live in `schemas/`
+- implementation modules live in `modules/`
+- tests live in `tests/`
+
+## Public Repository Hygiene
+
+- do not commit secrets, tokens, or local credentials
+- do not commit `.env` files, local virtual environments, or terminal dumps
+- use obviously fake placeholders when examples need values
+
+## License
+
+License selection is not defined in this file. Maintainers should confirm the intended open-source license before making the repository public.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ The goal is not to out-reason model-native task runners. The goal is to make AI-
 
 The Harness runtime is Python. Integration with OpenClaw is API-first rather than a Node extension model.
 
+## What Harness Is
+
+Harness is a system for:
+
+- receiving validated work through explicit contracts
+- normalizing work into canonical task structures
+- delegating execution to replaceable workers
+- requiring evidence before trusting completion
+- reconciling lifecycle state across systems such as Linear and GitHub
+
+## What Harness Is Not
+
+Harness is not:
+
+- a generic agent framework
+- a model-hosted plugin extension
+- a bet against improving model-native reasoning
+- a system that treats executor-reported success as sufficient evidence of completion
+
 ## Purpose
 
 Harness is a continuation of the ideas behind InboxToBacklog, but in a fresh repository with a tighter focus on correctness, verification, and control-plane guarantees.
@@ -69,21 +88,52 @@ For now, Harness should optimize for clarity over automation theater.
 
 ## Status
 
-This is an early project scaffold. The README currently captures the intent and operating model so the repo has a concrete starting point.
+This repository is still early, but the architecture direction is established.
+
+Current focus:
+
+- canonical contracts such as `TaskEnvelope`
+- artifact and completion evidence modeling
+- intake normalization
+- verification, auditability, and system-of-record reconciliation
+
+Not yet in scope:
+
+- full planner sophistication
+- advanced dispatcher behavior
+- workflow-heavy runtime features beyond what is needed for control-plane guarantees
+
+## Explore The Repo
+
+- `docs/architecture/` contains the main system model and contract docs
+- `docs/adrs/` contains architecture decision records
+- `docs/planning/` contains near-term planning notes
+- `modules/` contains the current Python implementation work
+- `schemas/` contains canonical machine-readable contracts
+- `tests/` contains Python tests for contract validation and module behavior
+
+## Public Readiness Notes
+
+- No license file has been added in this change set because license selection should be maintainer-confirmed before the repository is made public.
+- Secrets and local-only files should continue to be reviewed before changing repository visibility, even though this pass did not find obvious committed credentials.
 
 ## Architecture Docs
 
 The architecture baseline for Epic 1 lives under `docs/`:
 
-- [System Context](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/system-context.md)
-- [TaskEnvelope Contract](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/task-envelope.md)
-- [Artifact And Completion Evidence](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/artifact-and-completion-evidence.md)
-- [Intake To TaskEnvelope Mapping](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/intake-to-task-envelope.md)
-- [Module Boundaries](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/module-boundaries.md)
-- [Canonical Vocabulary](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/canonical-vocabulary.md)
-- [Repository Layout Proposal](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/repository-layout.md)
-- [ADR 0001](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/adrs/0001-openclaw-as-ingress-harness-as-control-plane.md)
-- [ADR 0002](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/adrs/0002-initial-substrate-choice-and-replacement-strategy.md)
-- [ADR 0003](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/adrs/0003-harness-implementation-runtime.md)
-- [ADR 0004](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/adrs/0004-harness-strategic-positioning-reliability-layer.md)
-- [Initial Codex Tickets](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/planning/initial-codex-tickets.md)
+- [System Context](docs/architecture/system-context.md)
+- [TaskEnvelope Contract](docs/architecture/task-envelope.md)
+- [Artifact And Completion Evidence](docs/architecture/artifact-and-completion-evidence.md)
+- [Intake To TaskEnvelope Mapping](docs/architecture/intake-to-task-envelope.md)
+- [Module Boundaries](docs/architecture/module-boundaries.md)
+- [Canonical Vocabulary](docs/architecture/canonical-vocabulary.md)
+- [Repository Layout Proposal](docs/architecture/repository-layout.md)
+- [ADR 0001](docs/adrs/0001-openclaw-as-ingress-harness-as-control-plane.md)
+- [ADR 0002](docs/adrs/0002-initial-substrate-choice-and-replacement-strategy.md)
+- [ADR 0003](docs/adrs/0003-harness-implementation-runtime.md)
+- [ADR 0004](docs/adrs/0004-harness-strategic-positioning-reliability-layer.md)
+- [Initial Codex Tickets](docs/planning/initial-codex-tickets.md)
+
+## Contributing
+
+Lightweight contributor guidance lives in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/architecture/intake-to-task-envelope.md
+++ b/docs/architecture/intake-to-task-envelope.md
@@ -143,6 +143,6 @@ Fields deferred beyond intake:
 
 ## Validation Rule
 
-Every produced envelope must be validated against [task_envelope.schema.json](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/schemas/task_envelope.schema.json) before leaving intake.
+Every produced envelope must be validated against [task_envelope.schema.json](../../schemas/task_envelope.schema.json) before leaving intake.
 
 If validation fails, intake must reject the envelope rather than emitting a partial or schema-invalid object.

--- a/docs/architecture/system-context.md
+++ b/docs/architecture/system-context.md
@@ -17,7 +17,7 @@ Harness sits between the user-facing ingress layer and the execution layer as th
 
 ## Context Diagram
 
-The Mermaid source for the diagram lives in [system-context.mmd](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/docs/architecture/system-context.mmd).
+The Mermaid source for the diagram lives in [system-context.mmd](system-context.mmd).
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/task-envelope.md
+++ b/docs/architecture/task-envelope.md
@@ -298,4 +298,4 @@ This distinction matters because Linear and Harness business logic should reason
 
 ## Schema Reference
 
-The machine-readable schema lives in [task_envelope.schema.json](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/schemas/task_envelope.schema.json).
+The machine-readable schema lives in [task_envelope.schema.json](../../schemas/task_envelope.schema.json).


### PR DESCRIPTION
## Summary
- clean up public-facing documentation and repository hygiene for a public release
- replace local filesystem links with repository-relative links
- add lightweight contributor guidance and clarify current status for outside readers
- expand ignore rules for common Python/local-only files

## Testing
- .venv/bin/python -m unittest discover -s tests

## Maintainer review
- no LICENSE file was added; license selection still requires maintainer confirmation before making the repository public