### PR TITLE
Implement ingress request builder adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,40 @@ That spike:
 
 It uses only the public API and preserves OpenClaw-style source metadata in the canonical task payload. See [docs/integration/openclaw-harness-spike.md](docs/integration/openclaw-harness-spike.md) for the narrow scope and what was learned.
 
+## Ingress Request Builder
+
+To reduce canonical task payload construction friction for ingress clients, Harness now includes a thin ingress-side builder adapter:
+
+```bash
+python - <<'PY'
+from modules.connectors import (
+    IngressSourceContext,
+    IngressTaskIntent,
+    build_task_submission_payload,
+)
+
+payload = build_task_submission_payload(
+    intent=IngressTaskIntent(
+        task_id="task-example-1",
+        title="Example task",
+        description="Construct a canonical Harness submission payload.",
+        acceptance_criteria=("The payload validates at the API boundary.",),
+    ),
+    context=IngressSourceContext(
+        source_system="openclaw",
+        source_id="msg-example-1",
+        ingress_name="OpenClaw",
+        ingress_id="conv-example-1",
+        extension_namespace="openclaw",
+        extension_payload={"conversation_id": "conv-example-1", "channel": "cli"},
+    ),
+)
+print(payload["request"]["task_envelope"]["origin"])
+PY
+```
+
+The builder keeps the API unchanged. It just helps ingress clients construct valid `POST /tasks` and reevaluation payloads without reimplementing canonical defaults.
+
 ## Canonical Demo Pack
 
 You can run a packaged set of canonical demo scenarios that generate:

--- a/docs/integration/openclaw-harness-spike.md
+++ b/docs/integration/openclaw-harness-spike.md
@@ -70,6 +70,8 @@ The main friction point is task creation verbosity:
 
 That means the right next move, if this grows, is not deeper coupling. It is a small ingress-side request builder or adapter, similar to the existing Linear-shaped ingress adapter.
 
+That builder now exists in [`modules/connectors/ingress_request_builder.py`](/Users/ssbob/Documents/Developer/Knox_Analytics/Harness/modules/connectors/ingress_request_builder.py) and is reused by the OpenClaw spike client.
+
 Other observations:
 
 - duplicate task handling is clear: `POST /tasks` returns `409`, and reevaluation remains explicit

--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -21,19 +21,27 @@ from .linear_ingress import (
     LinearIngressInputError,
     translate_linear_submission_payload,
 )
