### PR TITLE
Implement simple CLI and demo runner for Harness evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ Not yet in scope:
 - `schemas/` contains canonical machine-readable contracts
 - `tests/` contains Python tests for contract validation and module behavior
 
+## Local Demo
+
+You can run the current control-plane evaluation loop locally through the minimal CLI/demo runner:
+
+```bash
+python -m modules.cli list
+python -m modules.cli run accepted_completion
+python -m modules.cli run blocked_reconciliation_mismatch --json
+```
+
+The CLI uses canonical `TaskEnvelope` fixtures plus normalized GitHub/Linear fact bundles.
+It does not call live external APIs.
+
 ## License
 
 Licensed under the Apache License 2.0.

--- a/modules/cli.py
+++ b/modules/cli.py
@@ -1,0 +1,88 @@
+"""Minimal CLI/demo runner for Harness evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from typing import Any
+
+from modules.demo_cases import build_demo_request, list_demo_cases
+from modules.evaluation import evaluate_task_case
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _format_text_result(case_name: str, payload: dict[str, Any]) -> str:
+    lines = [
+        f"case: {case_name}",
+        f"action: {payload['action']}",
+        f"target_status: {payload['target_status']}",
+        f"task_status: {payload['task_envelope']['status']}",
+        f"accepted_completion: {payload['accepted_completion']}",
+        f"requires_review: {payload['requires_review']}",
+        f"invalid_input: {payload['invalid_input']}",
+    ]
+    reasons = payload.get("reasons") or []
+    if reasons:
+        lines.append("reasons:")
+        lines.extend(f"- {reason}" for reason in reasons)
+    error = payload.get("error")
+    if error:
+        lines.append(f"error: {error}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the minimal CLI parser."""
+
+    parser = argparse.ArgumentParser(description="Run a canonical Harness evaluation demo case.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List canonical demo cases")
+    list_parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON output")
+
+    run_parser = subparsers.add_parser("run", help="Evaluate a canonical demo case")
+    run_parser.add_argument("case_name", choices=list_demo_cases(), help="Canonical demo case to evaluate")
+    run_parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON output")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for local Harness evaluation demos."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "list":
+        cases = list_demo_cases()
+        if args.as_json:
+            print(json.dumps({"cases": list(cases)}, indent=2, sort_keys=True))
+        else:
+            print("\n".join(cases))
+        return 0
+
+    request = build_demo_request(args.case_name)
+    result = evaluate_task_case(request)
+    payload = _to_jsonable(result)
+    if args.as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_text_result(args.case_name, payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/demo_cases.py
+++ b/modules/demo_cases.py
@@ -1,0 +1,277 @@
+"""Canonical demo cases for local Harness evaluation."""
+
+from __future__ import annotations
+
+from modules.contracts.task_envelope_end_to_end import (
+    build_canonical_fact_bundle,
+    build_expected_code_context,
+    build_github_completion_facts,
+    build_linear_completion_facts,
+)
+from modules.contracts.task_envelope_review import ReviewOutcome, ReviewRequest, ReviewTrigger
+from modules.contracts.task_envelope_verification import RuntimeVerificationFacts
+from modules.evaluation import HarnessEvaluationRequest
+
+
+def _valid_artifacts() -> dict:
+    return {
+        "items": [
+            {
+                "id": "artifact-pr-1",
+                "type": "pull_request",
+                "title": "Harness demo case",
+                "description": None,
+                "location": "https://github.com/example/harness/pull/300",
+                "content_type": None,
+                "external_id": "PR-300",
+                "commit_sha": None,
+                "pull_request_number": 300,
+                "review_state": "approved",
+                "provenance": {
+                    "source_system": "github",
+                    "source_type": "api",
+                    "source_id": "pull/300",
+                    "captured_by": "github-sync",
+                },
+                "verification_status": "verified",
+                "repository": {
+                    "host": "github.com",
+                    "owner": "sfayka",
+                    "name": "Harness",
+                    "external_id": "repo-123",
+                },
+                "branch": {
+                    "name": "codex/demo",
+                    "base_branch": "main",
+                    "head_commit_sha": "abcdef1234567890",
+                },
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T20:10:00Z",
+                "metadata": {},
+            },
+            {
+                "id": "artifact-commit-1",
+                "type": "commit",
+                "title": None,
+                "description": None,
+                "location": "https://github.com/example/harness/commit/abcdef1234567890",
+                "content_type": None,
+                "external_id": "commit-abcdef1234567890",
+                "commit_sha": "abcdef1234567890",
+                "pull_request_number": None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "github",
+                    "source_type": "api",
+                    "source_id": "commit/abcdef1234567890",
+                    "captured_by": "github-sync",
+                },
+                "verification_status": "verified",
+                "repository": {
+                    "host": "github.com",
+                    "owner": "sfayka",
+                    "name": "Harness",
+                    "external_id": "repo-123",
+                },
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T20:11:00Z",
+                "metadata": {},
+            },
+        ],
+        "completion_evidence": {
+            "policy": "required",
+            "status": "satisfied",
+            "required_artifact_types": ["pull_request", "commit"],
+            "validated_artifact_ids": ["artifact-pr-1", "artifact-commit-1"],
+            "validation_method": "external_reconciliation",
+            "validated_at": "2026-03-24T20:14:00Z",
+            "validator": {
+                "source_system": "harness",
+                "source_type": "verification",
+                "source_id": "verification-run-demo-1",
+                "captured_by": "github-sync",
+            },
+        },
+    }
+
+
+def _base_task(status: str = "executing") -> dict:
+    assigned_executor = None
+    completed_at = None
+    if status in {"executing", "assigned"}:
+        assigned_executor = {
+            "executor_type": "codex",
+            "executor_id": "executor-1",
+            "assignment_reason": "Capability match.",
+        }
+    if status == "completed":
+        completed_at = "2026-03-24T20:15:00Z"
+
+    return {
+        "id": f"task-demo-{status}-1",
+        "title": "Harness demo task",
+        "description": "Task used to demonstrate the Harness evaluation entry point.",
+        "origin": {
+            "source_system": "openclaw",
+            "source_type": "ingress_request",
+            "source_id": "req-demo-1",
+            "ingress_id": None,
+            "ingress_name": "OpenClaw",
+            "requested_by": None,
+        },
+        "status": status,
+        "timestamps": {
+            "created_at": "2026-03-24T20:00:00Z",
+            "updated_at": "2026-03-24T20:05:00Z",
+            "completed_at": completed_at,
+        },
+        "status_history": [],
+        "objective": {
+            "summary": "Demonstrate the Harness evaluation path.",
+            "deliverable_type": "code_change",
+            "success_signal": "The evaluator returns a structured control-plane result.",
+        },
+        "constraints": [],
+        "acceptance_criteria": [
+            {
+                "id": "ac-1",
+                "description": "Completion is backed by valid evidence and normalized external facts.",
+                "required": True,
+            }
+        ],
+        "parent_task_id": None,
+        "child_task_ids": [],
+        "dependencies": [],
+        "assigned_executor": assigned_executor,
+        "required_capabilities": [],
+        "priority": "normal",
+        "artifacts": _valid_artifacts(),
+        "observability": {
+            "errors": [],
+            "retries": {
+                "attempt_count": 0,
+                "max_attempts": 0,
+                "last_retry_at": None,
+            },
+            "execution_metadata": {},
+        },
+    }
+
+
+def _aligned_bundle(*, linear_state: str = "in_progress"):
+    return build_canonical_fact_bundle(
+        expected_code_context=build_expected_code_context(
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_name="codex/demo",
+            base_branch="main",
+        ),
+        github_facts=build_github_completion_facts(
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_name="codex/demo",
+            base_branch="main",
+            pull_request_number=300,
+            review_state="approved",
+        ),
+        linear_facts=build_linear_completion_facts(
+            issue_id="lin-demo-1",
+            issue_key="HAR-300",
+            state=linear_state,
+        ),
+    )
+
+
+def list_demo_cases() -> tuple[str, ...]:
+    """Return the canonical demo-case names supported by the CLI."""
+
+    return (
+        "accepted_completion",
+        "blocked_insufficient_evidence",
+        "blocked_reconciliation_mismatch",
+        "review_required",
+        "invalid_input",
+    )
+
+
+def build_demo_request(case_name: str) -> HarnessEvaluationRequest:
+    """Build a canonical demo request by name."""
+
+    if case_name == "accepted_completion":
+        return HarnessEvaluationRequest(
+            task_envelope=_base_task(status="executing"),
+            external_facts=_aligned_bundle(linear_state="in_progress"),
+            claimed_completion=True,
+            acceptance_criteria_satisfied=True,
+            runtime_facts=RuntimeVerificationFacts(executor_reported_success=True, attempt_count=1),
+        )
+
+    if case_name == "blocked_insufficient_evidence":
+        task = _base_task(status="completed")
+        task["artifacts"]["completion_evidence"]["required_artifact_types"].append("review_note")
+        return HarnessEvaluationRequest(
+            task_envelope=task,
+            external_facts=_aligned_bundle(linear_state="completed"),
+            claimed_completion=True,
+            acceptance_criteria_satisfied=True,
+            runtime_facts=RuntimeVerificationFacts(executor_reported_success=True),
+        )
+
+    if case_name == "blocked_reconciliation_mismatch":
+        return HarnessEvaluationRequest(
+            task_envelope=_base_task(status="completed"),
+            external_facts=_aligned_bundle(linear_state="in_progress"),
+            claimed_completion=True,
+            acceptance_criteria_satisfied=True,
+            runtime_facts=RuntimeVerificationFacts(executor_reported_success=True),
+        )
+
+    if case_name == "review_required":
+        task = _base_task(status="completed")
+        review_request = ReviewRequest(
+            review_request_id="review-request-demo-1",
+            task_id=task["id"],
+            requested_at="2026-03-24T20:20:00Z",
+            requested_by="verification",
+            trigger=ReviewTrigger.RECONCILIATION,
+            summary="Linear record needs manual judgment.",
+            presented_sections=("task_state", "evidence", "reconciliation"),
+            allowed_outcomes=(ReviewOutcome.ACCEPT_COMPLETION, ReviewOutcome.KEEP_BLOCKED),
+        )
+        return HarnessEvaluationRequest(
+            task_envelope=task,
+            external_facts=build_canonical_fact_bundle(
+                expected_code_context=build_expected_code_context(branch_name="codex/demo"),
+                github_facts=build_github_completion_facts(branch_name="codex/demo", pull_request_number=300),
+                linear_facts=build_linear_completion_facts(
+                    record_found=False,
+                    reasons=("Linear record is not yet resolvable.",),
+                ),
+            ),
+            claimed_completion=True,
+            acceptance_criteria_satisfied=True,
+            runtime_facts=RuntimeVerificationFacts(executor_reported_success=True),
+            review_request=review_request,
+        )
+
+    if case_name == "invalid_input":
+        task = _base_task(status="completed")
+        task["artifacts"]["completion_evidence"]["validated_artifact_ids"].append("artifact-missing")
+        return HarnessEvaluationRequest(
+            task_envelope=task,
+            external_facts=_aligned_bundle(linear_state="completed"),
+            claimed_completion=True,
+            acceptance_criteria_satisfied=True,
+            runtime_facts=RuntimeVerificationFacts(executor_reported_success=True),
+        )
+
+    raise ValueError(f"Unknown demo case {case_name!r}")
+
+
+__all__ = [
+    "build_demo_request",
+    "list_demo_cases",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import unittest
+
+from modules.cli import main
+
+
+class HarnessCliTests(unittest.TestCase):
+    def _run_cli(self, *args: str) -> tuple[int, str]:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = main(list(args))
+        return exit_code, stdout.getvalue()
+
+    def test_lists_demo_cases(self) -> None:
+        exit_code, output = self._run_cli("list")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("accepted_completion", output)
+        self.assertIn("blocked_reconciliation_mismatch", output)
+
+    def test_runs_accepted_completion_case_with_readable_output(self) -> None:
+        exit_code, output = self._run_cli("run", "accepted_completion")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("case: accepted_completion", output)
+        self.assertIn("action: transition_applied", output)
+        self.assertIn("task_status: completed", output)
+
+    def test_runs_blocked_case_with_json_output(self) -> None:
+        exit_code, output = self._run_cli("run", "blocked_reconciliation_mismatch", "--json")
+        payload = json.loads(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["action"], "transition_applied")
+        self.assertEqual(payload["target_status"], "blocked")
+        self.assertEqual(payload["task_envelope"]["status"], "blocked")
+
+    def test_runs_review_required_case(self) -> None:
+        exit_code, output = self._run_cli("run", "review_required")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("requires_review: True", output)
+        self.assertIn("action: review_required", output)
+
+    def test_runs_invalid_input_case(self) -> None:
+        exit_code, output = self._run_cli("run", "invalid_input", "--json")
+        payload = json.loads(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["action"], "invalid_input")
+        self.assertTrue(payload["invalid_input"])
+        self.assertIsNotNone(payload["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a minimal `argparse` CLI that runs canonical Harness evaluation cases through the existing public evaluation entry point
- add reusable demo-case builders for accepted completion, blocked evidence failure, reconciliation mismatch, review-required, and invalid-input scenarios
- document local demo usage in the README and add CLI tests for list, text output, JSON output, and representative scenario execution

## Validation
- `.venv/bin/python -m unittest discover -s tests`
- `.venv/bin/python -m modules.cli run accepted_completion`

## Notes
- the CLI remains local-only and connector-neutral; it uses canonical TaskEnvelope fixtures plus normalized GitHub and Linear fact bundles without live external API calls