### PR TITLE
Introduce long-running handoff and progress artifact types

### DIFF
--- a/docs/architecture/artifact-and-completion-evidence.md
+++ b/docs/architecture/artifact-and-completion-evidence.md
@@ -34,8 +34,17 @@ Supported canonical artifact types:
 - `log`
 - `output`
 - `review_note`
+- `progress_artifact`
+- `plan_artifact`
+- `handoff_artifact`
 
 These artifact types are broad enough to support code-bearing tasks, advisory tasks, and reconciliation across external systems.
+
+The long-running support artifact types are intentionally distinct from completion evidence:
+
+- `progress_artifact` captures structured progress state across multiple evaluation cycles or execution sessions
+- `plan_artifact` captures decomposition, feature lists, or work-plan state that verification may inspect later
+- `handoff_artifact` captures session-transition or executor-transition context needed to continue work safely across sessions
 
 ## Artifact Record
 
@@ -160,6 +169,51 @@ Typical use:
 - manual verification statements
 - review commentary
 
+### progress_artifact
+
+Required:
+
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- progress logs that summarize what has been completed so far
+- feature or checklist state carried across multiple sessions
+- intermediate status snapshots used during later verification or review
+
+These artifacts improve continuity and auditability, but they do not imply completion by themselves.
+
+### plan_artifact
+
+Required:
+
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- structured decomposition output
+- feature implementation plans
+- reviewable work plans used during later enforcement or manual review
+
+These artifacts document intended execution shape. They are verification inputs, not completion proof by default.
+
+### handoff_artifact
+
+Required:
+
+- `provenance`
+- `verification_status`
+
+Typical use:
+
+- session handoff summaries between agent runs
+- environment-state notes required to resume long-running work
+- executor transition context when work spans multiple sessions or workers
+
+These artifacts preserve continuity across long-running work, but they do not override completion policy or lifecycle enforcement.
+
 ## Repository And Branch Identity
 
 Repository identity is represented as:
@@ -199,6 +253,14 @@ Every artifact record must include provenance:
 - `captured_by` optional
 
 Provenance is required so Harness can later explain where evidence came from and whether it came directly from an external system, from an executor report, or from a manual verifier.
+
+For long-running artifacts, `metadata` should carry structured continuity details when relevant, such as:
+
+- progress counters or checklist summaries for `progress_artifact`
+- plan scope, decomposition revision, or feature list identifiers for `plan_artifact`
+- previous session identifiers, next executor identifiers, or resume instructions for `handoff_artifact`
+
+Harness stores these as auditable task artifacts, but keeps the metadata executor-neutral and substrate-neutral.
 
 ## Completion Evidence
 
@@ -245,6 +307,7 @@ Canonical rules:
 - if evidence is required but missing, completion must not be accepted
 - executor-reported success without evidence is not sufficient for `completed`
 - advisory or research tasks may use `advisory_only` or `not_applicable`, but that must be explicit
+- progress, plan, and handoff artifacts may inform verification and review, but they are not completion-bearing artifact types in the current contract
 
 ## Distinguishing Outcome Classes
 
@@ -276,6 +339,8 @@ The model supports later reconciliation by:
 - allowing external references back to GitHub and Linear identifiers
 - separating evidence presence from evidence validation
 - making it possible to compare Harness lifecycle state against both structured work state and artifact state
+
+Long-running support artifacts may also be reconciled where applicable, for example when a handoff artifact references a GitHub branch or a Linear issue key. They remain informative inputs unless a later contract explicitly promotes them into completion policy.
 
 ## TaskEnvelope Alignment
 

--- a/docs/architecture/task-envelope.md
+++ b/docs/architecture/task-envelope.md
@@ -237,7 +237,7 @@ Artifacts are product-facing outputs and verification evidence attached to the t
 
 `artifacts` contains:
 
-- `items`: canonical artifact records such as pull requests, commits, changed files, logs, outputs, and review notes
+- `items`: canonical artifact records such as pull requests, commits, changed files, logs, outputs, review notes, progress artifacts, plan artifacts, and handoff artifacts
 - `completion_evidence`: the current policy and validation state for deciding whether a task may be treated as complete
 
 Each artifact record may carry:
@@ -252,6 +252,8 @@ Each artifact record may carry:
 Completion is not trusted purely because an executor claims success. `artifacts.completion_evidence` is where Harness records whether the evidence requirement is deferred, required, satisfied, insufficient, or not applicable.
 
 Verification consumes this evidence state but remains a distinct control-plane decision layer. Evidence presence and completion acceptance must not collapse into one concept.
+
+Long-running support artifacts such as `progress_artifact`, `plan_artifact`, and `handoff_artifact` are first-class task artifacts. Harness preserves them for auditability and may use them as verification or review inputs, but they are not completion-bearing by default in the current contract.
 
 ### Completion Trust Levels
 

--- a/modules/contracts/task_envelope_evidence.py
+++ b/modules/contracts/task_envelope_evidence.py
@@ -37,6 +37,11 @@ _EVIDENCE_RELEVANT_TYPES = {
     "output",
     "review_note",
 }
