### PR TITLE
Add stateful TaskEnvelope reevaluation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,13 @@ Then submit canonical evaluation requests to:
 
 - `GET /health`
 - `POST /evaluate`
+- `POST /tasks/<task_id>/reevaluate`
 - `GET /tasks/<task_id>`
 - `GET /tasks/<task_id>/evaluations`
 
 The API accepts canonical `TaskEnvelope` input plus normalized external facts and returns structured evaluation results.
 Successful evaluations persist the current task snapshot and append an evaluation record under the configured store root.
+Re-evaluation requests load the latest stored task, append any new canonical artifacts, apply new normalized facts or review outcomes, and persist the next task snapshot plus a new evaluation record.
 It is a thin wrapper over the existing evaluator and store scaffolding, not a production service.
 
 ## License

--- a/docs/architecture/state-transition-enforcement.md
+++ b/docs/architecture/state-transition-enforcement.md
@@ -71,6 +71,7 @@ No module may cause lifecycle movement outside its authority just because it obs
 | `executing` | `failed` | yes | runtime or verification | execution attempt or resulting outcome is terminally unusable under policy |
 | `executing` | `canceled` | yes | operator or authorized control-plane policy | execution is intentionally stopped |
 | `completed` | `blocked` | yes | verification or reconciliation-driven control-plane policy | later verification/reconciliation shows outcome is provisional, insufficient, or contradictory |
+| `blocked` | `completed` | yes | verification or manual review | the task was blocked on unresolved completion acceptance and later evidence/reconciliation resolves that blocker |
 | `blocked` | `intake_ready` | yes | clarification handling or operator | blocked intake task has newly resolved clarification and must resume normalization |
 | `blocked` | `planned` | yes | planner, clarification handling, or operator | planning blocker resolved and task should return to planned state |
 | `blocked` | `dispatch_ready` | yes | dispatcher or operator | dispatch blocker resolved and task is ready for assignment |
@@ -138,6 +139,7 @@ May cause:
 - `executing` -> `blocked`
 - `executing` -> `failed`
 - `completed` -> `blocked`
+- `blocked` -> `completed`
 
 Verification owns completion acceptance policy and may reverse a provisional completed state when later facts invalidate it.
 

--- a/docs/architecture/task-envelope.md
+++ b/docs/architecture/task-envelope.md
@@ -112,6 +112,7 @@ Canonical transitions:
 - `blocked` -> `dispatch_ready`
 - `blocked` -> `assigned`
 - `blocked` -> `executing`
+- `blocked` -> `completed`
 - `blocked` -> `canceled`
 
 Terminal states:
@@ -126,6 +127,8 @@ Allowed transitions are not sufficient by themselves. Each transition must also 
 For tasks with required completion evidence, transition to `completed` is only valid after `artifacts.completion_evidence.status` reaches `satisfied`.
 
 `completed` must be treated as provisional until required reconciliation succeeds. If reconciliation later detects a blocking mismatch, the task may move back to `blocked` rather than remaining permanently completed.
+
+`blocked` may also move back to `completed` when the blocking condition was specifically about unresolved completion acceptance and later verification or manual review resolves that blocker with sufficient evidence and non-blocking reconciliation.
 
 `completed` is preserved only when verification policy accepts the outcome. Executor-reported success, evidence attachment, or reconciliation in isolation are not enough by themselves.
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+from copy import deepcopy
 import json
 from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -48,6 +50,10 @@ class ApiRequestError(ValueError):
     """Raised when the HTTP API receives malformed request payloads."""
 
 
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 def _require_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ApiRequestError(f"{field_name} must be an object")
@@ -66,6 +72,17 @@ def _optional_string_tuple(value: Any, *, field_name: str) -> tuple[str, ...]:
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise ApiRequestError(f"{field_name} must be an array of strings")
     return tuple(value)
