### PR TITLE
Implement dashboard-friendly read model and timeline API

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,12 +284,16 @@ Then submit canonical evaluation requests to:
 - `POST /tasks/<task_id>/reevaluate`
 - `GET /tasks/<task_id>`
 - `GET /tasks/<task_id>/evaluations`
+- `GET /tasks/<task_id>/read-model`
+- `GET /tasks/<task_id>/timeline`
 
 The API accepts canonical `TaskEnvelope` input plus normalized external facts and returns structured evaluation results.
 `POST /tasks` is the canonical ingress submission path for new work. It creates a new persisted task record, runs the initial evaluation, and appends the first evaluation record. Duplicate task IDs are rejected with `409 Conflict`.
 `POST /ingress/linear` is a thin example adapter that accepts a Linear-shaped issue payload, translates it into a canonical `TaskEnvelope` plus normalized `LinearFacts`, and then reuses the same `POST /tasks` submission path.
 Successful evaluations persist the current task snapshot and append an evaluation record under the configured store root.
 Re-evaluation requests load the latest stored task, append any new canonical artifacts, apply new normalized facts or review outcomes, and persist the next task snapshot plus a new evaluation record.
+`GET /tasks/<task_id>/read-model` returns a dashboard-friendly task inspection shape with current evidence, verification, reconciliation, review, and lifecycle context.
+`GET /tasks/<task_id>/timeline` returns a flattened event timeline suitable for task-detail and timeline views.
 It is a thin wrapper over the existing evaluator and store scaffolding, not a production service.
 
 ## License

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -6,6 +6,7 @@ from .evaluation import (
     HarnessEvaluator,
     evaluate_task_case,
 )