+_LONG_RUNNING_CONTEXT_TYPES = {
+    "progress_artifact",
+    "plan_artifact",
+    "handoff_artifact",
+}
 _SATISFYING_VERIFICATION_STATUSES = {"verified"}
 
 
@@ -117,6 +122,16 @@ def validate_artifact_record(artifact: dict[str, Any]) -> ArtifactValidationResu
     artifact_id = artifact.get("id") if isinstance(artifact, dict) else None
     artifact_type = artifact.get("type") if isinstance(artifact, dict) else None
     issues = _schema_issues(_ARTIFACT_VALIDATOR, artifact, artifact_id=artifact_id)
+
+    # Long-running context artifacts are valid first-class artifacts in the schema,
+    # but they do not carry extra completion-bearing semantics by default.
+    if not issues and artifact_type in _LONG_RUNNING_CONTEXT_TYPES:
+        return ArtifactValidationResult(
+            artifact_id=artifact_id,
+            artifact_type=artifact_type,
+            is_valid=True,
+            issues=(),
+        )
 
     if not issues and artifact_type in _EVIDENCE_RELEVANT_TYPES:
         if artifact_type == "pull_request" and artifact.get("pull_request_number") is None:

--- a/schemas/task_envelope.schema.json
+++ b/schemas/task_envelope.schema.json
@@ -741,7 +741,10 @@
             "changed_file",
             "log",
             "output",
-            "review_note"
+            "review_note",
+            "progress_artifact",
+            "plan_artifact",
+            "handoff_artifact"
           ]
         },
         "title": {

--- a/tests/contracts/test_task_envelope_artifacts.py
+++ b/tests/contracts/test_task_envelope_artifacts.py
@@ -167,6 +167,105 @@ class TaskEnvelopeArtifactSchemaTests(unittest.TestCase):
         errors = validate_task_envelope(task_envelope)
         self.assertEqual(errors, [])
 
+    def test_accepts_progress_plan_and_handoff_artifacts_without_affecting_completion_evidence_shape(self) -> None:
+        task_envelope = _base_task_envelope()
+        task_envelope["artifacts"]["items"] = [
+            {
+                "id": "artifact-progress-1",
+                "type": "progress_artifact",
+                "title": "Progress snapshot",
+                "description": "Feature checklist updated after the first execution session.",
+                "location": None,
+                "content_type": "application/json",
+                "external_id": None,
+                "commit_sha": None,
+                "pull_request_number": None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "codex",
+                    "source_type": "executor_report",
+                    "source_id": "session-progress-1",
+                    "captured_by": "harness-api",
+                },
+                "verification_status": "informational",
+                "repository": None,
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T16:08:00Z",
+                "metadata": {
+                    "completed_items": "2",
+                    "remaining_items": "1",
+                },
+            },
+            {
+                "id": "artifact-plan-1",
+                "type": "plan_artifact",
+                "title": "Implementation plan",
+                "description": "Structured decomposition for the feature task.",
+                "location": None,
+                "content_type": "text/markdown",
+                "external_id": None,
+                "commit_sha": None,
+                "pull_request_number": None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "harness",
+                    "source_type": "planner_output",
+                    "source_id": "plan-1",
+                    "captured_by": "planner",
+                },
+                "verification_status": "informational",
+                "repository": None,
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T16:09:00Z",
+                "metadata": {
+                    "plan_version": "v1",
+                    "scope": "feature_implementation",
+                },
+            },
+            {
+                "id": "artifact-handoff-1",
+                "type": "handoff_artifact",
+                "title": "Session handoff",
+                "description": "Resume from the PR validation step on the next session.",
+                "location": None,
+                "content_type": "application/json",
+                "external_id": None,
+                "commit_sha": None,
+                "pull_request_number": None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "codex",
+                    "source_type": "executor_report",
+                    "source_id": "handoff-1",
+                    "captured_by": "harness-api",
+                },
+                "verification_status": "informational",
+                "repository": None,
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T16:12:00Z",
+                "metadata": {
+                    "from_session_id": "session-1",
+                    "resume_hint": "Validate PR evidence and update Linear state.",
+                },
+            },
+        ]
+        task_envelope["artifacts"]["completion_evidence"]["policy"] = "not_applicable"
+        task_envelope["artifacts"]["completion_evidence"]["status"] = "not_applicable"
+        task_envelope["artifacts"]["completion_evidence"]["required_artifact_types"] = []
+        task_envelope["artifacts"]["completion_evidence"]["validated_artifact_ids"] = []
+        task_envelope["artifacts"]["completion_evidence"]["validation_method"] = "none"
+        task_envelope["artifacts"]["completion_evidence"]["validated_at"] = None
+        task_envelope["artifacts"]["completion_evidence"]["validator"] = None
+
+        errors = validate_task_envelope(task_envelope)
+        self.assertEqual(errors, [])
+
     def test_rejects_pull_request_artifact_missing_repository_context(self) -> None:
         task_envelope = _base_task_envelope()
         task_envelope["artifacts"]["items"] = [
@@ -200,6 +299,40 @@ class TaskEnvelopeArtifactSchemaTests(unittest.TestCase):
         errors = validate_task_envelope(task_envelope)
         self.assertTrue(errors)
         self.assertTrue(any("/artifacts/items/0/repository" in error for error in errors))
+
+    def test_rejects_unknown_long_running_artifact_type(self) -> None:
+        task_envelope = _base_task_envelope()
+        task_envelope["artifacts"]["items"] = [
+            {
+                "id": "artifact-progress-1",
+                "type": "session_state",
+                "title": "Unknown artifact type",
+                "description": None,
+                "location": None,
+                "content_type": None,
+                "external_id": None,
+                "commit_sha": None,
+                "pull_request_number": None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "codex",
+                    "source_type": "executor_report",
+                    "source_id": "session-1",
+                    "captured_by": "harness-api",
+                },
+                "verification_status": "informational",
+                "repository": None,
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T16:10:00Z",
+                "metadata": {},
+            }
+        ]
+
+        errors = validate_task_envelope(task_envelope)
+        self.assertTrue(errors)
+        self.assertTrue(any("/artifacts/items/0/type" in error for error in errors))
 
 
 if __name__ == "__main__":