+
+
+def _optional_object_list(value: Any, *, field_name: str) -> tuple[dict[str, Any], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ApiRequestError(f"{field_name} must be an array of objects")
+    result = []
+    for index, item in enumerate(value):
+        result.append(_require_mapping(item, field_name=f"{field_name}[{index}]"))
+    return tuple(result)
 
 
 def _parse_repository(payload: dict[str, Any] | None) -> RepositoryFact | None:
@@ -233,6 +250,84 @@ def parse_evaluation_request(payload: dict[str, Any]) -> HarnessEvaluationReques
     )
 
 
+def _merge_artifacts(existing_task: dict[str, Any], *, new_artifacts: tuple[dict[str, Any], ...]) -> dict[str, Any]:
+    merged_task = deepcopy(existing_task)
+    artifact_items = list(merged_task["artifacts"]["items"])
+    existing_ids = {str(item.get("id")) for item in artifact_items if item.get("id") is not None}
+
+    for artifact in new_artifacts:
+        artifact_id = artifact.get("id")
+        if artifact_id is not None and str(artifact_id) in existing_ids:
+            raise ApiRequestError(f"new_artifacts contains duplicate artifact id {artifact_id!r}")
+        artifact_items.append(deepcopy(artifact))
+        if artifact_id is not None:
+            existing_ids.add(str(artifact_id))
+
+    merged_task["artifacts"]["items"] = artifact_items
+    return merged_task
+
+
+def _merge_completion_evidence(
+    existing_task: dict[str, Any],
+    *,
+    completion_evidence_update: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if completion_evidence_update is None:
+        return existing_task
+
+    merged_task = deepcopy(existing_task)
+    merged_task["artifacts"]["completion_evidence"].update(dict(completion_evidence_update))
+    return merged_task
+
+
+def parse_reevaluation_request(task_envelope: dict[str, Any], payload: dict[str, Any]) -> HarnessEvaluationRequest:
+    """Parse a reevaluation payload against an existing stored TaskEnvelope."""
+
+    request_payload = _require_mapping(payload.get("request"), field_name="request")
+    merged_task = deepcopy(task_envelope)
+
+    new_artifacts = _optional_object_list(request_payload.get("new_artifacts"), field_name="new_artifacts")
+    if new_artifacts:
+        merged_task = _merge_artifacts(merged_task, new_artifacts=new_artifacts)
+
+    completion_evidence_update = _optional_mapping(
+        request_payload.get("completion_evidence"),
+        field_name="completion_evidence",
+    )
+    if completion_evidence_update is not None:
+        merged_task = _merge_completion_evidence(
+            merged_task,
+            completion_evidence_update=completion_evidence_update,
+        )
+
+    merged_task["timestamps"]["updated_at"] = _iso_now()
+
+    review_request = _parse_review_request(_optional_mapping(request_payload.get("review_request"), field_name="review_request"))
+    review_decision = _parse_review_decision(
+        _optional_mapping(request_payload.get("review_decision"), field_name="review_decision")
+    )
+
+    if review_request is not None and review_request.task_id != merged_task["id"]:
+        raise ApiRequestError("review_request.task_id must match the stored task id")
+    if review_decision is not None and review_decision.record.task_id != merged_task["id"]:
+        raise ApiRequestError("review_decision.record.task_id must match the stored task id")
+
+    return HarnessEvaluationRequest(
+        task_envelope=merged_task,
+        external_facts=_parse_external_facts(_optional_mapping(request_payload.get("external_facts"), field_name="external_facts")),
+        claimed_completion=bool(request_payload.get("claimed_completion", False)),
+        acceptance_criteria_satisfied=bool(request_payload.get("acceptance_criteria_satisfied", False)),
+        runtime_facts=_parse_runtime_facts(_optional_mapping(request_payload.get("runtime_facts"), field_name="runtime_facts")),
+        unresolved_conditions=_optional_string_tuple(
+            request_payload.get("unresolved_conditions"),
+            field_name="unresolved_conditions",
+        ),
+        review_reasons=_optional_string_tuple(request_payload.get("review_reasons"), field_name="review_reasons"),
+        review_request=review_request,
+        review_decision=review_decision,
+    )
+
+
 def _to_jsonable(value: Any) -> Any:
     if is_dataclass(value):
         return {key: _to_jsonable(val) for key, val in asdict(value).items()}
@@ -308,6 +403,33 @@ class HarnessApiService:
         response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
+    def reevaluate(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            stored_task = self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+
+        try:
+            request = parse_reevaluation_request(stored_task, payload)
+        except Exception as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        result = evaluate_task_case(request)
+        status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
+        response_payload = _to_jsonable(result)
+
+        if result.invalid_input:
+            return status, response_payload
+
+        stored_task = self.store.update_task(result.task_envelope)
+        record = self.store.put_evaluation_record(request=request, result=result)
+        response_payload["task_envelope"] = _to_jsonable(stored_task)
+        response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        return status, response_payload
+
     def get_task(self, task_id: str) -> tuple[int, dict[str, Any]]:
         try:
             task = self.store.get_task(task_id)
@@ -366,7 +488,12 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
 
     def do_POST(self) -> None:  # noqa: N802
-        if urlparse(self.path).path != "/evaluate":
+        path_components = _task_path_components(self.path)
+        request_path = urlparse(self.path).path
+
+        if request_path != "/evaluate" and not (
+            len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "reevaluate"
+        ):
             self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
             return
 
@@ -379,7 +506,10 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             return
 
         service = self.service or HarnessApiService()
-        status, response_payload = service.evaluate(payload)
+        if request_path == "/evaluate":
+            status, response_payload = service.evaluate(payload)
+        else:
+            status, response_payload = service.reevaluate(path_components[1], payload)
         self._write_json(status, response_payload)
 
 

--- a/modules/contracts/task_envelope_enforcement.py
+++ b/modules/contracts/task_envelope_enforcement.py
@@ -201,12 +201,21 @@ def enforce_task_envelope(
     if enforcement_input.review_decision is not None:
         review_decision = enforcement_input.review_decision
         reason = review_decision.record.reasoning
+        review_transition_facts = {"terminal_failure": review_decision.record.outcome.value == "mark_failed"}
+        if review_decision.recommended_target_status == "completed":
+            review_transition_facts.update(
+                {
+                    "verification_passed": True,
+                    "acceptance_criteria_satisfied": True,
+                    "reconciliation_passed": True,
+                }
+            )
         return _apply_transition(
             task_envelope,
             actor="manual_review",
             to_status=review_decision.recommended_target_status,
             reason=reason,
-            facts={"terminal_failure": review_decision.record.outcome.value == "mark_failed"},
+            facts=review_transition_facts,
             evidence_result=evidence_result,
             review_decision=review_decision,
         )

--- a/modules/contracts/task_envelope_lifecycle.py
+++ b/modules/contracts/task_envelope_lifecycle.py
@@ -61,7 +61,7 @@ _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "dispatch_ready": {"assigned", "blocked", "canceled"},
     "assigned": {"executing", "blocked", "failed", "canceled"},
     "executing": {"completed", "blocked", "failed", "canceled"},
-    "blocked": {"intake_ready", "planned", "dispatch_ready", "assigned", "executing", "canceled"},
+    "blocked": {"intake_ready", "planned", "dispatch_ready", "assigned", "executing", "completed", "canceled"},
     "completed": {"blocked"},
     "failed": set(),
     "canceled": set(),
@@ -90,6 +90,7 @@ _AUTHORIZED_ACTORS: dict[tuple[str, str], set[str]] = {
     ("blocked", "dispatch_ready"): {"dispatcher", "operator", "manual_review"},
     ("blocked", "assigned"): {"dispatcher"},
     ("blocked", "executing"): {"runtime"},
+    ("blocked", "completed"): {"verification", "manual_review"},
     ("blocked", "canceled"): {"operator", "manual_review"},
 }
 

--- a/tests/contracts/test_task_envelope_lifecycle.py
+++ b/tests/contracts/test_task_envelope_lifecycle.py
@@ -199,6 +199,43 @@ class TaskEnvelopeLifecycleTests(unittest.TestCase):
         self.assertIsNone(result.task_envelope["timestamps"]["completed_at"])
         self.assertEqual(result.task_envelope["status_history"][-1]["from_status"], "completed")
 
+    def test_blocked_to_completed_is_allowed_when_verification_later_resolves_the_blocker(self) -> None:
+        task = _base_task()
+        task["status"] = "blocked"
+        task["artifacts"]["completion_evidence"] = {
+            "policy": "required",
+            "status": "satisfied",
+            "required_artifact_types": ["commit"],
+            "validated_artifact_ids": ["artifact-1"],
+            "validation_method": "external_reconciliation",
+            "validated_at": "2026-03-25T12:40:00Z",
+            "validator": {
+                "source_system": "harness",
+                "source_type": "verification",
+                "source_id": "verification-2",
+                "captured_by": "verification",
+            },
+            "notes": "Later evidence resolved the blocked completion claim.",
+        }
+
+        result = apply_task_transition(
+            task,
+            to_status="completed",
+            actor="verification",
+            reason="Previously blocked completion claim is now verified.",
+            now="2026-03-25T12:41:00Z",
+            facts={
+                "verification_passed": True,
+                "acceptance_criteria_satisfied": True,
+                "reconciliation_passed": True,
+            },
+        )
+
+        self.assertEqual(result.task_envelope["status"], "completed")
+        self.assertEqual(result.task_envelope["timestamps"]["completed_at"], "2026-03-25T12:41:00Z")
+        self.assertEqual(result.task_envelope["status_history"][-1]["from_status"], "blocked")
+        self.assertEqual(result.task_envelope["status_history"][-1]["to_status"], "completed")
+
     def test_blocked_to_planned_rejects_unresolved_clarification(self) -> None:
         task = _base_task()
         task["status"] = "blocked"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,12 +4,20 @@ import json
 import tempfile
 import threading
 import unittest
+from copy import deepcopy
 from dataclasses import asdict, is_dataclass
 from enum import Enum
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from modules.api import HarnessApiService, evaluate_http_payload, run_server
+from modules.contracts.task_envelope_review import (
+    ReviewOutcome,
+    ReviewRequest,
+    ReviewTrigger,
+    ReviewerIdentity,
+    resolve_review_request,
+)
 from modules.demo_cases import build_demo_request
 from modules.store import FileBackedHarnessStore
 
@@ -28,6 +36,121 @@ def _to_jsonable(value):
 
 def _request_payload(case_name: str) -> dict:
     return {"request": _to_jsonable(build_demo_request(case_name))}
+
+
+def _review_note_artifact(artifact_id: str = "artifact-review-note-1") -> dict:
+    return {
+        "id": artifact_id,
+        "type": "review_note",
+        "title": "Manual evidence note",
+        "description": "Evidence was manually confirmed during reevaluation.",
+        "location": None,
+        "content_type": "text/plain",
+        "external_id": None,
+        "commit_sha": None,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "harness",
+            "source_type": "manual_review",
+            "source_id": f"review/{artifact_id}",
+            "captured_by": "operator",
+        },
+        "verification_status": "verified",
+        "repository": None,
+        "branch": None,
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-03-24T17:10:00Z",
+        "metadata": {},
+    }
+
+
+def _progress_artifact(artifact_id: str = "artifact-progress-1") -> dict:
+    return {
+        "id": artifact_id,
+        "type": "progress_artifact",
+        "title": "Progress snapshot",
+        "description": "Progress carried across reevaluations.",
+        "location": None,
+        "content_type": "application/json",
+        "external_id": None,
+        "commit_sha": None,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "codex",
+            "source_type": "executor_report",
+            "source_id": f"progress/{artifact_id}",
+            "captured_by": "harness-api",
+        },
+        "verification_status": "informational",
+        "repository": None,
+        "branch": None,
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-03-24T17:15:00Z",
+        "metadata": {
+            "completed_items": "2",
+            "remaining_items": "1",
+        },
+    }
+
+
+def _handoff_artifact(artifact_id: str = "artifact-handoff-1") -> dict:
+    return {
+        "id": artifact_id,
+        "type": "handoff_artifact",
+        "title": "Session handoff",
+        "description": "Resume from external reconciliation on the next session.",
+        "location": None,
+        "content_type": "application/json",
+        "external_id": None,
+        "commit_sha": None,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "codex",
+            "source_type": "executor_report",
+            "source_id": f"handoff/{artifact_id}",
+            "captured_by": "harness-api",
+        },
+        "verification_status": "informational",
+        "repository": None,
+        "branch": None,
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-03-24T17:20:00Z",
+        "metadata": {
+            "from_session_id": "session-1",
+            "resume_hint": "Continue verification after the next sync.",
+        },
+    }
+
+
+def _review_decision_payload(task_id: str) -> dict:
+    review_request = ReviewRequest(
+        review_request_id="review-request-api-1",
+        task_id=task_id,
+        requested_at="2026-03-24T17:30:00Z",
+        requested_by="verification",
+        trigger=ReviewTrigger.VERIFICATION,
+        summary="Manual confirmation is required before completion can be accepted.",
+        presented_sections=("task_state", "evidence", "reconciliation"),
+        allowed_outcomes=(ReviewOutcome.ACCEPT_COMPLETION,),
+    )
+    review_decision = resolve_review_request(
+        review_request,
+        review_id="review-api-1",
+        reviewer=ReviewerIdentity(
+            reviewer_id="operator-1",
+            reviewer_name="Casey Reviewer",
+            authority_role="operator",
+        ),
+        outcome=ReviewOutcome.ACCEPT_COMPLETION,
+        reasoning="Additional evidence and manual review resolve the remaining uncertainty.",
+    )
+    return _to_jsonable(review_decision)
 
 
 class HarnessApiPayloadTests(unittest.TestCase):
