### PR TITLE
Implement TaskEnvelope persistence and evaluation store scaffolding

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -6,10 +6,24 @@ from .evaluation import (
     HarnessEvaluator,
     evaluate_task_case,
 )
+from .store import (
+    EvaluationRecord,
+    EvaluationRecordStore,
+    FileBackedHarnessStore,
+    StoreError,
+    TaskEnvelopeNotFoundError,
+    TaskEnvelopeStore,
+)
 
 __all__ = [
     "HarnessEvaluationRequest",
     "HarnessEvaluationResult",
     "HarnessEvaluator",
+    "EvaluationRecord",
+    "EvaluationRecordStore",
+    "FileBackedHarnessStore",
+    "StoreError",
+    "TaskEnvelopeNotFoundError",
+    "TaskEnvelopeStore",
     "evaluate_task_case",
 ]

--- a/modules/store.py
+++ b/modules/store.py
@@ -1,0 +1,177 @@
+"""Minimal persistence scaffolding for TaskEnvelope and evaluation records."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Protocol
+
+from modules.evaluation import HarnessEvaluationRequest, HarnessEvaluationResult
+
+TaskEnvelope = dict[str, object]
+
+
+class StoreError(ValueError):
+    """Base error for Harness persistence operations."""
+
+
+class TaskEnvelopeNotFoundError(StoreError):
+    """Raised when a requested TaskEnvelope does not exist in the store."""
+
+
+class EvaluationRecordNotFoundError(StoreError):
+    """Raised when a requested evaluation record does not exist in the store."""
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class EvaluationRecord:
+    """Append-only persisted evaluation record associated with one task."""
+
+    evaluation_id: str
+    task_id: str
+    recorded_at: str
+    request: dict[str, Any]
+    result: dict[str, Any]
+
+
+class TaskEnvelopeStore(Protocol):
+    """Storage boundary for canonical TaskEnvelope records."""
+
+    def put_task(self, task_envelope: TaskEnvelope) -> TaskEnvelope: ...
+
+    def get_task(self, task_id: str) -> TaskEnvelope: ...
+
+    def update_task(self, task_envelope: TaskEnvelope) -> TaskEnvelope: ...
+
+
+class EvaluationRecordStore(Protocol):
+    """Storage boundary for persisted evaluation records."""
+
+    def put_evaluation_record(
+        self,
+        *,
+        request: HarnessEvaluationRequest,
+        result: HarnessEvaluationResult,
+        evaluation_id: str | None = None,
+        recorded_at: str | None = None,
+    ) -> EvaluationRecord: ...
+
+    def list_evaluation_records(self, task_id: str) -> tuple[EvaluationRecord, ...]: ...
+
+
+class FileBackedHarnessStore(TaskEnvelopeStore, EvaluationRecordStore):
+    """JSON-file local store for canonical tasks and evaluation records.
+
+    This is local-development scaffolding, not the final production storage strategy.
+    """
+
+    def __init__(self, root_dir: str | Path) -> None:
+        self.root_dir = Path(root_dir)
+        self.tasks_dir = self.root_dir / "tasks"
+        self.evaluations_dir = self.root_dir / "evaluations"
+        self.tasks_dir.mkdir(parents=True, exist_ok=True)
+        self.evaluations_dir.mkdir(parents=True, exist_ok=True)
+
+    def _task_path(self, task_id: str) -> Path:
+        return self.tasks_dir / f"{task_id}.json"
+
+    def _evaluation_task_dir(self, task_id: str) -> Path:
+        task_dir = self.evaluations_dir / task_id
+        task_dir.mkdir(parents=True, exist_ok=True)
+        return task_dir
+
+    def _evaluation_path(self, task_id: str, evaluation_id: str) -> Path:
+        return self._evaluation_task_dir(task_id) / f"{evaluation_id}.json"
+
+    def _write_json(self, path: Path, payload: dict[str, Any]) -> None:
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    def _read_json(self, path: Path) -> dict[str, Any]:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def put_task(self, task_envelope: TaskEnvelope) -> TaskEnvelope:
+        task_id = str(task_envelope["id"])
+        self._write_json(self._task_path(task_id), _jsonable(task_envelope))
+        return task_envelope
+
+    def get_task(self, task_id: str) -> TaskEnvelope:
+        path = self._task_path(task_id)
+        if not path.exists():
+            raise TaskEnvelopeNotFoundError(f"TaskEnvelope {task_id!r} was not found")
+        return self._read_json(path)
+
+    def update_task(self, task_envelope: TaskEnvelope) -> TaskEnvelope:
+        task_id = str(task_envelope["id"])
+        if not self._task_path(task_id).exists():
+            raise TaskEnvelopeNotFoundError(f"TaskEnvelope {task_id!r} was not found")
+        self._write_json(self._task_path(task_id), _jsonable(task_envelope))
+        return task_envelope
+
+    def put_evaluation_record(
+        self,
+        *,
+        request: HarnessEvaluationRequest,
+        result: HarnessEvaluationResult,
+        evaluation_id: str | None = None,
+        recorded_at: str | None = None,
+    ) -> EvaluationRecord:
+        task_id = str(request.task_envelope["id"])
+        record = EvaluationRecord(
+            evaluation_id=evaluation_id or str(uuid.uuid4()),
+            task_id=task_id,
+            recorded_at=recorded_at or _iso_now(),
+            request=_jsonable(request),
+            result=_jsonable(result),
+        )
+        self._write_json(self._evaluation_path(task_id, record.evaluation_id), _jsonable(record))
+        return record
+
+    def list_evaluation_records(self, task_id: str) -> tuple[EvaluationRecord, ...]:
+        task_dir = self.evaluations_dir / task_id
+        if not task_dir.exists():
+            return ()
+
+        records: list[EvaluationRecord] = []
+        for path in sorted(task_dir.glob("*.json")):
+            payload = self._read_json(path)
+            records.append(
+                EvaluationRecord(
+                    evaluation_id=payload["evaluation_id"],
+                    task_id=payload["task_id"],
+                    recorded_at=payload["recorded_at"],
+                    request=payload["request"],
+                    result=payload["result"],
+                )
+            )
+        return tuple(records)
+
+
+__all__ = [
+    "EvaluationRecord",
+    "EvaluationRecordNotFoundError",
+    "EvaluationRecordStore",
+    "FileBackedHarnessStore",
+    "StoreError",
+    "TaskEnvelopeNotFoundError",
+    "TaskEnvelopeStore",
+]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from modules.demo_cases import build_demo_request
+from modules.evaluation import evaluate_task_case
+from modules.store import FileBackedHarnessStore, TaskEnvelopeNotFoundError
+
+
+class HarnessStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = FileBackedHarnessStore(self.temp_dir.name)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_stores_and_reads_task_envelope_by_id(self) -> None:
+        request = build_demo_request("accepted_completion")
+
+        self.store.put_task(request.task_envelope)
+        stored = self.store.get_task(request.task_envelope["id"])
+
+        self.assertEqual(stored["id"], request.task_envelope["id"])
+        self.assertEqual(stored["status"], request.task_envelope["status"])
+
+    def test_updates_task_after_lifecycle_change(self) -> None:
+        request = build_demo_request("accepted_completion")
+        result = evaluate_task_case(request)
+
+        self.store.put_task(request.task_envelope)
+        self.store.update_task(result.task_envelope)
+        stored = self.store.get_task(request.task_envelope["id"])
+
+        self.assertEqual(stored["status"], "completed")
+        self.assertEqual(len(stored["status_history"]), 1)
+        self.assertEqual(stored["status_history"][0]["to_status"], "completed")
+
+    def test_raises_for_missing_task_lookup(self) -> None:
+        with self.assertRaises(TaskEnvelopeNotFoundError):
+            self.store.get_task("missing-task")
+
+    def test_persists_evaluation_records_for_task(self) -> None:
+        request = build_demo_request("blocked_reconciliation_mismatch")
+        result = evaluate_task_case(request)
+
+        self.store.put_task(request.task_envelope)
+        record = self.store.put_evaluation_record(
+            request=request,
+            result=result,
+            evaluation_id="eval-1",
+            recorded_at="2026-03-24T21:00:00Z",
+        )
+        records = self.store.list_evaluation_records(request.task_envelope["id"])
+
+        self.assertEqual(record.evaluation_id, "eval-1")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].task_id, request.task_envelope["id"])
+        self.assertEqual(records[0].result["target_status"], "blocked")
+
+    def test_evaluation_records_preserve_auditable_decision_data(self) -> None:
+        request = build_demo_request("accepted_completion")
+        result = evaluate_task_case(request)
+
+        self.store.put_task(request.task_envelope)
+        self.store.put_evaluation_record(
+            request=request,
+            result=result,
+            evaluation_id="eval-2",
+            recorded_at="2026-03-24T21:05:00Z",
+        )
+        record = self.store.list_evaluation_records(request.task_envelope["id"])[0]
+
+        self.assertEqual(record.recorded_at, "2026-03-24T21:05:00Z")
+        self.assertEqual(record.result["action"], "transition_applied")
+        self.assertEqual(record.result["task_envelope"]["status"], "completed")
+        self.assertIn("accepted_completion", record.result["enforcement_result"]["verification_result"]["outcome"])
+
+    def test_uses_explicit_task_and_evaluation_directories(self) -> None:
+        request = build_demo_request("invalid_input")
+        result = evaluate_task_case(request)
+
+        self.store.put_task(request.task_envelope)
+        self.store.put_evaluation_record(request=request, result=result, evaluation_id="eval-3")
+
+        task_path = Path(self.temp_dir.name) / "tasks" / f"{request.task_envelope['id']}.json"
+        evaluation_path = Path(self.temp_dir.name) / "evaluations" / request.task_envelope["id"] / "eval-3.json"
+
+        self.assertTrue(task_path.exists())
+        self.assertTrue(evaluation_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a backend-neutral store boundary for canonical TaskEnvelope records and persisted evaluation records
- add a lightweight file-backed JSON implementation for local development that stores tasks by ID and evaluation records under per-task append-only directories
- add tests covering task create/read/update, missing-task lookup, durable evaluation record capture, and preservation of auditable lifecycle/evaluation data

## Validation
- `.venv/bin/python -m unittest discover -s tests`
- `.venv/bin/python` against a temporary file-backed store to persist an accepted-completion task snapshot and evaluation record

## Notes
- this is initial store scaffolding only; the control-plane core remains storage-backend-neutral and this does not commit Harness to a final production database strategy