### PR TITLE
Implement one-command local demo bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,32 @@ This walkthrough seeds named tasks such as:
 
 The generated `walkthrough.txt` and `walkthrough.json` files include task IDs, direct dashboard URLs, and per-scenario operator focus points. See [docs/demo/operator-walkthrough.md](docs/demo/operator-walkthrough.md) for the narrated flow.
 
+## One-Command Local Demo Bootstrap
+
+For the lowest-friction local demo path, use the bootstrap command:
+
+```bash
+python -m modules.demo_bootstrap
+```
+
+That single command will:
+
+- clear the local demo store and walkthrough output
+- start the Python API on `http://127.0.0.1:8000`
+- start the dashboard on `http://127.0.0.1:3000`
+- seed the deterministic walkthrough tasks
+- print the dashboard URL plus direct `/?task=` links for each canonical demo task
+
+Useful options:
+
+```bash
+python -m modules.demo_bootstrap --exit-after-seed
+python -m modules.demo_bootstrap successful_completion review_required_then_completed
+python -m modules.demo_bootstrap --json --exit-after-seed
+```
+
+The bootstrap command uses the existing public API, walkthrough seeding flow, and dashboard wiring. It does not introduce a separate demo-only control path.
+
 ## Local HTTP API
 
 You can also run a minimal local HTTP wrapper around the same evaluation entry point:

