### PR TITLE
Implement Linear connector scaffolding for normalized facts

### DIFF
--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -10,9 +10,17 @@ from .github_facts import (
     translate_github_pull_request,
     translate_github_repository,
 )
+from .linear_facts import (
+    LinearConnectorInputError,
+    translate_linear_facts,
+    translate_linear_project,
+    translate_linear_task_reference,
+    translate_linear_workflow,
+)
 
 __all__ = [
     "GitHubConnectorInputError",
+    "LinearConnectorInputError",
     "translate_github_artifact_facts",
     "translate_github_artifact_references",
     "translate_github_branch",
@@ -20,4 +28,8 @@ __all__ = [
     "translate_github_commit",
     "translate_github_pull_request",
     "translate_github_repository",
+    "translate_linear_facts",
+    "translate_linear_project",
+    "translate_linear_task_reference",
+    "translate_linear_workflow",
 ]

--- a/modules/connectors/linear_facts.py
+++ b/modules/connectors/linear_facts.py
@@ -1,0 +1,169 @@
+"""Linear connector scaffolding that translates vendor-shaped inputs into normalized facts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from modules.contracts.task_envelope_external_facts import (
+    ExternalFactValidationError,
+    LinearFacts,
+    LinearProjectFact,
+    LinearTaskReference,
+    LinearWorkflowFact,
+    validate_linear_facts,
+)
+
+
+class LinearConnectorInputError(ValueError):
+    """Raised when Linear-shaped connector input is malformed."""
+
+
+def _require_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise LinearConnectorInputError(f"{field_name} must be a mapping")
+    return payload
+
+
+def _optional_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any] | None:
+    if payload is None:
+        return None
+    return _require_mapping(payload, field_name=field_name)
+
+
+def _require_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise LinearConnectorInputError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise LinearConnectorInputError("Expected string or null value")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise LinearConnectorInputError("Expected bool or null value")
+    return value
+
+
+def _optional_string_sequence(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, (list, tuple)):
+        raise LinearConnectorInputError(f"{field_name} must be a list or tuple of strings")
+
+    normalized: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise LinearConnectorInputError(f"{field_name}[{index}] must be a non-empty string")
+        normalized.append(item.strip())
+    return tuple(normalized)
+
+
+def translate_linear_workflow(workflow_payload: Mapping[str, Any]) -> LinearWorkflowFact:
+    """Translate a Linear-shaped workflow/state payload into a normalized workflow fact."""
+
+    workflow_payload = _require_mapping(workflow_payload, field_name="workflow")
+    return LinearWorkflowFact(
+        workflow_id=_require_string(workflow_payload.get("id"), field_name="workflow.id"),
+        workflow_name=_require_string(
+            workflow_payload.get("name") or workflow_payload.get("label"),
+            field_name="workflow.name",
+        ),
+        state_type=_optional_string(
+            workflow_payload.get("state_type")
+            or workflow_payload.get("type")
+            or workflow_payload.get("stateType")
+        ),
+    )
+
+
+def translate_linear_project(project_payload: Mapping[str, Any]) -> LinearProjectFact:
+    """Translate a Linear-shaped project payload into a normalized project fact."""
+
+    project_payload = _require_mapping(project_payload, field_name="project")
+    return LinearProjectFact(
+        project_id=_require_string(project_payload.get("id"), field_name="project.id"),
+        project_name=_optional_string(project_payload.get("name")),
+    )
+
+
+def translate_linear_task_reference(task_reference_payload: Mapping[str, Any]) -> LinearTaskReference:
+    """Translate a Linear-shaped task reference payload into a normalized task reference."""
+
+    task_reference_payload = _require_mapping(task_reference_payload, field_name="task_reference")
+    return LinearTaskReference(
+        harness_task_id=_optional_string(
+            task_reference_payload.get("harness_task_id") or task_reference_payload.get("taskId")
+        ),
+        external_ref=_optional_string(
+            task_reference_payload.get("external_ref") or task_reference_payload.get("externalRef")
+        ),
+    )
+
+
+def translate_linear_facts(payload: Mapping[str, Any]) -> LinearFacts:
+    """Translate a Linear-shaped payload bundle into validated normalized facts."""
+
+    payload = _require_mapping(payload, field_name="linear_payload")
+    record_found = payload.get("record_found", True)
+    if not isinstance(record_found, bool):
+        raise LinearConnectorInputError("record_found must be a boolean")
+
+    issue_payload = _optional_mapping(payload.get("issue"), field_name="issue")
+    raw_state_payload = payload.get("state") or payload.get("status")
+    project_payload = _optional_mapping(payload.get("project"), field_name="project")
+    task_reference_payload = _optional_mapping(payload.get("task_reference"), field_name="task_reference")
+
+    issue_id = None
+    issue_key = None
+    if issue_payload is not None:
+        issue_id = _optional_string(issue_payload.get("id"))
+        issue_key = _optional_string(
+            issue_payload.get("identifier")
+            or issue_payload.get("key")
+            or issue_payload.get("issueKey")
+        )
+
+    state_name = _optional_string(payload.get("state_name"))
+    workflow = None
+    if isinstance(raw_state_payload, Mapping):
+        workflow = translate_linear_workflow(raw_state_payload)
+        state_name = workflow.workflow_name
+    elif raw_state_payload is not None:
+        state_name = _optional_string(raw_state_payload)
+
+    linear_facts = LinearFacts(
+        record_found=record_found,
+        issue_id=issue_id,
+        issue_key=issue_key,
+        state=state_name,
+        workflow=workflow,
+        project=translate_linear_project(project_payload) if project_payload is not None else None,
+        task_reference=(
+            translate_linear_task_reference(task_reference_payload) if task_reference_payload is not None else None
+        ),
+        reasons=_optional_string_sequence(payload.get("reasons"), field_name="reasons"),
+    )
+
+    try:
+        return validate_linear_facts(linear_facts)
+    except ExternalFactValidationError as error:
+        raise LinearConnectorInputError(str(error)) from error
+
+
+__all__ = [
+    "LinearConnectorInputError",
+    "translate_linear_facts",
+    "translate_linear_project",
+    "translate_linear_task_reference",
+    "translate_linear_workflow",
+]

--- a/tests/connectors/test_linear_facts.py
+++ b/tests/connectors/test_linear_facts.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.connectors import LinearConnectorInputError, translate_linear_facts
+from modules.contracts.task_envelope_external_facts import LinearFacts
+from modules.contracts.task_envelope_reconciliation import (
+    ReconciliationEvaluationInput,
+    ReconciliationInputError,
+    ReconciliationOutcome,
+    evaluate_reconciliation,
+)
+
+
+def _base_task_envelope() -> dict:
+    return {
+        "id": "task-linear-1",
+        "title": "Reconcile Linear facts",
+        "description": "Task used to validate Linear connector scaffolding.",
+        "origin": {
+            "source_system": "openclaw",
+            "source_type": "ingress_request",
+            "source_id": "req-linear-1",
+            "ingress_id": None,
+            "ingress_name": "OpenClaw",
+            "requested_by": None,
+        },
+        "status": "completed",
+        "timestamps": {
+            "created_at": "2026-03-24T17:00:00Z",
+            "updated_at": "2026-03-24T17:10:00Z",
+            "completed_at": "2026-03-24T17:10:00Z",
+        },
+        "status_history": [],
+        "objective": {
+            "summary": "Validate Linear connector translation behavior.",
+            "deliverable_type": "code_change",
+            "success_signal": "Linear connector outputs normalized facts consumed by reconciliation.",
+        },
+        "constraints": [],
+        "acceptance_criteria": [
+            {
+                "id": "ac-1",
+                "description": "Linear task facts are available for reconciliation.",
+                "required": True,
+            }
+        ],
+        "parent_task_id": None,
+        "child_task_ids": [],
+        "dependencies": [],
+        "assigned_executor": None,
+        "required_capabilities": [],
+        "priority": "normal",
+        "artifacts": {
+            "items": [],
+            "completion_evidence": {
+                "policy": "required",
+                "status": "satisfied",
+                "required_artifact_types": ["pull_request"],
+                "validated_artifact_ids": ["artifact-pr-1"],
+                "validation_method": "external_reconciliation",
+                "validated_at": "2026-03-24T17:09:00Z",
+                "validator": {
+                    "source_system": "harness",
+                    "source_type": "verification",
+                    "source_id": "verification-run-linear-1",
+                    "captured_by": "linear-sync",
+                },
+            },
+        },
+        "observability": {
+            "errors": [],
+            "retries": {
+                "attempt_count": 0,
+                "max_attempts": 0,
+                "last_retry_at": None,
+            },
+            "execution_metadata": {},
+        },
+    }
+
+
+class LinearConnectorTranslationTests(unittest.TestCase):
+    def test_translates_linear_payload_into_normalized_facts(self) -> None:
+        facts = translate_linear_facts(
+            {
+                "issue": {
+                    "id": "lin_123",
+                    "identifier": "HAR-14",
+                },
+                "state": {
+                    "id": "workflow_done",
+                    "name": "completed",
+                    "type": "completed",
+                },
+                "project": {
+                    "id": "project_1",
+                    "name": "Harness rollout",
+                },
+                "task_reference": {
+                    "harness_task_id": "task-linear-1",
+                    "external_ref": "HAR-14",
+                },
+                "reasons": ["Linear sync succeeded"],
+            }
+        )
+
+        self.assertEqual(
+            facts,
+            LinearFacts(
+                record_found=True,
+                issue_id="lin_123",
+                issue_key="HAR-14",
+                state="completed",
+                workflow=facts.workflow,
+                project=facts.project,
+                task_reference=facts.task_reference,
+                reasons=("Linear sync succeeded",),
+            ),
+        )
+        self.assertEqual(facts.workflow.workflow_id, "workflow_done")
+        self.assertEqual(facts.workflow.workflow_name, "completed")
+        self.assertEqual(facts.workflow.state_type, "completed")
+        self.assertEqual(facts.project.project_id, "project_1")
+        self.assertEqual(facts.task_reference.harness_task_id, "task-linear-1")
+
+    def test_allows_string_state_without_workflow_object(self) -> None:
+        facts = translate_linear_facts(
+            {
+                "issue": {"id": "lin_124"},
+                "state": "in_progress",
+            }
+        )
+
+        self.assertEqual(facts.state, "in_progress")
+        self.assertIsNone(facts.workflow)
+
+    def test_rejects_missing_issue_identity(self) -> None:
+        with self.assertRaises(LinearConnectorInputError):
+            translate_linear_facts(
+                {
+                    "state": {
+                        "id": "workflow_todo",
+                        "name": "planned",
+                    }
+                }
+            )
+
+    def test_rejects_non_sequence_reasons(self) -> None:
+        with self.assertRaises(LinearConnectorInputError):
+            translate_linear_facts(
+                {
+                    "issue": {"id": "lin_125"},
+                    "state": "planned",
+                    "reasons": "sync complete",
+                }
+            )
+
+    def test_rejects_record_not_found_with_resolved_record_fields(self) -> None:
+        with self.assertRaises(LinearConnectorInputError):
+            translate_linear_facts(
+                {
+                    "record_found": False,
+                    "issue": {"id": "lin_126"},
+                    "state": "completed",
+                }
+            )
+
+    def test_reconciliation_consumes_translated_linear_facts_directly(self) -> None:
+        result = evaluate_reconciliation(
+            _base_task_envelope(),
+            reconciliation_input=ReconciliationEvaluationInput(
+                claimed_completion=True,
+                evidence_policy="required",
+                evidence_status="satisfied",
+                linear_facts=translate_linear_facts(
+                    {
+                        "issue": {
+                            "id": "lin_127",
+                            "identifier": "HAR-15",
+                        },
+                        "state": {
+                            "id": "workflow_done",
+                            "name": "completed",
+                            "type": "completed",
+                        },
+                    }
+                ),
+            ),
+        )
+
+        self.assertEqual(result.outcome, ReconciliationOutcome.NO_MISMATCH)
+
+    def test_reconciliation_rejects_malformed_normalized_linear_facts_at_boundary(self) -> None:
+        with self.assertRaises(ReconciliationInputError):
+            evaluate_reconciliation(
+                _base_task_envelope(),
+                reconciliation_input=ReconciliationEvaluationInput(
+                    claimed_completion=True,
+                    evidence_policy="required",
+                    evidence_status="satisfied",
+                    linear_facts=LinearFacts(record_found=True, issue_id="lin_128", state=None),
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Linear connector translation helpers that convert Linear-shaped payloads into validated normalized fact objects
- keep malformed vendor-shaped input at the connector boundary, including missing issue identity and invalid reason payloads
- prove reconciliation consumes translated Linear facts directly and still rejects malformed normalized facts before policy evaluation

## Validation
- `.venv/bin/python -m unittest discover -s tests`

## Notes
- this is connector scaffolding only; policy code continues to consume normalized Harness-owned fact models rather than raw Linear payloads