### PR TITLE
Implement canonical end-to-end demo walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,30 @@ Artifacts are written under the output directory as:
 
 The demo runner uses only the public API or simulator surface. It does not duplicate control-plane logic.
 
+## End-to-End Operator Walkthrough
+
+For a polished local demo that seeds real tasks into the API and then makes them easy to inspect in the dashboard, use the canonical walkthrough helper:
+
+```bash
+python -m modules.demo_walkthrough reset --store-root .demo-store --output-dir demo-output/walkthrough
+.venv/bin/python -m modules.api --host 127.0.0.1 --port 8000 --store-root .demo-store
+pnpm dev
+python -m modules.demo_walkthrough seed \
+  --base-url http://127.0.0.1:8000 \
+  --dashboard-url http://127.0.0.1:3000 \
+  --output-dir demo-output/walkthrough
+```
+
+This walkthrough seeds named tasks such as:
+
+- `demo-successful-completion`
+- `demo-missing-evidence-then-completed`
+- `demo-contradictory-facts-blocked`
+- `demo-review-required-then-completed`
+- `demo-long-running-handoff`
+
+The generated `walkthrough.txt` and `walkthrough.json` files include task IDs, direct dashboard URLs, and per-scenario operator focus points. See [docs/demo/operator-walkthrough.md](docs/demo/operator-walkthrough.md) for the narrated flow.
+
 ## Local HTTP API
 
 You can also run a minimal local HTTP wrapper around the same evaluation entry point:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,23 @@ export default function DashboardPage() {
   const [detailError, setDetailError] = useState<string | null>(null);
 
   useEffect(() => {
+    const initialTaskId = new URLSearchParams(window.location.search).get("task");
+    if (initialTaskId) {
+      setSelectedTaskId(initialTaskId);
+    }
+  }, []);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    if (selectedTaskId) {
+      url.searchParams.set("task", selectedTaskId);
+    } else {
+      url.searchParams.delete("task");
+    }
+    window.history.replaceState({}, "", url);
+  }, [selectedTaskId]);
+
+  useEffect(() => {
     let cancelled = false;
 
     async function loadTasks() {

--- a/docs/demo/operator-walkthrough.md
+++ b/docs/demo/operator-walkthrough.md
@@ -1,0 +1,85 @@
+# Harness Operator Demo Walkthrough
+
+This walkthrough uses the real public Harness API, persisted task state, and the dashboard's real inspection surfaces.
+
+## Purpose
+
+Use this flow when you want one repeatable demo that shows:
+
+- accepted completion
+- blocked due to insufficient evidence, then later accepted
+- contradictory external facts forcing rollback to blocked
+- review-required flow with explicit manual resolution
+- long-running progress and handoff artifacts visible in timeline/evidence views
+
+## Local Demo Flow
+
+1. Reset prior demo state:
+
+```bash
+python -m modules.demo_walkthrough reset --store-root .demo-store --output-dir demo-output/walkthrough
+```
+
+2. Start the Harness API against the demo store:
+
+```bash
+.venv/bin/python -m modules.api --host 127.0.0.1 --port 8000 --store-root .demo-store
+```
+
+3. Start the dashboard in a separate terminal:
+
+```bash
+cp .env.example .env.local
+pnpm install --frozen-lockfile
+pnpm dev
+```
+
+The dashboard reads `HARNESS_API_BASE_URL` server-side through the Next proxy route. Set it in `.env.local`:
+
+```bash
+HARNESS_API_BASE_URL=http://127.0.0.1:8000
+```
+
+4. Seed the canonical walkthrough scenarios:
+
+```bash
+python -m modules.demo_walkthrough seed \
+  --base-url http://127.0.0.1:8000 \
+  --dashboard-url http://127.0.0.1:3000 \
+  --output-dir demo-output/walkthrough
+```
+
+This writes:
+
+- `demo-output/walkthrough/walkthrough.txt`
+- `demo-output/walkthrough/walkthrough.json`
+- per-scenario `.timeline.txt`, `.mmd`, and `.json` trace files
+
+## Operator Narrative
+
+Open the dashboard and inspect these seeded tasks:
+
+- `demo-successful-completion`
+  - Show that aligned evidence and reconciliation allow Harness to preserve `completed`.
+- `demo-missing-evidence-then-completed`
+  - Show the initial blocked decision, then the later evidence-driven completion.
+- `demo-contradictory-facts-blocked`
+  - Show a previously acceptable completion being rolled back to `blocked` because facts no longer align.
+- `demo-review-required-then-completed`
+  - Show that review is explicit and auditable, then later resolved.
+- `demo-long-running-handoff`
+  - Show `progress_artifact` and `handoff_artifact` appearing in the timeline before final completion.
+
+If you passed `--dashboard-url`, the walkthrough summary prints direct links like:
+
+- `http://127.0.0.1:3000/?task=demo-successful-completion`
+
+## What To Explain
+
+For each task, narrate:
+
+1. what happened
+2. what evidence or external facts arrived
+3. what verification or reconciliation outcome Harness produced
+4. which lifecycle transition resulted
+5. why the final state is trustworthy or blocked

--- a/modules/demo_walkthrough.py
+++ b/modules/demo_walkthrough.py
@@ -1,0 +1,270 @@
+"""Canonical end-to-end demo walkthrough for Harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from modules.demo_runner import render_console_timeline, render_mermaid_trace
+from modules.simulator import SimulationResult, run_scenario
+
+
+@dataclass(frozen=True)
+class DemoWalkthroughScenario:
+    """One polished operator-facing demo scenario."""
+
+    name: str
+    title: str
+    operator_focus: str
+    dashboard_focus: str
+
+
+@dataclass(frozen=True)
+class DemoWalkthroughItem:
+    """Persisted summary for one seeded demo scenario."""
+
+    scenario_name: str
+    scenario_title: str
+    task_id: str
+    final_status: str | None
+    operator_focus: str
+    dashboard_focus: str
+    dashboard_url: str | None
+    artifact_files: dict[str, str]
+
+
+@dataclass(frozen=True)
+class DemoWalkthroughResult:
+    """Structured output for a canonical demo walkthrough seed run."""
+
+    base_url: str
+    output_dir: str
+    scenarios: tuple[DemoWalkthroughItem, ...]
+
+
+CANONICAL_WALKTHROUGH: tuple[DemoWalkthroughScenario, ...] = (
+    DemoWalkthroughScenario(
+        "successful_completion",
+        "Accepted Completion",
+        "Explain how aligned evidence and reconciliation allow Harness to preserve completed.",
+        "Open the task timeline and show the single verification pass that ends in completed.",
+    ),
+    DemoWalkthroughScenario(
+        "missing_evidence_then_completed",
+        "Blocked To Completed",
+        "Show that completion claims are blocked until the missing evidence actually arrives.",
+        "Open the timeline and point out the blocked evaluation before the later review note resolves it.",
+    ),
+    DemoWalkthroughScenario(
+        "contradictory_facts_blocked",
+        "Contradictory Facts Rollback",
+        "Show Harness reversing a previously accepted completion when external facts contradict it.",
+        "Open the task detail and highlight the completed-to-blocked lifecycle reversal.",
+    ),
+    DemoWalkthroughScenario(
+        "review_required_then_completed",
+        "Review Required To Completed",
+        "Show that manual review is explicit, auditable, and non-terminal until resolved.",
+        "Open the review panel and timeline to show request then decision.",
+    ),
+    DemoWalkthroughScenario(
+        "long_running_handoff",
+        "Long-Running Handoff",
+        "Show progress and handoff artifacts accumulating across evaluations without counting as completion evidence by default.",
+        "Open evidence and timeline views to point out progress_artifact and handoff_artifact before final completion.",
+    ),
+)
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _slug(value: str) -> str:
+    return value.replace("_", "-")
+
+
+def reset_demo_state(*, store_root: str | None = None, output_dir: str | None = None) -> None:
+    """Remove persisted demo state and walkthrough artifacts."""
+
+    for target in (store_root, output_dir):
+        if not target:
+            continue
+        path = Path(target)
+        if path.exists():
+            shutil.rmtree(path)
+
+
+def _write_scenario_artifacts(output_dir: Path, result: SimulationResult) -> dict[str, str]:
+    timeline_path = output_dir / f"{result.scenario_name}.timeline.txt"
+    mermaid_path = output_dir / f"{result.scenario_name}.mmd"
+    json_path = output_dir / f"{result.scenario_name}.json"
+
+    timeline_path.write_text(render_console_timeline(result) + "\n", encoding="utf-8")
+    mermaid_path.write_text(render_mermaid_trace(result) + "\n", encoding="utf-8")
+    json_path.write_text(json.dumps(_to_jsonable(result), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return {
+        "timeline": str(timeline_path),
+        "mermaid": str(mermaid_path),
+        "json": str(json_path),
+    }
+
+
+def run_demo_walkthrough(
+    *,
+    base_url: str,
+    output_dir: str = "demo-output/walkthrough",
+    dashboard_url: str | None = None,
+    scenario_names: tuple[str, ...] | None = None,
+) -> DemoWalkthroughResult:
+    """Seed the canonical demo scenarios into one live Harness API."""
+
+    selected_specs = tuple(
+        spec for spec in CANONICAL_WALKTHROUGH if scenario_names is None or spec.name in scenario_names
+    )
+    invalid = sorted(set(scenario_names or ()) - {spec.name for spec in CANONICAL_WALKTHROUGH})
+    if invalid:
+        raise ValueError(f"Unknown walkthrough scenarios: {', '.join(invalid)}")
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    scenario_items: list[DemoWalkthroughItem] = []
+    for spec in selected_specs:
+        task_id = f"demo-{_slug(spec.name)}"
+        title = f"Demo: {spec.title}"
+        result = run_scenario(
+            spec.name,
+            base_url=base_url,
+            task_id_override=task_id,
+            task_title_override=title,
+            origin_source_id_override=task_id,
+        )
+        files = _write_scenario_artifacts(output_path, result)
+        scenario_items.append(
+            DemoWalkthroughItem(
+                scenario_name=spec.name,
+                scenario_title=spec.title,
+                task_id=task_id,
+                final_status=result.final_task_status,
+                operator_focus=spec.operator_focus,
+                dashboard_focus=spec.dashboard_focus,
+                dashboard_url=f"{dashboard_url.rstrip('/')}/?task={task_id}" if dashboard_url else None,
+                artifact_files=files,
+            )
+        )
+
+    result = DemoWalkthroughResult(
+        base_url=base_url,
+        output_dir=str(output_path),
+        scenarios=tuple(scenario_items),
+    )
+
+    (output_path / "walkthrough.json").write_text(
+        json.dumps(_to_jsonable(result), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_path / "walkthrough.txt").write_text(format_walkthrough_summary(result) + "\n", encoding="utf-8")
+    return result
+
+
+def format_walkthrough_summary(result: DemoWalkthroughResult) -> str:
+    """Render a concise operator-facing walkthrough summary."""
+
+    lines = [
+        "Harness End-to-End Demo Walkthrough",
+        f"API Base URL: {result.base_url}",
+        f"Artifacts Directory: {Path(result.output_dir).resolve()}",
+        "",
+        "Scenarios:",
+    ]
+    for index, scenario in enumerate(result.scenarios, start=1):
+        lines.extend(
+            [
+                f"{index}. {scenario.scenario_title}",
+                f"   task_id: {scenario.task_id}",
+                f"   final_status: {scenario.final_status}",
+                f"   operator_focus: {scenario.operator_focus}",
+                f"   dashboard_focus: {scenario.dashboard_focus}",
+                f"   timeline: {scenario.artifact_files['timeline']}",
+                f"   mermaid: {scenario.artifact_files['mermaid']}",
+                f"   json: {scenario.artifact_files['json']}",
+            ]
+        )
+        if scenario.dashboard_url:
+            lines.append(f"   dashboard_url: {scenario.dashboard_url}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the walkthrough CLI parser."""
+
+    parser = argparse.ArgumentParser(description="Run the canonical Harness operator demo walkthrough.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List walkthrough scenarios")
+    list_parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON")
+
+    reset_parser = subparsers.add_parser("reset", help="Delete persisted demo store and generated walkthrough artifacts")
+    reset_parser.add_argument("--store-root", default=".demo-store", help="Store root directory to remove")
+    reset_parser.add_argument("--output-dir", default="demo-output/walkthrough", help="Walkthrough output directory to remove")
+
+    seed_parser = subparsers.add_parser("seed", help="Seed the canonical walkthrough scenarios into a running Harness API")
+    seed_parser.add_argument("--base-url", default="http://127.0.0.1:8000", help="Harness API base URL")
+    seed_parser.add_argument("--output-dir", default="demo-output/walkthrough", help="Directory for walkthrough artifacts")
+    seed_parser.add_argument("--dashboard-url", default=None, help="Optional dashboard URL used to print direct task links")
+    seed_parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON")
+    seed_parser.add_argument("scenario_names", nargs="*", help="Optional subset of walkthrough scenarios to seed")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the canonical operator walkthrough."""
+
+    args = build_parser().parse_args(argv)
+
+    if args.command == "list":
+        payload = [{"name": spec.name, "title": spec.title} for spec in CANONICAL_WALKTHROUGH]
+        if args.as_json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            for item in payload:
+                print(f"{item['name']}: {item['title']}")
+        return 0
+
+    if args.command == "reset":
+        reset_demo_state(store_root=args.store_root, output_dir=args.output_dir)
+        print(f"Removed demo state under {Path(args.store_root).resolve()} and {Path(args.output_dir).resolve()}")
+        return 0
+
+    selected = tuple(args.scenario_names) if args.scenario_names else None
+    result = run_demo_walkthrough(
+        base_url=args.base_url,
+        output_dir=args.output_dir,
+        dashboard_url=args.dashboard_url,
+        scenario_names=selected,
+    )
+    if args.as_json:
+        print(json.dumps(_to_jsonable(result), indent=2, sort_keys=True))
+    else:
+        print(format_walkthrough_summary(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/simulator.py
+++ b/modules/simulator.py
@@ -37,6 +37,35 @@ def _canonical_payload(case_name: str) -> dict[str, Any]:
     return {"request": _to_jsonable(build_demo_request(case_name))}
 
 
+def _customize_canonical_payload(
+    payload: dict[str, Any],
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> dict[str, Any]:
+    customized = deepcopy(payload)
+    request = customized.get("request")
+    if not isinstance(request, dict):
+        return customized
+
+    task_envelope = request.get("task_envelope")
+    if isinstance(task_envelope, dict):
+        if task_id_override is not None:
+            task_envelope["id"] = task_id_override
+        if task_title_override is not None:
+            task_envelope["title"] = task_title_override
+        origin = task_envelope.get("origin")
+        if isinstance(origin, dict) and origin_source_id_override is not None:
+            origin["source_id"] = origin_source_id_override
+
+    review_request = request.get("review_request")
+    if isinstance(review_request, dict) and task_id_override is not None:
+        review_request["task_id"] = task_id_override
+
+    return customized
+
+
 def _review_note_artifact(artifact_id: str = "artifact-review-note-sim-1") -> dict[str, Any]:
     return {
         "id": artifact_id,
@@ -191,9 +220,26 @@ class HarnessSimulatorClient:
 
 
 class _ScenarioContext:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        task_id_override: str | None = None,
+        task_title_override: str | None = None,
+        origin_source_id_override: str | None = None,
+    ) -> None:
         self.task_id: str | None = None
         self.steps: list[SimulationStepResult] = []
+        self.task_id_override = task_id_override
+        self.task_title_override = task_title_override
+        self.origin_source_id_override = origin_source_id_override
+
+    def canonical_payload(self, case_name: str) -> dict[str, Any]:
+        return _customize_canonical_payload(
+            _canonical_payload(case_name),
+            task_id_override=self.task_id_override,
+            task_title_override=self.task_title_override,
+            origin_source_id_override=self.origin_source_id_override,
+        )
 
     def record(
         self,
@@ -313,16 +359,36 @@ def _review_decision_payload(task_id: str) -> dict[str, Any]:
     return _to_jsonable(decision)
 
 
-def _scenario_successful_completion(client: HarnessSimulatorClient) -> SimulationResult:
-    context = _ScenarioContext()
-    _submit_step(client, context, "submit", _canonical_payload("accepted_completion"))
+def _scenario_successful_completion(
+    client: HarnessSimulatorClient,
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
+    context = _ScenarioContext(
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
+    _submit_step(client, context, "submit", context.canonical_payload("accepted_completion"))
     task_snapshot, history = _fetch_final_state(client, context)
     return SimulationResult("successful_completion", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
 
 
-def _scenario_missing_evidence_then_completed(client: HarnessSimulatorClient) -> SimulationResult:
-    context = _ScenarioContext()
-    initial_payload = _canonical_payload("blocked_insufficient_evidence")
+def _scenario_missing_evidence_then_completed(
+    client: HarnessSimulatorClient,
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
+    context = _ScenarioContext(
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
+    initial_payload = context.canonical_payload("blocked_insufficient_evidence")
     _submit_step(client, context, "submit", initial_payload)
     _reevaluate_step(
         client,
@@ -338,7 +404,7 @@ def _scenario_missing_evidence_then_completed(client: HarnessSimulatorClient) ->
                         "artifact-review-note-sim-1",
                     ]
                 },
-                "external_facts": deepcopy(_canonical_payload("accepted_completion")["request"]["external_facts"]),
+                "external_facts": deepcopy(context.canonical_payload("accepted_completion")["request"]["external_facts"]),
                 "claimed_completion": True,
                 "acceptance_criteria_satisfied": True,
                 "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
@@ -349,9 +415,19 @@ def _scenario_missing_evidence_then_completed(client: HarnessSimulatorClient) ->
     return SimulationResult("missing_evidence_then_completed", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
 
 
-def _scenario_wrong_target_corrected(client: HarnessSimulatorClient) -> SimulationResult:
-    context = _ScenarioContext()
-    initial_payload = _canonical_payload("accepted_completion")
+def _scenario_wrong_target_corrected(
+    client: HarnessSimulatorClient,
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
+    context = _ScenarioContext(
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
+    initial_payload = context.canonical_payload("accepted_completion")
     wrong_target_payload = deepcopy(initial_payload)
     wrong_target_payload["request"]["task_envelope"]["status"] = "blocked"
     wrong_target_payload["request"]["task_envelope"]["timestamps"]["completed_at"] = None
@@ -375,16 +451,26 @@ def _scenario_wrong_target_corrected(client: HarnessSimulatorClient) -> Simulati
     return SimulationResult("wrong_target_corrected", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
 
 
-def _scenario_review_required_then_completed(client: HarnessSimulatorClient) -> SimulationResult:
-    context = _ScenarioContext()
-    accepted_payload = _canonical_payload("accepted_completion")
+def _scenario_review_required_then_completed(
+    client: HarnessSimulatorClient,
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
+    context = _ScenarioContext(
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
+    accepted_payload = context.canonical_payload("accepted_completion")
     review_payload = {
         "request": deepcopy(accepted_payload["request"]),
     }
     review_payload["request"]["task_envelope"]["status"] = "blocked"
     review_payload["request"]["task_envelope"]["timestamps"]["completed_at"] = None
     review_payload["request"]["review_request"] = _review_request_payload(review_payload["request"]["task_envelope"]["id"])
-    review_payload["request"]["external_facts"] = deepcopy(_canonical_payload("review_required")["request"]["external_facts"])
+    review_payload["request"]["external_facts"] = deepcopy(context.canonical_payload("review_required")["request"]["external_facts"])
 
     _submit_step(client, context, "submit", review_payload)
     _reevaluate_step(
@@ -401,9 +487,19 @@ def _scenario_review_required_then_completed(client: HarnessSimulatorClient) -> 
     return SimulationResult("review_required_then_completed", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
 
 
-def _scenario_contradictory_facts_rollback(client: HarnessSimulatorClient) -> SimulationResult:
-    context = _ScenarioContext()
-    accepted_payload = _canonical_payload("accepted_completion")
+def _scenario_contradictory_facts_rollback(
+    client: HarnessSimulatorClient,
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
+    context = _ScenarioContext(
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
+    accepted_payload = context.canonical_payload("accepted_completion")
     _submit_step(client, context, "submit", accepted_payload)
     _reevaluate_step(
         client,
@@ -411,7 +507,7 @@ def _scenario_contradictory_facts_rollback(client: HarnessSimulatorClient) -> Si
         "introduce_contradictory_facts",
         {
             "request": {
-                "external_facts": deepcopy(_canonical_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
+                "external_facts": deepcopy(context.canonical_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
                 "claimed_completion": True,
                 "acceptance_criteria_satisfied": True,
                 "runtime_facts": deepcopy(accepted_payload["request"]["runtime_facts"]),
@@ -435,9 +531,19 @@ def _scenario_contradictory_facts_rollback(client: HarnessSimulatorClient) -> Si
     return SimulationResult("contradictory_facts_rollback", context.task_id, task_snapshot.get("status") if task_snapshot else None, tuple(context.steps), task_snapshot, history)
 
 
-def _scenario_contradictory_facts_blocked(client: HarnessSimulatorClient) -> SimulationResult:
-    context = _ScenarioContext()
-    accepted_payload = _canonical_payload("accepted_completion")
+def _scenario_contradictory_facts_blocked(
+    client: HarnessSimulatorClient,
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
+    context = _ScenarioContext(
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
+    accepted_payload = context.canonical_payload("accepted_completion")
     _submit_step(client, context, "submit", accepted_payload)
     _reevaluate_step(
         client,
@@ -445,7 +551,7 @@ def _scenario_contradictory_facts_blocked(client: HarnessSimulatorClient) -> Sim
         "introduce_contradictory_facts",
         {
             "request": {
-                "external_facts": deepcopy(_canonical_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
+                "external_facts": deepcopy(context.canonical_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
                 "claimed_completion": True,
                 "acceptance_criteria_satisfied": True,
                 "runtime_facts": deepcopy(accepted_payload["request"]["runtime_facts"]),
@@ -463,9 +569,19 @@ def _scenario_contradictory_facts_blocked(client: HarnessSimulatorClient) -> Sim
     )
 
 
-def _scenario_long_running_handoff(client: HarnessSimulatorClient) -> SimulationResult:
-    context = _ScenarioContext()
-    initial_payload = _canonical_payload("blocked_insufficient_evidence")
+def _scenario_long_running_handoff(
+    client: HarnessSimulatorClient,
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
+    context = _ScenarioContext(
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
+    initial_payload = context.canonical_payload("blocked_insufficient_evidence")
     _submit_step(client, context, "submit", initial_payload)
     _reevaluate_step(
         client,
@@ -509,7 +625,7 @@ def _scenario_long_running_handoff(client: HarnessSimulatorClient) -> Simulation
                         "artifact-review-note-sim-1",
                     ]
                 },
-                "external_facts": deepcopy(_canonical_payload("accepted_completion")["request"]["external_facts"]),
+                "external_facts": deepcopy(context.canonical_payload("accepted_completion")["request"]["external_facts"]),
                 "claimed_completion": True,
                 "acceptance_criteria_satisfied": True,
                 "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
@@ -537,12 +653,24 @@ def list_scenarios() -> tuple[str, ...]:
     return tuple(_SCENARIOS.keys())
 
 
-def run_scenario(scenario_name: str, *, base_url: str = "http://127.0.0.1:8000") -> SimulationResult:
+def run_scenario(
+    scenario_name: str,
+    *,
+    base_url: str = "http://127.0.0.1:8000",
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
     """Run one simulator scenario entirely through the public Harness HTTP API."""
 
     if scenario_name not in _SCENARIOS:
         raise ValueError(f"Unknown simulator scenario {scenario_name!r}")
-    return _SCENARIOS[scenario_name](HarnessSimulatorClient(base_url))
+    return _SCENARIOS[scenario_name](
+        HarnessSimulatorClient(base_url),
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
 
 
 def _format_step(step: SimulationStepResult) -> str:

--- a/tests/test_demo_walkthrough.py
+++ b/tests/test_demo_walkthrough.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+from modules.api import run_server
+from modules.demo_walkthrough import main, reset_demo_state, run_demo_walkthrough
+from modules.store import FileBackedHarnessStore
+
+
+class DemoWalkthroughTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store_root = Path(self.temp_dir.name) / "store"
+        self.output_dir = Path(self.temp_dir.name) / "output"
+        self.server = run_server(host="127.0.0.1", port=0, store_root=str(self.store_root))
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.temp_dir.cleanup()
+
+    def _run_cli(self, *args: str) -> tuple[int, str]:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = main(list(args))
+        return exit_code, stdout.getvalue()
+
+    def test_runs_canonical_walkthrough_and_persists_tasks(self) -> None:
+        result = run_demo_walkthrough(
+            base_url=self.base_url,
+            output_dir=str(self.output_dir),
+            dashboard_url="http://127.0.0.1:3000",
+        )
+
+        store = FileBackedHarnessStore(self.store_root)
+        tasks = store.list_tasks()
+        task_ids = {task["id"] for task in tasks}
+
+        self.assertEqual(len(result.scenarios), 5)
+        self.assertEqual(len(tasks), 5)
+        self.assertIn("demo-successful-completion", task_ids)
+        self.assertIn("demo-review-required-then-completed", task_ids)
+        self.assertTrue((self.output_dir / "walkthrough.txt").exists())
+        self.assertTrue((self.output_dir / "walkthrough.json").exists())
+        self.assertTrue(all(item.dashboard_url for item in result.scenarios))
+
+    def test_reset_helper_removes_demo_state(self) -> None:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.store_root.mkdir(parents=True, exist_ok=True)
+        (self.output_dir / "placeholder.txt").write_text("demo", encoding="utf-8")
+        (self.store_root / "placeholder.txt").write_text("store", encoding="utf-8")
+
+        reset_demo_state(store_root=str(self.store_root), output_dir=str(self.output_dir))
+
+        self.assertFalse(self.output_dir.exists())
+        self.assertFalse(self.store_root.exists())
+
+    def test_cli_seed_emits_json_summary(self) -> None:
+        exit_code, output = self._run_cli(
+            "seed",
+            "--base-url",
+            self.base_url,
+            "--output-dir",
+            str(self.output_dir),
+            "--dashboard-url",
+            "http://127.0.0.1:3000",
+            "successful_completion",
+            "--json",
+        )
+        payload = json.loads(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(len(payload["scenarios"]), 1)
+        self.assertEqual(payload["scenarios"][0]["task_id"], "demo-successful-completion")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -86,6 +86,19 @@ class HarnessSimulatorTests(unittest.TestCase):
         self.assertIn("handoff_artifact", artifact_types)
         self.assertEqual(len(result.evaluation_history), 4)
 
+    def test_can_run_scenario_with_deterministic_task_identity(self) -> None:
+        result = run_scenario(
+            "successful_completion",
+            base_url=self.base_url,
+            task_id_override="demo-successful-completion",
+            task_title_override="Demo: Accepted Completion",
+            origin_source_id_override="demo-successful-completion",
+        )
+
+        self.assertEqual(result.final_task_id, "demo-successful-completion")
+        self.assertEqual(result.task_snapshot["title"], "Demo: Accepted Completion")
+        self.assertEqual(result.task_snapshot["origin"]["source_id"], "demo-successful-completion")
+
     def test_cli_lists_scenarios(self) -> None:
         exit_code, output = self._run_cli("list")
 


### PR DESCRIPTION
## Summary
- add a canonical walkthrough helper that seeds the live Harness API with deterministic demo tasks and writes operator-friendly summary artifacts
- make simulator scenarios support deterministic task IDs, titles, and source labels so multiple scenarios can coexist in one persisted dashboard state
- add direct dashboard task links using `/?task=<task_id>` and document the full local operator flow

## Validation
- `.venv/bin/python -m unittest tests.test_simulator tests.test_demo_walkthrough`
- `.venv/bin/python -m unittest discover -s tests`
- `pnpm build`

## Notes
- the walkthrough uses only the public API and persisted state; it does not duplicate control-plane logic
- seeded walkthrough tasks are easy to find in the dashboard: `demo-successful-completion`, `demo-missing-evidence-then-completed`, `demo-contradictory-facts-blocked`, `demo-review-required-then-completed`, and `demo-long-running-handoff`