--- a/modules/demo_bootstrap.py
+++ b/modules/demo_bootstrap.py
@@ -1,0 +1,253 @@
+"""One-command local demo bootstrap for Harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.request import urlopen
+
+from modules.api import run_server
+from modules.demo_walkthrough import CANONICAL_WALKTHROUGH, DemoWalkthroughResult, reset_demo_state, run_demo_walkthrough
+
+
+@dataclass(frozen=True)
+class DemoBootstrapResult:
+    """Structured result for a local demo bootstrap run."""
+
+    api_base_url: str
+    dashboard_url: str
+    store_root: str
+    output_dir: str
+    walkthrough: DemoWalkthroughResult
+
+
+def _wait_for_http_ready(url: str, *, timeout_seconds: float, interval_seconds: float = 0.25) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(url) as response:
+                if 200 <= response.status < 500:
+                    return
+        except Exception as error:  # pragma: no cover - exercised via timeout path
+            last_error = error
+        time.sleep(interval_seconds)
+
+    detail = f": {last_error}" if last_error is not None else ""
+    raise TimeoutError(f"Timed out waiting for {url}{detail}")
+
+
+def _default_dashboard_command(*, host: str, port: int) -> list[str]:
+    return ["pnpm", "dev", "--", "--hostname", host, "--port", str(port)]
+
+
+def _start_dashboard_process(
+    *,
+    command: list[str],
+    cwd: Path,
+    api_base_url: str,
+) -> subprocess.Popen[str]:
+    env = dict(os.environ)
+    env["HARNESS_API_BASE_URL"] = api_base_url
+    return subprocess.Popen(command, cwd=str(cwd), env=env)
+
+
+def _stop_dashboard_process(process: subprocess.Popen[str] | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def format_bootstrap_summary(result: DemoBootstrapResult) -> str:
+    """Render the operator-facing bootstrap summary."""
+
+    lines = [
+        "Harness Local Demo Bootstrap",
+        f"Dashboard URL: {result.dashboard_url}",
+        f"API Base URL: {result.api_base_url}",
+        f"Store Root: {Path(result.store_root).resolve()}",
+        f"Artifacts Directory: {Path(result.output_dir).resolve()}",
+        "",
+        "Demo Scenarios:",
+    ]
+
+    for index, scenario in enumerate(result.walkthrough.scenarios, start=1):
+        lines.extend(
+            [
+                f"{index}. {scenario.scenario_title}",
+                f"   task_id: {scenario.task_id}",
+                f"   final_status: {scenario.final_status}",
+                f"   dashboard_url: {scenario.dashboard_url}",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "Available walkthrough scenarios:",
+        ]
+    )
+    for scenario in CANONICAL_WALKTHROUGH:
+        lines.append(f"- {scenario.name}: {scenario.title}")
+
+    return "\n".join(lines)
+
+
+def bootstrap_demo(
+    *,
+    api_host: str = "127.0.0.1",
+    api_port: int = 8000,
+    dashboard_host: str = "127.0.0.1",
+    dashboard_port: int = 3000,
+    store_root: str = ".demo-store",
+    output_dir: str = "demo-output/walkthrough",
+    dashboard_command: list[str] | None = None,
+    scenario_names: tuple[str, ...] | None = None,
+    readiness_timeout_seconds: float = 90.0,
+) -> tuple[DemoBootstrapResult, Any, threading.Thread, subprocess.Popen[str]]:
+    """Reset local demo state, start local surfaces, and seed the walkthrough."""
+
+    repo_root = Path(__file__).resolve().parent.parent
+    reset_demo_state(store_root=store_root, output_dir=output_dir)
+
+    server = run_server(host=api_host, port=api_port, store_root=store_root)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    api_base_url = f"http://{api_host}:{server.server_port}"
+    _wait_for_http_ready(f"{api_base_url}/health", timeout_seconds=readiness_timeout_seconds)
+
+    dashboard_url = f"http://{dashboard_host}:{dashboard_port}"
+    command = dashboard_command or _default_dashboard_command(host=dashboard_host, port=dashboard_port)
+    dashboard_process = _start_dashboard_process(command=command, cwd=repo_root, api_base_url=api_base_url)
+
+    try:
+        _wait_for_http_ready(dashboard_url, timeout_seconds=readiness_timeout_seconds)
+    except Exception:
+        _stop_dashboard_process(dashboard_process)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+        raise
+
+    try:
+        walkthrough = run_demo_walkthrough(
+            base_url=api_base_url,
+            output_dir=output_dir,
+            dashboard_url=dashboard_url,
+            scenario_names=scenario_names,
+        )
+    except Exception:
+        _stop_dashboard_process(dashboard_process)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+        raise
+    result = DemoBootstrapResult(
+        api_base_url=api_base_url,
+        dashboard_url=dashboard_url,
+        store_root=store_root,
+        output_dir=output_dir,
+        walkthrough=walkthrough,
+    )
+    return result, server, thread, dashboard_process
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the local demo bootstrap CLI parser."""
+
+    parser = argparse.ArgumentParser(description="Run the one-command Harness local demo bootstrap.")
+    parser.add_argument("--api-host", default="127.0.0.1", help="Host interface for the Harness API")
+    parser.add_argument("--api-port", type=int, default=8000, help="Port for the Harness API")
+    parser.add_argument("--dashboard-host", default="127.0.0.1", help="Host for the dashboard dev server")
+    parser.add_argument("--dashboard-port", type=int, default=3000, help="Port for the dashboard dev server")
+    parser.add_argument("--store-root", default=".demo-store", help="Directory for persisted demo task state")
+    parser.add_argument("--output-dir", default="demo-output/walkthrough", help="Directory for walkthrough artifacts")
+    parser.add_argument(
+        "--dashboard-command",
+        default=None,
+        help="Optional dashboard command override, for example 'pnpm dev -- --hostname 127.0.0.1 --port 3000'",
+    )
+    parser.add_argument(
+        "--readiness-timeout",
+        type=float,
+        default=90.0,
+        help="Seconds to wait for the API and dashboard to become reachable",
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON summary")
+    parser.add_argument(
+        "--exit-after-seed",
+        action="store_true",
+        help="Exit after printing the seeded demo summary instead of keeping local surfaces running",
+    )
+    parser.add_argument("scenario_names", nargs="*", help="Optional subset of canonical demo scenarios to seed")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the one-command local demo bootstrap."""
+
+    args = build_parser().parse_args(argv)
+    scenario_names = tuple(args.scenario_names) if args.scenario_names else None
+    dashboard_command = shlex.split(args.dashboard_command) if args.dashboard_command else None
+
+    result, server, thread, dashboard_process = bootstrap_demo(
+        api_host=args.api_host,
+        api_port=args.api_port,
+        dashboard_host=args.dashboard_host,
+        dashboard_port=args.dashboard_port,
+        store_root=args.store_root,
+        output_dir=args.output_dir,
+        dashboard_command=dashboard_command,
+        scenario_names=scenario_names,
+        readiness_timeout_seconds=args.readiness_timeout,
+    )
+
+    if args.as_json:
+        print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    else:
+        print(format_bootstrap_summary(result))
+
+    if args.exit_after_seed:
+        _stop_dashboard_process(dashboard_process)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+        return 0
+
+    print("")
+    print("Local demo surfaces are running. Press Ctrl-C to stop them.")
+
+    try:
+        while True:
+            if dashboard_process.poll() is not None:
+                raise RuntimeError("Dashboard process exited unexpectedly")
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        _stop_dashboard_process(dashboard_process)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_demo_bootstrap.py
+++ b/tests/test_demo_bootstrap.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import socket
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from modules.demo_bootstrap import bootstrap_demo, main
+from modules.store import FileBackedHarnessStore
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class DemoBootstrapTests(unittest.TestCase):
+    def _dashboard_command(self, *, port: int, root: Path) -> list[str]:
+        return [
+            sys.executable,
+            "-m",
+            "http.server",
+            str(port),
+            "--bind",
+            "127.0.0.1",
+            "--directory",
+            str(root),
+        ]
+
+    def test_bootstrap_seeds_demo_and_returns_urls(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            dashboard_root = temp_path / "dashboard"
+            dashboard_root.mkdir()
+            (dashboard_root / "index.html").write_text("<html><body>Harness Demo</body></html>", encoding="utf-8")
+
+            store_root = temp_path / "store"
+            output_dir = temp_path / "output"
+            api_port = _free_port()
+            dashboard_port = _free_port()
+
+            result, server, thread, dashboard_process = bootstrap_demo(
+                api_port=api_port,
+                dashboard_port=dashboard_port,
+                store_root=str(store_root),
+                output_dir=str(output_dir),
+                dashboard_command=self._dashboard_command(port=dashboard_port, root=dashboard_root),
+                readiness_timeout_seconds=10.0,
+            )
+            try:
+                self.assertEqual(result.dashboard_url, f"http://127.0.0.1:{dashboard_port}")
+                self.assertEqual(result.api_base_url, f"http://127.0.0.1:{api_port}")
+                self.assertEqual(len(result.walkthrough.scenarios), 5)
+                self.assertTrue((output_dir / "walkthrough.txt").exists())
+
+                store = FileBackedHarnessStore(str(store_root))
+                tasks = store.list_tasks()
+                task_ids = {task["id"] for task in tasks}
+                self.assertIn("demo-successful-completion", task_ids)
+                self.assertIn("demo-long-running-handoff", task_ids)
+            finally:
+                dashboard_process.terminate()
+                dashboard_process.wait(timeout=5)
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_cli_exit_after_seed_emits_json_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            dashboard_root = temp_path / "dashboard"
+            dashboard_root.mkdir()
+            (dashboard_root / "index.html").write_text("<html><body>Harness Demo</body></html>", encoding="utf-8")
+
+            stdout = io.StringIO()
+            api_port = _free_port()
+            dashboard_port = _free_port()
+            with contextlib.redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "--api-port",
+                        str(api_port),
+                        "--dashboard-port",
+                        str(dashboard_port),
+                        "--store-root",
+                        str(temp_path / "store"),
+                        "--output-dir",
+                        str(temp_path / "output"),
+                        "--dashboard-command",
+                        " ".join(self._dashboard_command(port=dashboard_port, root=dashboard_root)),
+                        "--exit-after-seed",
+                        "--json",
+                        "successful_completion",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["walkthrough"]["scenarios"][0]["task_id"], "demo-successful-completion")
+            self.assertEqual(payload["dashboard_url"], f"http://127.0.0.1:{dashboard_port}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a local-only bootstrap command that resets demo state, starts the Harness API, starts the dashboard, seeds the deterministic walkthrough tasks, and prints direct task URLs
- reuse the existing public API and walkthrough seeding flow rather than introducing a separate demo-only path
- add focused bootstrap tests using a dummy local dashboard server so the supervisor logic stays covered without depending on a real Next dev server in tests

## Validation
- `python3 -m py_compile modules/demo_bootstrap.py`
- `.venv/bin/python -m unittest tests.test_demo_bootstrap tests.test_demo_walkthrough`
- `.venv/bin/python -m unittest discover -s tests`

## Notes
- the bootstrap command defaults to `pnpm dev -- --hostname 127.0.0.1 --port 3000` for the dashboard and injects `HARNESS_API_BASE_URL` automatically
- `--exit-after-seed` is available for CI and quick local verification without leaving processes running