@@ -82,6 +205,37 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertIn("not found", task_payload["error"].lower())
         self.assertEqual(history_status, 404)
         self.assertIn("not found", history_payload["error"].lower())
+
+    def test_service_can_reevaluate_existing_blocked_task_to_completed(self) -> None:
+        initial_payload = _request_payload("blocked_insufficient_evidence")
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+
+        reevaluation_payload = {
+            "request": {
+                "new_artifacts": [_review_note_artifact()],
+                "completion_evidence": {
+                    "validated_artifact_ids": [
+                        "artifact-pr-1",
+                        "artifact-commit-1",
+                        "artifact-review-note-1",
+                    ]
+                },
+                "external_facts": deepcopy(_request_payload("accepted_completion")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        }
+        reevaluation_status, reevaluation_response = self.service.reevaluate(
+            initial_response["task_envelope"]["id"],
+            reevaluation_payload,
+        )
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(initial_response["task_envelope"]["status"], "blocked")
+        self.assertEqual(reevaluation_status, 200)
+        self.assertEqual(reevaluation_response["task_envelope"]["status"], "completed")
+        self.assertEqual(reevaluation_response["action"], "transition_applied")
 
 
 class HarnessHttpApiTests(unittest.TestCase):
@@ -244,6 +398,203 @@ class HarnessHttpApiTests(unittest.TestCase):
         except HTTPError as error:
             self.assertEqual(error.code, 400)
             error.close()
+
+    def test_api_can_reevaluate_blocked_task_to_completed_when_new_evidence_arrives(self) -> None:
+        initial_payload = _request_payload("blocked_insufficient_evidence")
+        initial_status, initial_response = self._post_json("/evaluate", initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        reevaluation_payload = {
+            "request": {
+                "new_artifacts": [_review_note_artifact()],
+                "completion_evidence": {
+                    "validated_artifact_ids": [
+                        "artifact-pr-1",
+                        "artifact-commit-1",
+                        "artifact-review-note-1",
+                    ]
+                },
+                "external_facts": deepcopy(_request_payload("accepted_completion")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        }
+        reevaluation_status, reevaluation_response = self._post_json(
+            f"/tasks/{task_id}/reevaluate",
+            reevaluation_payload,
+        )
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(initial_response["task_envelope"]["status"], "blocked")
+        self.assertEqual(reevaluation_status, 200)
+        self.assertEqual(reevaluation_response["task_envelope"]["status"], "completed")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 2)
+
+    def test_api_can_reevaluate_completed_task_back_to_blocked_for_contradictory_facts(self) -> None:
+        initial_payload = _request_payload("accepted_completion")
+        initial_status, initial_response = self._post_json("/evaluate", initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        reevaluation_payload = {
+            "request": {
+                "external_facts": deepcopy(_request_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        }
+        reevaluation_status, reevaluation_response = self._post_json(
+            f"/tasks/{task_id}/reevaluate",
+            reevaluation_payload,
+        )
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(initial_response["task_envelope"]["status"], "completed")
+        self.assertEqual(reevaluation_status, 200)
+        self.assertEqual(reevaluation_response["task_envelope"]["status"], "blocked")
+        self.assertEqual(
+            reevaluation_response["enforcement_result"]["verification_result"]["outcome"],
+            "external_mismatch",
+        )
+
+    def test_api_can_reevaluate_review_required_path_to_completed_after_manual_review(self) -> None:
+        accepted_payload = _request_payload("accepted_completion")
+        initial_payload = {
+            "request": deepcopy(accepted_payload["request"]),
+        }
+        initial_payload["request"]["task_envelope"]["status"] = "blocked"
+        initial_payload["request"]["task_envelope"]["timestamps"]["completed_at"] = None
+        initial_payload["request"]["review_request"] = deepcopy(_request_payload("review_required")["request"]["review_request"])
+        initial_payload["request"]["review_request"]["task_id"] = initial_payload["request"]["task_envelope"]["id"]
+        initial_payload["request"]["external_facts"] = deepcopy(_request_payload("review_required")["request"]["external_facts"])
+
+        initial_status, initial_response = self._post_json("/evaluate", initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        reevaluation_payload = {
+            "request": {
+                "review_decision": _review_decision_payload(task_id),
+            }
+        }
+        reevaluation_status, reevaluation_response = self._post_json(
+            f"/tasks/{task_id}/reevaluate",
+            reevaluation_payload,
+        )
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(initial_response["action"], "review_required")
+        self.assertEqual(reevaluation_status, 200)
+        self.assertEqual(reevaluation_response["task_envelope"]["status"], "completed")
+        self.assertIn(reevaluation_response["action"], {"transition_applied", "follow_up_authorized"})
+
+    def test_api_can_reevaluate_pending_task_to_completed_when_external_facts_arrive(self) -> None:
+        initial_payload = _request_payload("accepted_completion")
+        initial_payload["request"]["external_facts"] = None
+
+        initial_status, initial_response = self._post_json("/evaluate", initial_payload)
+        task_id = initial_payload["request"]["task_envelope"]["id"]
+
+        reevaluation_payload = {
+            "request": {
+                "external_facts": deepcopy(_request_payload("accepted_completion")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        }
+        reevaluation_status, reevaluation_response = self._post_json(
+            f"/tasks/{task_id}/reevaluate",
+            reevaluation_payload,
+        )
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(initial_response["task_envelope"]["status"], "blocked")
+        self.assertEqual(
+            initial_response["enforcement_result"]["verification_result"]["outcome"],
+            "blocked_unresolved_conditions",
+        )
+        self.assertEqual(reevaluation_status, 200)
+        self.assertEqual(reevaluation_response["task_envelope"]["status"], "completed")
+
+    def test_api_appends_long_running_support_artifacts_across_reevaluations(self) -> None:
+        initial_payload = _request_payload("blocked_insufficient_evidence")
+        initial_status, initial_response = self._post_json("/evaluate", initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        first_reevaluation_status, _ = self._post_json(
+            f"/tasks/{task_id}/reevaluate",
+            {
+                "request": {
+                    "new_artifacts": [_progress_artifact()],
+                    "external_facts": deepcopy(initial_payload["request"]["external_facts"]),
+                    "claimed_completion": True,
+                    "acceptance_criteria_satisfied": True,
+                    "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+                }
+            },
+        )
+        second_reevaluation_status, _ = self._post_json(
+            f"/tasks/{task_id}/reevaluate",
+            {
+                "request": {
+                    "new_artifacts": [_handoff_artifact()],
+                    "external_facts": deepcopy(initial_payload["request"]["external_facts"]),
+                    "claimed_completion": True,
+                    "acceptance_criteria_satisfied": True,
+                    "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+                }
+            },
+        )
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        artifact_types = [item["type"] for item in task_payload["task"]["artifacts"]["items"]]
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(first_reevaluation_status, 200)
+        self.assertEqual(second_reevaluation_status, 200)
+        self.assertEqual(task_status, 200)
+        self.assertEqual(history_status, 200)
+        self.assertIn("progress_artifact", artifact_types)
+        self.assertIn("handoff_artifact", artifact_types)
+        self.assertEqual(len(history_payload["evaluations"]), 3)
+        self.assertEqual(
+            task_payload["task"]["artifacts"]["completion_evidence"]["validated_artifact_ids"],
+            ["artifact-pr-1", "artifact-commit-1"],
+        )
+
+    def test_api_rejects_invalid_reevaluation_without_corrupting_store_state(self) -> None:
+        initial_payload = _request_payload("accepted_completion")
+        initial_status, initial_response = self._post_json("/evaluate", initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+        before_task_status, before_task_payload = self._get_json(f"/tasks/{task_id}")
+        before_history_status, before_history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        invalid_status, invalid_payload = self._post_json(
+            f"/tasks/{task_id}/reevaluate",
+            {
+                "request": {
+                    "new_artifacts": [_review_note_artifact("artifact-pr-1")],
+                    "claimed_completion": True,
+                    "acceptance_criteria_satisfied": True,
+                }
+            },
+        )
+        after_task_status, after_task_payload = self._get_json(f"/tasks/{task_id}")
+        after_history_status, after_history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(before_task_status, 200)
+        self.assertEqual(before_history_status, 200)
+        self.assertEqual(invalid_status, 400)
+        self.assertTrue(invalid_payload["invalid_input"])
+        self.assertEqual(after_task_status, 200)
+        self.assertEqual(after_history_status, 200)
+        self.assertEqual(before_task_payload["task"], after_task_payload["task"])
+        self.assertEqual(before_history_payload["evaluations"], after_history_payload["evaluations"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a stored-task re-evaluation path that loads the latest TaskEnvelope snapshot, applies new normalized facts, appends new canonical artifacts, and reruns the existing evaluator
- expose `POST /tasks/<task_id>/reevaluate` through the HTTP API and persist both the updated task snapshot and a new append-only evaluation record on each valid re-evaluation
- preserve invalid-input safety so malformed re-evaluation requests do not mutate stored task state or evaluation history
- support long-running progress, plan, and handoff artifacts being added over time without turning them into completion evidence by default
- align lifecycle docs and enforcement so a previously blocked completion claim can later transition to `completed` when verification or manual review resolves the blocker

## Validation
- `.venv/bin/python -m unittest tests.contracts.test_task_envelope_lifecycle tests.test_api`
- `.venv/bin/python -m unittest discover -s tests`
