### PR TITLE
Implement OpenClaw-style ingress simulator for Harness API

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,26 @@ python -m modules.cli run blocked_reconciliation_mismatch --json
 The CLI uses canonical `TaskEnvelope` fixtures plus normalized GitHub/Linear fact bundles.
 It does not call live external APIs.
 
+## OpenClaw-Style Simulator
+
+You can also run a lightweight ingress simulator against the public Harness API.
+
+Start the API first:
+
+```bash
+python -m modules.api --host 127.0.0.1 --port 8000 --store-root .harness-store
+```
+
+Then run simulator scenarios such as:
+
+```bash
+python -m modules.simulator list
+python -m modules.simulator --base-url http://127.0.0.1:8000 run successful_completion
+python -m modules.simulator --base-url http://127.0.0.1:8000 run long_running_handoff --json
+```
+
+The simulator is entirely client-side. It uses only the public HTTP API to submit tasks, reevaluate tasks, and inspect persisted state over time.
+
 ## Local HTTP API
 
 You can also run a minimal local HTTP wrapper around the same evaluation entry point:

--- a/modules/simulator.py
+++ b/modules/simulator.py
@@ -1,0 +1,556 @@
+"""OpenClaw-style ingress simulator that exercises the public Harness HTTP API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from copy import deepcopy
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from modules.contracts.task_envelope_review import (
+    ReviewOutcome,
+    ReviewRequest,
+    ReviewTrigger,
+    ReviewerIdentity,
+    resolve_review_request,
+)
+from modules.demo_cases import build_demo_request
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _canonical_payload(case_name: str) -> dict[str, Any]:
+    return {"request": _to_jsonable(build_demo_request(case_name))}
+
+
+def _review_note_artifact(artifact_id: str = "artifact-review-note-sim-1") -> dict[str, Any]:
+    return {
+        "id": artifact_id,
+        "type": "review_note",
+        "title": "Manual evidence note",
+        "description": "The missing evidence was confirmed during simulator re-evaluation.",
+        "location": None,
+        "content_type": "text/plain",
+        "external_id": None,
+        "commit_sha": None,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "harness",
+            "source_type": "manual_review",
+            "source_id": f"review/{artifact_id}",
+            "captured_by": "openclaw-simulator",
+        },
+        "verification_status": "verified",
+        "repository": None,
+        "branch": None,
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-03-25T12:00:00Z",
+        "metadata": {},
+    }
+
+
+def _progress_artifact(artifact_id: str = "artifact-progress-sim-1") -> dict[str, Any]:
+    return {
+        "id": artifact_id,
+        "type": "progress_artifact",
+        "title": "Progress update",
+        "description": "The worker reports incremental progress before completion evidence is ready.",
+        "location": None,
+        "content_type": "application/json",
+        "external_id": None,
+        "commit_sha": None,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "codex",
+            "source_type": "executor_report",
+            "source_id": f"progress/{artifact_id}",
+            "captured_by": "openclaw-simulator",
+        },
+        "verification_status": "informational",
+        "repository": None,
+        "branch": None,
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-03-25T12:05:00Z",
+        "metadata": {
+            "completed_items": "2",
+            "remaining_items": "1",
+        },
+    }
+
+
+def _handoff_artifact(artifact_id: str = "artifact-handoff-sim-1") -> dict[str, Any]:
+    return {
+        "id": artifact_id,
+        "type": "handoff_artifact",
+        "title": "Session handoff",
+        "description": "The task is being handed off across sessions before verification can complete.",
+        "location": None,
+        "content_type": "application/json",
+        "external_id": None,
+        "commit_sha": None,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "codex",
+            "source_type": "executor_report",
+            "source_id": f"handoff/{artifact_id}",
+            "captured_by": "openclaw-simulator",
+        },
+        "verification_status": "informational",
+        "repository": None,
+        "branch": None,
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-03-25T12:10:00Z",
+        "metadata": {
+            "resume_hint": "Continue after artifact sync completes.",
+        },
+    }
+
+
+@dataclass(frozen=True)
+class SimulationStepResult:
+    """One recorded API interaction in a simulator scenario."""
+
+    name: str
+    method: str
+    path: str
+    http_status: int
+    action: str | None
+    target_status: str | None
+    task_status: str | None
+    task_id: str | None
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    """Structured result for one end-to-end simulator scenario."""
+
+    scenario_name: str
+    final_task_id: str | None
+    final_task_status: str | None
+    steps: tuple[SimulationStepResult, ...]
+    task_snapshot: dict[str, Any] | None
+    evaluation_history: tuple[dict[str, Any], ...]
+
+
+class HarnessSimulatorClient:
+    """Thin HTTP client that uses only the public Harness API surface."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def _request_json(self, method: str, path: str, payload: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
+        data = None
+        headers = {}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = Request(self.base_url + path, data=data, headers=headers, method=method)
+        try:
+            with urlopen(request) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            try:
+                return error.code, json.loads(error.read().decode("utf-8"))
+            finally:
+                error.close()
+
+    def submit_task(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", "/tasks", payload)
+
+    def reevaluate_task(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", f"/tasks/{task_id}/reevaluate", payload)
+
+    def get_task(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/tasks/{task_id}")
+
+    def get_evaluation_history(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/tasks/{task_id}/evaluations")
+
+
+class _ScenarioContext:
+    def __init__(self) -> None:
+        self.task_id: str | None = None
+        self.steps: list[SimulationStepResult] = []
+
+    def record(self, *, name: str, method: str, path: str, http_status: int, payload: dict[str, Any]) -> dict[str, Any]:
+        task_envelope = payload.get("task_envelope")
+        task_id = payload.get("task_envelope", {}).get("id") if isinstance(task_envelope, dict) else None
+        if task_id is None and "task" in payload and isinstance(payload["task"], dict):
+            task_id = payload["task"].get("id")
+        if task_id is None and "task_id" in payload:
+            task_id = payload.get("task_id")
+        if task_id is not None:
+            self.task_id = str(task_id)
+
+        self.steps.append(
+            SimulationStepResult(
+                name=name,
+                method=method,
+                path=path,
+                http_status=http_status,
+                action=payload.get("action"),
+                target_status=payload.get("target_status"),
+                task_status=(task_envelope or payload.get("task") or {}).get("status")
+                if isinstance(task_envelope or payload.get("task"), dict)
+                else None,
+                task_id=self.task_id,
+                payload=payload,
+            )
+        )
+        return payload
+
+
+def _submit_step(client: HarnessSimulatorClient, context: _ScenarioContext, name: str, payload: dict[str, Any]) -> dict[str, Any]:
+    status, response_payload = client.submit_task(payload)
+    return context.record(name=name, method="POST", path="/tasks", http_status=status, payload=response_payload)
+
+
+def _reevaluate_step(
+    client: HarnessSimulatorClient,
+    context: _ScenarioContext,
+    name: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    if context.task_id is None:
+        raise ValueError("task_id is required before reevaluation")
+    path = f"/tasks/{context.task_id}/reevaluate"
+    status, response_payload = client.reevaluate_task(context.task_id, payload)
+    return context.record(name=name, method="POST", path=path, http_status=status, payload=response_payload)
+
+
+def _fetch_final_state(client: HarnessSimulatorClient, context: _ScenarioContext) -> tuple[dict[str, Any] | None, tuple[dict[str, Any], ...]]:
+    if context.task_id is None:
+        return None, ()
+
+    _, task_payload = client.get_task(context.task_id)
+    _, history_payload = client.get_evaluation_history(context.task_id)
+    return task_payload.get("task"), tuple(history_payload.get("evaluations", ()))
+
+
+def _review_request_payload(task_id: str) -> dict[str, Any]:
+    request = ReviewRequest(
+        review_request_id="review-request-sim-1",
+        task_id=task_id,
+        requested_at="2026-03-25T12:15:00Z",
+        requested_by="verification",
+        trigger=ReviewTrigger.RECONCILIATION,
+        summary="Manual review is required before completion can be accepted.",
+        presented_sections=("task_state", "evidence", "reconciliation"),
+        allowed_outcomes=(ReviewOutcome.ACCEPT_COMPLETION, ReviewOutcome.KEEP_BLOCKED),
+    )
+    return _to_jsonable(request)
+
+
+def _review_decision_payload(task_id: str) -> dict[str, Any]:
+    request = ReviewRequest(
+        review_request_id="review-request-sim-1",
+        task_id=task_id,
+        requested_at="2026-03-25T12:15:00Z",
+        requested_by="verification",
+        trigger=ReviewTrigger.RECONCILIATION,
+        summary="Manual review is required before completion can be accepted.",
+        presented_sections=("task_state", "evidence", "reconciliation"),
+        allowed_outcomes=(ReviewOutcome.ACCEPT_COMPLETION,),
+    )
+    decision = resolve_review_request(
+        request,
+        review_id="review-sim-1",
+        reviewer=ReviewerIdentity(
+            reviewer_id="operator-1",
+            reviewer_name="Simulator Reviewer",
+            authority_role="operator",
+        ),
+        outcome=ReviewOutcome.ACCEPT_COMPLETION,
+        reasoning="The reviewed facts support accepted completion.",
+    )
+    return _to_jsonable(decision)
+
+
+def _scenario_successful_completion(client: HarnessSimulatorClient) -> SimulationResult:
+    context = _ScenarioContext()
+    _submit_step(client, context, "submit", _canonical_payload("accepted_completion"))
+    task_snapshot, history = _fetch_final_state(client, context)
+    return SimulationResult("successful_completion", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
+
+
+def _scenario_missing_evidence_then_completed(client: HarnessSimulatorClient) -> SimulationResult:
+    context = _ScenarioContext()
+    initial_payload = _canonical_payload("blocked_insufficient_evidence")
+    _submit_step(client, context, "submit", initial_payload)
+    _reevaluate_step(
+        client,
+        context,
+        "provide_missing_evidence",
+        {
+            "request": {
+                "new_artifacts": [_review_note_artifact()],
+                "completion_evidence": {
+                    "validated_artifact_ids": [
+                        "artifact-pr-1",
+                        "artifact-commit-1",
+                        "artifact-review-note-sim-1",
+                    ]
+                },
+                "external_facts": deepcopy(_canonical_payload("accepted_completion")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        },
+    )
+    task_snapshot, history = _fetch_final_state(client, context)
+    return SimulationResult("missing_evidence_then_completed", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
+
+
+def _scenario_wrong_target_corrected(client: HarnessSimulatorClient) -> SimulationResult:
+    context = _ScenarioContext()
+    initial_payload = _canonical_payload("accepted_completion")
+    wrong_target_payload = deepcopy(initial_payload)
+    wrong_target_payload["request"]["external_facts"]["github_facts"]["branch"]["name"] = "codex/wrong-target"
+
+    _submit_step(client, context, "submit", wrong_target_payload)
+    _reevaluate_step(
+        client,
+        context,
+        "correct_artifact_target",
+        {
+            "request": {
+                "external_facts": deepcopy(initial_payload["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        },
+    )
+    task_snapshot, history = _fetch_final_state(client, context)
+    return SimulationResult("wrong_target_corrected", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
+
+
+def _scenario_review_required_then_completed(client: HarnessSimulatorClient) -> SimulationResult:
+    context = _ScenarioContext()
+    accepted_payload = _canonical_payload("accepted_completion")
+    review_payload = {
+        "request": deepcopy(accepted_payload["request"]),
+    }
+    review_payload["request"]["task_envelope"]["status"] = "blocked"
+    review_payload["request"]["task_envelope"]["timestamps"]["completed_at"] = None
+    review_payload["request"]["review_request"] = _review_request_payload(review_payload["request"]["task_envelope"]["id"])
+    review_payload["request"]["external_facts"] = deepcopy(_canonical_payload("review_required")["request"]["external_facts"])
+
+    _submit_step(client, context, "submit", review_payload)
+    _reevaluate_step(
+        client,
+        context,
+        "resolve_review",
+        {
+            "request": {
+                "review_decision": _review_decision_payload(context.task_id or review_payload["request"]["task_envelope"]["id"]),
+            }
+        },
+    )
+    task_snapshot, history = _fetch_final_state(client, context)
+    return SimulationResult("review_required_then_completed", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
+
+
+def _scenario_contradictory_facts_rollback(client: HarnessSimulatorClient) -> SimulationResult:
+    context = _ScenarioContext()
+    accepted_payload = _canonical_payload("accepted_completion")
+    _submit_step(client, context, "submit", accepted_payload)
+    _reevaluate_step(
+        client,
+        context,
+        "introduce_contradictory_facts",
+        {
+            "request": {
+                "external_facts": deepcopy(_canonical_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(accepted_payload["request"]["runtime_facts"]),
+            }
+        },
+    )
+    _reevaluate_step(
+        client,
+        context,
+        "resolve_contradiction",
+        {
+            "request": {
+                "external_facts": deepcopy(accepted_payload["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(accepted_payload["request"]["runtime_facts"]),
+            }
+        },
+    )
+    task_snapshot, history = _fetch_final_state(client, context)
+    return SimulationResult("contradictory_facts_rollback", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
+
+
+def _scenario_long_running_handoff(client: HarnessSimulatorClient) -> SimulationResult:
+    context = _ScenarioContext()
+    initial_payload = _canonical_payload("blocked_insufficient_evidence")
+    _submit_step(client, context, "submit", initial_payload)
+    _reevaluate_step(
+        client,
+        context,
+        "append_progress_artifact",
+        {
+            "request": {
+                "new_artifacts": [_progress_artifact()],
+                "external_facts": deepcopy(initial_payload["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        },
+    )
+    _reevaluate_step(
+        client,
+        context,
+        "append_handoff_artifact",
+        {
+            "request": {
+                "new_artifacts": [_handoff_artifact()],
+                "external_facts": deepcopy(initial_payload["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        },
+    )
+    _reevaluate_step(
+        client,
+        context,
+        "complete_after_handoff",
+        {
+            "request": {
+                "new_artifacts": [_review_note_artifact()],
+                "completion_evidence": {
+                    "validated_artifact_ids": [
+                        "artifact-pr-1",
+                        "artifact-commit-1",
+                        "artifact-review-note-sim-1",
+                    ]
+                },
+                "external_facts": deepcopy(_canonical_payload("accepted_completion")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        },
+    )
+    task_snapshot, history = _fetch_final_state(client, context)
+    return SimulationResult("long_running_handoff", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
+
+
+_SCENARIOS = {
+    "successful_completion": _scenario_successful_completion,
+    "missing_evidence_then_completed": _scenario_missing_evidence_then_completed,
+    "wrong_target_corrected": _scenario_wrong_target_corrected,
+    "review_required_then_completed": _scenario_review_required_then_completed,
+    "contradictory_facts_rollback": _scenario_contradictory_facts_rollback,
+    "long_running_handoff": _scenario_long_running_handoff,
+}
+
+
+def list_scenarios() -> tuple[str, ...]:
+    """Return the supported OpenClaw-style simulator scenarios."""
+
+    return tuple(_SCENARIOS.keys())
+
+
+def run_scenario(scenario_name: str, *, base_url: str = "http://127.0.0.1:8000") -> SimulationResult:
+    """Run one simulator scenario entirely through the public Harness HTTP API."""
+
+    if scenario_name not in _SCENARIOS:
+        raise ValueError(f"Unknown simulator scenario {scenario_name!r}")
+    return _SCENARIOS[scenario_name](HarnessSimulatorClient(base_url))
+
+
+def _format_step(step: SimulationStepResult) -> str:
+    lines = [
+        f"- {step.name}: {step.method} {step.path} -> {step.http_status}",
+        f"  action={step.action} target_status={step.target_status} task_status={step.task_status}",
+    ]
+    return "\n".join(lines)
+
+
+def _format_text_result(result: SimulationResult) -> str:
+    lines = [
+        f"scenario: {result.scenario_name}",
+        f"final_task_id: {result.final_task_id}",
+        f"final_task_status: {result.final_task_status}",
+        "steps:",
+    ]
+    lines.extend(_format_step(step) for step in result.steps)
+    lines.append(f"evaluation_count: {len(result.evaluation_history)}")
+    if result.task_snapshot is not None:
+        artifact_count = len(result.task_snapshot.get("artifacts", {}).get("items", []))
+        lines.append(f"artifact_count: {artifact_count}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the simulator CLI parser."""
+
+    parser = argparse.ArgumentParser(description="Run an OpenClaw-style ingress simulator against the Harness API.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000", help="Harness API base URL")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List simulator scenarios")
+    list_parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON output")
+
+    run_parser = subparsers.add_parser("run", help="Run one simulator scenario")
+    run_parser.add_argument("scenario_name", choices=list_scenarios(), help="Simulator scenario to run")
+    run_parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON output")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the OpenClaw-style ingress simulator."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "list":
+        scenarios = list_scenarios()
+        if args.as_json:
+            print(json.dumps({"scenarios": list(scenarios)}, indent=2, sort_keys=True))
+        else:
+            print("\n".join(scenarios))
+        return 0
+
+    result = run_scenario(args.scenario_name, base_url=args.base_url)
+    payload = _to_jsonable(result)
+    if args.as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_text_result(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import threading
+import unittest
+
+from modules.api import run_server
+from modules.simulator import list_scenarios, main, run_scenario
+
+
+class HarnessSimulatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.server = run_server(host="127.0.0.1", port=0, store_root=self.temp_dir.name)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.temp_dir.cleanup()
+
+    def _run_cli(self, *args: str) -> tuple[int, str]:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = main(list(args))
+        return exit_code, stdout.getvalue()
+
+    def test_lists_supported_scenarios(self) -> None:
+        scenarios = list_scenarios()
+
+        self.assertIn("successful_completion", scenarios)
+        self.assertIn("missing_evidence_then_completed", scenarios)
+        self.assertIn("review_required_then_completed", scenarios)
+        self.assertIn("contradictory_facts_rollback", scenarios)
+        self.assertIn("long_running_handoff", scenarios)
+
+    def test_runs_successful_completion_scenario_end_to_end(self) -> None:
+        result = run_scenario("successful_completion", base_url=self.base_url)
+
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertEqual(len(result.steps), 1)
+        self.assertEqual(result.steps[0].http_status, 200)
+        self.assertEqual(result.steps[0].action, "transition_applied")
+        self.assertEqual(len(result.evaluation_history), 1)
+
+    def test_runs_missing_evidence_then_completed_scenario(self) -> None:
+        result = run_scenario("missing_evidence_then_completed", base_url=self.base_url)
+
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertEqual(len(result.steps), 2)
+        self.assertEqual(result.steps[0].task_status, "blocked")
+        self.assertEqual(result.steps[1].task_status, "completed")
+        self.assertEqual(len(result.evaluation_history), 2)
+
+    def test_runs_review_required_then_completed_scenario(self) -> None:
+        result = run_scenario("review_required_then_completed", base_url=self.base_url)
+
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertEqual(result.steps[0].action, "review_required")
+        self.assertIn(result.steps[1].action, {"transition_applied", "follow_up_authorized"})
+        self.assertEqual(len(result.evaluation_history), 2)
+
+    def test_runs_contradictory_facts_rollback_scenario(self) -> None:
+        result = run_scenario("contradictory_facts_rollback", base_url=self.base_url)
+
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertEqual(len(result.steps), 3)
+        self.assertEqual(result.steps[0].task_status, "completed")
+        self.assertEqual(result.steps[1].task_status, "blocked")
+        self.assertEqual(result.steps[2].task_status, "completed")
+
+    def test_runs_long_running_handoff_scenario(self) -> None:
+        result = run_scenario("long_running_handoff", base_url=self.base_url)
+
+        artifact_types = [artifact["type"] for artifact in result.task_snapshot["artifacts"]["items"]]
+
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertEqual(len(result.steps), 4)
+        self.assertIn("progress_artifact", artifact_types)
+        self.assertIn("handoff_artifact", artifact_types)
+        self.assertEqual(len(result.evaluation_history), 4)
+
+    def test_cli_lists_scenarios(self) -> None:
+        exit_code, output = self._run_cli("list")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("successful_completion", output)
+        self.assertIn("long_running_handoff", output)
+
+    def test_cli_runs_scenario_with_json_output(self) -> None:
+        exit_code, output = self._run_cli(
+            "--base-url",
+            self.base_url,
+            "run",
+            "missing_evidence_then_completed",
+            "--json",
+        )
+        payload = json.loads(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["scenario_name"], "missing_evidence_then_completed")
+        self.assertEqual(payload["final_task_status"], "completed")
+        self.assertEqual(len(payload["steps"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a client-side simulator module that exercises the public Harness HTTP API through realistic ingress and re-evaluation flows
- include predefined scenarios for successful completion, missing evidence resolution, wrong-target correction, review-required resolution, contradictory-fact rollback, and long-running handoff support artifacts
- add simulator CLI coverage and README run instructions for local demos against the stateful API

## Validation
- `python3 -m py_compile modules/simulator.py`
- `.venv/bin/python -m unittest tests.test_simulator`
- `.venv/bin/python -m unittest discover -s tests`

## Notes
- the simulator uses only the public HTTP API surface and does not call service or policy internals directly
- scenarios are intentionally synchronous and explicit; this does not introduce any background worker or runtime orchestration behavior