### PR TITLE
Implement Linear-shaped ingress adapter and example submission flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ python -m modules.api --host 127.0.0.1 --port 8000 --store-root .harness-store
 Then submit canonical evaluation requests to:
 
 - `GET /health`
+- `POST /ingress/linear`
 - `POST /tasks`
 - `POST /evaluate`
 - `POST /tasks/<task_id>/reevaluate`
@@ -231,6 +232,7 @@ Then submit canonical evaluation requests to:
 
 The API accepts canonical `TaskEnvelope` input plus normalized external facts and returns structured evaluation results.
 `POST /tasks` is the canonical ingress submission path for new work. It creates a new persisted task record, runs the initial evaluation, and appends the first evaluation record. Duplicate task IDs are rejected with `409 Conflict`.
+`POST /ingress/linear` is a thin example adapter that accepts a Linear-shaped issue payload, translates it into a canonical `TaskEnvelope` plus normalized `LinearFacts`, and then reuses the same `POST /tasks` submission path.
 Successful evaluations persist the current task snapshot and append an evaluation record under the configured store root.
 Re-evaluation requests load the latest stored task, append any new canonical artifacts, apply new normalized facts or review outcomes, and persist the next task snapshot plus a new evaluation record.
 It is a thin wrapper over the existing evaluator and store scaffolding, not a production service.

--- a/modules/api.py
+++ b/modules/api.py
@@ -13,6 +13,11 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import unquote, urlparse
 