+from .read_model import HarnessReadModelService, TaskReadModel
 from .store import (
     EvaluationRecord,
     EvaluationRecordStore,
@@ -19,6 +20,8 @@ __all__ = [
     "HarnessEvaluationRequest",
     "HarnessEvaluationResult",
     "HarnessEvaluator",
+    "HarnessReadModelService",
+    "TaskReadModel",
     "EvaluationRecord",
     "EvaluationRecordStore",
     "FileBackedHarnessStore",

--- a/modules/api.py
+++ b/modules/api.py
@@ -44,6 +44,7 @@ from modules.contracts.task_envelope_review import (
 )
 from modules.contracts.task_envelope_verification import RuntimeVerificationFacts
 from modules.evaluation import HarnessEvaluationRequest, evaluate_task_case
+from modules.read_model import HarnessReadModelService
 from modules.store import (
     EvaluationRecord,
     FileBackedHarnessStore,
@@ -378,6 +379,7 @@ class HarnessApiService:
 
     def __init__(self, *, store: FileBackedHarnessStore | None = None) -> None:
         self.store = store or FileBackedHarnessStore(".harness-store")
+        self.read_model_service = HarnessReadModelService(store=self.store)
 
     def _upsert_task(self, task_envelope: dict[str, Any]) -> dict[str, Any]:
         task_id = str(task_envelope["id"])
@@ -505,6 +507,20 @@ class HarnessApiService:
             "evaluations": [_serialize_evaluation_record(record) for record in records],
         }
 
+    def get_task_read_model(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        try:
+            read_model = self.read_model_service.build_task_read_model(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+        return HTTPStatus.OK, {"task": _to_jsonable(read_model)}
+
+    def get_task_timeline(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        try:
+            timeline = self.read_model_service.build_task_timeline(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+        return HTTPStatus.OK, timeline
+
 
 class HarnessApiHandler(BaseHTTPRequestHandler):
     """Minimal HTTP handler exposing the Harness evaluation entry point."""
@@ -538,6 +554,16 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
 
         if len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "evaluations":
             status, payload = service.get_evaluation_history(path_components[1])
+            self._write_json(status, payload)
+            return
+
+        if len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "read-model":
+            status, payload = service.get_task_read_model(path_components[1])
+            self._write_json(status, payload)
+            return
+
+        if len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "timeline":
+            status, payload = service.get_task_timeline(path_components[1])
             self._write_json(status, payload)
             return
 

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -1,0 +1,338 @@
+"""Dashboard-friendly task read model and timeline builders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from modules.store import EvaluationRecord, FileBackedHarnessStore, TaskEnvelopeNotFoundError
+
+TaskEnvelope = dict[str, Any]
+
+
+def _parse_iso_timestamp(value: str | None) -> datetime:
+    if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _count_by(items: list[dict[str, Any]], field_name: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        key = str(item.get(field_name) or "unknown")
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _latest_mapping(records: tuple[EvaluationRecord, ...], path: tuple[str, ...]) -> dict[str, Any] | None:
+    for record in reversed(records):
+        current: Any = record.result
+        for key in path:
+            if not isinstance(current, dict):
+                current = None
+                break
+            current = current.get(key)
+        if isinstance(current, dict):
+            return current
+    return None
+
+
+def _review_status(
+    *,
+    requests: list[dict[str, Any]],
+    decisions: list[dict[str, Any]],
+) -> str:
+    if not requests and not decisions:
+        return "none"
+    if not decisions:
+        return "requested"
+    latest_request_at = max((_parse_iso_timestamp(item.get("requested_at")) for item in requests), default=None)
+    latest_decision_at = max((_parse_iso_timestamp(item.get("reviewed_at")) for item in decisions), default=None)
+    if latest_request_at is not None and (latest_decision_at is None or latest_request_at > latest_decision_at):
+        return "requested"
+    return "resolved"
+
+
+def _build_evidence_summary(task_envelope: TaskEnvelope) -> dict[str, Any]:
+    artifacts = dict(task_envelope.get("artifacts") or {})
+    items = list(artifacts.get("items") or [])
+    completion_evidence = dict(artifacts.get("completion_evidence") or {})
+    return {
+        "artifact_count": len(items),
+        "artifact_type_counts": _count_by(items, "type"),
+        "verification_status_counts": _count_by(items, "verification_status"),
+        "validated_artifact_count": len(tuple(completion_evidence.get("validated_artifact_ids") or ())),
+        "completion_evidence": {
+            "policy": completion_evidence.get("policy"),
+            "status": completion_evidence.get("status"),
+            "required_artifact_types": list(completion_evidence.get("required_artifact_types") or []),
+            "validated_artifact_ids": list(completion_evidence.get("validated_artifact_ids") or []),
+            "validation_method": completion_evidence.get("validation_method"),
+            "validated_at": completion_evidence.get("validated_at"),
+            "validator": completion_evidence.get("validator"),
+        },
+    }
+
+
+def _build_review_summary(records: tuple[EvaluationRecord, ...]) -> dict[str, Any]:
+    requests: list[dict[str, Any]] = []
+    decisions: list[dict[str, Any]] = []
+
+    for record in records:
+        result_payload = record.result if isinstance(record.result, dict) else {}
+        request_payload = record.request if isinstance(record.request, dict) else {}
+        result_enforcement = dict(result_payload.get("enforcement_result") or {})
+
+        review_request = result_enforcement.get("review_request") or request_payload.get("review_request")
+        if isinstance(review_request, dict):
+            requests.append(review_request)
+
+        review_decision = result_enforcement.get("review_decision") or request_payload.get("review_decision")
+        if isinstance(review_decision, dict):
+            record_payload = review_decision.get("record")
+            if isinstance(record_payload, dict):
+                decisions.append(record_payload)
+
+    return {
+        "status": _review_status(requests=requests, decisions=decisions),
+        "request_count": len(requests),
+        "decision_count": len(decisions),
+        "latest_request": requests[-1] if requests else None,
+        "latest_decision": decisions[-1] if decisions else None,
+        "requests": requests,
+        "decisions": decisions,
+    }
+
+
+def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord, ...]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+
+    timestamps = dict(task_envelope.get("timestamps") or {})
+    created_at = timestamps.get("created_at")
+    if created_at:
+        events.append(
+            {
+                "event_id": f"{task_envelope['id']}:created",
+                "event_type": "task_created",
+                "occurred_at": created_at,
+                "summary": "Task created",
+                "source": str((task_envelope.get("origin") or {}).get("source_system") or "harness"),
+                "details": {
+                    "status": task_envelope.get("status"),
+                    "title": task_envelope.get("title"),
+                    "origin": task_envelope.get("origin"),
+                },
+            }
+        )
+
+    for index, entry in enumerate(task_envelope.get("status_history") or []):
+        if not isinstance(entry, dict):
+            continue
+        events.append(
+            {
+                "event_id": f"{task_envelope['id']}:status:{index}",
+                "event_type": "status_transition",
+                "occurred_at": entry.get("changed_at") or timestamps.get("updated_at"),
+                "summary": f"Status changed {entry.get('from_status')} -> {entry.get('to_status')}",
+                "source": entry.get("changed_by") or "harness",
+                "details": dict(entry),
+            }
+        )
+
+    artifacts = list(((task_envelope.get("artifacts") or {}).get("items") or []))
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        events.append(
+            {
+                "event_id": f"{task_envelope['id']}:artifact:{artifact.get('id')}",
+                "event_type": "artifact_captured",
+                "occurred_at": artifact.get("captured_at") or timestamps.get("updated_at"),
+                "summary": f"Artifact captured: {artifact.get('type')}",
+                "source": str((artifact.get("provenance") or {}).get("source_system") or "unknown"),
+                "details": {
+                    "artifact_id": artifact.get("id"),
+                    "type": artifact.get("type"),
+                    "title": artifact.get("title"),
+                    "verification_status": artifact.get("verification_status"),
+                    "repository": artifact.get("repository"),
+                    "branch": artifact.get("branch"),
+                },
+            }
+        )
+
+    for record in records:
+        result_payload = record.result if isinstance(record.result, dict) else {}
+        enforcement_result = dict(result_payload.get("enforcement_result") or {})
+        verification_result = enforcement_result.get("verification_result")
+        reconciliation_result = enforcement_result.get("reconciliation_result")
+
+        events.append(
+            {
+                "event_id": f"{task_envelope['id']}:evaluation:{record.evaluation_id}",
+                "event_type": "evaluation_recorded",
+                "occurred_at": record.recorded_at,
+                "summary": f"Evaluation recorded: {result_payload.get('action')}",
+                "source": "harness",
+                "details": {
+                    "evaluation_id": record.evaluation_id,
+                    "action": result_payload.get("action"),
+                    "target_status": result_payload.get("target_status"),
+                    "accepted_completion": result_payload.get("accepted_completion"),
+                    "requires_review": result_payload.get("requires_review"),
+                    "reasons": list(result_payload.get("reasons") or []),
+                    "verification_result": verification_result,
+                    "reconciliation_result": reconciliation_result,
+                },
+            }
+        )
+
+        review_request = enforcement_result.get("review_request") or (
+            record.request.get("review_request") if isinstance(record.request, dict) else None
+        )
+        if isinstance(review_request, dict):
+            events.append(
+                {
+                    "event_id": f"{task_envelope['id']}:review-request:{review_request.get('review_request_id')}",
+                    "event_type": "review_requested",
+                    "occurred_at": review_request.get("requested_at") or record.recorded_at,
+                    "summary": "Manual review requested",
+                    "source": review_request.get("requested_by") or "harness",
+                    "details": review_request,
+                }
+            )
+
+        review_decision = enforcement_result.get("review_decision") or (
+            record.request.get("review_decision") if isinstance(record.request, dict) else None
+        )
+        if isinstance(review_decision, dict) and isinstance(review_decision.get("record"), dict):
+            review_record = review_decision["record"]
+            events.append(
+                {
+                    "event_id": f"{task_envelope['id']}:review-decision:{review_record.get('review_id')}",
+                    "event_type": "review_decided",
+                    "occurred_at": review_record.get("reviewed_at") or record.recorded_at,
+                    "summary": f"Manual review decided: {review_record.get('outcome')}",
+                    "source": str((review_record.get("reviewer") or {}).get("reviewer_name") or "operator"),
+                    "details": review_record,
+                }
+            )
+
+    order = {
+        "task_created": 0,
+        "artifact_captured": 1,
+        "review_requested": 2,
+        "review_decided": 3,
+        "evaluation_recorded": 4,
+        "status_transition": 5,
+    }
+    return sorted(
+        events,
+        key=lambda event: (
+            _parse_iso_timestamp(event.get("occurred_at")),
+            order.get(str(event.get("event_type")), 99),
+            str(event.get("event_id")),
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class TaskReadModel:
+    """Presentation-friendly read model for task inspection surfaces."""
+
+    task_id: str
+    title: str
+    description: str | None
+    current_status: str
+    objective_summary: str | None
+    origin: dict[str, Any]
+    relationships: dict[str, Any]
+    assigned_executor: dict[str, Any] | None
+    evidence_summary: dict[str, Any]
+    verification_summary: dict[str, Any] | None
+    reconciliation_summary: dict[str, Any] | None
+    review_summary: dict[str, Any]
+    evaluation_summary: dict[str, Any]
+    lifecycle_history: list[dict[str, Any]]
+    timestamps: dict[str, Any]
+    extensions: dict[str, Any]
+    timeline: list[dict[str, Any]]
+
+
+class HarnessReadModelService:
+    """Build dashboard-friendly task inspection surfaces from persisted records."""
+
+    def __init__(self, *, store: FileBackedHarnessStore | None = None) -> None:
+        self.store = store or FileBackedHarnessStore(".harness-store")
+
+    def _load_task_and_records(self, task_id: str) -> tuple[TaskEnvelope, tuple[EvaluationRecord, ...]]:
+        task = self.store.get_task(task_id)
+        records = tuple(
+            sorted(
+                self.store.list_evaluation_records(task_id),
+                key=lambda record: (_parse_iso_timestamp(record.recorded_at), record.evaluation_id),
+            )
+        )
+        return task, records
+
+    def build_task_read_model(self, task_id: str) -> TaskReadModel:
+        task, records = self._load_task_and_records(task_id)
+        verification_summary = _latest_mapping(records, ("enforcement_result", "verification_result"))
+        reconciliation_summary = _latest_mapping(records, ("enforcement_result", "reconciliation_result"))
+        review_summary = _build_review_summary(records)
+        timeline = _build_timeline(task, records)
+
+        return TaskReadModel(
+            task_id=str(task["id"]),
+            title=str(task.get("title") or ""),
+            description=task.get("description"),
+            current_status=str(task.get("status") or ""),
+            objective_summary=str(((task.get("objective") or {}).get("summary"))) if (task.get("objective") or {}).get("summary") is not None else None,
+            origin=dict(task.get("origin") or {}),
+            relationships={
+                "parent_task_id": task.get("parent_task_id"),
+                "child_task_ids": list(task.get("child_task_ids") or []),
+                "dependencies": list(task.get("dependencies") or []),
+            },
+            assigned_executor=dict(task.get("assigned_executor") or {}) if task.get("assigned_executor") is not None else None,
+            evidence_summary=_build_evidence_summary(task),
+            verification_summary=verification_summary,
+            reconciliation_summary=reconciliation_summary,
+            review_summary=review_summary,
+            evaluation_summary={
+                "count": len(records),
+                "latest_recorded_at": records[-1].recorded_at if records else None,
+                "latest_action": records[-1].result.get("action") if records and isinstance(records[-1].result, dict) else None,
+                "latest_target_status": records[-1].result.get("target_status") if records and isinstance(records[-1].result, dict) else None,
+                "history": [
+                    {
+                        "evaluation_id": record.evaluation_id,
+                        "recorded_at": record.recorded_at,
+                        "action": record.result.get("action") if isinstance(record.result, dict) else None,
+                        "target_status": record.result.get("target_status") if isinstance(record.result, dict) else None,
+                    }
+                    for record in records
+                ],
+            },
+            lifecycle_history=list(task.get("status_history") or []),
+            timestamps=dict(task.get("timestamps") or {}),
+            extensions=dict(task.get("extensions") or {}),
+            timeline=timeline,
+        )
+
+    def build_task_timeline(self, task_id: str) -> dict[str, Any]:
+        task, records = self._load_task_and_records(task_id)
+        timeline = _build_timeline(task, records)
+        return {
+            "task_id": task_id,
+            "current_status": task.get("status"),
+            "event_count": len(timeline),
+            "timeline": timeline,
+        }
+
+
+__all__ = [
+    "HarnessReadModelService",
+    "TaskReadModel",
+]

--- a/modules/store.py
+++ b/modules/store.py
@@ -166,7 +166,7 @@ class FileBackedHarnessStore(TaskEnvelopeStore, EvaluationRecordStore):
             return ()
 
         records: list[EvaluationRecord] = []
-        for path in sorted(task_dir.glob("*.json")):
+        for path in task_dir.glob("*.json"):
             payload = self._read_json(path)
             records.append(
                 EvaluationRecord(
@@ -177,6 +177,7 @@ class FileBackedHarnessStore(TaskEnvelopeStore, EvaluationRecordStore):
                     result=payload["result"],
                 )
             )
+        records.sort(key=lambda record: (record.recorded_at, record.evaluation_id))
         return tuple(records)
 
 

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import unittest
+from copy import deepcopy
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from modules.api import HarnessApiService, run_server
+from modules.demo_cases import build_demo_request
+from modules.goal_to_work import GoalToWorkRequest, run_goal_to_work_flow
+from modules.store import FileBackedHarnessStore
+from modules.contracts.task_envelope_review import (
+    ReviewOutcome,
+    ReviewRequest,
+    ReviewTrigger,
+    ReviewerIdentity,
+    resolve_review_request,
+)
+
+
+def _to_jsonable(value):
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _request_payload(case_name: str) -> dict:
+    return {"request": _to_jsonable(build_demo_request(case_name))}
+
+
+def _goal_request() -> GoalToWorkRequest:
+    return GoalToWorkRequest(
+        goal_id="goal-read-model-demo",
+        title="Harness dashboard read model",
+        product_goal="Show control-plane task state in a dashboard-friendly read surface.",
+        target_user="Operators and reviewers inspecting AI-driven work.",
+        problem_statement="Current state, evidence, verification, and review context should be easy to inspect.",
+        scope=(
+            {
+                "id": "read-model",
+                "title": "Task read model",
+                "description": "Build a presentation-friendly detail view contract.",
+                "category": "inspection",
+            },
+        ),
+        constraints=(
+            "Use canonical Harness ingress and persistence boundaries.",
+            "Keep the result auditable and deterministic.",
+        ),
+        success_criteria=(
+            "Operators can inspect current status and history for an ingested task.",
+        ),
+        priority="high",
+    )
+
+
+def _review_decision_payload(task_id: str) -> dict:
+    review_request = ReviewRequest(
+        review_request_id="review-request-read-model-1",
+        task_id=task_id,
+        requested_at="2026-03-24T17:30:00Z",
+        requested_by="verification",
+        trigger=ReviewTrigger.VERIFICATION,
+        summary="Manual confirmation is required before completion can be accepted.",
+        presented_sections=("task_state", "evidence", "reconciliation"),
+        allowed_outcomes=(ReviewOutcome.ACCEPT_COMPLETION,),
+    )
+    review_decision = resolve_review_request(
+        review_request,
+        review_id="review-read-model-1",
+        reviewer=ReviewerIdentity(
+            reviewer_id="operator-1",
+            reviewer_name="Casey Reviewer",
+            authority_role="operator",
+        ),
+        outcome=ReviewOutcome.ACCEPT_COMPLETION,
+        reasoning="Manual review confirms the completion claim should be accepted.",
+    )
+    return _to_jsonable(review_decision)
+
+
+class HarnessReadModelServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = FileBackedHarnessStore(self.temp_dir.name)
+        self.service = HarnessApiService(store=self.store)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_builds_read_model_for_accepted_completion_task(self) -> None:
+        submit_status, submit_payload = self.service.submit(_request_payload("accepted_completion"))
+
+        status, payload = self.service.get_task_read_model(submit_payload["task_envelope"]["id"])
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task"]["current_status"], "completed")
+        self.assertEqual(payload["task"]["verification_summary"]["outcome"], "accepted_completion")
+        self.assertEqual(payload["task"]["reconciliation_summary"]["outcome"], "no_mismatch")
+        self.assertEqual(payload["task"]["evidence_summary"]["artifact_count"], 2)
+        self.assertEqual(payload["task"]["evaluation_summary"]["count"], 1)
+
+    def test_builds_read_model_for_blocked_insufficient_evidence(self) -> None:
+        submit_status, submit_payload = self.service.submit(_request_payload("blocked_insufficient_evidence"))
+
+        status, payload = self.service.get_task_read_model(submit_payload["task_envelope"]["id"])
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task"]["current_status"], "blocked")
+        self.assertEqual(payload["task"]["verification_summary"]["outcome"], "insufficient_evidence")
+
+    def test_timeline_shows_completed_to_blocked_rollback(self) -> None:
+        initial_status, initial_payload = self.service.submit(_request_payload("accepted_completion"))
+        task_id = initial_payload["task_envelope"]["id"]
+
+        reevaluation_payload = {
+            "request": {
+                "external_facts": deepcopy(_request_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(_request_payload("accepted_completion")["request"]["runtime_facts"]),
+            }
+        }
+        reevaluation_status, _ = self.service.reevaluate(task_id, reevaluation_payload)
+        status, payload = self.service.get_task_timeline(task_id)
+
+        transition_targets = [
+            event["details"]["to_status"]
+            for event in payload["timeline"]
+            if event["event_type"] == "status_transition"
+        ]
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(reevaluation_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(transition_targets[-2:], ["completed", "blocked"])
+
+    def test_review_summary_shows_request_then_resolution(self) -> None:
+        accepted_payload = _request_payload("accepted_completion")
+        initial_payload = {"request": deepcopy(accepted_payload["request"])}
+        initial_payload["request"]["task_envelope"]["status"] = "blocked"
+        initial_payload["request"]["task_envelope"]["timestamps"]["completed_at"] = None
+        initial_payload["request"]["review_request"] = deepcopy(_request_payload("review_required")["request"]["review_request"])
+        initial_payload["request"]["review_request"]["task_id"] = initial_payload["request"]["task_envelope"]["id"]
+        initial_payload["request"]["external_facts"] = deepcopy(_request_payload("review_required")["request"]["external_facts"])
+
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        reevaluation_status, _ = self.service.reevaluate(
+            task_id,
+            {"request": {"review_decision": _review_decision_payload(task_id)}},
+        )
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(reevaluation_status, 200)
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["current_status"], "completed")
+        self.assertEqual(read_payload["task"]["review_summary"]["status"], "resolved")
+        self.assertEqual(read_payload["task"]["review_summary"]["request_count"], 1)
+        self.assertEqual(read_payload["task"]["review_summary"]["decision_count"], 1)
+
+    def test_read_model_handles_goal_to_work_ingested_task(self) -> None:
+        flow_result = run_goal_to_work_flow(_goal_request(), auto_approve=True, service=self.service)
+        ingested_task_id = next(
+            item.task_id for item in flow_result.ingestion_result.item_results if item.ingested and item.task_id
+        )
+
+        status, payload = self.service.get_task_read_model(ingested_task_id)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task"]["origin"]["source_system"], "linear")
+        self.assertIn("linear", payload["task"]["extensions"])
+        self.assertGreaterEqual(payload["task"]["evaluation_summary"]["count"], 1)
+
+
+class HarnessReadModelHttpApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.server = run_server(host="127.0.0.1", port=0, store_root=self.temp_dir.name)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.temp_dir.cleanup()
+
+    def _get_json(self, path: str) -> tuple[int, dict]:
+        try:
+            with urlopen(self.base_url + path) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            try:
+                return error.code, json.loads(error.read().decode("utf-8"))
+            finally:
+                error.close()
+
+    def _post_json(self, path: str, payload: dict) -> tuple[int, dict]:
+        request = Request(
+            self.base_url + path,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            try:
+                return error.code, json.loads(error.read().decode("utf-8"))
+            finally:
+                error.close()
+
+    def test_api_exposes_task_read_model_endpoint(self) -> None:
+        submit_status, submit_payload = self._post_json("/tasks", _request_payload("accepted_completion"))
+        task_id = submit_payload["task_envelope"]["id"]
+
+        status, payload = self._get_json(f"/tasks/{task_id}/read-model")
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task"]["task_id"], task_id)
+        self.assertEqual(payload["task"]["current_status"], "completed")
+        self.assertEqual(payload["task"]["verification_summary"]["outcome"], "accepted_completion")
+
+    def test_api_exposes_task_timeline_endpoint(self) -> None:
+        submit_status, submit_payload = self._post_json("/tasks", _request_payload("blocked_insufficient_evidence"))
+        task_id = submit_payload["task_envelope"]["id"]
+
+        status, payload = self._get_json(f"/tasks/{task_id}/timeline")
+
+        event_types = {event["event_type"] for event in payload["timeline"]}
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task_id"], task_id)
+        self.assertIn("task_created", event_types)
+        self.assertIn("evaluation_recorded", event_types)
+        self.assertIn("status_transition", event_types)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dashboard-friendly task read model built from persisted task snapshots and append-only evaluation records
- expose `GET /tasks/<task_id>/read-model` and `GET /tasks/<task_id>/timeline` for inspection and timeline views
- include read-model coverage for accepted, blocked, rollback, review-resolution, and goal-to-work-ingested task cases

## Validation
- `.venv/bin/python -m unittest tests.test_read_model`
- `.venv/bin/python -m unittest tests.test_api tests.test_read_model tests.test_goal_to_work`
- `.venv/bin/python -m unittest discover -s tests`
- `python3 -m py_compile modules/read_model.py modules/api.py`

## Notes
- evaluation history ordering now sorts by `recorded_at` so timeline output reflects actual event order