+from .ingress_request_builder import (
+    IngressRequestBuilderError,
+    IngressSourceContext,
+    IngressTaskIntent,
+    build_task_reevaluation_payload,
+    build_task_submission_payload,
+)
 from .openclaw_harness_spike import (
     OpenClawHarnessSpikeClient,
     OpenClawHarnessSpikeError,
     OpenClawHarnessSpikeResult,
     OpenClawSourceContext,
     OpenClawTaskIntent,
-    build_task_reevaluation_payload,
-    build_task_submission_payload,
     run_openclaw_spike_flow,
 )
 
 __all__ = [
     "GitHubConnectorInputError",
+    "IngressRequestBuilderError",
+    "IngressSourceContext",
+    "IngressTaskIntent",
     "LinearConnectorInputError",
     "LinearIngressInputError",
     "OpenClawHarnessSpikeClient",

--- a/modules/connectors/ingress_request_builder.py
+++ b/modules/connectors/ingress_request_builder.py
@@ -1,0 +1,223 @@
+"""Thin ingress-side builders for canonical Harness submission payloads."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+from modules.contracts.task_envelope_validation import assert_valid_task_envelope
+from modules.intake.task_envelope import create_task_envelope
+
+
+class IngressRequestBuilderError(ValueError):
+    """Raised when higher-level ingress inputs cannot produce canonical payloads."""
+
+
+def _require_non_empty(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise IngressRequestBuilderError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_string(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise IngressRequestBuilderError(f"{field_name} must be a string when provided")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _normalize_string_tuple(values: tuple[str, ...], *, field_name: str) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for index, value in enumerate(values):
+        normalized.append(_require_non_empty(value, field_name=f"{field_name}[{index}]"))
+    return tuple(normalized)
+
+
+@dataclass(frozen=True)
+class IngressSourceContext:
+    """Ingress-owned source metadata carried into the canonical task boundary."""
+
+    source_system: str
+    source_id: str
+    ingress_name: str | None = None
+    ingress_id: str | None = None
+    requested_by: str | None = None
+    source_type: str = "ingress_request"
+    extension_namespace: str | None = None
+    extension_payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class IngressTaskIntent:
+    """Higher-level ingress task intent converted into a canonical submission payload."""
+
+    task_id: str
+    title: str
+    description: str
+    acceptance_criteria: tuple[str, ...]
+    objective_summary: str | None = None
+    deliverable_type: str = "unspecified"
+    success_signal: str = "Task satisfies declared acceptance criteria."
+    status: str = "intake_ready"
+    priority: str = "normal"
+    linked_artifacts: tuple[dict[str, Any], ...] = ()
+    completion_evidence: dict[str, Any] | None = None
+    constraints: tuple[dict[str, Any], ...] = ()
+    requested_by: str | None = None
+
+
+def _build_origin(context: IngressSourceContext) -> dict[str, Any]:
+    return {
+        "source_system": _require_non_empty(context.source_system, field_name="context.source_system"),
+        "source_type": _require_non_empty(context.source_type, field_name="context.source_type"),
+        "source_id": _require_non_empty(context.source_id, field_name="context.source_id"),
+        "ingress_id": _optional_string(context.ingress_id, field_name="context.ingress_id"),
+        "ingress_name": _optional_string(context.ingress_name, field_name="context.ingress_name"),
+        "requested_by": _optional_string(context.requested_by, field_name="context.requested_by"),
+    }
+
+
+def _default_completion_evidence() -> dict[str, Any]:
+    return {
+        "policy": "deferred",
+        "status": "deferred",
+        "required_artifact_types": [],
+        "validated_artifact_ids": [],
+        "validation_method": "deferred",
+        "validated_at": None,
+        "validator": None,
+        "notes": None,
+    }
+
+
+def build_task_submission_payload(
+    *,
+    intent: IngressTaskIntent,
+    context: IngressSourceContext,
+    external_facts: dict[str, Any] | None = None,
+    claimed_completion: bool = False,
+    acceptance_criteria_satisfied: bool = False,
+    runtime_facts: dict[str, Any] | None = None,
+    unresolved_conditions: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build a canonical POST /tasks payload from ingress-side inputs."""
+
+    normalized_acceptance_criteria = _normalize_string_tuple(
+        intent.acceptance_criteria,
+        field_name="intent.acceptance_criteria",
+    )
+    if not normalized_acceptance_criteria:
+        raise IngressRequestBuilderError("intent.acceptance_criteria must contain at least one item")
+
+    task_envelope = create_task_envelope(
+        {
+            "id": _require_non_empty(intent.task_id, field_name="intent.task_id"),
+            "title": _require_non_empty(intent.title, field_name="intent.title"),
+            "description": _require_non_empty(intent.description, field_name="intent.description"),
+            "origin": {
+                **_build_origin(context),
+                "requested_by": _optional_string(intent.requested_by or context.requested_by, field_name="requested_by"),
+            },
+            "objective": {
+                "summary": _require_non_empty(
+                    intent.objective_summary or intent.description,
+                    field_name="intent.objective_summary",
+                ),
+                "deliverable_type": _require_non_empty(
+                    intent.deliverable_type,
+                    field_name="intent.deliverable_type",
+                ),
+                "success_signal": _require_non_empty(
+                    intent.success_signal,
+                    field_name="intent.success_signal",
+                ),
+            },
+            "constraints": [deepcopy(item) for item in intent.constraints],
+            "acceptance_criteria": [
+                {"id": f"ac-{index + 1}", "description": criterion, "required": True}
+                for index, criterion in enumerate(normalized_acceptance_criteria)
+            ],
+        }
+    )
+
+    task_envelope["status"] = _require_non_empty(intent.status, field_name="intent.status")
+    if task_envelope["status"] == "completed":
+        task_envelope["timestamps"]["completed_at"] = task_envelope["timestamps"]["updated_at"]
+    else:
+        task_envelope["timestamps"]["completed_at"] = None
+
+    task_envelope["priority"] = _require_non_empty(intent.priority, field_name="intent.priority")
+    task_envelope["artifacts"]["items"] = [deepcopy(artifact) for artifact in intent.linked_artifacts]
+    task_envelope["artifacts"]["completion_evidence"] = (
+        deepcopy(intent.completion_evidence)
+        if intent.completion_evidence is not None
+        else _default_completion_evidence()
+    )
+
+    if context.extension_namespace:
+        task_envelope["extensions"] = {
+            _require_non_empty(context.extension_namespace, field_name="context.extension_namespace"): deepcopy(
+                context.extension_payload
+            )
+        }
+
+    request_payload: dict[str, Any] = {
+        "task_envelope": assert_valid_task_envelope(task_envelope),
+        "external_facts": deepcopy(external_facts or {}),
+        "claimed_completion": claimed_completion,
+        "acceptance_criteria_satisfied": acceptance_criteria_satisfied,
+    }
+    if runtime_facts is not None:
+        request_payload["runtime_facts"] = deepcopy(runtime_facts)
+    if unresolved_conditions:
+        request_payload["unresolved_conditions"] = list(
+            _normalize_string_tuple(unresolved_conditions, field_name="unresolved_conditions")
+        )
+    return {"request": request_payload}
+
+
+def build_task_reevaluation_payload(
+    *,
+    external_facts: dict[str, Any] | None = None,
+    new_artifacts: tuple[dict[str, Any], ...] = (),
+    completion_evidence: dict[str, Any] | None = None,
+    claimed_completion: bool = False,
+    acceptance_criteria_satisfied: bool = False,
+    runtime_facts: dict[str, Any] | None = None,
+    unresolved_conditions: tuple[str, ...] = (),
+    review_request: dict[str, Any] | None = None,
+    review_decision: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a canonical POST /tasks/<id>/reevaluate payload."""
+
+    request_payload: dict[str, Any] = {
+        "external_facts": deepcopy(external_facts or {}),
+        "new_artifacts": [deepcopy(artifact) for artifact in new_artifacts],
+        "claimed_completion": claimed_completion,
+        "acceptance_criteria_satisfied": acceptance_criteria_satisfied,
+    }
+    if completion_evidence is not None:
+        request_payload["completion_evidence"] = deepcopy(completion_evidence)
+    if runtime_facts is not None:
+        request_payload["runtime_facts"] = deepcopy(runtime_facts)
+    if unresolved_conditions:
+        request_payload["unresolved_conditions"] = list(
+            _normalize_string_tuple(unresolved_conditions, field_name="unresolved_conditions")
+        )
+    if review_request is not None:
+        request_payload["review_request"] = deepcopy(review_request)
+    if review_decision is not None:
+        request_payload["review_decision"] = deepcopy(review_decision)
+    return {"request": request_payload}
+
+
+__all__ = [
+    "IngressRequestBuilderError",
+    "IngressSourceContext",
+    "IngressTaskIntent",
+    "build_task_reevaluation_payload",
+    "build_task_submission_payload",
+]

--- a/modules/connectors/openclaw_harness_spike.py
+++ b/modules/connectors/openclaw_harness_spike.py
@@ -4,34 +4,22 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from dataclasses import asdict, dataclass
 from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
+from .ingress_request_builder import (
+    IngressRequestBuilderError,
+    IngressSourceContext,
+    IngressTaskIntent,
+    build_task_reevaluation_payload as build_ingress_task_reevaluation_payload,
+    build_task_submission_payload as build_ingress_task_submission_payload,
+)
 
-class OpenClawHarnessSpikeError(ValueError):
+
+class OpenClawHarnessSpikeError(IngressRequestBuilderError):
     """Raised when the spike client receives malformed local inputs."""
-
-
-def _iso_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _require_non_empty(value: str, *, field_name: str) -> str:
-    if not isinstance(value, str) or not value.strip():
-        raise OpenClawHarnessSpikeError(f"{field_name} is required")
-    return value.strip()
-
-
-def _optional_string(value: str | None, *, field_name: str) -> str | None:
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise OpenClawHarnessSpikeError(f"{field_name} must be a string when provided")
-    stripped = value.strip()
-    return stripped or None
 
 
 @dataclass(frozen=True)
@@ -46,22 +34,7 @@ class OpenClawSourceContext:
     agent_id: str | None = None
 
 
-@dataclass(frozen=True)
-class OpenClawTaskIntent:
-    """Reviewable task intent extracted from an OpenClaw-side interaction."""
-
-    task_id: str
-    title: str
-    description: str
-    acceptance_criteria: tuple[str, ...]
-    objective_summary: str | None = None
-    deliverable_type: str = "unspecified"
-    success_signal: str = "Task satisfies declared acceptance criteria."
-    status: str = "intake_ready"
-    priority: str = "normal"
-    linked_artifacts: tuple[dict[str, Any], ...] = ()
-    completion_evidence: dict[str, Any] | None = None
-    requested_by: str | None = None
+OpenClawTaskIntent = IngressTaskIntent
 
 
 @dataclass(frozen=True)
@@ -92,100 +65,32 @@ def build_task_submission_payload(
 ) -> dict[str, Any]:
     """Build a canonical POST /tasks payload from OpenClaw-side intent."""
 
-    task_id = _require_non_empty(intent.task_id, field_name="intent.task_id")
-    title = _require_non_empty(intent.title, field_name="intent.title")
-    description = _require_non_empty(intent.description, field_name="intent.description")
+    ingress_context = IngressSourceContext(
+        source_system="openclaw",
+        source_id=context.message_id,
+        ingress_name="OpenClaw",
+        ingress_id=context.conversation_id,
+        requested_by=intent.requested_by or context.user_id,
+        extension_namespace="openclaw",
+        extension_payload={
+            "conversation_id": context.conversation_id,
+            "message_id": context.message_id,
+            "channel": context.channel,
+            "workspace_id": context.workspace_id,
+            "user_id": context.user_id,
+            "agent_id": context.agent_id,
+        },
+    )
 
-    if not intent.acceptance_criteria:
-        raise OpenClawHarnessSpikeError("intent.acceptance_criteria must contain at least one item")
-
-    created_at = _iso_now()
-    task_envelope: dict[str, Any] = {
-        "id": task_id,
-        "title": title,
-        "description": description,
-        "origin": {
-            "source_system": "openclaw",
-            "source_type": "ingress_request",
-            "source_id": _require_non_empty(context.message_id, field_name="context.message_id"),
-            "ingress_id": _optional_string(context.conversation_id, field_name="context.conversation_id"),
-            "ingress_name": "OpenClaw",
-            "requested_by": _optional_string(intent.requested_by or context.user_id, field_name="requested_by"),
-        },
-        "status": intent.status,
-        "timestamps": {
-            "created_at": created_at,
-            "updated_at": created_at,
-            "completed_at": created_at if intent.status == "completed" else None,
-        },
-        "status_history": [],
-        "objective": {
-            "summary": _require_non_empty(intent.objective_summary or description, field_name="intent.objective_summary"),
-            "deliverable_type": _require_non_empty(intent.deliverable_type, field_name="intent.deliverable_type"),
-            "success_signal": _require_non_empty(intent.success_signal, field_name="intent.success_signal"),
-        },
-        "constraints": [],
-        "acceptance_criteria": [
-            {
-                "id": f"ac-{index + 1}",
-                "description": _require_non_empty(criterion, field_name=f"intent.acceptance_criteria[{index}]"),
-                "required": True,
-            }
-            for index, criterion in enumerate(intent.acceptance_criteria)
-        ],
-        "parent_task_id": None,
-        "child_task_ids": [],
-        "dependencies": [],
-        "assigned_executor": None,
-        "required_capabilities": [],
-        "priority": intent.priority,
-        "artifacts": {
-            "items": [dict(artifact) for artifact in intent.linked_artifacts],
-            "completion_evidence": dict(intent.completion_evidence)
-            if intent.completion_evidence is not None
-            else {
-                "policy": "deferred",
-                "status": "deferred",
-                "required_artifact_types": [],
-                "validated_artifact_ids": [],
-                "validation_method": "deferred",
-                "validated_at": None,
-                "validator": None,
-                "notes": None,
-            },
-        },
-        "observability": {
-            "errors": [],
-            "retries": {
-                "attempt_count": 0,
-                "max_attempts": 0,
-                "last_retry_at": None,
-            },
-            "execution_metadata": {},
-        },
-        "extensions": {
-            "openclaw": {
-                "conversation_id": context.conversation_id,
-                "message_id": context.message_id,
-                "channel": _require_non_empty(context.channel, field_name="context.channel"),
-                "workspace_id": context.workspace_id,
-                "user_id": context.user_id,
-                "agent_id": context.agent_id,
-            }
-        },
-    }
-
-    request_payload: dict[str, Any] = {
-        "task_envelope": task_envelope,
-        "external_facts": dict(external_facts or {}),
-        "claimed_completion": claimed_completion,
-        "acceptance_criteria_satisfied": acceptance_criteria_satisfied,
-    }
-    if runtime_facts is not None:
-        request_payload["runtime_facts"] = dict(runtime_facts)
-    if unresolved_conditions:
-        request_payload["unresolved_conditions"] = list(unresolved_conditions)
-    return {"request": request_payload}
+    return build_ingress_task_submission_payload(
+        intent=intent,
+        context=ingress_context,
+        external_facts=external_facts,
+        claimed_completion=claimed_completion,
+        acceptance_criteria_satisfied=acceptance_criteria_satisfied,
+        runtime_facts=runtime_facts,
+        unresolved_conditions=unresolved_conditions,
+    )
 
 
 def build_task_reevaluation_payload(
@@ -202,30 +107,27 @@ def build_task_reevaluation_payload(
 ) -> dict[str, Any]:
     """Build a canonical POST /tasks/<id>/reevaluate payload."""
 
-    request_payload: dict[str, Any] = {
-        "external_facts": dict(external_facts or {}),
-        "new_artifacts": [dict(artifact) for artifact in new_artifacts],
-        "claimed_completion": claimed_completion,
-        "acceptance_criteria_satisfied": acceptance_criteria_satisfied,
-    }
-    if completion_evidence is not None:
-        request_payload["completion_evidence"] = dict(completion_evidence)
-    if runtime_facts is not None:
-        request_payload["runtime_facts"] = dict(runtime_facts)
-    if unresolved_conditions:
-        request_payload["unresolved_conditions"] = list(unresolved_conditions)
-    if review_request is not None:
-        request_payload["review_request"] = dict(review_request)
-    if review_decision is not None:
-        request_payload["review_decision"] = dict(review_decision)
-    return {"request": request_payload}
+    return build_ingress_task_reevaluation_payload(
+        external_facts=external_facts,
+        new_artifacts=new_artifacts,
+        completion_evidence=completion_evidence,
+        claimed_completion=claimed_completion,
+        acceptance_criteria_satisfied=acceptance_criteria_satisfied,
+        runtime_facts=runtime_facts,
+        unresolved_conditions=unresolved_conditions,
+        review_request=review_request,
+        review_decision=review_decision,
+    )
 
 
 class OpenClawHarnessSpikeClient:
     """Thin OpenClaw-style HTTP client for the public Harness API."""
 
     def __init__(self, base_url: str) -> None:
-        self.base_url = _require_non_empty(base_url.rstrip("/"), field_name="base_url")
+        normalized = base_url.rstrip("/")
+        if not normalized:
+            raise OpenClawHarnessSpikeError("base_url is required")
+        self.base_url = normalized
 
     def _request_json(self, method: str, path: str, payload: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
         data = None

--- a/tests/connectors/test_ingress_request_builder.py
+++ b/tests/connectors/test_ingress_request_builder.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import tempfile
+import threading
+import unittest
+
+from modules.api import run_server
+from modules.connectors.ingress_request_builder import (
+    IngressRequestBuilderError,
+    IngressSourceContext,
+    IngressTaskIntent,
+    build_task_reevaluation_payload,
+    build_task_submission_payload,
+)
+
+
+class IngressRequestBuilderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.server = run_server(host="127.0.0.1", port=0, store_root=self.temp_dir.name)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.temp_dir.cleanup()
+
+    def _context(self) -> IngressSourceContext:
+        return IngressSourceContext(
+            source_system="openclaw",
+            source_id="msg-ingress-1",
+            ingress_name="OpenClaw",
+            ingress_id="conv-ingress-1",
+            requested_by="operator@example.com",
+            extension_namespace="openclaw",
+            extension_payload={
+                "conversation_id": "conv-ingress-1",
+                "message_id": "msg-ingress-1",
+                "channel": "cli",
+            },
+        )
+
+    def _intent(self) -> IngressTaskIntent:
+        return IngressTaskIntent(
+            task_id="task-ingress-builder-1",
+            title="Ingress builder task",
+            description="Construct a canonical Harness submission payload from higher-level ingress inputs.",
+            acceptance_criteria=(
+                "The task submission payload validates at the Harness API boundary.",
+                "The source metadata remains auditable.",
+            ),
+            objective_summary="Reduce ingress-side task submission friction.",
+        )
+
+    def _post_json(self, path: str, payload: dict) -> tuple[int, dict]:
+        from json import dumps, loads
+        from urllib.error import HTTPError
+        from urllib.request import Request, urlopen
+
+        request = Request(
+            self.base_url + path,
+            data=dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request) as response:
+                return response.status, loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            try:
+                return error.code, loads(error.read().decode("utf-8"))
+            finally:
+                error.close()
+
+    def test_builds_valid_new_task_submission_payload(self) -> None:
+        payload = build_task_submission_payload(intent=self._intent(), context=self._context())
+
+        task = payload["request"]["task_envelope"]
+        self.assertEqual(task["origin"]["source_system"], "openclaw")
+        self.assertEqual(task["extensions"]["openclaw"]["conversation_id"], "conv-ingress-1")
+
+        status, response = self._post_json("/tasks", payload)
+        self.assertEqual(status, 200)
+        self.assertEqual(response["task_envelope"]["id"], "task-ingress-builder-1")
+
+    def test_builds_valid_reevaluation_payload(self) -> None:
+        payload = build_task_reevaluation_payload(
+            external_facts={"linear_facts": {"record_found": False, "reasons": ["awaiting sync"]}},
+            new_artifacts=(
+                {
+                    "id": "artifact-ingress-review-note-1",
+                    "type": "review_note",
+                    "title": "Ingress review note",
+                    "description": "The ingress client supplied a manual review note.",
+                    "location": None,
+                    "content_type": "text/plain",
+                    "external_id": None,
+                    "commit_sha": None,
+                    "pull_request_number": None,
+                    "review_state": None,
+                    "provenance": {
+                        "source_system": "openclaw",
+                        "source_type": "manual",
+                        "source_id": "msg-ingress-review-note-1",
+                        "captured_by": "ingress-builder-test",
+                    },
+                    "verification_status": "verified",
+                    "repository": None,
+                    "branch": None,
+                    "changed_files": [],
+                    "external_refs": [],
+                    "captured_at": "2026-03-25T18:00:00Z",
+                    "metadata": {},
+                },
+            ),
+            claimed_completion=True,
+            acceptance_criteria_satisfied=True,
+        )
+
+        self.assertEqual(payload["request"]["new_artifacts"][0]["type"], "review_note")
+        self.assertTrue(payload["request"]["claimed_completion"])
+
+    def test_rejects_missing_required_upstream_inputs(self) -> None:
+        with self.assertRaises(IngressRequestBuilderError):
+            build_task_submission_payload(
+                intent=IngressTaskIntent(
+                    task_id="task-ingress-invalid-1",
+                    title="",
+                    description="Missing title should fail fast.",
+                    acceptance_criteria=("A criterion exists.",),
+                ),
+                context=self._context(),
+            )
+
+        with self.assertRaises(IngressRequestBuilderError):
+            build_task_submission_payload(
+                intent=IngressTaskIntent(
+                    task_id="task-ingress-invalid-2",
+                    title="No criteria",
+                    description="Missing criteria should fail fast.",
+                    acceptance_criteria=(),
+                ),
+                context=self._context(),
+            )
+
+    def test_preserves_openclaw_extension_metadata_without_runtime_coupling(self) -> None:
+        payload = build_task_submission_payload(intent=self._intent(), context=self._context())
+
+        task = payload["request"]["task_envelope"]
+        self.assertEqual(task["extensions"]["openclaw"]["channel"], "cli")
+        self.assertEqual(task["origin"]["ingress_name"], "OpenClaw")
+        self.assertEqual(task["origin"]["source_type"], "ingress_request")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a thin ingress-neutral request builder for canonical `POST /tasks` and reevaluation payload construction
- refactor the OpenClaw spike to consume the generic builder instead of handcrafting canonical task payloads itself
- document the intended usage so ingress clients can carry source metadata and extension payloads without changing the Harness API

## Validation
- `python3 -m py_compile modules/connectors/ingress_request_builder.py modules/connectors/openclaw_harness_spike.py`
- `.venv/bin/python -m unittest tests.connectors.test_ingress_request_builder tests.connectors.test_openclaw_harness_spike`
- `.venv/bin/python -m unittest tests.connectors.test_ingress_request_builder tests.connectors.test_openclaw_harness_spike tests.test_api tests.test_simulator`
- `.venv/bin/python -m unittest discover -s tests`

## Notes
- the builder stays ingress-neutral even though `extensions.openclaw` is one documented use case
- canonical API behavior is unchanged; this is strictly an ergonomics layer at the ingress boundary
