### PR TITLE
Wire HTTP API to persistence store and expose retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,16 +217,19 @@ It does not call live external APIs.
 You can also run a minimal local HTTP wrapper around the same evaluation entry point:
 
 ```bash
-python -m modules.api --host 127.0.0.1 --port 8000
+python -m modules.api --host 127.0.0.1 --port 8000 --store-root .harness-store
 ```
 
 Then submit canonical evaluation requests to:
 
 - `GET /health`
 - `POST /evaluate`
+- `GET /tasks/<task_id>`
+- `GET /tasks/<task_id>/evaluations`
 
 The API accepts canonical `TaskEnvelope` input plus normalized external facts and returns structured evaluation results.
-It is a thin wrapper over the existing evaluator, not a production service.
+Successful evaluations persist the current task snapshot and append an evaluation record under the configured store root.
+It is a thin wrapper over the existing evaluator and store scaffolding, not a production service.
 
 ## License
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -9,6 +9,7 @@ from enum import Enum
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
 from modules.contracts.task_envelope_external_facts import (
@@ -36,6 +37,11 @@ from modules.contracts.task_envelope_review import (
 )
 from modules.contracts.task_envelope_verification import RuntimeVerificationFacts
 from modules.evaluation import HarnessEvaluationRequest, evaluate_task_case
+from modules.store import (
+    EvaluationRecord,
+    FileBackedHarnessStore,
+    TaskEnvelopeNotFoundError,
+)
 
 
 class ApiRequestError(ValueError):
@@ -208,7 +214,7 @@ def _parse_review_decision(payload: dict[str, Any] | None) -> ReviewDecisionResu
 def parse_evaluation_request(payload: dict[str, Any]) -> HarnessEvaluationRequest:
     """Parse a canonical HTTP evaluation request into the public evaluator input."""
 
-    request_payload = _require_mapping(payload, field_name="request")
+    request_payload = _require_mapping(payload.get("request"), field_name="request")
     task_envelope = _require_mapping(request_payload.get("task_envelope"), field_name="task_envelope")
 
     return HarnessEvaluationRequest(
@@ -255,10 +261,78 @@ def evaluate_http_payload(payload: dict[str, Any]) -> tuple[int, dict[str, Any]]
     return status, _to_jsonable(result)
 
 
+def _task_path_components(path: str) -> tuple[str, ...]:
+    parsed_path = urlparse(path).path.strip("/")
+    if not parsed_path:
+        return ()
+    return tuple(unquote(component) for component in parsed_path.split("/"))
+
+
+def _serialize_evaluation_record(record: EvaluationRecord) -> dict[str, Any]:
+    return _to_jsonable(record)
+
+
+class HarnessApiService:
+    """Stateful HTTP-facing service that reuses the canonical evaluator and store."""
+
+    def __init__(self, *, store: FileBackedHarnessStore | None = None) -> None:
+        self.store = store or FileBackedHarnessStore(".harness-store")
+
+    def _upsert_task(self, task_envelope: dict[str, Any]) -> dict[str, Any]:
+        task_id = str(task_envelope["id"])
+        try:
+            self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return self.store.put_task(task_envelope)
+        return self.store.update_task(task_envelope)
+
+    def evaluate(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            request = parse_evaluation_request(payload)
+        except Exception as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        result = evaluate_task_case(request)
+        status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
+        response_payload = _to_jsonable(result)
+
+        if result.invalid_input:
+            return status, response_payload
+
+        stored_task = self._upsert_task(result.task_envelope)
+        record = self.store.put_evaluation_record(request=request, result=result)
+        response_payload["task_envelope"] = _to_jsonable(stored_task)
+        response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        return status, response_payload
+
+    def get_task(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        try:
+            task = self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+        return HTTPStatus.OK, {"task": task}
+
+    def get_evaluation_history(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        try:
+            self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+
+        records = self.store.list_evaluation_records(task_id)
+        return HTTPStatus.OK, {
+            "task_id": task_id,
+            "evaluations": [_serialize_evaluation_record(record) for record in records],
+        }
+
+
 class HarnessApiHandler(BaseHTTPRequestHandler):
     """Minimal HTTP handler exposing the Harness evaluation entry point."""
 
     server_version = "HarnessHTTP/0.1"
+    service: HarnessApiService | None = None
 
     def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
         return
@@ -272,13 +346,27 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_GET(self) -> None:  # noqa: N802
-        if self.path == "/health":
+        path_components = _task_path_components(self.path)
+        service = self.service or HarnessApiService()
+
+        if path_components == ("health",):
             self._write_json(HTTPStatus.OK, {"status": "ok"})
             return
+
+        if len(path_components) == 2 and path_components[0] == "tasks":
+            status, payload = service.get_task(path_components[1])
+            self._write_json(status, payload)
+            return
+
+        if len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "evaluations":
+            status, payload = service.get_evaluation_history(path_components[1])
+            self._write_json(status, payload)
+            return
+
         self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
 
     def do_POST(self) -> None:  # noqa: N802
-        if self.path != "/evaluate":
+        if urlparse(self.path).path != "/evaluate":
             self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
             return
 
@@ -290,14 +378,26 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             self._write_json(HTTPStatus.BAD_REQUEST, {"error": f"Invalid JSON body: {error}"})
             return
 
-        status, response_payload = evaluate_http_payload(payload)
+        service = self.service or HarnessApiService()
+        status, response_payload = service.evaluate(payload)
         self._write_json(status, response_payload)
 
 
-def run_server(*, host: str = "127.0.0.1", port: int = 8000) -> ThreadingHTTPServer:
+def run_server(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    store_root: str = ".harness-store",
+    service: HarnessApiService | None = None,
+) -> ThreadingHTTPServer:
     """Create and run the minimal HTTP API server."""
 
-    server = ThreadingHTTPServer((host, port), HarnessApiHandler)
+    api_service = service or HarnessApiService(store=FileBackedHarnessStore(store_root))
+
+    class _ConfiguredHarnessApiHandler(HarnessApiHandler):
+        service = api_service
+
+    server = ThreadingHTTPServer((host, port), _ConfiguredHarnessApiHandler)
     return server
 
 
@@ -307,6 +407,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run the minimal Harness HTTP API wrapper.")
     parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind")
     parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    parser.add_argument(
+        "--store-root",
+        default=".harness-store",
+        help="Directory for persisted task snapshots and evaluation history",
+    )
     return parser
 
 
@@ -314,7 +419,7 @@ def main(argv: list[str] | None = None) -> int:
     """Run the minimal HTTP API server."""
 
     args = build_parser().parse_args(argv)
-    server = run_server(host=args.host, port=args.port)
+    server = run_server(host=args.host, port=args.port, store_root=args.store_root)
     print(f"Harness API listening on http://{args.host}:{args.port}")
     try:
         server.serve_forever()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import tempfile
 import threading
 import unittest
 from dataclasses import asdict, is_dataclass
@@ -8,8 +9,9 @@ from enum import Enum
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-from modules.api import HarnessApiHandler, evaluate_http_payload, run_server
+from modules.api import HarnessApiService, evaluate_http_payload, run_server
 from modules.demo_cases import build_demo_request
+from modules.store import FileBackedHarnessStore
 
 
 def _to_jsonable(value):
@@ -25,7 +27,7 @@ def _to_jsonable(value):
 
 
 def _request_payload(case_name: str) -> dict:
-    return _to_jsonable(build_demo_request(case_name))
+    return {"request": _to_jsonable(build_demo_request(case_name))}
 
 
 class HarnessApiPayloadTests(unittest.TestCase):
@@ -44,9 +46,48 @@ class HarnessApiPayloadTests(unittest.TestCase):
         self.assertTrue(payload["invalid_input"])
 
 
+class HarnessApiServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.service = HarnessApiService(store=FileBackedHarnessStore(self.temp_dir.name))
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_service_persists_evaluation_and_task_snapshot(self) -> None:
+        status, payload = self.service.evaluate(_request_payload("accepted_completion"))
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task_envelope"]["status"], "completed")
+        self.assertEqual(payload["evaluation_record"]["task_id"], payload["task_envelope"]["id"])
+
+        task_status, task_payload = self.service.get_task(payload["task_envelope"]["id"])
+        history_status, history_payload = self.service.get_evaluation_history(payload["task_envelope"]["id"])
+
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], "completed")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
+    def test_service_rejects_invalid_input_without_persisting_state(self) -> None:
+        task_id = _request_payload("invalid_input")["request"]["task_envelope"]["id"]
+
+        status, payload = self.service.evaluate(_request_payload("invalid_input"))
+        task_status, task_payload = self.service.get_task(task_id)
+        history_status, history_payload = self.service.get_evaluation_history(task_id)
+
+        self.assertEqual(status, 400)
+        self.assertTrue(payload["invalid_input"])
+        self.assertEqual(task_status, 404)
+        self.assertIn("not found", task_payload["error"].lower())
+        self.assertEqual(history_status, 404)
+        self.assertIn("not found", history_payload["error"].lower())
+
+
 class HarnessHttpApiTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.server = run_server(host="127.0.0.1", port=0)
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.server = run_server(host="127.0.0.1", port=0, store_root=self.temp_dir.name)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()
         self.base_url = f"http://127.0.0.1:{self.server.server_port}"
@@ -55,6 +96,17 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.server.shutdown()
         self.server.server_close()
         self.thread.join(timeout=2)
+        self.temp_dir.cleanup()
+
+    def _get_json(self, path: str) -> tuple[int, dict]:
+        try:
+            with urlopen(self.base_url + path) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            try:
+                return error.code, json.loads(error.read().decode("utf-8"))
+            finally:
+                error.close()
 
     def _post_json(self, path: str, payload: dict) -> tuple[int, dict]:
         request = Request(
@@ -67,49 +119,117 @@ class HarnessHttpApiTests(unittest.TestCase):
             with urlopen(request) as response:
                 return response.status, json.loads(response.read().decode("utf-8"))
         except HTTPError as error:
-            return error.code, json.loads(error.read().decode("utf-8"))
+            try:
+                return error.code, json.loads(error.read().decode("utf-8"))
+            finally:
+                error.close()
 
     def test_health_endpoint(self) -> None:
-        with urlopen(self.base_url + "/health") as response:
-            payload = json.loads(response.read().decode("utf-8"))
+        status, payload = self._get_json("/health")
 
-        self.assertEqual(response.status, 200)
+        self.assertEqual(status, 200)
         self.assertEqual(payload["status"], "ok")
 
-    def test_api_returns_accepted_completion(self) -> None:
+    def test_api_persists_accepted_completion_and_exposes_history(self) -> None:
         status, payload = self._post_json("/evaluate", _request_payload("accepted_completion"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
 
         self.assertEqual(status, 200)
         self.assertEqual(payload["action"], "transition_applied")
         self.assertEqual(payload["task_envelope"]["status"], "completed")
+        self.assertIn("evaluation_record", payload)
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], "completed")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+        self.assertEqual(history_payload["evaluations"][0]["result"]["task_envelope"]["status"], "completed")
 
-    def test_api_returns_blocked_for_insufficient_evidence(self) -> None:
+    def test_api_persists_blocked_result(self) -> None:
         status, payload = self._post_json("/evaluate", _request_payload("blocked_insufficient_evidence"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
 
         self.assertEqual(status, 200)
         self.assertEqual(payload["target_status"], "blocked")
-        self.assertEqual(payload["task_envelope"]["status"], "blocked")
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], "blocked")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(history_payload["evaluations"][0]["result"]["target_status"], "blocked")
 
-    def test_api_returns_blocked_for_reconciliation_mismatch(self) -> None:
+    def test_api_persists_reconciliation_mismatch_result(self) -> None:
         status, payload = self._post_json("/evaluate", _request_payload("blocked_reconciliation_mismatch"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
 
         self.assertEqual(status, 200)
         self.assertEqual(payload["target_status"], "blocked")
-        self.assertEqual(payload["task_envelope"]["status"], "blocked")
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], "blocked")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(
+            history_payload["evaluations"][0]["result"]["enforcement_result"]["verification_result"]["outcome"],
+            "external_mismatch",
+        )
 
-    def test_api_returns_review_required(self) -> None:
+    def test_api_persists_review_required_result(self) -> None:
         status, payload = self._post_json("/evaluate", _request_payload("review_required"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
 
         self.assertEqual(status, 200)
         self.assertEqual(payload["action"], "review_required")
         self.assertTrue(payload["requires_review"])
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], payload["task_envelope"]["status"])
+        self.assertEqual(history_status, 200)
+        self.assertEqual(history_payload["evaluations"][0]["result"]["action"], "review_required")
 
-    def test_api_rejects_invalid_input(self) -> None:
-        status, payload = self._post_json("/evaluate", _request_payload("invalid_input"))
+    def test_api_rejects_invalid_input_without_persisting_state(self) -> None:
+        invalid_payload = _request_payload("invalid_input")
+        task_id = invalid_payload["request"]["task_envelope"]["id"]
+
+        status, payload = self._post_json("/evaluate", invalid_payload)
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
 
         self.assertEqual(status, 400)
         self.assertEqual(payload["action"], "invalid_input")
         self.assertTrue(payload["invalid_input"])
+        self.assertEqual(task_status, 404)
+        self.assertEqual(history_status, 404)
+        self.assertIn("not found", task_payload["error"].lower())
+        self.assertIn("not found", history_payload["error"].lower())
+
+    def test_api_retrieves_append_only_evaluation_history(self) -> None:
+        payload = _request_payload("accepted_completion")
+        task_id = payload["request"]["task_envelope"]["id"]
+
+        first_status, _ = self._post_json("/evaluate", payload)
+        second_status, _ = self._post_json("/evaluate", payload)
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(first_status, 200)
+        self.assertEqual(second_status, 200)
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 2)
+
+    def test_api_returns_not_found_for_missing_task(self) -> None:
+        task_status, task_payload = self._get_json("/tasks/missing-task")
+        history_status, history_payload = self._get_json("/tasks/missing-task/evaluations")
+
+        self.assertEqual(task_status, 404)
+        self.assertEqual(history_status, 404)
+        self.assertIn("not found", task_payload["error"].lower())
+        self.assertIn("not found", history_payload["error"].lower())
 
     def test_api_rejects_malformed_json(self) -> None:
         request = Request(


### PR DESCRIPTION
## Summary
- wire the minimal HTTP API to the existing file-backed Harness store through a small API service layer
- persist evaluated TaskEnvelope snapshots and append auditable evaluation records on successful API evaluations
- add `GET /tasks/<task_id>` and `GET /tasks/<task_id>/evaluations` for current state and evaluation history retrieval
- keep invalid input non-persistent so rejected requests do not corrupt stored task state
- document the stateful API surface and store-root flag in the README

## Validation
- `.venv/bin/python -m unittest tests.test_api`
- `.venv/bin/python -m unittest discover -s tests`
