### PR TITLE
Implement canonical demo scenario pack with timeline and trace output

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,35 @@ python -m modules.simulator --base-url http://127.0.0.1:8000 run long_running_ha
 
 The simulator is entirely client-side. It uses only the public HTTP API to submit tasks, reevaluate tasks, and inspect persisted state over time.
 
+## Canonical Demo Pack
+
+You can run a packaged set of canonical demo scenarios that generate:
+
+- readable console timelines
+- Mermaid visual trace files
+- JSON trace artifacts
+
+Run the full pack locally:
+
+```bash
+python -m modules.demo_runner --output-dir demo-output
+```
+
+Run a subset:
+
+```bash
+python -m modules.demo_runner --output-dir demo-output successful_completion contradictory_facts_blocked
+```
+
+Artifacts are written under the output directory as:
+
+- `<scenario>.timeline.txt`
+- `<scenario>.mmd`
+- `<scenario>.json`
+- `index.json`
+
+The demo runner uses only the public API or simulator surface. It does not duplicate control-plane logic.
+
 ## Local HTTP API
 
 You can also run a minimal local HTTP wrapper around the same evaluation entry point:

--- a/modules/demo_runner.py
+++ b/modules/demo_runner.py
@@ -1,0 +1,269 @@
+"""Canonical demo scenario pack with timeline and visual trace output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
+from pathlib import Path
+import threading
+from typing import Any
+
+from modules.api import run_server
+from modules.simulator import SimulationResult, SimulationStepResult, list_scenarios, run_scenario
+
+
+@dataclass(frozen=True)
+class DemoScenarioSpec:
+    """Canonical public demo scenario definition."""
+
+    name: str
+    title: str
+    description: str
+
+
+CANONICAL_DEMO_SCENARIOS: tuple[DemoScenarioSpec, ...] = (
+    DemoScenarioSpec("successful_completion", "Accepted Completion", "A task is submitted with aligned evidence and accepted immediately."),
+    DemoScenarioSpec("missing_evidence_then_completed", "Blocked To Completed", "A task is blocked for insufficient evidence, then resolved with additional artifacts."),
+    DemoScenarioSpec("wrong_target_corrected", "Wrong Target Corrected", "A task starts with wrong repo or branch facts, then is corrected and accepted."),
+    DemoScenarioSpec("review_required_then_completed", "Review Required To Completed", "A task enters manual review, then completes after an explicit review decision."),
+    DemoScenarioSpec("contradictory_facts_blocked", "Contradictory Facts Rollback", "A task is accepted, then contradictory external facts force a rollback to blocked."),
+    DemoScenarioSpec("long_running_handoff", "Long-Running Handoff", "A task accumulates progress and handoff artifacts over time before final completion."),
+)
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _extract_updates(step: SimulationStepResult) -> list[str]:
+    request = step.request_payload or {}
+    request_body = request.get("request") if isinstance(request, dict) else None
+    if not isinstance(request_body, dict):
+        return []
+
+    updates: list[str] = []
+    if "new_artifacts" in request_body:
+        artifacts = request_body.get("new_artifacts") or []
+        artifact_types = [artifact.get("type", "unknown") for artifact in artifacts if isinstance(artifact, dict)]
+        if artifact_types:
+            updates.append(f"new_artifacts={', '.join(artifact_types)}")
+    elif step.name == "submit":
+        task_envelope = request_body.get("task_envelope")
+        if isinstance(task_envelope, dict):
+            items = task_envelope.get("artifacts", {}).get("items", [])
+            artifact_types = [item.get("type", "unknown") for item in items if isinstance(item, dict)]
+            if artifact_types:
+                updates.append(f"artifacts={', '.join(artifact_types)}")
+
+    if "external_facts" in request_body:
+        external_facts = request_body.get("external_facts") or {}
+        if isinstance(external_facts, dict):
+            if external_facts.get("github_facts") is not None:
+                branch_name = (((external_facts.get("github_facts") or {}).get("branch") or {}).get("name"))
+                if branch_name:
+                    updates.append(f"github_branch={branch_name}")
+            if external_facts.get("linear_facts") is not None:
+                linear_state = (external_facts.get("linear_facts") or {}).get("state")
+                if linear_state:
+                    updates.append(f"linear_state={linear_state}")
+
+    if "completion_evidence" in request_body:
+        evidence = request_body.get("completion_evidence") or {}
+        validated_ids = evidence.get("validated_artifact_ids") or []
+        if validated_ids:
+            updates.append(f"validated_artifacts={len(validated_ids)}")
+
+    if "review_decision" in request_body:
+        decision = request_body.get("review_decision") or {}
+        record = decision.get("record") or {}
+        outcome = record.get("outcome")
+        if outcome:
+            updates.append(f"review_decision={outcome}")
+
+    return updates
+
+
+def _extract_verification_outcome(step: SimulationStepResult) -> str | None:
+    return (
+        (((step.payload.get("enforcement_result") or {}).get("verification_result") or {}).get("outcome"))
+        if isinstance(step.payload, dict)
+        else None
+    )
+
+
+def _extract_reconciliation_outcome(step: SimulationStepResult) -> str | None:
+    verification = ((step.payload.get("enforcement_result") or {}).get("verification_result") or {})
+    reconciliation = verification.get("reconciliation_result") or {}
+    return reconciliation.get("outcome")
+
+
+def render_console_timeline(result: SimulationResult) -> str:
+    """Render a readable step-by-step timeline for one demo scenario."""
+
+    lines = [
+        f"Scenario: {result.scenario_name}",
+        f"Task ID: {result.final_task_id}",
+        f"Initial Task State: {result.steps[0].task_status if result.steps else 'unknown'}",
+    ]
+    for index, step in enumerate(result.steps, start=1):
+        verification_outcome = _extract_verification_outcome(step) or "n/a"
+        reconciliation_outcome = _extract_reconciliation_outcome(step) or "n/a"
+        updates = _extract_updates(step)
+        update_text = "; ".join(updates) if updates else "no new facts or artifacts"
+        lines.extend(
+            [
+                f"{index}. {step.name}",
+                f"   request: {step.method} {step.path}",
+                f"   http_status: {step.http_status}",
+                f"   added: {update_text}",
+                f"   verification: {verification_outcome}",
+                f"   reconciliation: {reconciliation_outcome}",
+                f"   lifecycle: action={step.action} target_status={step.target_status} task_status={step.task_status}",
+            ]
+        )
+    lines.append(f"Final Task State: {result.final_task_status}")
+    return "\n".join(lines)
+
+
+def render_mermaid_trace(result: SimulationResult) -> str:
+    """Render a Mermaid sequence diagram for one demo scenario."""
+
+    lines = [
+        "sequenceDiagram",
+        '    actor Simulator as "Demo Runner"',
+        '    participant API as "Harness API"',
+        '    participant Store as "Task Store"',
+    ]
+    for step in result.steps:
+        updates = _extract_updates(step)
+        verification_outcome = _extract_verification_outcome(step) or "n/a"
+        reconciliation_outcome = _extract_reconciliation_outcome(step) or "n/a"
+        update_label = "\\n".join(updates) if updates else "no new facts"
+        lines.extend(
+            [
+                f'    Simulator->>API: {step.method} {step.path}\\n{step.name}',
+                f'    Note right of API: {update_label}',
+                f'    API->>Store: persist evaluation for {step.task_id}',
+                f'    Store-->>API: task_status={step.task_status}',
+                f'    API-->>Simulator: action={step.action}\\ntarget={step.target_status}\\nverification={verification_outcome}\\nreconciliation={reconciliation_outcome}',
+            ]
+        )
+    lines.append(f'    Note over Simulator,API: final task state = {result.final_task_status}')
+    return "\n".join(lines)
+
+
+def _write_scenario_artifacts(output_dir: Path, result: SimulationResult) -> dict[str, str]:
+    slug = result.scenario_name
+    timeline_path = output_dir / f"{slug}.timeline.txt"
+    mermaid_path = output_dir / f"{slug}.mmd"
+    json_path = output_dir / f"{slug}.json"
+
+    timeline_path.write_text(render_console_timeline(result) + "\n", encoding="utf-8")
+    mermaid_path.write_text(render_mermaid_trace(result) + "\n", encoding="utf-8")
+    json_path.write_text(json.dumps(_to_jsonable(result), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return {
+        "timeline": str(timeline_path),
+        "mermaid": str(mermaid_path),
+        "json": str(json_path),
+    }
+
+
+def run_demo_pack(
+    *,
+    scenario_names: tuple[str, ...] | None = None,
+    output_dir: str = "demo-output",
+    base_url: str | None = None,
+    store_root: str | None = None,
+) -> tuple[SimulationResult, ...]:
+    """Run the canonical demo scenario pack and write trace artifacts."""
+
+    selected = scenario_names or tuple(spec.name for spec in CANONICAL_DEMO_SCENARIOS)
+    invalid = [name for name in selected if name not in list_scenarios()]
+    if invalid:
+        raise ValueError(f"Unknown demo scenarios: {', '.join(invalid)}")
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if base_url is not None:
+        results = tuple(run_scenario(name, base_url=base_url) for name in selected)
+    else:
+        collected: list[SimulationResult] = []
+        for name in selected:
+            scenario_store_root = store_root or str(output_path / ".demo-store" / name)
+            Path(scenario_store_root).mkdir(parents=True, exist_ok=True)
+            server = run_server(host="127.0.0.1", port=0, store_root=scenario_store_root)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                collected.append(run_scenario(name, base_url=base))
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+        results = tuple(collected)
+
+    index: list[dict[str, Any]] = []
+    for result in results:
+        files = _write_scenario_artifacts(output_path, result)
+        index.append(
+            {
+                "scenario_name": result.scenario_name,
+                "final_task_id": result.final_task_id,
+                "final_task_status": result.final_task_status,
+                "files": files,
+            }
+        )
+
+    (output_path / "index.json").write_text(json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return results
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the demo-runner CLI parser."""
+
+    parser = argparse.ArgumentParser(description="Run canonical Harness demo scenarios and generate trace artifacts.")
+    parser.add_argument("--output-dir", default="demo-output", help="Directory where demo artifacts will be written")
+    parser.add_argument("--base-url", default=None, help="Existing Harness API base URL; if omitted the runner starts a local API server")
+    parser.add_argument("--store-root", default=None, help="Store root when the runner starts its own local API server")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable summary JSON to stdout")
+    parser.add_argument("scenario_names", nargs="*", help="Optional subset of demo scenarios to run")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the canonical demo scenario pack."""
+
+    args = build_parser().parse_args(argv)
+    selected = tuple(args.scenario_names) if args.scenario_names else None
+    results = run_demo_pack(
+        scenario_names=selected,
+        output_dir=args.output_dir,
+        base_url=args.base_url,
+        store_root=args.store_root,
+    )
+
+    if args.as_json:
+        print(json.dumps(_to_jsonable(results), indent=2, sort_keys=True))
+    else:
+        for result in results:
+            print(render_console_timeline(result))
+            print("")
+        print(f"Artifacts written to {Path(args.output_dir).resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/simulator.py
+++ b/modules/simulator.py
@@ -138,6 +138,7 @@ class SimulationStepResult:
     target_status: str | None
     task_status: str | None
     task_id: str | None
+    request_payload: dict[str, Any] | None
     payload: dict[str, Any]
 
 
@@ -194,7 +195,16 @@ class _ScenarioContext:
         self.task_id: str | None = None
         self.steps: list[SimulationStepResult] = []
 
-    def record(self, *, name: str, method: str, path: str, http_status: int, payload: dict[str, Any]) -> dict[str, Any]:
+    def record(
+        self,
+        *,
+        name: str,
+        method: str,
+        path: str,
+        http_status: int,
+        request_payload: dict[str, Any] | None,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
         task_envelope = payload.get("task_envelope")
         task_id = payload.get("task_envelope", {}).get("id") if isinstance(task_envelope, dict) else None
         if task_id is None and "task" in payload and isinstance(payload["task"], dict):
@@ -216,6 +226,7 @@ class _ScenarioContext:
                 if isinstance(task_envelope or payload.get("task"), dict)
                 else None,
                 task_id=self.task_id,
+                request_payload=deepcopy(request_payload),
                 payload=payload,
             )
         )
@@ -224,7 +235,14 @@ class _ScenarioContext:
 
 def _submit_step(client: HarnessSimulatorClient, context: _ScenarioContext, name: str, payload: dict[str, Any]) -> dict[str, Any]:
     status, response_payload = client.submit_task(payload)
-    return context.record(name=name, method="POST", path="/tasks", http_status=status, payload=response_payload)
+    return context.record(
+        name=name,
+        method="POST",
+        path="/tasks",
+        http_status=status,
+        request_payload=payload,
+        payload=response_payload,
+    )
 
 
 def _reevaluate_step(
@@ -237,7 +255,14 @@ def _reevaluate_step(
         raise ValueError("task_id is required before reevaluation")
     path = f"/tasks/{context.task_id}/reevaluate"
     status, response_payload = client.reevaluate_task(context.task_id, payload)
-    return context.record(name=name, method="POST", path=path, http_status=status, payload=response_payload)
+    return context.record(
+        name=name,
+        method="POST",
+        path=path,
+        http_status=status,
+        request_payload=payload,
+        payload=response_payload,
+    )
 
 
 def _fetch_final_state(client: HarnessSimulatorClient, context: _ScenarioContext) -> tuple[dict[str, Any] | None, tuple[dict[str, Any], ...]]:
@@ -328,6 +353,8 @@ def _scenario_wrong_target_corrected(client: HarnessSimulatorClient) -> Simulati
     context = _ScenarioContext()
     initial_payload = _canonical_payload("accepted_completion")
     wrong_target_payload = deepcopy(initial_payload)
+    wrong_target_payload["request"]["task_envelope"]["status"] = "blocked"
+    wrong_target_payload["request"]["task_envelope"]["timestamps"]["completed_at"] = None
     wrong_target_payload["request"]["external_facts"]["github_facts"]["branch"]["name"] = "codex/wrong-target"
 
     _submit_step(client, context, "submit", wrong_target_payload)
@@ -408,6 +435,34 @@ def _scenario_contradictory_facts_rollback(client: HarnessSimulatorClient) -> Si
     return SimulationResult("contradictory_facts_rollback", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
 
 
+def _scenario_contradictory_facts_blocked(client: HarnessSimulatorClient) -> SimulationResult:
+    context = _ScenarioContext()
+    accepted_payload = _canonical_payload("accepted_completion")
+    _submit_step(client, context, "submit", accepted_payload)
+    _reevaluate_step(
+        client,
+        context,
+        "introduce_contradictory_facts",
+        {
+            "request": {
+                "external_facts": deepcopy(_canonical_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(accepted_payload["request"]["runtime_facts"]),
+            }
+        },
+    )
+    task_snapshot, history = _fetch_final_state(client, context)
+    return SimulationResult(
+        "contradictory_facts_blocked",
+        context.task_id,
+        task_snapshot.get("status") if task_snapshot else None,
+        tuple(context.steps),
+        task_snapshot,
+        history,
+    )
+
+
 def _scenario_long_running_handoff(client: HarnessSimulatorClient) -> SimulationResult:
     context = _ScenarioContext()
     initial_payload = _canonical_payload("blocked_insufficient_evidence")
@@ -470,6 +525,7 @@ _SCENARIOS = {
     "missing_evidence_then_completed": _scenario_missing_evidence_then_completed,
     "wrong_target_corrected": _scenario_wrong_target_corrected,
     "review_required_then_completed": _scenario_review_required_then_completed,
+    "contradictory_facts_blocked": _scenario_contradictory_facts_blocked,
     "contradictory_facts_rollback": _scenario_contradictory_facts_rollback,
     "long_running_handoff": _scenario_long_running_handoff,
 }

--- a/tests/test_demo_runner.py
+++ b/tests/test_demo_runner.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from modules.demo_runner import (
+    CANONICAL_DEMO_SCENARIOS,
+    main,
+    render_console_timeline,
+    render_mermaid_trace,
+    run_demo_pack,
+)
+from modules.simulator import run_scenario
+
+
+class HarnessDemoRunnerTests(unittest.TestCase):
+    def _run_cli(self, *args: str) -> tuple[int, str]:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = main(list(args))
+        return exit_code, stdout.getvalue()
+
+    def test_runs_canonical_demo_pack_and_writes_trace_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            results = run_demo_pack(output_dir=temp_dir)
+            output_path = Path(temp_dir)
+
+            self.assertEqual(len(results), len(CANONICAL_DEMO_SCENARIOS))
+            self.assertTrue((output_path / "index.json").exists())
+
+            expected_final_states = {
+                "successful_completion": "completed",
+                "missing_evidence_then_completed": "completed",
+                "wrong_target_corrected": "completed",
+                "review_required_then_completed": "completed",
+                "contradictory_facts_blocked": "blocked",
+                "long_running_handoff": "completed",
+            }
+
+            for result in results:
+                self.assertEqual(result.final_task_status, expected_final_states[result.scenario_name])
+                self.assertTrue((output_path / f"{result.scenario_name}.timeline.txt").exists())
+                self.assertTrue((output_path / f"{result.scenario_name}.mmd").exists())
+                self.assertTrue((output_path / f"{result.scenario_name}.json").exists())
+
+    def test_console_timeline_includes_key_flow_details(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = run_demo_pack(
+                scenario_names=("missing_evidence_then_completed",),
+                output_dir=temp_dir,
+            )[0]
+            timeline = render_console_timeline(result)
+
+        self.assertIn("Task ID:", timeline)
+        self.assertIn("verification:", timeline)
+        self.assertIn("reconciliation:", timeline)
+        self.assertIn("lifecycle:", timeline)
+        self.assertIn("new_artifacts=review_note", timeline)
+        self.assertIn("Final Task State: completed", timeline)
+
+    def test_mermaid_trace_includes_transitions_and_final_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = run_demo_pack(
+                scenario_names=("contradictory_facts_blocked",),
+                output_dir=temp_dir,
+            )[0]
+            mermaid = render_mermaid_trace(result)
+
+        self.assertIn("sequenceDiagram", mermaid)
+        self.assertIn("introduce_contradictory_facts", mermaid)
+        self.assertIn("action=transition_applied", mermaid)
+        self.assertIn("final task state = blocked", mermaid)
+
+    def test_cli_runs_subset_and_prints_timeline(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            exit_code, output = self._run_cli(
+                "--output-dir",
+                temp_dir,
+                "successful_completion",
+                "contradictory_facts_blocked",
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Scenario: successful_completion", output)
+        self.assertIn("Scenario: contradictory_facts_blocked", output)
+        self.assertIn("Artifacts written to", output)
+
+    def test_cli_can_emit_json_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            exit_code, output = self._run_cli(
+                "--output-dir",
+                temp_dir,
+                "--json",
+                "successful_completion",
+            )
+            payload = json.loads(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload[0]["scenario_name"], "successful_completion")
+        self.assertEqual(payload[0]["final_task_status"], "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a canonical demo runner that packages the public simulator scenarios into one local demo entry point
- generate readable console timelines plus Mermaid and JSON trace artifacts for each scenario
- add a blocked-ending contradiction scenario so the demo pack covers the required rollback case directly
- document how to run the demo pack and where artifacts are written

## Validation
- `python3 -m py_compile modules/demo_runner.py modules/simulator.py`
- `.venv/bin/python -m unittest tests.test_demo_runner tests.test_simulator`
- `.venv/bin/python -m unittest discover -s tests`
- `.venv/bin/python -m modules.demo_runner --output-dir <tmpdir> successful_completion contradictory_facts_blocked`

## Notes
- the demo runner starts isolated local API/store instances when needed so canonical scenarios stay deterministic even when task IDs overlap
- visual traces are emitted as Mermaid sequence diagrams (`.mmd`) alongside timeline and JSON trace files for documentation and build-in-public use