### PR TITLE
Implement end-to-end reconciliation and enforcement path

### DIFF
--- a/modules/contracts/__init__.py
+++ b/modules/contracts/__init__.py
@@ -41,6 +41,15 @@ from .task_envelope_enforcement import (
     EnforcementResult,
     enforce_task_envelope,
 )
+from .task_envelope_end_to_end import (
+    CanonicalCaseInput,
+    CanonicalExternalFactBundle,
+    build_canonical_fact_bundle,
+    build_expected_code_context,
+    build_github_completion_facts,
+    build_linear_completion_facts,
+    enforce_canonical_task_case,
+)
 from .task_envelope_reconciliation import (
     ExpectedCodeContext,
     MismatchCategory,
@@ -92,6 +101,8 @@ __all__ = [
     "ArtifactValidationError",
     "ArtifactValidationResult",
     "BranchFact",
+    "CanonicalCaseInput",
+    "CanonicalExternalFactBundle",
     "ChangedFileFact",
     "ChangedFilesSummary",
     "CommitFact",
@@ -143,6 +154,11 @@ __all__ = [
     "assert_valid_completion_evidence",
     "assert_valid_task_envelope",
     "append_review_record",
+    "build_canonical_fact_bundle",
+    "build_expected_code_context",
+    "build_github_completion_facts",
+    "build_linear_completion_facts",
+    "enforce_canonical_task_case",
     "enforce_task_envelope",
     "evaluate_reconciliation",
     "evaluate_verification_decision",

--- a/modules/contracts/task_envelope_end_to_end.py
+++ b/modules/contracts/task_envelope_end_to_end.py
@@ -1,0 +1,243 @@
+"""End-to-end canonical enforcement helpers built on normalized external facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from modules.contracts.task_envelope_enforcement import (
+    EnforcementInput,
+    EnforcementResult,
+    enforce_task_envelope,
+)
+from modules.contracts.task_envelope_external_facts import (
+    BranchFact,
+    ChangedFilesSummary,
+    CommitFact,
+    GitHubArtifactFacts,
+    LinearFacts,
+    LinearProjectFact,
+    LinearTaskReference,
+    LinearWorkflowFact,
+    PullRequestFact,
+    RepositoryFact,
+)
+from modules.contracts.task_envelope_reconciliation import (
+    ExpectedCodeContext,
+    ReconciliationEvaluationInput,
+)
+from modules.contracts.task_envelope_review import ReviewDecisionResult, ReviewRequest
+from modules.contracts.task_envelope_validation import assert_valid_task_envelope
+from modules.contracts.task_envelope_verification import RuntimeVerificationFacts
+
+TaskEnvelope = dict[str, object]
+
+
+@dataclass(frozen=True)
+class CanonicalExternalFactBundle:
+    """Normalized external facts plus expected code context for reconciliation."""
+
+    expected_code_context: ExpectedCodeContext | None = None
+    github_facts: GitHubArtifactFacts | None = None
+    linear_facts: LinearFacts | None = None
+
+
+@dataclass(frozen=True)
+class CanonicalCaseInput:
+    """Canonical end-to-end enforcement input for representative task cases."""
+
+    claimed_completion: bool = False
+    acceptance_criteria_satisfied: bool = False
+    runtime_facts: RuntimeVerificationFacts = RuntimeVerificationFacts()
+    external_facts: CanonicalExternalFactBundle | None = None
+    unresolved_conditions: tuple[str, ...] = ()
+    review_reasons: tuple[str, ...] = ()
+    review_request: ReviewRequest | None = None
+    review_decision: ReviewDecisionResult | None = None
+
+
+def build_expected_code_context(
+    *,
+    repository_host: str = "github.com",
+    repository_owner: str = "sfayka",
+    repository_name: str = "Harness",
+    branch_name: str | None = "codex/end-to-end",
+    base_branch: str | None = "main",
+) -> ExpectedCodeContext:
+    """Build a representative normalized expected code context."""
+
+    return ExpectedCodeContext(
+        repository_host=repository_host,
+        repository_owner=repository_owner,
+        repository_name=repository_name,
+        branch_name=branch_name,
+        base_branch=base_branch,
+    )
+
+
+def build_github_completion_facts(
+    *,
+    repository_host: str = "github.com",
+    repository_owner: str = "sfayka",
+    repository_name: str = "Harness",
+    branch_name: str = "codex/end-to-end",
+    base_branch: str | None = "main",
+    commit_sha: str = "abcdef1234567890",
+    pull_request_number: int = 200,
+    review_state: str | None = "approved",
+    artifact_found: bool = True,
+    changed_files_match: bool | None = True,
+    reasons: tuple[str, ...] = (),
+) -> GitHubArtifactFacts:
+    """Build representative normalized GitHub facts for canonical enforcement cases."""
+
+    if not artifact_found:
+        return GitHubArtifactFacts(artifact_found=False, reasons=reasons)
+
+    return GitHubArtifactFacts(
+        artifact_found=True,
+        repository=RepositoryFact(
+            host=repository_host,
+            owner=repository_owner,
+            name=repository_name,
+        ),
+        branch=BranchFact(
+            name=branch_name,
+            base_branch=base_branch,
+            head_commit_sha=commit_sha,
+        ),
+        commit=CommitFact(sha=commit_sha),
+        pull_request=PullRequestFact(number=pull_request_number, review_state=review_state),
+        changed_files=ChangedFilesSummary(matches_expected_scope=changed_files_match),
+        reasons=reasons,
+    )
+
+
+def build_linear_completion_facts(
+    *,
+    record_found: bool = True,
+    issue_id: str = "lin-1",
+    issue_key: str | None = None,
+    state: str | None = "completed",
+    workflow_id: str | None = None,
+    workflow_name: str | None = None,
+    workflow_state_type: str | None = None,
+    project_id: str | None = None,
+    project_name: str | None = None,
+    harness_task_id: str | None = None,
+    external_ref: str | None = None,
+    reasons: tuple[str, ...] = (),
+) -> LinearFacts:
+    """Build representative normalized Linear facts for canonical enforcement cases."""
+
+    if not record_found:
+        return LinearFacts(record_found=False, reasons=reasons)
+
+    workflow = None
+    if workflow_id or workflow_name or workflow_state_type:
+        workflow = LinearWorkflowFact(
+            workflow_id=workflow_id or "workflow-default",
+            workflow_name=workflow_name or state or "unknown",
+            state_type=workflow_state_type,
+        )
+
+    project = None
+    if project_id or project_name:
+        project = LinearProjectFact(
+            project_id=project_id or "project-default",
+            project_name=project_name,
+        )
+
+    task_reference = None
+    if harness_task_id or external_ref:
+        task_reference = LinearTaskReference(
+            harness_task_id=harness_task_id,
+            external_ref=external_ref,
+        )
+
+    return LinearFacts(
+        record_found=True,
+        issue_id=issue_id,
+        issue_key=issue_key,
+        state=state,
+        workflow=workflow,
+        project=project,
+        task_reference=task_reference,
+        reasons=reasons,
+    )
+
+
+def build_canonical_fact_bundle(
+    *,
+    expected_code_context: ExpectedCodeContext | None = None,
+    github_facts: GitHubArtifactFacts | None = None,
+    linear_facts: LinearFacts | None = None,
+) -> CanonicalExternalFactBundle:
+    """Assemble normalized external facts for the end-to-end enforcement path."""
+
+    return CanonicalExternalFactBundle(
+        expected_code_context=expected_code_context,
+        github_facts=github_facts,
+        linear_facts=linear_facts,
+    )
+
+
+def _build_reconciliation_input(
+    task_envelope: TaskEnvelope,
+    *,
+    claimed_completion: bool,
+    external_facts: CanonicalExternalFactBundle,
+) -> ReconciliationEvaluationInput:
+    completion_evidence = task_envelope["artifacts"]["completion_evidence"]
+    evidence_policy = str(completion_evidence["policy"])
+    evidence_status = str(completion_evidence["status"])
+
+    return ReconciliationEvaluationInput(
+        claimed_completion=claimed_completion,
+        evidence_policy=evidence_policy,
+        evidence_status=evidence_status,
+        expected_code_context=external_facts.expected_code_context,
+        github_facts=external_facts.github_facts,
+        linear_facts=external_facts.linear_facts,
+    )
+
+
+def enforce_canonical_task_case(
+    task_envelope: TaskEnvelope,
+    *,
+    case_input: CanonicalCaseInput,
+) -> EnforcementResult:
+    """Evaluate a canonical TaskEnvelope end-to-end using normalized external facts only."""
+
+    assert_valid_task_envelope(task_envelope)
+    reconciliation_input = None
+    if case_input.external_facts is not None:
+        reconciliation_input = _build_reconciliation_input(
+            task_envelope,
+            claimed_completion=case_input.claimed_completion,
+            external_facts=case_input.external_facts,
+        )
+
+    return enforce_task_envelope(
+        task_envelope,
+        enforcement_input=EnforcementInput(
+            claimed_completion=case_input.claimed_completion,
+            acceptance_criteria_satisfied=case_input.acceptance_criteria_satisfied,
+            runtime_facts=case_input.runtime_facts,
+            reconciliation_input=reconciliation_input,
+            unresolved_conditions=case_input.unresolved_conditions,
+            review_reasons=case_input.review_reasons,
+            review_request=case_input.review_request,
+            review_decision=case_input.review_decision,
+        ),
+    )
+
+
+__all__ = [
+    "CanonicalCaseInput",
+    "CanonicalExternalFactBundle",
+    "build_canonical_fact_bundle",
+    "build_expected_code_context",
+    "build_github_completion_facts",
+    "build_linear_completion_facts",
+    "enforce_canonical_task_case",
+]

--- a/tests/contracts/test_task_envelope_end_to_end.py
+++ b/tests/contracts/test_task_envelope_end_to_end.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.contracts.task_envelope_end_to_end import (
+    CanonicalCaseInput,
+    build_canonical_fact_bundle,
+    build_expected_code_context,
+    build_github_completion_facts,
+    build_linear_completion_facts,
+    enforce_canonical_task_case,
+)
+from modules.contracts.task_envelope_enforcement import EnforcementAction
+from modules.contracts.task_envelope_review import (
+    ReviewOutcome,
+    ReviewRequest,
+    ReviewTrigger,
+)
+from modules.contracts.task_envelope_verification import RuntimeVerificationFacts, VerificationOutcome
+
+
+def _valid_artifacts() -> dict:
+    return {
+        "items": [
+            {
+                "id": "artifact-pr-1",
+                "type": "pull_request",
+                "title": "Implement end-to-end enforcement",
+                "description": None,
+                "location": "https://github.com/example/harness/pull/250",
+                "content_type": None,
+                "external_id": "PR-250",
+                "commit_sha": None,
+                "pull_request_number": 250,
+                "review_state": "approved",
+                "provenance": {
+                    "source_system": "github",
+                    "source_type": "api",
+                    "source_id": "pull/250",
+                    "captured_by": "github-sync",
+                },
+                "verification_status": "verified",
+                "repository": {
+                    "host": "github.com",
+                    "owner": "sfayka",
+                    "name": "Harness",
+                    "external_id": "repo-123",
+                },
+                "branch": {
+                    "name": "codex/end-to-end",
+                    "base_branch": "main",
+                    "head_commit_sha": "abcdef1234567890",
+                },
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T18:10:00Z",
+                "metadata": {},
+            },
+            {
+                "id": "artifact-commit-1",
+                "type": "commit",
+                "title": None,
+                "description": None,
+                "location": "https://github.com/example/harness/commit/abcdef1234567890",
+                "content_type": None,
+                "external_id": "commit-abcdef1234567890",
+                "commit_sha": "abcdef1234567890",
+                "pull_request_number": None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "github",
+                    "source_type": "api",
+                    "source_id": "commit/abcdef1234567890",
+                    "captured_by": "github-sync",
+                },
+                "verification_status": "verified",
+                "repository": {
+                    "host": "github.com",
+                    "owner": "sfayka",
+                    "name": "Harness",
+                    "external_id": "repo-123",
+                },
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T18:11:00Z",
+                "metadata": {},
+            },
+        ],
+        "completion_evidence": {
+            "policy": "required",
+            "status": "satisfied",
+            "required_artifact_types": ["pull_request", "commit"],
+            "validated_artifact_ids": ["artifact-pr-1", "artifact-commit-1"],
+            "validation_method": "external_reconciliation",
+            "validated_at": "2026-03-24T18:14:00Z",
+            "validator": {
+                "source_system": "harness",
+                "source_type": "verification",
+                "source_id": "verification-run-e2e-1",
+                "captured_by": "github-sync",
+            },
+            "notes": "Artifacts reconciled before completion.",
+        },
+    }
+
+
+def _base_task(status: str = "executing") -> dict:
+    assigned_executor = None
+    completed_at = None
+    if status in {"executing", "assigned"}:
+        assigned_executor = {
+            "executor_type": "codex",
+            "executor_id": "executor-1",
+            "assignment_reason": "Capability match.",
+        }
+    if status == "completed":
+        completed_at = "2026-03-24T18:15:00Z"
+
+    return {
+        "id": f"task-e2e-{status}-1",
+        "title": "End-to-end enforcement task",
+        "description": "Task used to validate end-to-end reconciliation and enforcement.",
+        "origin": {
+            "source_system": "openclaw",
+            "source_type": "ingress_request",
+            "source_id": "req-e2e-1",
+            "ingress_id": None,
+            "ingress_name": "OpenClaw",
+            "requested_by": None,
+        },
+        "status": status,
+        "timestamps": {
+            "created_at": "2026-03-24T18:00:00Z",
+            "updated_at": "2026-03-24T18:05:00Z",
+            "completed_at": completed_at,
+        },
+        "status_history": [],
+        "objective": {
+            "summary": "Validate canonical end-to-end enforcement outcomes.",
+            "deliverable_type": "code_change",
+            "success_signal": "The control-plane path applies the correct lifecycle outcome.",
+        },
+        "constraints": [],
+        "acceptance_criteria": [
+            {
+                "id": "ac-1",
+                "description": "Completion is backed by valid evidence and normalized external facts.",
+                "required": True,
+            }
+        ],
+        "parent_task_id": None,
+        "child_task_ids": [],
+        "dependencies": [],
+        "assigned_executor": assigned_executor,
+        "required_capabilities": [],
+        "priority": "normal",
+        "artifacts": _valid_artifacts(),
+        "observability": {
+            "errors": [],
+            "retries": {
+                "attempt_count": 0,
+                "max_attempts": 0,
+                "last_retry_at": None,
+            },
+            "execution_metadata": {},
+        },
+    }
+
+
+def _aligned_bundle(*, linear_state: str = "in_progress"):
+    return build_canonical_fact_bundle(
+        expected_code_context=build_expected_code_context(
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_name="codex/end-to-end",
+            base_branch="main",
+        ),
+        github_facts=build_github_completion_facts(
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_name="codex/end-to-end",
+            base_branch="main",
+            pull_request_number=250,
+            review_state="approved",
+        ),
+        linear_facts=build_linear_completion_facts(
+            issue_id="lin-e2e-1",
+            issue_key="HAR-250",
+            state=linear_state,
+        ),
+    )
+
+
+class EndToEndEnforcementTests(unittest.TestCase):
+    def test_accepts_completion_when_evidence_and_normalized_facts_align(self) -> None:
+        task = _base_task(status="executing")
+
+        result = enforce_canonical_task_case(
+            task,
+            case_input=CanonicalCaseInput(
+                claimed_completion=True,
+                acceptance_criteria_satisfied=True,
+                runtime_facts=RuntimeVerificationFacts(executor_reported_success=True, attempt_count=1),
+                external_facts=_aligned_bundle(linear_state="in_progress"),
+            ),
+        )
+
+        self.assertEqual(result.action, EnforcementAction.TRANSITION_APPLIED)
+        self.assertEqual(result.task_envelope["status"], "completed")
+        self.assertEqual(result.verification_result.outcome, VerificationOutcome.ACCEPTED_COMPLETION)
+
+    def test_rolls_completed_task_back_to_blocked_for_insufficient_evidence(self) -> None:
+        task = _base_task(status="completed")
+        task["artifacts"]["completion_evidence"]["required_artifact_types"].append("review_note")
+
+        result = enforce_canonical_task_case(
+            task,
+            case_input=CanonicalCaseInput(
+                claimed_completion=True,
+                acceptance_criteria_satisfied=True,
+                runtime_facts=RuntimeVerificationFacts(executor_reported_success=True),
+                external_facts=_aligned_bundle(linear_state="completed"),
+            ),
+        )
+
+        self.assertEqual(result.action, EnforcementAction.TRANSITION_APPLIED)
+        self.assertEqual(result.task_envelope["status"], "blocked")
+        self.assertEqual(result.verification_result.outcome, VerificationOutcome.INSUFFICIENT_EVIDENCE)
+
+    def test_rolls_completed_task_back_to_blocked_for_reconciliation_mismatch(self) -> None:
+        task = _base_task(status="completed")
+
+        result = enforce_canonical_task_case(
+            task,
+            case_input=CanonicalCaseInput(
+                claimed_completion=True,
+                acceptance_criteria_satisfied=True,
+                runtime_facts=RuntimeVerificationFacts(executor_reported_success=True),
+                external_facts=_aligned_bundle(linear_state="in_progress"),
+            ),
+        )
+
+        self.assertEqual(result.action, EnforcementAction.TRANSITION_APPLIED)
+        self.assertEqual(result.task_envelope["status"], "blocked")
+        self.assertEqual(result.verification_result.outcome, VerificationOutcome.EXTERNAL_MISMATCH)
+
+    def test_returns_review_required_when_normalized_facts_require_human_review(self) -> None:
+        task = _base_task(status="completed")
+        review_request = ReviewRequest(
+            review_request_id="review-request-e2e-1",
+            task_id=task["id"],
+            requested_at="2026-03-24T18:20:00Z",
+            requested_by="verification",
+            trigger=ReviewTrigger.RECONCILIATION,
+            summary="Linear record requires manual review.",
+            presented_sections=("task_state", "evidence", "reconciliation"),
+            allowed_outcomes=(ReviewOutcome.ACCEPT_COMPLETION, ReviewOutcome.KEEP_BLOCKED),
+        )
+
+        result = enforce_canonical_task_case(
+            task,
+            case_input=CanonicalCaseInput(
+                claimed_completion=True,
+                acceptance_criteria_satisfied=True,
+                runtime_facts=RuntimeVerificationFacts(executor_reported_success=True),
+                external_facts=build_canonical_fact_bundle(
+                    expected_code_context=build_expected_code_context(branch_name="codex/end-to-end"),
+                    github_facts=build_github_completion_facts(branch_name="codex/end-to-end", pull_request_number=250),
+                    linear_facts=build_linear_completion_facts(record_found=False, reasons=("Linear sync has not resolved record identity.",)),
+                ),
+                review_request=review_request,
+            ),
+        )
+
+        self.assertEqual(result.action, EnforcementAction.REVIEW_REQUIRED)
+        self.assertEqual(result.verification_result.outcome, VerificationOutcome.REVIEW_REQUIRED)
+        self.assertEqual(result.review_request.review_request_id, "review-request-e2e-1")
+
+    def test_wrong_target_execution_fails_when_normalized_github_facts_point_to_other_branch(self) -> None:
+        task = _base_task(status="executing")
+
+        result = enforce_canonical_task_case(
+            task,
+            case_input=CanonicalCaseInput(
+                claimed_completion=True,
+                acceptance_criteria_satisfied=True,
+                runtime_facts=RuntimeVerificationFacts(executor_reported_success=True),
+                external_facts=build_canonical_fact_bundle(
+                    expected_code_context=build_expected_code_context(branch_name="codex/end-to-end"),
+                    github_facts=build_github_completion_facts(
+                        repository_owner="sfayka",
+                        repository_name="Harness",
+                        branch_name="codex/wrong-branch",
+                        pull_request_number=250,
+                    ),
+                    linear_facts=build_linear_completion_facts(issue_id="lin-e2e-2", state="in_progress"),
+                ),
+            ),
+        )
+
+        self.assertEqual(result.action, EnforcementAction.TRANSITION_APPLIED)
+        self.assertEqual(result.task_envelope["status"], "failed")
+        self.assertEqual(result.verification_result.outcome, VerificationOutcome.TERMINAL_INVALID)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a canonical end-to-end enforcement helper that composes the existing lifecycle, evidence, reconciliation, verification, and review primitives around a TaskEnvelope
- add reusable normalized GitHub and Linear fact builders so representative control-plane cases can be exercised without live connectors
- cover accepted completion, blocked rollback for insufficient evidence, blocked rollback for mismatch, review-required, and wrong-target execution through the integrated path

## Validation
- `.venv/bin/python -m unittest discover -s tests`

## Notes
- this integration layer accepts normalized external facts only and derives reconciliation input from the canonical TaskEnvelope evidence contract rather than introducing a second policy surface