--- a/tests/contracts/test_task_envelope_evidence.py
+++ b/tests/contracts/test_task_envelope_evidence.py
@@ -196,6 +196,41 @@ class ArtifactValidationPrimitiveTests(unittest.TestCase):
         self.assertFalse(result.is_valid)
         self.assertTrue(any(issue.code == "required_artifact_field_missing" for issue in result.issues))
 
+    def test_accepts_handoff_artifact_as_auditable_non_completion_context(self) -> None:
+        artifact = {
+            "id": "artifact-handoff-1",
+            "type": "handoff_artifact",
+            "title": "Executor handoff",
+            "description": "Carry forward the current progress and resume hints.",
+            "location": None,
+            "content_type": "application/json",
+            "external_id": None,
+            "commit_sha": None,
+            "pull_request_number": None,
+            "review_state": None,
+            "provenance": {
+                "source_system": "codex",
+                "source_type": "executor_report",
+                "source_id": "handoff-1",
+                "captured_by": "harness-api",
+            },
+            "verification_status": "informational",
+            "repository": None,
+            "branch": None,
+            "changed_files": [],
+            "external_refs": [],
+            "captured_at": "2026-03-24T16:12:00Z",
+                "metadata": {
+                    "from_session_id": "session-1",
+                    "resume_hint": "Resume from verification.",
+            },
+        }
+
+        result = validate_artifact_record(artifact)
+
+        self.assertTrue(result.is_valid)
+        self.assertEqual(result.issues, ())
+
 
 class CompletionEvidenceValidationPrimitiveTests(unittest.TestCase):
     def test_accepts_required_satisfied_evidence_when_validated_artifacts_cover_required_types(self) -> None:
@@ -290,6 +325,45 @@ class CompletionEvidenceValidationPrimitiveTests(unittest.TestCase):
         self.assertTrue(
             any(issue.code == "not_applicable_requires_no_validated_artifacts" for issue in result.issues)
         )
+
+    def test_long_running_support_artifacts_do_not_change_required_completion_evidence_by_default(self) -> None:
+        task_envelope = _base_task_envelope()
+        task_envelope["artifacts"]["items"].append(
+            {
+                "id": "artifact-progress-1",
+                "type": "progress_artifact",
+                "title": "Progress snapshot",
+                "description": "Progress carried between sessions.",
+                "location": None,
+                "content_type": "application/json",
+                "external_id": None,
+                "commit_sha": None,
+                "pull_request_number": None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "codex",
+                    "source_type": "executor_report",
+                    "source_id": "progress-1",
+                    "captured_by": "harness-api",
+                },
+                "verification_status": "informational",
+                "repository": None,
+                "branch": None,
+                "changed_files": [],
+                "external_refs": [],
+                "captured_at": "2026-03-24T16:08:00Z",
+                "metadata": {
+                    "completed_items": "2",
+                    "remaining_items": "1",
+                },
+            }
+        )
+
+        result = validate_task_evidence(task_envelope)
+
+        self.assertTrue(result.is_valid)
+        self.assertTrue(result.is_sufficient)
+        self.assertEqual(result.validated_artifact_ids, ("artifact-pr-1", "artifact-commit-1"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend the canonical artifact model with `progress_artifact`, `plan_artifact`, and `handoff_artifact`
- document how long-running support artifacts are preserved for auditability and may inform verification without becoming completion evidence by default
- keep the completion-evidence contract intentionally narrow so these artifacts do not weaken artifact-backed completion rules
- update artifact validation tests to cover valid and invalid long-running artifact shapes

## Validation
- `python3 -m json.tool schemas/task_envelope.schema.json >/dev/null`
- `.venv/bin/python -m unittest tests.contracts.test_task_envelope_artifacts tests.contracts.test_task_envelope_evidence`
- `.venv/bin/python -m unittest discover -s tests`
