### PR TITLE
Implement canonical goal-to-work end-to-end flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,8 @@ Current focus:
 - artifact and completion evidence modeling
 - Linear-aligned intake and normalization
 - PRD-to-work-breakdown generation for upstream structure creation
-<<<<<<< codex/prd-bulk-ingestion
 - review-and-approve bulk ingestion of generated work into persisted Harness tasks
-=======
->>>>>>> main
+- canonical goal-to-work composition from high-level request to persisted Harness tasks
 - verification, auditability, and system-of-record reconciliation
 
 Not yet in scope:

--- a/modules/goal_to_work.py
+++ b/modules/goal_to_work.py
@@ -1,0 +1,184 @@
+"""Canonical goal-to-work orchestration flow for Harness."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from modules.api import HarnessApiService
+from modules.prd_breakdown import (
+    PRDBreakdownInputError,
+    WorkBreakdownProposal,
+    generate_linear_work_breakdown,
+)
+from modules.prd_ingestion import (
+    BulkIngestionResult,
+    ReviewableWorkItemSet,
+    WorkItemReviewDecision,
+    approve_all_items,
+    ingest_reviewed_work_items,
+    prepare_reviewable_work_items,
+)
+
+
+class GoalToWorkInputError(ValueError):
+    """Raised when a high-level goal request cannot be normalized into a PRD-like artifact."""
+
+
+@dataclass(frozen=True)
+class GoalToWorkRequest:
+    """Structured high-level goal input for the canonical upstream flow."""
+
+    title: str
+    product_goal: str
+    target_user: str
+    problem_statement: str
+    scope: tuple[dict[str, Any] | str, ...]
+    constraints: tuple[str, ...]
+    success_criteria: tuple[str, ...]
+    goal_id: str | None = None
+    priority: str | int | None = None
+
+
+@dataclass(frozen=True)
+class GoalToWorkFlowResult:
+    """Auditable output of the canonical goal-to-work flow."""
+
+    prd_artifact: dict[str, Any]
+    proposal: WorkBreakdownProposal
+    reviewable_set: ReviewableWorkItemSet
+    review_decisions: tuple[WorkItemReviewDecision, ...]
+    ingestion_result: BulkIngestionResult | None
+
+
+def _require_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise GoalToWorkInputError(f"{field_name} is required")
+    return value.strip()
+
+
+def _require_string_list(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise GoalToWorkInputError(f"{field_name} must be a list of strings")
+    normalized: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise GoalToWorkInputError(f"{field_name}[{index}] must be a non-empty string")
+        normalized.append(item.strip())
+    if not normalized:
+        raise GoalToWorkInputError(f"{field_name} must contain at least one item")
+    return tuple(normalized)
+
+
+def _normalize_scope(value: Any) -> tuple[dict[str, Any] | str, ...]:
+    if not isinstance(value, (list, tuple)) or not value:
+        raise GoalToWorkInputError("scope must contain at least one proposed workstream")
+    normalized: list[dict[str, Any] | str] = []
+    for index, item in enumerate(value):
+        if isinstance(item, str):
+            if not item.strip():
+                raise GoalToWorkInputError(f"scope[{index}] must be a non-empty string")
+            normalized.append(item.strip())
+            continue
+        if not isinstance(item, dict):
+            raise GoalToWorkInputError(f"scope[{index}] must be either a string or an object")
+        normalized.append(dict(item))
+    return tuple(normalized)
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "goal"
+
+
+def build_prd_artifact(goal_request: GoalToWorkRequest | dict[str, Any]) -> dict[str, Any]:
+    """Build the canonical PRD-like artifact used by the goal-to-work flow."""
+
+    if isinstance(goal_request, GoalToWorkRequest):
+        title = _require_string(goal_request.title, field_name="title")
+        goal_id = goal_request.goal_id or _slugify(title)
+        return {
+            "id": goal_id,
+            "title": title,
+            "product_goal": _require_string(goal_request.product_goal, field_name="product_goal"),
+            "target_user": _require_string(goal_request.target_user, field_name="target_user"),
+            "problem_statement": _require_string(goal_request.problem_statement, field_name="problem_statement"),
+            "scope": [item if isinstance(item, str) else dict(item) for item in goal_request.scope],
+            "constraints": list(goal_request.constraints),
+            "success_criteria": list(goal_request.success_criteria),
+            "priority": goal_request.priority,
+        }
+
+    if not isinstance(goal_request, dict):
+        raise GoalToWorkInputError("goal_request must be a GoalToWorkRequest or mapping")
+
+    title = _require_string(goal_request.get("title"), field_name="title")
+    goal_id = goal_request.get("goal_id") or goal_request.get("id") or _slugify(title)
+
+    return {
+        "id": _require_string(goal_id, field_name="goal_id"),
+        "title": title,
+        "product_goal": _require_string(goal_request.get("product_goal"), field_name="product_goal"),
+        "target_user": _require_string(goal_request.get("target_user"), field_name="target_user"),
+        "problem_statement": _require_string(goal_request.get("problem_statement"), field_name="problem_statement"),
+        "scope": list(_normalize_scope(goal_request.get("scope"))),
+        "constraints": list(_require_string_list(goal_request.get("constraints"), field_name="constraints")),
+        "success_criteria": list(_require_string_list(goal_request.get("success_criteria"), field_name="success_criteria")),
+        "priority": goal_request.get("priority"),
+    }
+
+
+def run_goal_to_work_flow(
+    goal_request: GoalToWorkRequest | dict[str, Any],
+    *,
+    review_decisions: tuple[WorkItemReviewDecision, ...] | list[WorkItemReviewDecision] | None = None,
+    auto_approve: bool = False,
+    service: HarnessApiService | None = None,
+) -> GoalToWorkFlowResult:
+    """Run the canonical flow from high-level goal to reviewable and ingestible work."""
+
+    prd_artifact = build_prd_artifact(goal_request)
+
+    try:
+        proposal = generate_linear_work_breakdown(prd_artifact)
+    except PRDBreakdownInputError as error:
+        raise GoalToWorkInputError(str(error)) from error
+
+    reviewable_set = prepare_reviewable_work_items(proposal)
+
+    normalized_decisions: tuple[WorkItemReviewDecision, ...]
+    if review_decisions is not None:
+        normalized_decisions = tuple(review_decisions)
+    elif auto_approve:
+        normalized_decisions = approve_all_items(
+            reviewable_set,
+            review_notes="Auto-approved for the canonical goal-to-work flow.",
+        )
+    else:
+        normalized_decisions = ()
+
+    ingestion_result = None
+    if normalized_decisions:
+        ingestion_result = ingest_reviewed_work_items(
+            reviewable_set,
+            normalized_decisions,
+            service=service,
+        )
+
+    return GoalToWorkFlowResult(
+        prd_artifact=prd_artifact,
+        proposal=proposal,
+        reviewable_set=reviewable_set,
+        review_decisions=normalized_decisions,
+        ingestion_result=ingestion_result,
+    )
+
+
+__all__ = [
+    "GoalToWorkFlowResult",
+    "GoalToWorkInputError",
+    "GoalToWorkRequest",
+    "build_prd_artifact",
+    "run_goal_to_work_flow",
+]

--- a/tests/test_goal_to_work.py
+++ b/tests/test_goal_to_work.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from modules.api import HarnessApiService
+from modules.goal_to_work import GoalToWorkInputError, GoalToWorkRequest, build_prd_artifact, run_goal_to_work_flow
+from modules.prd_ingestion import WorkItemReviewDecision
+from modules.store import FileBackedHarnessStore
+
+
+def _goal_request() -> GoalToWorkRequest:
+    return GoalToWorkRequest(
+        goal_id="goal-harness-launch",
+        title="Harness verification launch",
+        product_goal="Ship a verifiable AI-work control plane that proves task outcomes with evidence.",
+        target_user="Engineering teams coordinating AI-assisted delivery through Linear and GitHub.",
+        problem_statement="Teams cannot trust task completion claims without artifact-backed verification and reconciliation.",
+        scope=(
+            {
+                "id": "linear-ingress",
+                "title": "Linear ingress alignment",
+                "description": "Map Linear work into canonical Harness task contracts and retain upstream traceability.",
+                "category": "integration",
+            },
+            {
+                "id": "verification",
+                "title": "Verification and evidence policy",
+                "description": "Enforce completion based on evidence validation and reconciled external facts.",
+                "category": "verification",
+                "depends_on": ["linear-ingress"],
+            },
+        ),
+        constraints=(
+            "Use only canonical Harness contracts and public API surfaces.",
+            "Keep external integrations connector-neutral and testable without live services.",
+        ),
+        success_criteria=(
+            "Generated work can be reviewed before issue creation.",
+            "Each proposed item is compatible with the Linear-shaped ingress adapter.",
+        ),
+        priority="high",
+    )
+
+
+class GoalToWorkFlowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.service = HarnessApiService(store=FileBackedHarnessStore(self.temp_dir.name))
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_builds_prd_artifact_from_high_level_goal_request(self) -> None:
+        prd_artifact = build_prd_artifact(_goal_request())
+
+        self.assertEqual(prd_artifact["id"], "goal-harness-launch")
+        self.assertEqual(prd_artifact["title"], "Harness verification launch")
+        self.assertEqual(len(prd_artifact["scope"]), 2)
+
+    def test_runs_accepted_end_to_end_flow(self) -> None:
+        result = run_goal_to_work_flow(
+            _goal_request(),
+            auto_approve=True,
+            service=self.service,
+        )
+
+        self.assertEqual(result.prd_artifact["id"], "goal-harness-launch")
+        self.assertEqual(result.proposal.proposal_id, "proposal-goal-harness-launch")
+        self.assertEqual(len(result.reviewable_set.items), 3)
+        self.assertEqual(len(result.review_decisions), 3)
+        self.assertIsNotNone(result.ingestion_result)
+        self.assertEqual(result.ingestion_result.approved_items, 3)
+        self.assertEqual(result.ingestion_result.ingested_items, 3)
+
+    def test_runs_partially_approved_flow(self) -> None:
+        preview = run_goal_to_work_flow(_goal_request(), service=self.service)
+        decisions = (
+            WorkItemReviewDecision(preview.reviewable_set.items[0].item_id, True, review_notes="Keep umbrella item."),
+            WorkItemReviewDecision(preview.reviewable_set.items[1].item_id, True, review_notes="Start with ingress."),
+            WorkItemReviewDecision(preview.reviewable_set.items[2].item_id, False, review_notes="Defer verification slice."),
+        )
+
+        result = run_goal_to_work_flow(
+            _goal_request(),
+            review_decisions=decisions,
+            service=self.service,
+        )
+
+        self.assertIsNotNone(result.ingestion_result)
+        self.assertEqual(result.ingestion_result.approved_items, 2)
+        self.assertEqual(result.ingestion_result.ingested_items, 2)
+        skipped = [item for item in result.ingestion_result.item_results if item.skipped]
+        self.assertEqual(len(skipped), 1)
+
+    def test_rejects_invalid_goal_input_cleanly(self) -> None:
+        with self.assertRaises(GoalToWorkInputError):
+            run_goal_to_work_flow(
+                {
+                    "title": "Incomplete goal",
+                    "product_goal": "Ship something",
+                    "target_user": "",
+                    "problem_statement": "Missing required data",
+                    "scope": [],
+                    "constraints": [],
+                    "success_criteria": [],
+                },
+                service=self.service,
+            )
+
+    def test_duplicate_id_behavior_is_preserved_during_ingestion(self) -> None:
+        first = run_goal_to_work_flow(_goal_request(), auto_approve=True, service=self.service)
+        second = run_goal_to_work_flow(_goal_request(), auto_approve=True, service=self.service)
+
+        self.assertEqual(first.ingestion_result.ingested_items, 3)
+        self.assertEqual(second.ingestion_result.ingested_items, 0)
+        self.assertTrue(
+            all(item.duplicate_task_id for item in second.ingestion_result.item_results if item.approved)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a top-level goal-to-work flow that composes PRD artifact construction, PRD-to-work-breakdown generation, reviewable work-item preparation, approval decisions, and bulk ingestion into Harness
- keep the flow auditable by returning each intermediate stage explicitly: PRD artifact, proposal, review set, review decisions, and ingestion result
- add tests covering accepted end-to-end flow, partial approval, invalid high-level input rejection, and duplicate-ID behavior passed through from canonical ingestion

## Validation
- `python3 -m py_compile modules/goal_to_work.py`
- `.venv/bin/python -m unittest tests.test_goal_to_work`
- `.venv/bin/python -m unittest discover -s tests`

## Notes
- this is a composition layer only; it does not add new planning or policy logic
- the flow stays deterministic and reviewable by reusing the existing PRD generator, review-and-approve ingestion path, and canonical submission behavior