+from modules.connectors import (
+    LinearConnectorInputError,
+    LinearIngressInputError,
+    translate_linear_submission_payload,
+)
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
 from modules.contracts.task_envelope_external_facts import (
     BranchFact,
@@ -421,6 +426,17 @@ class HarnessApiService:
         response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
+    def submit_linear_ingress(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            canonical_payload = translate_linear_submission_payload(payload)
+        except (LinearIngressInputError, LinearConnectorInputError, ValueError) as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        return self.submit(canonical_payload)
+
     def evaluate(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:
             request = parse_evaluation_request(payload)
@@ -531,7 +547,7 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         path_components = _task_path_components(self.path)
         request_path = urlparse(self.path).path
 
-        if request_path not in {"/evaluate", "/tasks"} and not (
+        if request_path not in {"/evaluate", "/tasks", "/ingress/linear"} and not (
             len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "reevaluate"
         ):
             self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
@@ -548,6 +564,8 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         service = self.service or HarnessApiService()
         if request_path == "/tasks":
             status, response_payload = service.submit(payload)
+        elif request_path == "/ingress/linear":
+            status, response_payload = service.submit_linear_ingress(payload)
         elif request_path == "/evaluate":
             status, response_payload = service.evaluate(payload)
         else:

--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -17,10 +17,15 @@ from .linear_facts import (
     translate_linear_task_reference,
     translate_linear_workflow,
 )
+from .linear_ingress import (
+    LinearIngressInputError,
+    translate_linear_submission_payload,
+)
 
 __all__ = [
     "GitHubConnectorInputError",
     "LinearConnectorInputError",
+    "LinearIngressInputError",
     "translate_github_artifact_facts",
     "translate_github_artifact_references",
     "translate_github_branch",
@@ -29,6 +34,7 @@ __all__ = [
     "translate_github_pull_request",
     "translate_github_repository",
     "translate_linear_facts",
+    "translate_linear_submission_payload",
     "translate_linear_project",
     "translate_linear_task_reference",
     "translate_linear_workflow",

--- a/modules/connectors/linear_ingress.py
+++ b/modules/connectors/linear_ingress.py
@@ -1,0 +1,243 @@
+"""Linear-shaped ingress adapter that translates upstream work items into canonical submission payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from typing import Any
+
+from modules.connectors.linear_facts import LinearConnectorInputError, translate_linear_facts
+from modules.intake.task_envelope import create_task_envelope
+
+
+class LinearIngressInputError(ValueError):
+    """Raised when a Linear-shaped ingress payload cannot be translated canonically."""
+
+
+def _require_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise LinearIngressInputError(f"{field_name} must be a mapping")
+    return payload
+
+
+def _optional_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any] | None:
+    if payload is None:
+        return None
+    return _require_mapping(payload, field_name=field_name)
+
+
+def _require_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise LinearIngressInputError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_string(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise LinearIngressInputError(f"{field_name} must be a string when provided")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _optional_mapping_list(value: Any, *, field_name: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise LinearIngressInputError(f"{field_name} must be a list of objects")
+
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        normalized.append(dict(_require_mapping(item, field_name=f"{field_name}[{index}]")))
+    return normalized
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _derive_task_id(payload: Mapping[str, Any], *, issue_id: str) -> str:
+    task_reference = _optional_mapping(payload.get("task_reference"), field_name="task_reference")
+    if task_reference is not None:
+        harness_task_id = _optional_string(task_reference.get("harness_task_id"), field_name="task_reference.harness_task_id")
+        if harness_task_id is not None:
+            return harness_task_id
+
+    explicit_task_id = _optional_string(payload.get("task_id"), field_name="task_id")
+    if explicit_task_id is not None:
+        return explicit_task_id
+    return f"linear-{issue_id}"
+
+
+def _normalize_priority(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    if isinstance(value, int):
+        mapping = {
+            0: "backlog",
+            1: "critical",
+            2: "high",
+            3: "normal",
+            4: "low",
+        }
+        if value not in mapping:
+            raise LinearIngressInputError("priority integer must be one of 0, 1, 2, 3, or 4")
+        return mapping[value]
+
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        aliases = {
+            "urgent": "critical",
+            "critical": "critical",
+            "high": "high",
+            "normal": "normal",
+            "medium": "normal",
+            "low": "low",
+            "backlog": "backlog",
+            "none": "backlog",
+        }
+        if normalized not in aliases:
+            raise LinearIngressInputError("priority string must map to a canonical Harness priority")
+        return aliases[normalized]
+
+    raise LinearIngressInputError("priority must be a string, integer, or null")
+
+
+def _default_acceptance_criteria(issue_identifier: str | None) -> list[dict[str, Any]]:
+    ref = issue_identifier or "the upstream work item"
+    return [
+        {
+            "id": "linear-work-verified",
+            "description": f"Harness can verify completion for {ref} using artifacts and reconciled external facts.",
+            "required": True,
+        }
+    ]
+
+
+def _build_task_envelope(payload: Mapping[str, Any]) -> dict[str, Any]:
+    issue_payload = _require_mapping(payload.get("issue"), field_name="issue")
+    issue_id = _require_string(issue_payload.get("id"), field_name="issue.id")
+    issue_title = _require_string(issue_payload.get("title"), field_name="issue.title")
+    issue_description = _require_string(issue_payload.get("description"), field_name="issue.description")
+    issue_identifier = _optional_string(
+        issue_payload.get("identifier") or issue_payload.get("key") or issue_payload.get("issueKey"),
+        field_name="issue.identifier",
+    )
+
+    intake_input: dict[str, Any] = {
+        "id": _derive_task_id(payload, issue_id=issue_id),
+        "title": issue_title,
+        "description": issue_description,
+        "origin": {
+            "source_system": "linear",
+            "source_type": "synchronization",
+            "source_id": issue_id,
+            "ingress_name": "Linear",
+            "ingress_id": issue_identifier,
+            "requested_by": _optional_string(payload.get("requested_by"), field_name="requested_by"),
+        },
+        "objective": payload.get("objective"),
+        "constraints": payload.get("constraints"),
+        "acceptance_criteria": payload.get("acceptance_criteria") or _default_acceptance_criteria(issue_identifier),
+    }
+
+    task_envelope = create_task_envelope(intake_input)
+
+    task_status = _optional_string(payload.get("task_status"), field_name="task_status")
+    if task_status is not None:
+        task_envelope["status"] = task_status
+        if task_status == "completed":
+            task_envelope["timestamps"]["completed_at"] = task_envelope["timestamps"]["updated_at"]
+
+    assigned_executor = _optional_mapping(payload.get("assigned_executor"), field_name="assigned_executor")
+    if assigned_executor is not None:
+        task_envelope["assigned_executor"] = dict(assigned_executor)
+
+    priority = _normalize_priority(payload.get("priority"))
+    if priority is not None:
+        task_envelope["priority"] = priority
+
+    linked_artifacts = _optional_mapping_list(payload.get("linked_artifacts"), field_name="linked_artifacts")
+    if linked_artifacts:
+        task_envelope["artifacts"]["items"] = deepcopy(linked_artifacts)
+
+    completion_evidence = _optional_mapping(payload.get("completion_evidence"), field_name="completion_evidence")
+    if completion_evidence is not None:
+        task_envelope["artifacts"]["completion_evidence"].update(dict(completion_evidence))
+
+    labels = payload.get("labels")
+    if labels is not None:
+        if not isinstance(labels, list) or not all(isinstance(label, str) and label.strip() for label in labels):
+            raise LinearIngressInputError("labels must be a list of non-empty strings")
+        labels = [label.strip() for label in labels]
+    else:
+        labels = []
+
+    task_envelope["extensions"] = {
+        "linear": {
+            "issue_id": issue_id,
+            "issue_identifier": issue_identifier,
+            "labels": labels,
+            "project": _to_jsonable(payload.get("project")),
+            "state": _to_jsonable(payload.get("state") or payload.get("status")),
+            "task_reference": _to_jsonable(payload.get("task_reference")),
+            "metadata": _to_jsonable(payload.get("metadata", {})),
+        }
+    }
+
+    return task_envelope
+
+
+def translate_linear_submission_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate a Linear-shaped ingress payload into the canonical POST /tasks request body."""
+
+    payload = _require_mapping(payload, field_name="linear_ingress_payload")
+    task_envelope = _build_task_envelope(payload)
+    linear_facts = translate_linear_facts(payload)
+
+    external_facts_payload = _optional_mapping(payload.get("external_facts"), field_name="external_facts")
+    canonical_external_facts = (
+        {str(key): _to_jsonable(value) for key, value in external_facts_payload.items()}
+        if external_facts_payload is not None
+        else {}
+    )
+    canonical_external_facts["linear_facts"] = _to_jsonable(linear_facts)
+
+    request_payload: dict[str, Any] = {
+        "task_envelope": task_envelope,
+        "external_facts": canonical_external_facts,
+        "claimed_completion": bool(payload.get("claimed_completion", False)),
+        "acceptance_criteria_satisfied": bool(payload.get("acceptance_criteria_satisfied", False)),
+    }
+
+    runtime_facts = _optional_mapping(payload.get("runtime_facts"), field_name="runtime_facts")
+    if runtime_facts is not None:
+        request_payload["runtime_facts"] = dict(runtime_facts)
+
+    unresolved_conditions = payload.get("unresolved_conditions")
+    if unresolved_conditions is not None:
+        if not isinstance(unresolved_conditions, list) or not all(
+            isinstance(item, str) and item.strip() for item in unresolved_conditions
+        ):
+            raise LinearIngressInputError("unresolved_conditions must be a list of non-empty strings")
+        request_payload["unresolved_conditions"] = [item.strip() for item in unresolved_conditions]
+
+    return {"request": request_payload}
+
+
+__all__ = [
+    "LinearIngressInputError",
+    "translate_linear_submission_payload",
+]

--- a/tests/connectors/test_linear_ingress.py
+++ b/tests/connectors/test_linear_ingress.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import unittest
+from copy import deepcopy
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+
+from modules.connectors import LinearIngressInputError, translate_linear_submission_payload
+from modules.demo_cases import build_demo_request
+
+
+def _to_jsonable(value):
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _linear_ingress_payload() -> dict:
+    canonical_request = build_demo_request("accepted_completion")
+    task = deepcopy(canonical_request.task_envelope)
+    external_facts = deepcopy(canonical_request.external_facts)
+
+    return {
+        "issue": {
+            "id": "lin-ingress-1",
+            "identifier": "HAR-901",
+            "title": task["title"],
+            "description": task["description"],
+        },
+        "state": {
+            "id": "workflow_done",
+            "name": "completed",
+            "type": "completed",
+        },
+        "project": {
+            "id": "project-harness",
+            "name": "Harness",
+        },
+        "task_reference": {
+            "harness_task_id": "task-linear-ingress-1",
+            "external_ref": "HAR-901",
+        },
+        "labels": ["feature", "ai-workflow"],
+        "priority": "high",
+        "task_status": task["status"],
+        "assigned_executor": deepcopy(task["assigned_executor"]),
+        "acceptance_criteria": deepcopy(task["acceptance_criteria"]),
+        "linked_artifacts": deepcopy(task["artifacts"]["items"]),
+        "completion_evidence": deepcopy(task["artifacts"]["completion_evidence"]),
+        "external_facts": {
+            "expected_code_context": deepcopy(external_facts.expected_code_context),
+            "github_facts": deepcopy(external_facts.github_facts),
+        },
+        "claimed_completion": True,
+        "acceptance_criteria_satisfied": True,
+        "runtime_facts": _to_jsonable(canonical_request.runtime_facts),
+    }
+
+
+class LinearIngressTranslationTests(unittest.TestCase):
+    def test_translates_linear_payload_into_canonical_submission_request(self) -> None:
+        submission_payload = translate_linear_submission_payload(_linear_ingress_payload())
+
+        task = submission_payload["request"]["task_envelope"]
+        linear_facts = submission_payload["request"]["external_facts"]["linear_facts"]
+
+        self.assertEqual(task["id"], "task-linear-ingress-1")
+        self.assertEqual(task["origin"]["source_system"], "linear")
+        self.assertEqual(task["origin"]["source_id"], "lin-ingress-1")
+        self.assertEqual(task["priority"], "high")
+        self.assertEqual(task["extensions"]["linear"]["issue_identifier"], "HAR-901")
+        self.assertEqual(len(task["artifacts"]["items"]), 2)
+        self.assertEqual(linear_facts["issue_id"], "lin-ingress-1")
+        self.assertEqual(linear_facts["issue_key"], "HAR-901")
+        self.assertEqual(linear_facts["state"], "completed")
+        self.assertEqual(linear_facts["task_reference"]["harness_task_id"], "task-linear-ingress-1")
+
+    def test_rejects_missing_required_issue_fields(self) -> None:
+        payload = _linear_ingress_payload()
+        del payload["issue"]["title"]
+
+        with self.assertRaises(LinearIngressInputError):
+            translate_linear_submission_payload(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,61 @@ def _request_payload(case_name: str) -> dict:
     return {"request": _to_jsonable(build_demo_request(case_name))}
 
 
+def _linear_ingress_payload(case_name: str, *, task_id: str | None = None) -> dict:
+    canonical_request = _request_payload(case_name)["request"]
+    task = deepcopy(canonical_request["task_envelope"])
+    external_facts = deepcopy(canonical_request.get("external_facts") or {})
+
+    payload = {
+        "issue": {
+            "id": f"lin-{task['id']}",
+            "identifier": f"HAR-{task['id']}",
+            "title": task["title"],
+            "description": task["description"],
+        },
+        "state": {
+            "id": "workflow_in_progress" if case_name == "accepted_completion" else "workflow_completed",
+            "name": "in_progress" if case_name == "accepted_completion" else "completed",
+            "type": "started" if case_name == "accepted_completion" else "completed",
+        },
+        "project": {
+            "id": "project-harness",
+            "name": "Harness",
+        },
+        "task_reference": {
+            "harness_task_id": task_id or task["id"],
+            "external_ref": f"HAR-{task['id']}",
+        },
+        "labels": ["linear", "ingress"],
+        "priority": task.get("priority", "normal"),
+        "task_status": task["status"],
+        "acceptance_criteria": deepcopy(task["acceptance_criteria"]),
+        "linked_artifacts": deepcopy(task["artifacts"]["items"]),
+        "completion_evidence": deepcopy(task["artifacts"]["completion_evidence"]),
+        "external_facts": {},
+        "claimed_completion": canonical_request.get("claimed_completion", False),
+        "acceptance_criteria_satisfied": canonical_request.get("acceptance_criteria_satisfied", False),
+        "runtime_facts": _to_jsonable(canonical_request.get("runtime_facts") or {}),
+    }
+
+    if task.get("assigned_executor") is not None:
+        payload["assigned_executor"] = deepcopy(task["assigned_executor"])
+
+    if external_facts.get("expected_code_context") is not None:
+        payload["external_facts"]["expected_code_context"] = deepcopy(external_facts["expected_code_context"])
+    if external_facts.get("github_facts") is not None:
+        payload["external_facts"]["github_facts"] = deepcopy(external_facts["github_facts"])
+
+    if case_name == "review_required":
+        payload["state"] = {
+            "id": "workflow_in_progress",
+            "name": "in_progress",
+            "type": "started",
+        }
+
+    return payload
+
+
 def _review_note_artifact(artifact_id: str = "artifact-review-note-1") -> dict:
     return {
         "id": artifact_id,
@@ -230,6 +285,20 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history_payload["evaluations"]), 1)
 
+    def test_service_can_submit_linear_ingress_payload_via_canonical_submission_path(self) -> None:
+        status, payload = self.service.submit_linear_ingress(_linear_ingress_payload("accepted_completion"))
+
+        task_status, task_payload = self.service.get_task(payload["task_envelope"]["id"])
+        history_status, history_payload = self.service.get_evaluation_history(payload["task_envelope"]["id"])
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task_envelope"]["origin"]["source_system"], "linear")
+        self.assertEqual(payload["task_envelope"]["status"], "completed")
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["extensions"]["linear"]["issue_id"], f"lin-{payload['task_envelope']['id']}")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
     def test_service_can_reevaluate_existing_blocked_task_to_completed(self) -> None:
         initial_payload = _request_payload("blocked_insufficient_evidence")
         initial_status, initial_response = self.service.evaluate(initial_payload)
@@ -367,6 +436,57 @@ class HarnessHttpApiTests(unittest.TestCase):
         history_status, history_payload = self._get_json(
             f"/tasks/{initial_payload['task_envelope']['id']}/evaluations"
         )
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(duplicate_status, 409)
+        self.assertTrue(duplicate_payload["duplicate_task_id"])
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
+    def test_api_linear_ingress_can_submit_accepted_task(self) -> None:
+        status, payload = self._post_json("/ingress/linear", _linear_ingress_payload("accepted_completion"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task_envelope"]["origin"]["source_system"], "linear")
+        self.assertEqual(payload["task_envelope"]["status"], "completed")
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["extensions"]["linear"]["issue_id"], f"lin-{task_id}")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
+    def test_api_linear_ingress_can_submit_initial_blocked_task(self) -> None:
+        status, payload = self._post_json("/ingress/linear", _linear_ingress_payload("blocked_insufficient_evidence"))
+        task_id = payload["task_envelope"]["id"]
+
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["target_status"], "blocked")
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["status"], "blocked")
+
+    def test_api_linear_ingress_rejects_invalid_payload_without_persisting_state(self) -> None:
+        payload = _linear_ingress_payload("accepted_completion", task_id="task-linear-invalid-1")
+        del payload["issue"]["title"]
+
+        status, response_payload = self._post_json("/ingress/linear", payload)
+        task_status, task_payload = self._get_json("/tasks/task-linear-invalid-1")
+
+        self.assertEqual(status, 400)
+        self.assertTrue(response_payload["invalid_input"])
+        self.assertEqual(task_status, 404)
+        self.assertIn("not found", task_payload["error"].lower())
+
+    def test_api_linear_ingress_rejects_duplicate_task_id_consistently(self) -> None:
+        payload = _linear_ingress_payload("accepted_completion", task_id="task-linear-duplicate-1")
+
+        initial_status, _ = self._post_json("/ingress/linear", payload)
+        duplicate_status, duplicate_payload = self._post_json("/ingress/linear", payload)
+        history_status, history_payload = self._get_json("/tasks/task-linear-duplicate-1/evaluations")
 
         self.assertEqual(initial_status, 200)
         self.assertEqual(duplicate_status, 409)


### PR DESCRIPTION
## Summary
- add a Linear-shaped ingress adapter that translates issue/workflow/project/task-reference payloads into a canonical `TaskEnvelope` plus normalized `LinearFacts`
- add `POST /ingress/linear` as a thin API wrapper that reuses the existing canonical `POST /tasks` submission path
- add translation and API tests covering accepted submission, blocked submission, invalid payload rejection, and duplicate-ID handling

## Validation
- `.venv/bin/python -m unittest tests.connectors.test_linear_ingress tests.test_api`
- `.venv/bin/python -m unittest discover -s tests`
- `python3 -m py_compile modules/connectors/linear_ingress.py modules/api.py`

## Notes
- the adapter stays connector-neutral on the policy side by translating Linear-shaped input before evaluation/persistence logic runs
- duplicate task IDs still return `409 Conflict` because the adapter delegates to the canonical submission path rather than bypassing it