### PR TITLE
Add canonical ingress submission API

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,14 @@ python -m modules.api --host 127.0.0.1 --port 8000 --store-root .harness-store
 Then submit canonical evaluation requests to:
 
 - `GET /health`
+- `POST /tasks`
 - `POST /evaluate`
 - `POST /tasks/<task_id>/reevaluate`
 - `GET /tasks/<task_id>`
 - `GET /tasks/<task_id>/evaluations`
 
 The API accepts canonical `TaskEnvelope` input plus normalized external facts and returns structured evaluation results.
+`POST /tasks` is the canonical ingress submission path for new work. It creates a new persisted task record, runs the initial evaluation, and appends the first evaluation record. Duplicate task IDs are rejected with `409 Conflict`.
 Successful evaluations persist the current task snapshot and append an evaluation record under the configured store root.
 Re-evaluation requests load the latest stored task, append any new canonical artifacts, apply new normalized facts or review outcomes, and persist the next task snapshot plus a new evaluation record.
 It is a thin wrapper over the existing evaluator and store scaffolding, not a production service.

--- a/modules/api.py
+++ b/modules/api.py
@@ -42,6 +42,7 @@ from modules.evaluation import HarnessEvaluationRequest, evaluate_task_case
 from modules.store import (
     EvaluationRecord,
     FileBackedHarnessStore,
+    TaskEnvelopeAlreadyExistsError,
     TaskEnvelopeNotFoundError,
 )
 
@@ -381,6 +382,45 @@ class HarnessApiService:
             return self.store.put_task(task_envelope)
         return self.store.update_task(task_envelope)
 
