### PR TITLE
Implement narrow OpenClaw integration spike

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,23 @@ python -m modules.simulator --base-url http://127.0.0.1:8000 run long_running_ha
 
 The simulator is entirely client-side. It uses only the public HTTP API to submit tasks, reevaluate tasks, and inspect persisted state over time.
 
+## OpenClaw Boundary Spike
+
+There is also a narrow OpenClaw-informed client spike that validates the real ingress boundary against the public Harness API:
+
+```bash
+python -m modules.connectors.openclaw_harness_spike --base-url http://127.0.0.1:8000
+```
+
+That spike:
+
+- submits a new task through `POST /tasks`
+- fetches current task state and read-model data
+- submits new artifacts through `POST /tasks/<task_id>/reevaluate`
+- fetches timeline and evaluation history
+
+It uses only the public API and preserves OpenClaw-style source metadata in the canonical task payload. See [docs/integration/openclaw-harness-spike.md](docs/integration/openclaw-harness-spike.md) for the narrow scope and what was learned.
+
 ## Canonical Demo Pack
 
 You can run a packaged set of canonical demo scenarios that generate:

--- a/docs/integration/openclaw-harness-spike.md
+++ b/docs/integration/openclaw-harness-spike.md
@@ -1,0 +1,88 @@
+# OpenClaw -> Harness Integration Spike
+
+This spike validates the intended client boundary between OpenClaw and Harness without introducing runtime coupling.
+
+The reference point for this spike was the public [`openclaw/openclaw`](https://github.com/openclaw/openclaw) repository and its current packaging as a Node/TypeScript assistant, CLI, and gateway system.
+
+That reference matters because it reinforces the intended split:
+
+- OpenClaw acts as the ingress and client surface
+- Harness acts as the standalone control-plane service
+
+## What The Spike Proves
+
+The spike uses only the public Harness HTTP API to:
+
+1. submit a new task with OpenClaw-style source metadata
+2. inspect the stored task and dashboard-friendly read model
+3. submit reevaluation with new artifacts
+4. inspect the updated timeline and evaluation history
+
+No direct calls into Harness evaluation, persistence, or enforcement internals are used.
+
+## Client Shape
+
+The spike client lives in [`modules/connectors/openclaw_harness_spike.py`](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/modules/connectors/openclaw_harness_spike.py).
+
+It provides:
+
+- `OpenClawSourceContext`
+- `OpenClawTaskIntent`
+- `OpenClawHarnessSpikeClient`
+- `run_openclaw_spike_flow()`
+
+The client preserves OpenClaw-origin context in two places:
+
+- canonical `task_envelope.origin`
+- `task_envelope.extensions.openclaw`
+
+That keeps ingress metadata auditable without making Harness depend on OpenClaw internals.
+
+## Public API Surface Used
+
+The spike uses only:
+
+- `POST /tasks`
+- `POST /tasks/<task_id>/reevaluate`
+- `GET /tasks/<task_id>`
+- `GET /tasks/<task_id>/read-model`
+- `GET /tasks/<task_id>/timeline`
+- `GET /tasks/<task_id>/evaluations`
+
+## Representative Flow
+
+The built-in spike flow intentionally exercises a real control-plane change:
+
+1. OpenClaw-style client submits a task that claims completion
+2. Harness blocks the task because required evidence is still missing
+3. OpenClaw-style client submits reevaluation with the missing review-note artifact
+4. Harness accepts completion
+5. Client fetches read model, timeline, and evaluation history
+
+## What Was Learned
+
+The current boundary works cleanly for a thin client.
+
+The main friction point is task creation verbosity:
+
+- `POST /tasks` is explicit and stable
+- but canonical `TaskEnvelope` construction is still too verbose for most ingress clients to handcraft repeatedly
+
+That means the right next move, if this grows, is not deeper coupling. It is a small ingress-side request builder or adapter, similar to the existing Linear-shaped ingress adapter.
+
+Other observations:
+
+- duplicate task handling is clear: `POST /tasks` returns `409`, and reevaluation remains explicit
+- inspection endpoints are already sufficient for operator and dashboard visibility
+- no API redesign was required for this spike
+
+## Scope Limits
+
+This spike does not implement:
+
+- OpenClaw plugin lifecycle integration
+- OpenClaw gateway runtime integration
+- live OpenClaw message/channel wiring
+- a new Harness ingress endpoint for OpenClaw
+
+It is intentionally a narrow proof that OpenClaw can remain a client and Harness can remain a standalone service.

--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -21,11 +21,29 @@ from .linear_ingress import (
     LinearIngressInputError,
     translate_linear_submission_payload,
 )
+from .openclaw_harness_spike import (
+    OpenClawHarnessSpikeClient,
+    OpenClawHarnessSpikeError,
+    OpenClawHarnessSpikeResult,
+    OpenClawSourceContext,
+    OpenClawTaskIntent,
+    build_task_reevaluation_payload,
+    build_task_submission_payload,
+    run_openclaw_spike_flow,
+)
 
 __all__ = [
     "GitHubConnectorInputError",
     "LinearConnectorInputError",
     "LinearIngressInputError",
+    "OpenClawHarnessSpikeClient",
+    "OpenClawHarnessSpikeError",
+    "OpenClawHarnessSpikeResult",
+    "OpenClawSourceContext",
+    "OpenClawTaskIntent",
+    "build_task_reevaluation_payload",
+    "build_task_submission_payload",
+    "run_openclaw_spike_flow",
     "translate_github_artifact_facts",
     "translate_github_artifact_references",
     "translate_github_branch",

--- a/modules/connectors/openclaw_harness_spike.py
+++ b/modules/connectors/openclaw_harness_spike.py
@@ -1,0 +1,476 @@
+"""Narrow OpenClaw-informed client spike against the public Harness API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+class OpenClawHarnessSpikeError(ValueError):
+    """Raised when the spike client receives malformed local inputs."""
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _require_non_empty(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OpenClawHarnessSpikeError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_string(value: str | None, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise OpenClawHarnessSpikeError(f"{field_name} must be a string when provided")
+    stripped = value.strip()
+    return stripped or None
+
+
+@dataclass(frozen=True)
+class OpenClawSourceContext:
+    """Minimal OpenClaw-style source metadata for ingress submission."""
+
+    conversation_id: str
+    message_id: str
+    channel: str
+    workspace_id: str | None = None
+    user_id: str | None = None
+    agent_id: str | None = None
+
+
+@dataclass(frozen=True)
+class OpenClawTaskIntent:
+    """Reviewable task intent extracted from an OpenClaw-side interaction."""
+
+    task_id: str
+    title: str
+    description: str
+    acceptance_criteria: tuple[str, ...]
+    objective_summary: str | None = None
+    deliverable_type: str = "unspecified"
+    success_signal: str = "Task satisfies declared acceptance criteria."
+    status: str = "intake_ready"
+    priority: str = "normal"
+    linked_artifacts: tuple[dict[str, Any], ...] = ()
+    completion_evidence: dict[str, Any] | None = None
+    requested_by: str | None = None
+
+
+@dataclass(frozen=True)
+class OpenClawHarnessSpikeResult:
+    """Structured result for one representative OpenClaw -> Harness flow."""
+
+    task_id: str
+    submission_status: int
+    submission_action: str | None
+    initial_task_status: str | None
+    reevaluation_status: int
+    reevaluation_action: str | None
+    final_task_status: str | None
+    read_model_status: int
+    timeline_status: int
+    evaluation_history_count: int
+
+
+def build_task_submission_payload(
+    *,
+    intent: OpenClawTaskIntent,
+    context: OpenClawSourceContext,
+    external_facts: dict[str, Any] | None = None,
+    claimed_completion: bool = False,
+    acceptance_criteria_satisfied: bool = False,
+    runtime_facts: dict[str, Any] | None = None,
+    unresolved_conditions: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build a canonical POST /tasks payload from OpenClaw-side intent."""
+
+    task_id = _require_non_empty(intent.task_id, field_name="intent.task_id")
+    title = _require_non_empty(intent.title, field_name="intent.title")
+    description = _require_non_empty(intent.description, field_name="intent.description")
+
+    if not intent.acceptance_criteria:
+        raise OpenClawHarnessSpikeError("intent.acceptance_criteria must contain at least one item")
+
+    created_at = _iso_now()
+    task_envelope: dict[str, Any] = {
+        "id": task_id,
+        "title": title,
+        "description": description,
+        "origin": {
+            "source_system": "openclaw",
+            "source_type": "ingress_request",
+            "source_id": _require_non_empty(context.message_id, field_name="context.message_id"),
+            "ingress_id": _optional_string(context.conversation_id, field_name="context.conversation_id"),
+            "ingress_name": "OpenClaw",
+            "requested_by": _optional_string(intent.requested_by or context.user_id, field_name="requested_by"),
+        },
+        "status": intent.status,
+        "timestamps": {
+            "created_at": created_at,
+            "updated_at": created_at,
+            "completed_at": created_at if intent.status == "completed" else None,
+        },
+        "status_history": [],
+        "objective": {
+            "summary": _require_non_empty(intent.objective_summary or description, field_name="intent.objective_summary"),
+            "deliverable_type": _require_non_empty(intent.deliverable_type, field_name="intent.deliverable_type"),
+            "success_signal": _require_non_empty(intent.success_signal, field_name="intent.success_signal"),
+        },
+        "constraints": [],
+        "acceptance_criteria": [
+            {
+                "id": f"ac-{index + 1}",
+                "description": _require_non_empty(criterion, field_name=f"intent.acceptance_criteria[{index}]"),
+                "required": True,
+            }
+            for index, criterion in enumerate(intent.acceptance_criteria)
+        ],
+        "parent_task_id": None,
+        "child_task_ids": [],
+        "dependencies": [],
+        "assigned_executor": None,
+        "required_capabilities": [],
+        "priority": intent.priority,
+        "artifacts": {
+            "items": [dict(artifact) for artifact in intent.linked_artifacts],
+            "completion_evidence": dict(intent.completion_evidence)
+            if intent.completion_evidence is not None
+            else {
+                "policy": "deferred",
+                "status": "deferred",
+                "required_artifact_types": [],
+                "validated_artifact_ids": [],
+                "validation_method": "deferred",
+                "validated_at": None,
+                "validator": None,
+                "notes": None,
+            },
+        },
+        "observability": {
+            "errors": [],
+            "retries": {
+                "attempt_count": 0,
+                "max_attempts": 0,
+                "last_retry_at": None,
+            },
+            "execution_metadata": {},
+        },
+        "extensions": {
+            "openclaw": {
+                "conversation_id": context.conversation_id,
+                "message_id": context.message_id,
+                "channel": _require_non_empty(context.channel, field_name="context.channel"),
+                "workspace_id": context.workspace_id,
+                "user_id": context.user_id,
+                "agent_id": context.agent_id,
+            }
+        },
+    }
+
+    request_payload: dict[str, Any] = {
+        "task_envelope": task_envelope,
+        "external_facts": dict(external_facts or {}),
+        "claimed_completion": claimed_completion,
+        "acceptance_criteria_satisfied": acceptance_criteria_satisfied,
+    }
+    if runtime_facts is not None:
+        request_payload["runtime_facts"] = dict(runtime_facts)
+    if unresolved_conditions:
+        request_payload["unresolved_conditions"] = list(unresolved_conditions)
+    return {"request": request_payload}
+
+
+def build_task_reevaluation_payload(
+    *,
+    external_facts: dict[str, Any] | None = None,
+    new_artifacts: tuple[dict[str, Any], ...] = (),
+    completion_evidence: dict[str, Any] | None = None,
+    claimed_completion: bool = False,
+    acceptance_criteria_satisfied: bool = False,
+    runtime_facts: dict[str, Any] | None = None,
+    unresolved_conditions: tuple[str, ...] = (),
+    review_request: dict[str, Any] | None = None,
+    review_decision: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a canonical POST /tasks/<id>/reevaluate payload."""
+
+    request_payload: dict[str, Any] = {
+        "external_facts": dict(external_facts or {}),
+        "new_artifacts": [dict(artifact) for artifact in new_artifacts],
+        "claimed_completion": claimed_completion,
+        "acceptance_criteria_satisfied": acceptance_criteria_satisfied,
+    }
+    if completion_evidence is not None:
+        request_payload["completion_evidence"] = dict(completion_evidence)
+    if runtime_facts is not None:
+        request_payload["runtime_facts"] = dict(runtime_facts)
+    if unresolved_conditions:
+        request_payload["unresolved_conditions"] = list(unresolved_conditions)
+    if review_request is not None:
+        request_payload["review_request"] = dict(review_request)
+    if review_decision is not None:
+        request_payload["review_decision"] = dict(review_decision)
+    return {"request": request_payload}
+
+
+class OpenClawHarnessSpikeClient:
+    """Thin OpenClaw-style HTTP client for the public Harness API."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = _require_non_empty(base_url.rstrip("/"), field_name="base_url")
+
+    def _request_json(self, method: str, path: str, payload: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
+        data = None
+        headers = {}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = Request(self.base_url + path, data=data, headers=headers, method=method)
+        try:
+            with urlopen(request) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            try:
+                return error.code, json.loads(error.read().decode("utf-8"))
+            finally:
+                error.close()
+
+    def submit_task(
+        self,
+        *,
+        intent: OpenClawTaskIntent,
+        context: OpenClawSourceContext,
+        external_facts: dict[str, Any] | None = None,
+        claimed_completion: bool = False,
+        acceptance_criteria_satisfied: bool = False,
+        runtime_facts: dict[str, Any] | None = None,
+        unresolved_conditions: tuple[str, ...] = (),
+    ) -> tuple[int, dict[str, Any]]:
+        payload = build_task_submission_payload(
+            intent=intent,
+            context=context,
+            external_facts=external_facts,
+            claimed_completion=claimed_completion,
+            acceptance_criteria_satisfied=acceptance_criteria_satisfied,
+            runtime_facts=runtime_facts,
+            unresolved_conditions=unresolved_conditions,
+        )
+        return self._request_json("POST", "/tasks", payload)
+
+    def reevaluate_task(
+        self,
+        task_id: str,
+        *,
+        external_facts: dict[str, Any] | None = None,
+        new_artifacts: tuple[dict[str, Any], ...] = (),
+        completion_evidence: dict[str, Any] | None = None,
+        claimed_completion: bool = False,
+        acceptance_criteria_satisfied: bool = False,
+        runtime_facts: dict[str, Any] | None = None,
+        unresolved_conditions: tuple[str, ...] = (),
+        review_request: dict[str, Any] | None = None,
+        review_decision: dict[str, Any] | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        payload = build_task_reevaluation_payload(
+            external_facts=external_facts,
+            new_artifacts=new_artifacts,
+            completion_evidence=completion_evidence,
+            claimed_completion=claimed_completion,
+            acceptance_criteria_satisfied=acceptance_criteria_satisfied,
+            runtime_facts=runtime_facts,
+            unresolved_conditions=unresolved_conditions,
+            review_request=review_request,
+            review_decision=review_decision,
+        )
+        return self._request_json("POST", f"/tasks/{task_id}/reevaluate", payload)
+
+    def get_task(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/tasks/{task_id}")
+
+    def get_task_read_model(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/tasks/{task_id}/read-model")
+
+    def get_task_timeline(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/tasks/{task_id}/timeline")
+
+    def get_evaluation_history(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/tasks/{task_id}/evaluations")
+
+
+def _demo_review_note_artifact() -> dict[str, Any]:
+    return {
+        "id": "artifact-openclaw-review-note-1",
+        "type": "review_note",
+        "title": "Operator confirmation",
+        "description": "OpenClaw supplied the missing evidence note during reevaluation.",
+        "location": None,
+        "content_type": "text/plain",
+        "external_id": None,
+        "commit_sha": None,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "openclaw",
+            "source_type": "manual",
+            "source_id": "message-review-note-1",
+            "captured_by": "openclaw-spike",
+        },
+        "verification_status": "verified",
+        "repository": None,
+        "branch": None,
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-03-25T16:00:00Z",
+        "metadata": {
+            "note_kind": "manual_confirmation",
+        },
+    }
+
+
+def run_openclaw_spike_flow(*, base_url: str, task_id: str = "task-openclaw-spike-1") -> OpenClawHarnessSpikeResult:
+    """Run one representative OpenClaw -> Harness flow through the public API."""
+
+    client = OpenClawHarnessSpikeClient(base_url)
+    context = OpenClawSourceContext(
+        conversation_id="conv-openclaw-spike-1",
+        message_id="msg-openclaw-spike-1",
+        channel="cli",
+        workspace_id="workspace-openclaw-spike",
+        user_id="operator@example.com",
+        agent_id="openclaw-assistant",
+    )
+    intent = OpenClawTaskIntent(
+        task_id=task_id,
+        title="Validate Harness API boundary from OpenClaw",
+        description="Submit a task, observe the blocked result, then reevaluate with the missing evidence supplied.",
+        acceptance_criteria=(
+            "Harness returns a structured blocked result before the missing evidence exists.",
+            "Harness accepts completion once the missing evidence is supplied.",
+        ),
+        objective_summary="Prove that OpenClaw can submit and reevaluate tasks through the Harness API boundary.",
+        deliverable_type="integration_spike",
+        success_signal="The task moves from blocked to completed through public API calls only.",
+        status="completed",
+        linked_artifacts=(),
+        completion_evidence={
+            "policy": "required",
+            "status": "insufficient",
+            "required_artifact_types": ["review_note"],
+            "validated_artifact_ids": [],
+            "validation_method": "manual_review",
+            "validated_at": None,
+            "validator": None,
+            "notes": "OpenClaw has not yet provided the operator confirmation artifact.",
+        },
+        requested_by="operator@example.com",
+    )
+
+    submission_status, submission_payload = client.submit_task(
+        intent=intent,
+        context=context,
+        external_facts={},
+        claimed_completion=True,
+        acceptance_criteria_satisfied=True,
+        runtime_facts={"executor_reported_success": True, "attempt_count": 1},
+    )
+    if submission_status >= 400:
+        raise RuntimeError(f"OpenClaw spike submission failed: {submission_payload}")
+
+    read_model_status, _ = client.get_task_read_model(task_id)
+    if read_model_status >= 400:
+        raise RuntimeError(f"OpenClaw spike read-model fetch failed for {task_id}")
+
+    reevaluation_status, reevaluation_payload = client.reevaluate_task(
+        task_id,
+        new_artifacts=(_demo_review_note_artifact(),),
+        completion_evidence={
+            "status": "satisfied",
+            "validated_artifact_ids": ["artifact-openclaw-review-note-1"],
+            "validated_at": "2026-03-25T16:02:00Z",
+            "validator": {
+                "source_system": "harness",
+                "source_type": "verification",
+                "source_id": "verification/openclaw-spike-1",
+                "captured_by": "openclaw-spike",
+            },
+            "notes": "The missing review note arrived from the OpenClaw-side operator flow.",
+        },
+        claimed_completion=True,
+        acceptance_criteria_satisfied=True,
+        runtime_facts={"executor_reported_success": True, "attempt_count": 1},
+    )
+    if reevaluation_status >= 400:
+        raise RuntimeError(f"OpenClaw spike reevaluation failed: {reevaluation_payload}")
+
+    timeline_status, _ = client.get_task_timeline(task_id)
+    history_status, history_payload = client.get_evaluation_history(task_id)
+    if timeline_status >= 400 or history_status >= 400:
+        raise RuntimeError(f"OpenClaw spike inspection failed for {task_id}")
+
+    return OpenClawHarnessSpikeResult(
+        task_id=task_id,
+        submission_status=submission_status,
+        submission_action=submission_payload.get("action"),
+        initial_task_status=submission_payload.get("task_envelope", {}).get("status"),
+        reevaluation_status=reevaluation_status,
+        reevaluation_action=reevaluation_payload.get("action"),
+        final_task_status=reevaluation_payload.get("task_envelope", {}).get("status"),
+        read_model_status=read_model_status,
+        timeline_status=timeline_status,
+        evaluation_history_count=len(history_payload.get("evaluations", ())),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the spike CLI parser."""
+
+    parser = argparse.ArgumentParser(description="Run a narrow OpenClaw-informed client spike against the Harness API.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000", help="Harness API base URL")
+    parser.add_argument("--task-id", default="task-openclaw-spike-1", help="Task id to use for the representative spike")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the OpenClaw-informed Harness spike."""
+
+    args = build_parser().parse_args(argv)
+    result = run_openclaw_spike_flow(base_url=args.base_url, task_id=args.task_id)
+
+    if args.as_json:
+        print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    else:
+        print("OpenClaw -> Harness Spike")
+        print(f"task_id: {result.task_id}")
+        print(f"submission: {result.submission_status} ({result.submission_action}) -> {result.initial_task_status}")
+        print(f"reevaluation: {result.reevaluation_status} ({result.reevaluation_action}) -> {result.final_task_status}")
+        print(f"read_model: {result.read_model_status}")
+        print(f"timeline: {result.timeline_status}")
+        print(f"evaluation_history_count: {result.evaluation_history_count}")
+
+    return 0
+
+
+__all__ = [
+    "OpenClawHarnessSpikeClient",
+    "OpenClawHarnessSpikeError",
+    "OpenClawHarnessSpikeResult",
+    "OpenClawSourceContext",
+    "OpenClawTaskIntent",
+    "build_task_reevaluation_payload",
+    "build_task_submission_payload",
+    "run_openclaw_spike_flow",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/connectors/test_openclaw_harness_spike.py
+++ b/tests/connectors/test_openclaw_harness_spike.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import tempfile
+import threading
+import unittest
+
+from modules.api import run_server
+from modules.connectors.openclaw_harness_spike import (
+    OpenClawHarnessSpikeClient,
+    OpenClawSourceContext,
+    OpenClawTaskIntent,
+    build_task_submission_payload,
+    run_openclaw_spike_flow,
+)
+
+
+class OpenClawHarnessSpikeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.server = run_server(host="127.0.0.1", port=0, store_root=self.temp_dir.name)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+        self.client = OpenClawHarnessSpikeClient(self.base_url)
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.temp_dir.cleanup()
+
+    def _context(self) -> OpenClawSourceContext:
+        return OpenClawSourceContext(
+            conversation_id="conv-spike-1",
+            message_id="msg-spike-1",
+            channel="cli",
+            workspace_id="workspace-spike",
+            user_id="operator@example.com",
+            agent_id="openclaw-assistant",
+        )
+
+    def _intent(self, task_id: str = "task-openclaw-1") -> OpenClawTaskIntent:
+        return OpenClawTaskIntent(
+            task_id=task_id,
+            title="OpenClaw boundary spike",
+            description="Submit a task from an OpenClaw-style client and keep source metadata auditable.",
+            acceptance_criteria=(
+                "Harness accepts canonical task submission over HTTP.",
+                "Harness preserves OpenClaw source metadata for inspection.",
+            ),
+            objective_summary="Validate the OpenClaw -> Harness API boundary.",
+        )
+
+    def test_builder_embeds_openclaw_source_metadata(self) -> None:
+        payload = build_task_submission_payload(intent=self._intent(), context=self._context())
+        task = payload["request"]["task_envelope"]
+
+        self.assertEqual(task["origin"]["source_system"], "openclaw")
+        self.assertEqual(task["origin"]["ingress_name"], "OpenClaw")
+        self.assertEqual(task["extensions"]["openclaw"]["conversation_id"], "conv-spike-1")
+        self.assertEqual(task["extensions"]["openclaw"]["channel"], "cli")
+
+    def test_client_can_submit_and_inspect_task_through_public_api(self) -> None:
+        submit_status, submit_payload = self.client.submit_task(
+            intent=self._intent(),
+            context=self._context(),
+        )
+        self.assertEqual(submit_status, 200)
+        task_id = submit_payload["task_envelope"]["id"]
+
+        task_status, task_payload = self.client.get_task(task_id)
+        read_model_status, read_model_payload = self.client.get_task_read_model(task_id)
+        timeline_status, timeline_payload = self.client.get_task_timeline(task_id)
+        history_status, history_payload = self.client.get_evaluation_history(task_id)
+
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["id"], task_id)
+        self.assertEqual(read_model_status, 200)
+        self.assertEqual(read_model_payload["task"]["extensions"]["openclaw"]["conversation_id"], "conv-spike-1")
+        self.assertEqual(timeline_status, 200)
+        self.assertGreaterEqual(timeline_payload["event_count"], 1)
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
+    def test_representative_spike_flow_moves_blocked_to_completed(self) -> None:
+        result = run_openclaw_spike_flow(base_url=self.base_url, task_id="task-openclaw-flow-1")
+
+        self.assertEqual(result.submission_status, 200)
+        self.assertEqual(result.initial_task_status, "blocked")
+        self.assertEqual(result.reevaluation_status, 200)
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertEqual(result.read_model_status, 200)
+        self.assertEqual(result.timeline_status, 200)
+        self.assertEqual(result.evaluation_history_count, 2)
+
+    def test_duplicate_task_id_behavior_matches_canonical_submission_policy(self) -> None:
+        self.client.submit_task(intent=self._intent(task_id="task-openclaw-duplicate-1"), context=self._context())
+        duplicate_status, duplicate_payload = self.client.submit_task(
+            intent=self._intent(task_id="task-openclaw-duplicate-1"),
+            context=self._context(),
+        )
+
+        self.assertEqual(duplicate_status, 409)
+        self.assertTrue(duplicate_payload["duplicate_task_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a thin OpenClaw-informed HTTP client spike that uses only the public Harness API for task submission, reevaluation, and inspection
- preserve OpenClaw-style source metadata in canonical task payloads without adding a new OpenClaw-specific Harness endpoint
- add end-to-end tests and a short integration note documenting the real friction point at the boundary

## Validation
- `python3 -m py_compile modules/connectors/openclaw_harness_spike.py`
- `.venv/bin/python -m unittest tests.connectors.test_openclaw_harness_spike tests.test_api tests.test_simulator`
- `.venv/bin/python -m unittest discover -s tests`
- live in-process spike flow: submit blocked task, reevaluate with missing artifact, finish completed

## What We Learned
- the current Harness API is already clean enough for a thin OpenClaw-style client
- the main friction point is canonical `POST /tasks` payload verbosity, not transport or lifecycle behavior
- the right next step, if this grows, is a small ingress-side request builder or adapter rather than tighter runtime coupling or a broad API redesign
