### PR TITLE
Implement GitHub connector scaffolding for normalized external facts

### DIFF
--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -1,0 +1,23 @@
+"""Connector scaffolding for external-system translation."""
+
+from .github_facts import (
+    GitHubConnectorInputError,
+    translate_github_artifact_facts,
+    translate_github_artifact_references,
+    translate_github_branch,
+    translate_github_changed_files,
+    translate_github_commit,
+    translate_github_pull_request,
+    translate_github_repository,
+)
+
+__all__ = [
+    "GitHubConnectorInputError",
+    "translate_github_artifact_facts",
+    "translate_github_artifact_references",
+    "translate_github_branch",
+    "translate_github_changed_files",
+    "translate_github_commit",
+    "translate_github_pull_request",
+    "translate_github_repository",
+]

--- a/modules/connectors/github_facts.py
+++ b/modules/connectors/github_facts.py
@@ -1,0 +1,270 @@
+"""GitHub connector scaffolding that translates vendor-shaped inputs into normalized facts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from modules.contracts.task_envelope_external_facts import (
+    ArtifactReferenceFact,
+    BranchFact,
+    ChangedFileFact,
+    ChangedFilesSummary,
+    CommitFact,
+    ExternalFactValidationError,
+    GitHubArtifactFacts,
+    PullRequestFact,
+    RepositoryFact,
+    validate_github_facts,
+)
+
+
+class GitHubConnectorInputError(ValueError):
+    """Raised when GitHub-shaped connector input is malformed."""
+
+
+def _require_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise GitHubConnectorInputError(f"{field_name} must be a mapping")
+    return payload
+
+
+def _optional_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any] | None:
+    if payload is None:
+        return None
+    return _require_mapping(payload, field_name=field_name)
+
+
+def _require_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise GitHubConnectorInputError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise GitHubConnectorInputError("Expected string or null value")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise GitHubConnectorInputError("Expected bool or null value")
+    return value
+
+
+def _optional_int(value: Any, *, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        raise GitHubConnectorInputError(f"{field_name} must be an integer")
+    return value
+
+
+def _extract_owner(repository_payload: Mapping[str, Any]) -> str:
+    owner_value = repository_payload.get("owner")
+    if isinstance(owner_value, Mapping):
+        return _require_string(owner_value.get("login"), field_name="repository.owner.login")
+    if isinstance(owner_value, str):
+        return _require_string(owner_value, field_name="repository.owner")
+    full_name = repository_payload.get("full_name")
+    if isinstance(full_name, str) and "/" in full_name:
+        owner, _ = full_name.split("/", 1)
+        return _require_string(owner, field_name="repository.full_name.owner")
+    raise GitHubConnectorInputError("repository owner is required")
+
+
+def _extract_repository_name(repository_payload: Mapping[str, Any]) -> str:
+    name_value = repository_payload.get("name")
+    if isinstance(name_value, str) and name_value.strip():
+        return name_value.strip()
+    full_name = repository_payload.get("full_name")
+    if isinstance(full_name, str) and "/" in full_name:
+        _, name = full_name.split("/", 1)
+        return _require_string(name, field_name="repository.full_name.name")
+    raise GitHubConnectorInputError("repository name is required")
+
+
+def _normalize_change_type(status: str) -> str:
+    status_map = {
+        "added": "added",
+        "modified": "modified",
+        "removed": "deleted",
+        "deleted": "deleted",
+        "renamed": "renamed",
+        "copied": "copied",
+        "changed": "modified",
+    }
+    return status_map.get(status, "unknown")
+
+
+def translate_github_repository(repository_payload: Mapping[str, Any]) -> RepositoryFact:
+    """Translate a GitHub-shaped repository payload into a normalized repository fact."""
+
+    repository_payload = _require_mapping(repository_payload, field_name="repository")
+    repository = RepositoryFact(
+        host=_optional_string(repository_payload.get("host")) or "github.com",
+        owner=_extract_owner(repository_payload),
+        name=_extract_repository_name(repository_payload),
+        external_id=_optional_string(repository_payload.get("node_id") or repository_payload.get("id")),
+    )
+    return repository
+
+
+def translate_github_branch(branch_payload: Mapping[str, Any]) -> BranchFact:
+    """Translate a GitHub-shaped branch payload into a normalized branch fact."""
+
+    branch_payload = _require_mapping(branch_payload, field_name="branch")
+    commit_payload = _optional_mapping(branch_payload.get("commit"), field_name="branch.commit")
+    target_payload = _optional_mapping(branch_payload.get("target"), field_name="branch.target")
+    branch = BranchFact(
+        name=_require_string(branch_payload.get("name") or branch_payload.get("ref"), field_name="branch.name"),
+        base_branch=_optional_string(branch_payload.get("base_branch") or branch_payload.get("baseRefName")),
+        head_commit_sha=_optional_string(
+            branch_payload.get("head_commit_sha")
+            or (commit_payload or {}).get("sha")
+            or (target_payload or {}).get("oid")
+        ),
+    )
+    return branch
+
+
+def translate_github_commit(commit_payload: Mapping[str, Any]) -> CommitFact:
+    """Translate a GitHub-shaped commit payload into a normalized commit fact."""
+
+    commit_payload = _require_mapping(commit_payload, field_name="commit")
+    nested_commit = _optional_mapping(commit_payload.get("commit"), field_name="commit.commit")
+    commit = CommitFact(
+        sha=_require_string(commit_payload.get("sha") or commit_payload.get("oid"), field_name="commit.sha"),
+        url=_optional_string(commit_payload.get("html_url") or commit_payload.get("url")),
+        message_summary=_optional_string(
+            (nested_commit or {}).get("message") or commit_payload.get("message") or commit_payload.get("messageHeadline")
+        ),
+    )
+    return commit
+
+
+def translate_github_pull_request(pull_request_payload: Mapping[str, Any]) -> PullRequestFact:
+    """Translate a GitHub-shaped pull request payload into a normalized pull request fact."""
+
+    pull_request_payload = _require_mapping(pull_request_payload, field_name="pull_request")
+    number = _optional_int(pull_request_payload.get("number"), field_name="pull_request.number")
+    if number is None:
+        raise GitHubConnectorInputError("pull_request.number is required")
+    return PullRequestFact(
+        number=number,
+        state=_optional_string(pull_request_payload.get("state")),
+        review_state=_optional_string(
+            pull_request_payload.get("review_state")
+            or pull_request_payload.get("reviewDecision")
+            or pull_request_payload.get("review_decision")
+        ),
+        url=_optional_string(pull_request_payload.get("html_url") or pull_request_payload.get("url")),
+        merged=_optional_bool(pull_request_payload.get("merged")),
+    )
+
+
+def translate_github_changed_files(files_payload: Sequence[Mapping[str, Any]] | None) -> ChangedFilesSummary | None:
+    """Translate GitHub-shaped changed-file payloads into a normalized summary."""
+
+    if files_payload is None:
+        return None
+    if not isinstance(files_payload, Sequence) or isinstance(files_payload, (str, bytes, bytearray)):
+        raise GitHubConnectorInputError("files must be a sequence of mappings")
+
+    files: list[ChangedFileFact] = []
+    for index, file_payload in enumerate(files_payload):
+        file_mapping = _require_mapping(file_payload, field_name=f"files[{index}]")
+        status = _optional_string(file_mapping.get("status")) or "unknown"
+        additions = _optional_int(file_mapping.get("additions"), field_name=f"files[{index}].additions")
+        deletions = _optional_int(file_mapping.get("deletions"), field_name=f"files[{index}].deletions")
+        files.append(
+            ChangedFileFact(
+                path=_require_string(file_mapping.get("filename") or file_mapping.get("path"), field_name=f"files[{index}].filename"),
+                change_type=_normalize_change_type(status),
+                additions=additions,
+                deletions=deletions,
+                previous_path=_optional_string(file_mapping.get("previous_filename") or file_mapping.get("previous_path")),
+            )
+        )
+
+    return ChangedFilesSummary(files=tuple(files))
+
+
+def translate_github_artifact_references(payload: Mapping[str, Any]) -> tuple[ArtifactReferenceFact, ...]:
+    """Translate GitHub-shaped commit/PR references into normalized artifact refs."""
+
+    payload = _require_mapping(payload, field_name="github_payload")
+    refs: list[ArtifactReferenceFact] = []
+
+    pull_request_payload = _optional_mapping(payload.get("pull_request"), field_name="pull_request")
+    if pull_request_payload is not None:
+        pull_request = translate_github_pull_request(pull_request_payload)
+        refs.append(
+            ArtifactReferenceFact(
+                artifact_type="pull_request",
+                external_id=f"PR-{pull_request.number}",
+                url=pull_request.url,
+            )
+        )
+
+    commit_payload = _optional_mapping(payload.get("commit"), field_name="commit")
+    if commit_payload is not None:
+        commit = translate_github_commit(commit_payload)
+        refs.append(
+            ArtifactReferenceFact(
+                artifact_type="commit",
+                external_id=commit.sha,
+                url=commit.url,
+            )
+        )
+
+    return tuple(refs)
+
+
+def translate_github_artifact_facts(payload: Mapping[str, Any]) -> GitHubArtifactFacts:
+    """Translate a GitHub-shaped payload bundle into validated normalized facts."""
+
+    payload = _require_mapping(payload, field_name="github_payload")
+    artifact_found = payload.get("artifact_found", True)
+    if not isinstance(artifact_found, bool):
+        raise GitHubConnectorInputError("artifact_found must be a boolean")
+
+    repository_payload = _optional_mapping(payload.get("repository"), field_name="repository")
+    branch_payload = _optional_mapping(payload.get("branch"), field_name="branch")
+    commit_payload = _optional_mapping(payload.get("commit"), field_name="commit")
+    pull_request_payload = _optional_mapping(payload.get("pull_request"), field_name="pull_request")
+    changed_files_payload = payload.get("files")
+
+    github_facts = GitHubArtifactFacts(
+        artifact_found=artifact_found,
+        repository=translate_github_repository(repository_payload) if repository_payload is not None else None,
+        branch=translate_github_branch(branch_payload) if branch_payload is not None else None,
+        commit=translate_github_commit(commit_payload) if commit_payload is not None else None,
+        pull_request=translate_github_pull_request(pull_request_payload) if pull_request_payload is not None else None,
+        changed_files=translate_github_changed_files(changed_files_payload),
+        artifact_refs=translate_github_artifact_references(payload),
+        reasons=tuple(payload.get("reasons", ())),
+    )
+
+    try:
+        return validate_github_facts(github_facts)
+    except ExternalFactValidationError as error:
+        raise GitHubConnectorInputError(str(error)) from error
+
+
+__all__ = [
+    "GitHubConnectorInputError",
+    "translate_github_artifact_facts",
+    "translate_github_artifact_references",
+    "translate_github_branch",
+    "translate_github_changed_files",
+    "translate_github_commit",
+    "translate_github_pull_request",
+    "translate_github_repository",
+]

--- a/tests/connectors/__init__.py
+++ b/tests/connectors/__init__.py
@@ -1,0 +1,1 @@
+"""Connector translation tests."""

--- a/tests/connectors/test_github_facts.py
+++ b/tests/connectors/test_github_facts.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.connectors.github_facts import (
+    GitHubConnectorInputError,
+    translate_github_artifact_facts,
+    translate_github_artifact_references,
+    translate_github_changed_files,
+    translate_github_pull_request,
+    translate_github_repository,
+)
+from modules.contracts.task_envelope_reconciliation import (
+    ExpectedCodeContext,
+    ReconciliationEvaluationInput,
+    ReconciliationOutcome,
+    evaluate_reconciliation,
+)
+
+
+def _base_task_envelope() -> dict:
+    return {
+        "id": "task-github-connector-1",
+        "title": "Translate GitHub-shaped inputs",
+        "description": "Task used to validate GitHub connector scaffolding.",
+        "origin": {
+            "source_system": "openclaw",
+            "source_type": "ingress_request",
+            "source_id": "req-github-connector-1",
+            "ingress_id": None,
+            "ingress_name": "OpenClaw",
+            "requested_by": None,
+        },
+        "status": "completed",
+        "timestamps": {
+            "created_at": "2026-03-24T16:00:00Z",
+            "updated_at": "2026-03-24T16:15:00Z",
+            "completed_at": "2026-03-24T16:15:00Z",
+        },
+        "status_history": [],
+        "objective": {
+            "summary": "Validate GitHub connector translation.",
+            "deliverable_type": "code_change",
+            "success_signal": "Normalized GitHub facts can be consumed by reconciliation.",
+        },
+        "constraints": [],
+        "acceptance_criteria": [
+            {
+                "id": "ac-1",
+                "description": "GitHub facts normalize cleanly.",
+                "required": True,
+            }
+        ],
+        "parent_task_id": None,
+        "child_task_ids": [],
+        "dependencies": [],
+        "assigned_executor": None,
+        "required_capabilities": [],
+        "priority": "normal",
+        "artifacts": {
+            "items": [],
+            "completion_evidence": {
+                "policy": "required",
+                "status": "satisfied",
+                "required_artifact_types": ["pull_request", "commit"],
+                "validated_artifact_ids": [],
+                "validation_method": "external_reconciliation",
+                "validated_at": "2026-03-24T16:14:00Z",
+                "validator": {
+                    "source_system": "harness",
+                    "source_type": "verification",
+                    "source_id": "verification-run-1",
+                    "captured_by": "github-sync",
+                },
+                "notes": "GitHub facts consumed through connector scaffolding.",
+            },
+        },
+        "observability": {
+            "errors": [],
+            "retries": {
+                "attempt_count": 0,
+                "max_attempts": 0,
+                "last_retry_at": None,
+            },
+            "execution_metadata": {},
+        },
+    }
+
+
+class GitHubConnectorScaffoldingTests(unittest.TestCase):
+    def test_translates_github_shaped_payload_into_normalized_facts(self) -> None:
+        payload = {
+            "repository": {
+                "name": "Harness",
+                "owner": {"login": "sfayka"},
+                "node_id": "repo-123",
+            },
+            "branch": {
+                "name": "codex/github-connector",
+                "baseRefName": "main",
+                "target": {"oid": "abcdef1234567890"},
+            },
+            "commit": {
+                "sha": "abcdef1234567890",
+                "html_url": "https://github.com/example/harness/commit/abcdef1234567890",
+                "commit": {"message": "Implement connector scaffolding"},
+            },
+            "pull_request": {
+                "number": 321,
+                "state": "open",
+                "reviewDecision": "approved",
+                "html_url": "https://github.com/example/harness/pull/321",
+                "merged": False,
+            },
+            "files": [
+                {
+                    "filename": "modules/connectors/github_facts.py",
+                    "status": "modified",
+                    "additions": 120,
+                    "deletions": 0,
+                }
+            ],
+        }
+
+        github_facts = translate_github_artifact_facts(payload)
+
+        self.assertEqual(github_facts.repository_name, "Harness")
+        self.assertEqual(github_facts.repository_owner, "sfayka")
+        self.assertEqual(github_facts.branch_name, "codex/github-connector")
+        self.assertEqual(github_facts.review_state, "approved")
+        self.assertTrue(github_facts.commit_found)
+        self.assertTrue(github_facts.pull_request_found)
+        self.assertEqual(len(github_facts.artifact_refs), 2)
+
+    def test_rejects_repository_payload_missing_owner(self) -> None:
+        with self.assertRaisesRegex(GitHubConnectorInputError, "repository owner"):
+            translate_github_repository({"name": "Harness"})
+
+    def test_rejects_pull_request_payload_missing_number(self) -> None:
+        with self.assertRaisesRegex(GitHubConnectorInputError, "pull_request.number"):
+            translate_github_pull_request({"state": "open"})
+
+    def test_rejects_changed_files_payload_with_invalid_shape(self) -> None:
+        with self.assertRaisesRegex(GitHubConnectorInputError, "files\\[0\\]\\.filename"):
+            translate_github_changed_files([{"status": "modified"}])
+
+    def test_artifact_reference_translation_derives_commit_and_pr_refs(self) -> None:
+        refs = translate_github_artifact_references(
+            {
+                "commit": {"sha": "abcdef1234567890"},
+                "pull_request": {"number": 321},
+            }
+        )
+
+        self.assertEqual(len(refs), 2)
+        self.assertEqual(refs[0].artifact_type, "pull_request")
+        self.assertEqual(refs[1].artifact_type, "commit")
+
+    def test_normalized_connector_output_can_flow_into_reconciliation(self) -> None:
+        github_facts = translate_github_artifact_facts(
+            {
+                "repository": {"name": "Harness", "owner": {"login": "sfayka"}},
+                "branch": {"name": "codex/github-connector", "baseRefName": "main"},
+                "commit": {"sha": "abcdef1234567890"},
+                "pull_request": {"number": 321, "reviewDecision": "approved"},
+            }
+        )
+
+        result = evaluate_reconciliation(
+            _base_task_envelope(),
+            reconciliation_input=ReconciliationEvaluationInput(
+                claimed_completion=True,
+                evidence_policy="required",
+                evidence_status="satisfied",
+                expected_code_context=ExpectedCodeContext(
+                    repository_host="github.com",
+                    repository_owner="sfayka",
+                    repository_name="Harness",
+                    branch_name="codex/github-connector",
+                ),
+                github_facts=github_facts,
+                review_reasons=(),
+                pending_reasons=(),
+            ),
+        )
+
+        self.assertEqual(result.outcome, ReconciliationOutcome.NO_MISMATCH)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add GitHub connector-side translation helpers that convert GitHub-shaped inputs into validated Harness-owned normalized fact objects
- keep raw vendor payloads out of reconciliation and verification by establishing a clear connector boundary in `modules/connectors/github_facts.py`
- add tests covering valid translation, malformed GitHub-shaped input rejection, derived artifact references, and reconciliation consuming translated normalized GitHub facts directly

## Validation
- `.venv/bin/python -m unittest discover -s tests`

## Notes
- this is connector scaffolding only; it does not add live GitHub API polling, webhooks, or runtime integration
- policy code continues to consume normalized facts rather than raw GitHub response shapes