+    def submit(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            request = parse_evaluation_request(payload)
+        except Exception as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        task_id = str(request.task_envelope["id"])
+        try:
+            self.store.get_task(task_id)
+            return HTTPStatus.CONFLICT, {
+                "error": f"Task {task_id!r} already exists; use reevaluate for existing tasks",
+                "duplicate_task_id": True,
+            }
+        except TaskEnvelopeNotFoundError:
+            pass
+
+        result = evaluate_task_case(request)
+        status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
+        response_payload = _to_jsonable(result)
+
+        if result.invalid_input:
+            return status, response_payload
+
+        try:
+            stored_task = self.store.create_task(result.task_envelope)
+        except TaskEnvelopeAlreadyExistsError as error:
+            return HTTPStatus.CONFLICT, {
+                "error": str(error),
+                "duplicate_task_id": True,
+            }
+
+        record = self.store.put_evaluation_record(request=request, result=result)
+        response_payload["task_envelope"] = _to_jsonable(stored_task)
+        response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        return status, response_payload
+
     def evaluate(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:
             request = parse_evaluation_request(payload)
@@ -491,7 +531,7 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         path_components = _task_path_components(self.path)
         request_path = urlparse(self.path).path
 
-        if request_path != "/evaluate" and not (
+        if request_path not in {"/evaluate", "/tasks"} and not (
             len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "reevaluate"
         ):
             self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
@@ -506,7 +546,9 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             return
 
         service = self.service or HarnessApiService()
-        if request_path == "/evaluate":
+        if request_path == "/tasks":
+            status, response_payload = service.submit(payload)
+        elif request_path == "/evaluate":
             status, response_payload = service.evaluate(payload)
         else:
             status, response_payload = service.reevaluate(path_components[1], payload)

--- a/modules/store.py
+++ b/modules/store.py
@@ -23,6 +23,10 @@ class TaskEnvelopeNotFoundError(StoreError):
     """Raised when a requested TaskEnvelope does not exist in the store."""
 
 
+class TaskEnvelopeAlreadyExistsError(StoreError):
+    """Raised when a task create is attempted with an existing TaskEnvelope id."""
+
+
 class EvaluationRecordNotFoundError(StoreError):
     """Raised when a requested evaluation record does not exist in the store."""
 
@@ -56,6 +60,8 @@ class EvaluationRecord:
 
 class TaskEnvelopeStore(Protocol):
     """Storage boundary for canonical TaskEnvelope records."""
+
+    def create_task(self, task_envelope: TaskEnvelope) -> TaskEnvelope: ...
 
     def put_task(self, task_envelope: TaskEnvelope) -> TaskEnvelope: ...
 
@@ -112,6 +118,14 @@ class FileBackedHarnessStore(TaskEnvelopeStore, EvaluationRecordStore):
     def put_task(self, task_envelope: TaskEnvelope) -> TaskEnvelope:
         task_id = str(task_envelope["id"])
         self._write_json(self._task_path(task_id), _jsonable(task_envelope))
+        return task_envelope
+
+    def create_task(self, task_envelope: TaskEnvelope) -> TaskEnvelope:
+        task_id = str(task_envelope["id"])
+        path = self._task_path(task_id)
+        if path.exists():
+            raise TaskEnvelopeAlreadyExistsError(f"TaskEnvelope {task_id!r} already exists")
+        self._write_json(path, _jsonable(task_envelope))
         return task_envelope
 
     def get_task(self, task_id: str) -> TaskEnvelope:
@@ -172,6 +186,7 @@ __all__ = [
     "EvaluationRecordStore",
     "FileBackedHarnessStore",
     "StoreError",
+    "TaskEnvelopeAlreadyExistsError",
     "TaskEnvelopeNotFoundError",
     "TaskEnvelopeStore",
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -206,6 +206,30 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(history_status, 404)
         self.assertIn("not found", history_payload["error"].lower())
 
+    def test_service_submit_persists_new_task_and_initial_evaluation(self) -> None:
+        status, payload = self.service.submit(_request_payload("accepted_completion"))
+
+        task_status, task_payload = self.service.get_task(payload["task_envelope"]["id"])
+        history_status, history_payload = self.service.get_evaluation_history(payload["task_envelope"]["id"])
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task_envelope"]["status"], "completed")
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], "completed")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
+    def test_service_submit_rejects_duplicate_task_id(self) -> None:
+        initial_status, initial_payload = self.service.submit(_request_payload("accepted_completion"))
+        duplicate_status, duplicate_payload = self.service.submit(_request_payload("accepted_completion"))
+        history_status, history_payload = self.service.get_evaluation_history(initial_payload["task_envelope"]["id"])
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(duplicate_status, 409)
+        self.assertTrue(duplicate_payload["duplicate_task_id"])
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
     def test_service_can_reevaluate_existing_blocked_task_to_completed(self) -> None:
         initial_payload = _request_payload("blocked_insufficient_evidence")
         initial_status, initial_response = self.service.evaluate(initial_payload)
@@ -283,6 +307,72 @@ class HarnessHttpApiTests(unittest.TestCase):
 
         self.assertEqual(status, 200)
         self.assertEqual(payload["status"], "ok")
+
+    def test_api_submit_accepts_new_task_and_persists_initial_result(self) -> None:
+        status, payload = self._post_json("/tasks", _request_payload("accepted_completion"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task_envelope"]["status"], "completed")
+        self.assertIn("evaluation_record", payload)
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], "completed")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
+    def test_api_submit_can_persist_initial_blocked_result(self) -> None:
+        status, payload = self._post_json("/tasks", _request_payload("blocked_insufficient_evidence"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["target_status"], "blocked")
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], "blocked")
+
+    def test_api_submit_can_persist_initial_review_required_result(self) -> None:
+        status, payload = self._post_json("/tasks", _request_payload("review_required"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["action"], "review_required")
+        self.assertTrue(payload["requires_review"])
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["id"], task_id)
+        self.assertEqual(history_status, 200)
+        self.assertEqual(history_payload["evaluations"][0]["result"]["action"], "review_required")
+
+    def test_api_submit_rejects_invalid_input_without_persisting_state(self) -> None:
+        invalid_payload = _request_payload("invalid_input")
+        task_id = invalid_payload["request"]["task_envelope"]["id"]
+
+        status, payload = self._post_json("/tasks", invalid_payload)
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+
+        self.assertEqual(status, 400)
+        self.assertTrue(payload["invalid_input"])
+        self.assertEqual(task_status, 404)
+        self.assertIn("not found", task_payload["error"].lower())
+
+    def test_api_submit_rejects_duplicate_task_id_with_conflict(self) -> None:
+        initial_status, initial_payload = self._post_json("/tasks", _request_payload("accepted_completion"))
+        duplicate_status, duplicate_payload = self._post_json("/tasks", _request_payload("accepted_completion"))
+        history_status, history_payload = self._get_json(
+            f"/tasks/{initial_payload['task_envelope']['id']}/evaluations"
+        )
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(duplicate_status, 409)
+        self.assertTrue(duplicate_payload["duplicate_task_id"])
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
 
     def test_api_persists_accepted_completion_and_exposes_history(self) -> None:
         status, payload = self._post_json("/evaluate", _request_payload("accepted_completion"))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 from modules.demo_cases import build_demo_request
 from modules.evaluation import evaluate_task_case
-from modules.store import FileBackedHarnessStore, TaskEnvelopeNotFoundError
+from modules.store import (
+    FileBackedHarnessStore,
+    TaskEnvelopeAlreadyExistsError,
+    TaskEnvelopeNotFoundError,
+)
 
 
 class HarnessStoreTests(unittest.TestCase):
@@ -25,6 +29,14 @@ class HarnessStoreTests(unittest.TestCase):
 
         self.assertEqual(stored["id"], request.task_envelope["id"])
         self.assertEqual(stored["status"], request.task_envelope["status"])
+
+    def test_create_task_rejects_duplicate_id(self) -> None:
+        request = build_demo_request("accepted_completion")
+
+        self.store.create_task(request.task_envelope)
+
+        with self.assertRaises(TaskEnvelopeAlreadyExistsError):
+            self.store.create_task(request.task_envelope)
 
     def test_updates_task_after_lifecycle_change(self) -> None:
         request = build_demo_request("accepted_completion")


### PR DESCRIPTION
## Summary
- add `POST /tasks` as the canonical create-only ingress submission endpoint for new persisted TaskEnvelope records
- run the initial evaluation on submission, persist the resulting task snapshot, and append the first evaluation record on success
- keep submission distinct from re-evaluation of existing tasks, with duplicate task IDs rejected as `409 Conflict`
- extend store scaffolding with an explicit create path so duplicate-id behavior is enforced at the persistence boundary too
- document the submission endpoint and duplicate-id policy in the README

## Validation
- `.venv/bin/python -m unittest tests.test_api tests.test_store`
- `.venv/bin/python -m unittest discover -s tests`
