### PR TITLE
Implement TaskEnvelope lifecycle enforcement primitives

### DIFF
--- a/modules/contracts/__init__.py
+++ b/modules/contracts/__init__.py
@@ -1,1 +1,24 @@
 """Shared contract helpers for Harness modules."""
+
+from .task_envelope_lifecycle import (
+    ForbiddenTransitionError,
+    LifecycleTransitionError,
+    TransitionAuthorityError,
+    TransitionPreconditionError,
+    TransitionResult,
+    apply_task_transition,
+    validate_task_transition,
+)
+from .task_envelope_validation import assert_valid_task_envelope, validate_task_envelope
+
+__all__ = [
+    "ForbiddenTransitionError",
+    "LifecycleTransitionError",
+    "TransitionAuthorityError",
+    "TransitionPreconditionError",
+    "TransitionResult",
+    "apply_task_transition",
+    "assert_valid_task_envelope",
+    "validate_task_envelope",
+    "validate_task_transition",
+]

--- a/modules/contracts/task_envelope_lifecycle.py
+++ b/modules/contracts/task_envelope_lifecycle.py
@@ -1,0 +1,329 @@
+"""Lifecycle enforcement primitives for canonical TaskEnvelope state movement."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping
+
+from modules.contracts.task_envelope_validation import assert_valid_task_envelope
+
+TaskEnvelope = dict[str, Any]
+TransitionFacts = Mapping[str, Any]
+PreconditionHook = Callable[[TaskEnvelope, str, str, TransitionFacts], str | None]
+
+
+class LifecycleTransitionError(ValueError):
+    """Base error for invalid lifecycle transition attempts."""
+
+
+class ForbiddenTransitionError(LifecycleTransitionError):
+    """Raised when a transition is not part of the canonical state graph."""
+
+
+class TransitionAuthorityError(LifecycleTransitionError):
+    """Raised when an unauthorized actor attempts a transition."""
+
+
+class TransitionPreconditionError(LifecycleTransitionError):
+    """Raised when transition preconditions are not met."""
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    """Result of a successful lifecycle transition application."""
+
+    task_envelope: TaskEnvelope
+    from_status: str
+    to_status: str
+    changed_at: str
+    actor: str
+    reason: str | None
+    status_history_entry: dict[str, Any]
+
+
+_STATUSES = {
+    "intake_ready",
+    "planned",
+    "dispatch_ready",
+    "assigned",
+    "executing",
+    "blocked",
+    "completed",
+    "failed",
+    "canceled",
+}
+
+_ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    "intake_ready": {"planned", "blocked"},
+    "planned": {"dispatch_ready", "blocked", "canceled"},
+    "dispatch_ready": {"assigned", "blocked", "canceled"},
+    "assigned": {"executing", "blocked", "failed", "canceled"},
+    "executing": {"completed", "blocked", "failed", "canceled"},
+    "blocked": {"intake_ready", "planned", "dispatch_ready", "assigned", "executing", "canceled"},
+    "completed": {"blocked"},
+    "failed": set(),
+    "canceled": set(),
+}
+
+_AUTHORIZED_ACTORS: dict[tuple[str, str], set[str]] = {
+    ("intake_ready", "planned"): {"planner"},
+    ("intake_ready", "blocked"): {"intake", "clarification"},
+    ("planned", "dispatch_ready"): {"planner"},
+    ("planned", "blocked"): {"planner", "verification"},
+    ("planned", "canceled"): {"operator", "manual_review"},
+    ("dispatch_ready", "assigned"): {"dispatcher"},
+    ("dispatch_ready", "blocked"): {"dispatcher", "operator", "manual_review"},
+    ("dispatch_ready", "canceled"): {"operator", "manual_review"},
+    ("assigned", "executing"): {"runtime"},
+    ("assigned", "blocked"): {"dispatcher", "runtime", "operator", "manual_review"},
+    ("assigned", "failed"): {"runtime", "verification"},
+    ("assigned", "canceled"): {"operator", "manual_review"},
+    ("executing", "completed"): {"verification"},
+    ("executing", "blocked"): {"runtime", "clarification", "verification", "manual_review"},
+    ("executing", "failed"): {"runtime", "verification", "manual_review"},
+    ("executing", "canceled"): {"operator", "manual_review"},
+    ("completed", "blocked"): {"verification", "manual_review"},
+    ("blocked", "intake_ready"): {"clarification", "operator", "manual_review"},
+    ("blocked", "planned"): {"planner", "clarification", "operator", "manual_review"},
+    ("blocked", "dispatch_ready"): {"dispatcher", "operator", "manual_review"},
+    ("blocked", "assigned"): {"dispatcher"},
+    ("blocked", "executing"): {"runtime"},
+    ("blocked", "canceled"): {"operator", "manual_review"},
+}
+
+
+def _iso_timestamp(value: Any | None = None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    raise ValueError("Expected now to be a datetime, ISO-8601 string, or None")
+
+
+def _has_unresolved_clarification(task_envelope: TaskEnvelope) -> bool:
+    clarification = task_envelope.get("clarification")
+    if not clarification:
+        return False
+
+    if clarification.get("status") in {"required", "requested", "answered"}:
+        return True
+
+    for item in clarification.get("required_inputs", []):
+        if item.get("required") and item.get("status") == "open":
+            return True
+
+    return False
+
+
+def _has_active_assignment(task_envelope: TaskEnvelope) -> bool:
+    assigned_executor = task_envelope.get("assigned_executor")
+    return isinstance(assigned_executor, dict) and bool(assigned_executor.get("executor_type"))
+
+
+def _completion_evidence_satisfied(task_envelope: TaskEnvelope) -> bool:
+    evidence = task_envelope.get("artifacts", {}).get("completion_evidence", {})
+    policy = evidence.get("policy")
+    status = evidence.get("status")
+
+    if policy in {"deferred", "advisory_only", "not_applicable"}:
+        return True
+
+    return policy == "required" and status == "satisfied"
+
+
+def _reason_required(task_envelope: TaskEnvelope, from_status: str, to_status: str, facts: TransitionFacts) -> str | None:
+    del task_envelope
+    if to_status in {"blocked", "failed", "canceled"} and not facts.get("reason_provided", False):
+        return f"Transition {from_status} -> {to_status} requires a reason"
+    return None
+
+
+def _clarification_must_be_resolved(
+    task_envelope: TaskEnvelope, from_status: str, to_status: str, facts: TransitionFacts
+) -> str | None:
+    del from_status, facts
+    if to_status in {"planned", "dispatch_ready", "assigned"} and _has_unresolved_clarification(task_envelope):
+        return f"Transition to {to_status} requires clarification to be resolved"
+    return None
+
+
+def _assignment_required(
+    task_envelope: TaskEnvelope, from_status: str, to_status: str, facts: TransitionFacts
+) -> str | None:
+    del from_status, facts
+    if to_status == "assigned" and not _has_active_assignment(task_envelope):
+        return "Transition to assigned requires assigned_executor to record the active assignment"
+    return None
+
+
+def _execution_start_required(
+    task_envelope: TaskEnvelope, from_status: str, to_status: str, facts: TransitionFacts
+) -> str | None:
+    del from_status
+    if to_status != "executing":
+        return None
+    if not _has_active_assignment(task_envelope):
+        return "Transition to executing requires an active assignment"
+    if not facts.get("execution_started", False):
+        return "Transition to executing requires a real execution-start fact"
+    return None
+
+
+def _completion_requirements(
+    task_envelope: TaskEnvelope, from_status: str, to_status: str, facts: TransitionFacts
+) -> str | None:
+    del from_status
+    if to_status != "completed":
+        return None
+
+    if not facts.get("verification_passed", False):
+        return "Transition to completed requires a passing verification decision"
+    if not facts.get("acceptance_criteria_satisfied", False):
+        return "Transition to completed requires acceptance criteria to be satisfied"
+    if not facts.get("reconciliation_passed", False):
+        return "Transition to completed requires non-blocking reconciliation"
+    if not _completion_evidence_satisfied(task_envelope):
+        return "Transition to completed requires completion evidence to be satisfied"
+    return None
+
+
+def _terminal_failure_required(
+    task_envelope: TaskEnvelope, from_status: str, to_status: str, facts: TransitionFacts
+) -> str | None:
+    del task_envelope, from_status
+    if to_status == "failed" and not facts.get("terminal_failure", False):
+        return "Transition to failed requires a terminal failure determination"
+    return None
+
+
+def _blocked_reentry_requirements(
+    task_envelope: TaskEnvelope, from_status: str, to_status: str, facts: TransitionFacts
+) -> str | None:
+    del facts
+    if from_status != "blocked":
+        return None
+    if to_status in {"intake_ready", "planned", "dispatch_ready"} and _has_unresolved_clarification(task_envelope):
+        return f"Transition blocked -> {to_status} requires the blocking clarification to be resolved"
+    return None
+
+
+_DEFAULT_PRECONDITION_HOOKS: tuple[PreconditionHook, ...] = (
+    _reason_required,
+    _clarification_must_be_resolved,
+    _assignment_required,
+    _execution_start_required,
+    _completion_requirements,
+    _terminal_failure_required,
+    _blocked_reentry_requirements,
+)
+
+
+def validate_task_transition(
+    task_envelope: TaskEnvelope,
+    *,
+    to_status: str,
+    actor: str,
+    reason: str | None = None,
+    facts: TransitionFacts | None = None,
+    precondition_hooks: list[PreconditionHook] | tuple[PreconditionHook, ...] = (),
+) -> None:
+    """Validate that a requested task transition is allowed under lifecycle policy."""
+
+    assert_valid_task_envelope(task_envelope)
+
+    from_status = task_envelope["status"]
+    if from_status not in _STATUSES or to_status not in _STATUSES:
+        raise ForbiddenTransitionError(f"Unknown lifecycle transition {from_status} -> {to_status}")
+
+    if from_status == to_status:
+        raise ForbiddenTransitionError(f"No-op lifecycle transition {from_status} -> {to_status} is not allowed")
+
+    if to_status not in _ALLOWED_TRANSITIONS.get(from_status, set()):
+        raise ForbiddenTransitionError(f"Forbidden lifecycle transition {from_status} -> {to_status}")
+
+    allowed_actors = _AUTHORIZED_ACTORS.get((from_status, to_status), set())
+    if actor not in allowed_actors:
+        raise TransitionAuthorityError(
+            f"Actor {actor!r} is not authorized for transition {from_status} -> {to_status}"
+        )
+
+    facts = dict(facts or {})
+    facts["reason_provided"] = bool(reason and reason.strip())
+
+    for hook in (*_DEFAULT_PRECONDITION_HOOKS, *precondition_hooks):
+        error = hook(task_envelope, from_status, to_status, facts)
+        if error:
+            raise TransitionPreconditionError(error)
+
+
+def apply_task_transition(
+    task_envelope: TaskEnvelope,
+    *,
+    to_status: str,
+    actor: str,
+    reason: str | None = None,
+    changed_by: str | None = None,
+    now: datetime | str | None = None,
+    facts: TransitionFacts | None = None,
+    precondition_hooks: list[PreconditionHook] | tuple[PreconditionHook, ...] = (),
+) -> TransitionResult:
+    """Apply a validated lifecycle transition and append an audit history entry."""
+
+    validate_task_transition(
+        task_envelope,
+        to_status=to_status,
+        actor=actor,
+        reason=reason,
+        facts=facts,
+        precondition_hooks=precondition_hooks,
+    )
+
+    changed_at = _iso_timestamp(now)
+    from_status = task_envelope["status"]
+    updated = deepcopy(task_envelope)
+    updated["status"] = to_status
+    updated["timestamps"]["updated_at"] = changed_at
+
+    if to_status == "completed":
+        updated["timestamps"]["completed_at"] = changed_at
+    elif from_status == "completed":
+        updated["timestamps"]["completed_at"] = None
+
+    history_entry = {
+        "from_status": from_status,
+        "to_status": to_status,
+        "changed_at": changed_at,
+        "reason": reason,
+        "changed_by": changed_by or actor,
+    }
+    updated.setdefault("status_history", []).append(history_entry)
+
+    assert_valid_task_envelope(updated)
+
+    return TransitionResult(
+        task_envelope=updated,
+        from_status=from_status,
+        to_status=to_status,
+        changed_at=changed_at,
+        actor=actor,
+        reason=reason,
+        status_history_entry=history_entry,
+    )
+
+
+__all__ = [
+    "ForbiddenTransitionError",
+    "LifecycleTransitionError",
+    "TransitionAuthorityError",
+    "TransitionPreconditionError",
+    "TransitionResult",
+    "apply_task_transition",
+    "validate_task_transition",
+]

--- a/tests/contracts/test_task_envelope_lifecycle.py
+++ b/tests/contracts/test_task_envelope_lifecycle.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.contracts.task_envelope_lifecycle import (
+    ForbiddenTransitionError,
+    TransitionAuthorityError,
+    TransitionPreconditionError,
+    apply_task_transition,
+    validate_task_transition,
+)
+from modules.intake import create_task_envelope
+
+
+def _base_task() -> dict:
+    return create_task_envelope(
+        {
+            "id": "task-lifecycle-1",
+            "title": "Lifecycle primitive coverage",
+            "description": "Exercise TaskEnvelope state enforcement primitives.",
+            "origin": {
+                "source_system": "openclaw",
+                "source_type": "ingress_request",
+                "source_id": "req-lifecycle-1",
+            },
+            "acceptance_criteria": [
+                {
+                    "id": "ac-1",
+                    "description": "Lifecycle transitions are enforced in code.",
+                    "required": True,
+                }
+            ],
+        },
+        now="2026-03-25T12:00:00Z",
+    )
+
+
+class TaskEnvelopeLifecycleTests(unittest.TestCase):
+    def test_allows_planner_transition_and_records_history(self) -> None:
+        result = apply_task_transition(
+            _base_task(),
+            to_status="planned",
+            actor="planner",
+            reason="Planning preconditions satisfied.",
+            now="2026-03-25T12:05:00Z",
+        )
+
+        self.assertEqual(result.from_status, "intake_ready")
+        self.assertEqual(result.to_status, "planned")
+        self.assertEqual(result.task_envelope["status"], "planned")
+        self.assertEqual(result.task_envelope["timestamps"]["updated_at"], "2026-03-25T12:05:00Z")
+        self.assertEqual(
+            result.task_envelope["status_history"],
+            [
+                {
+                    "from_status": "intake_ready",
+                    "to_status": "planned",
+                    "changed_at": "2026-03-25T12:05:00Z",
+                    "reason": "Planning preconditions satisfied.",
+                    "changed_by": "planner",
+                }
+            ],
+        )
+
+    def test_rejects_forbidden_transition(self) -> None:
+        with self.assertRaisesRegex(ForbiddenTransitionError, "Forbidden lifecycle transition"):
+            validate_task_transition(
+                _base_task(),
+                to_status="assigned",
+                actor="dispatcher",
+                reason="Skip directly to assignment.",
+            )
+
+    def test_rejects_wrong_authority(self) -> None:
+        task = apply_task_transition(
+            _base_task(),
+            to_status="planned",
+            actor="planner",
+            reason="Ready for planning.",
+            now="2026-03-25T12:05:00Z",
+        ).task_envelope
+
+        with self.assertRaisesRegex(TransitionAuthorityError, "not authorized"):
+            validate_task_transition(
+                task,
+                to_status="dispatch_ready",
+                actor="dispatcher",
+                reason="Dispatcher should not finalize planning.",
+            )
+
+    def test_rejects_assignment_without_active_executor(self) -> None:
+        task = apply_task_transition(
+            _base_task(),
+            to_status="planned",
+            actor="planner",
+            reason="Plan created.",
+            now="2026-03-25T12:05:00Z",
+        ).task_envelope
+        task = apply_task_transition(
+            task,
+            to_status="dispatch_ready",
+            actor="planner",
+            reason="Routing preconditions satisfied.",
+            now="2026-03-25T12:06:00Z",
+        ).task_envelope
+
+        with self.assertRaisesRegex(TransitionPreconditionError, "assigned_executor"):
+            validate_task_transition(
+                task,
+                to_status="assigned",
+                actor="dispatcher",
+                reason="Try to dispatch without assignment.",
+            )
+
+    def test_rejects_execution_start_without_real_start_fact(self) -> None:
+        task = _base_task()
+        task["status"] = "assigned"
+        task["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-1",
+            "assignment_reason": "Capability match.",
+        }
+
+        with self.assertRaisesRegex(TransitionPreconditionError, "execution-start fact"):
+            validate_task_transition(
+                task,
+                to_status="executing",
+                actor="runtime",
+                reason="Attempted start without runtime fact.",
+            )
+
+    def test_allows_verified_completion_and_sets_completed_timestamp(self) -> None:
+        task = _base_task()
+        task["status"] = "executing"
+        task["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-1",
+            "assignment_reason": "Capability match.",
+        }
+        task["artifacts"]["completion_evidence"] = {
+            "policy": "required",
+            "status": "satisfied",
+            "required_artifact_types": ["commit"],
+            "validated_artifact_ids": ["artifact-1"],
+            "validation_method": "external_reconciliation",
+            "validated_at": "2026-03-25T12:20:00Z",
+            "validator": {
+                "source_system": "harness",
+                "source_type": "manual",
+                "source_id": "verification-1",
+                "captured_by": "verification",
+            },
+            "notes": None,
+        }
+
+        result = apply_task_transition(
+            task,
+            to_status="completed",
+            actor="verification",
+            reason="Verification accepted the completed outcome.",
+            now="2026-03-25T12:21:00Z",
+            facts={
+                "verification_passed": True,
+                "acceptance_criteria_satisfied": True,
+                "reconciliation_passed": True,
+            },
+        )
+
+        self.assertEqual(result.task_envelope["status"], "completed")
+        self.assertEqual(result.task_envelope["timestamps"]["completed_at"], "2026-03-25T12:21:00Z")
+        self.assertEqual(result.task_envelope["status_history"][-1]["to_status"], "completed")
+
+    def test_rejects_completion_without_verification_preconditions(self) -> None:
+        task = _base_task()
+        task["status"] = "executing"
+
+        with self.assertRaisesRegex(TransitionPreconditionError, "passing verification"):
+            validate_task_transition(
+                task,
+                to_status="completed",
+                actor="verification",
+                reason="Attempt completion without verification facts.",
+            )
+
+    def test_completed_to_blocked_clears_completed_timestamp(self) -> None:
+        task = _base_task()
+        task["status"] = "completed"
+        task["timestamps"]["completed_at"] = "2026-03-25T12:30:00Z"
+
+        result = apply_task_transition(
+            task,
+            to_status="blocked",
+            actor="verification",
+            reason="Later reconciliation invalidated the completed outcome.",
+            now="2026-03-25T12:35:00Z",
+        )
+
+        self.assertEqual(result.task_envelope["status"], "blocked")
+        self.assertIsNone(result.task_envelope["timestamps"]["completed_at"])
+        self.assertEqual(result.task_envelope["status_history"][-1]["from_status"], "completed")
+
+    def test_blocked_to_planned_rejects_unresolved_clarification(self) -> None:
+        task = _base_task()
+        task["status"] = "blocked"
+        task["clarification"] = {
+            "status": "requested",
+            "blocking_reason": "waiting_on_human_input",
+            "resume_target_status": "planned",
+            "required_inputs": [
+                {
+                    "id": "input-1",
+                    "label": "Target repo",
+                    "description": "Need repository target.",
+                    "required": True,
+                    "need_type": "missing",
+                    "status": "open",
+                    "value_summary": None,
+                }
+            ],
+            "questions": [],
+            "responses": [],
+            "requested_at": "2026-03-25T12:01:00Z",
+            "resolved_at": None,
+            "requested_by": "clarification",
+            "resolution_summary": None,
+        }
+
+        with self.assertRaisesRegex(TransitionPreconditionError, "clarification"):
+            validate_task_transition(
+                task,
+                to_status="planned",
+                actor="planner",
+                reason="Attempting to resume planning too early.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add reusable TaskEnvelope lifecycle primitives for validating and applying canonical state transitions
- enforce allowed transitions, authority ownership, and built-in preconditions for assignment, execution start, completion, blocking, and failure
- record successful transitions in auditable status history and expose focused lifecycle exceptions/results for downstream modules
- add contract tests covering allowed transitions, forbidden transitions, wrong authority, unmet preconditions, completion gating, and blocked re-entry

## Validation
- `.venv/bin/python -m unittest discover -s tests`
- `python3 -m json.tool schemas/task_envelope.schema.json >/dev/null`

## Notes
- no schema changes were introduced
- the primitive is designed for reuse by later intake/planner/dispatcher/runtime/verification code rather than embedding lifecycle logic in each module
