### PR TITLE
Fix dashboard detail projection from canonical read model

### DIFF
--- a/components/dashboard/evidence-panel.tsx
+++ b/components/dashboard/evidence-panel.tsx
@@ -28,7 +28,7 @@ function extractArtifacts(timeline?: TimelineEvent[]) {
   return timeline
     .filter((e) => e.event_type === "artifact_captured")
     .map((e) => ({
-      id: e.event_id,
+      id: typeof e.details.artifact_id === "string" ? e.details.artifact_id : e.event_id,
       type: (e.details.type as string) || "unknown",
       pr_number: e.details.pull_request_number as number | undefined,
       commit_sha: e.details.commit_sha as string | undefined,
@@ -43,11 +43,11 @@ export function EvidencePanel({ evidence, timeline }: EvidencePanelProps) {
   const artifacts = extractArtifacts(timeline);
 
   const statusConfig = {
-    validated: {
+    satisfied: {
       icon: CheckCircle2,
       color: "text-success",
       bg: "bg-success/10",
-      label: "Validated",
+      label: "Satisfied",
     },
     insufficient: {
       icon: AlertCircle,
@@ -61,23 +61,23 @@ export function EvidencePanel({ evidence, timeline }: EvidencePanelProps) {
       bg: "bg-info/10",
       label: "Pending",
     },
-    awaiting: {
+    deferred: {
       icon: Clock,
       color: "text-muted-foreground",
       bg: "bg-muted",
-      label: "Awaiting",
+      label: "Deferred",
     },
-    missing: {
-      icon: XCircle,
-      color: "text-destructive",
-      bg: "bg-destructive/10",
-      label: "Missing",
+    not_applicable: {
+      icon: FileOutput,
+      color: "text-muted-foreground",
+      bg: "bg-muted",
+      label: "Not Applicable",
     },
   };
 
   const status =
     statusConfig[completion_evidence.status as keyof typeof statusConfig] ||
-    statusConfig.awaiting;
+    statusConfig.deferred;
 
   // Check which required types are present
   const presentTypes = new Set(Object.keys(evidence.artifact_type_counts));
@@ -131,9 +131,7 @@ export function EvidencePanel({ evidence, timeline }: EvidencePanelProps) {
                           {type.replace("_", " ")}
                         </span>
                       </div>
-                      <span
-                        className={`text-xs font-mono ${isPresent ? "text-success" : "text-destructive"}`}
-                      >
+                      <span className={`text-xs font-mono ${isPresent ? "text-success" : "text-destructive"}`}>
                         {isPresent ? `${count} present` : "missing"}
                       </span>
                     </div>

--- a/components/dashboard/reconciliation-card.tsx
+++ b/components/dashboard/reconciliation-card.tsx
@@ -1,4 +1,4 @@
-import type { ReconciliationSummary } from "@/lib/types";
+import type { EvidenceSummary, ReconciliationSummary, TimelineEvent } from "@/lib/types";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { ReconciliationBadge } from "@/components/ui/status-badge";
 import { formatDateTime } from "@/lib/utils";
@@ -13,37 +13,49 @@ import {
 
 interface ReconciliationCardProps {
   summary: ReconciliationSummary | null;
+  evidence?: EvidenceSummary | null;
+  timeline?: TimelineEvent[];
+  currentStatus?: string | null;
 }
 
-// Determine if a system state indicates a problem
-function getSystemStatus(
-  state: string | null,
-  hasMismatch: boolean
-): "ok" | "missing" | "mismatch" | "unknown" {
-  if (!state || state === "-") return "missing";
-  if (hasMismatch) return "mismatch";
-
-  const okStates = [
-    "done",
-    "completed",
-    "merged",
-    "closed",
-    "resolved",
-    "accepted",
-  ];
-  const lowerState = state.toLowerCase();
-  if (okStates.some((s) => lowerState.includes(s))) return "ok";
-
-  return "unknown";
-}
-
-// Check if this system is mentioned in mismatches
 function systemHasMismatch(system: string, mismatches: string[]): boolean {
   const lowerSystem = system.toLowerCase();
   return mismatches.some((m) => m.toLowerCase().includes(lowerSystem));
 }
 
-export function ReconciliationCard({ summary }: ReconciliationCardProps) {
+function inferGithubState(
+  evidence?: EvidenceSummary | null,
+  timeline?: TimelineEvent[],
+): string | null {
+  const artifactTypeCounts = evidence?.artifact_type_counts ?? {};
+  const githubArtifactCount =
+    Number(artifactTypeCounts.pull_request ?? 0) +
+    Number(artifactTypeCounts.commit ?? 0) +
+    Number(artifactTypeCounts.branch ?? 0) +
+    Number(artifactTypeCounts.changed_file ?? 0);
+
+  if (githubArtifactCount > 0) {
+    const validatedCount = Number(evidence?.validated_artifact_count ?? 0);
+    return validatedCount > 0 ? `${validatedCount} validated artifact${validatedCount === 1 ? "" : "s"}` : `${githubArtifactCount} artifact${githubArtifactCount === 1 ? "" : "s"}`;
+  }
+
+  const timelineHasGithubArtifact = (timeline ?? []).some(
+    (event) =>
+      event.event_type === "artifact_captured" &&
+      ((event.source?.toLowerCase() === "github") ||
+        typeof event.details.pull_request_number === "number" ||
+        typeof event.details.commit_sha === "string"),
+  );
+
+  return timelineHasGithubArtifact ? "artifacts present" : null;
+}
+
+export function ReconciliationCard({
+  summary,
+  evidence,
+  timeline,
+  currentStatus,
+}: ReconciliationCardProps) {
   if (!summary) {
     return (
       <Card>
@@ -65,28 +77,58 @@ export function ReconciliationCard({ summary }: ReconciliationCardProps) {
     );
   }
 
-  const hasMismatches = summary.mismatches.length > 0;
+  const mismatchCategories = summary.mismatch_categories ?? [];
+  const mismatchReasons = summary.mismatches ?? [];
+  const hasMismatches = mismatchCategories.length > 0;
   const isContradictory =
-    summary.result === "contradictory_facts" ||
-    summary.result === "wrong_target";
+    summary.outcome === "contradictory_facts" ||
+    summary.outcome === "wrong_target" ||
+    summary.outcome === "terminal_invalid";
 
   const systems = [
     {
       name: "Linear",
-      state: summary.linear_state,
-      hasMismatch: systemHasMismatch("linear", summary.mismatches),
+      state: summary.status ?? summary.linear_state,
+      status: hasMismatches && systemHasMismatch("linear", mismatchCategories) ? "mismatch" : summary.status === "passed" ? "ok" : "unknown",
     },
     {
       name: "GitHub",
-      state: summary.github_state,
-      hasMismatch: systemHasMismatch("github", summary.mismatches),
+      state: summary.github_state ?? inferGithubState(evidence, timeline),
+      status: hasMismatches && systemHasMismatch("github", mismatchCategories) ? "mismatch" : inferGithubState(evidence, timeline) ? "ok" : "missing",
     },
     {
       name: "Harness",
-      state: summary.harness_state,
-      hasMismatch: systemHasMismatch("harness", summary.mismatches),
+      state: currentStatus ?? summary.harness_state,
+      status: hasMismatches && systemHasMismatch("harness", mismatchCategories) ? "mismatch" : (currentStatus ?? summary.harness_state) ? "ok" : "unknown",
     },
-  ];
+  ] as const;
+
+  const statusStyles = {
+    ok: {
+      bg: "bg-success/10 border-success/30",
+      icon: CheckCircle2,
+      iconColor: "text-success",
+      stateColor: "text-success",
+    },
+    missing: {
+      bg: "bg-muted/50 border-border",
+      icon: Minus,
+      iconColor: "text-muted-foreground",
+      stateColor: "text-muted-foreground",
+    },
+    mismatch: {
+      bg: "bg-warning/10 border-warning/30",
+      icon: AlertCircle,
+      iconColor: "text-warning",
+      stateColor: "text-warning",
+    },
+    unknown: {
+      bg: "bg-muted/50 border-border",
+      icon: Minus,
+      iconColor: "text-muted-foreground",
+      stateColor: "text-foreground",
+    },
+  } as const;
 
   return (
     <Card
@@ -112,36 +154,7 @@ export function ReconciliationCard({ summary }: ReconciliationCardProps) {
           {/* System States - with tension indicators */}
           <div className="space-y-1.5">
             {systems.map((system) => {
-              const status = getSystemStatus(system.state, system.hasMismatch);
-
-              const statusStyles = {
-                ok: {
-                  bg: "bg-success/10 border-success/30",
-                  icon: CheckCircle2,
-                  iconColor: "text-success",
-                  stateColor: "text-success",
-                },
-                missing: {
-                  bg: "bg-destructive/10 border-destructive/30",
-                  icon: XCircle,
-                  iconColor: "text-destructive",
-                  stateColor: "text-destructive",
-                },
-                mismatch: {
-                  bg: "bg-warning/10 border-warning/30",
-                  icon: AlertCircle,
-                  iconColor: "text-warning",
-                  stateColor: "text-warning",
-                },
-                unknown: {
-                  bg: "bg-muted/50 border-border",
-                  icon: Minus,
-                  iconColor: "text-muted-foreground",
-                  stateColor: "text-foreground",
-                },
-              };
-
-              const style = statusStyles[status];
+              const style = statusStyles[system.status];
               const Icon = style.icon;
 
               return (
@@ -188,7 +201,7 @@ export function ReconciliationCard({ summary }: ReconciliationCardProps) {
                 </span>
               </div>
               <ul className="space-y-1">
-                {summary.mismatches.map((mismatch, index) => (
+                {(mismatchReasons.length > 0 ? mismatchReasons : mismatchCategories).map((mismatch, index) => (
                   <li
                     key={index}
                     className="text-xs text-foreground flex items-start gap-1.5"
@@ -202,7 +215,7 @@ export function ReconciliationCard({ summary }: ReconciliationCardProps) {
           )}
 
           {/* All Aligned Banner */}
-          {!hasMismatches && summary.result === "no_mismatch" && (
+          {!hasMismatches && summary.outcome === "no_mismatch" && !summary.blocking && (
             <div className="flex items-center gap-2 p-2.5 rounded-lg bg-success/10 border border-success/30">
               <CheckCircle2 className="h-4 w-4 text-success" />
               <span className="text-sm font-medium text-success">

--- a/components/dashboard/task-detail-panel.tsx
+++ b/components/dashboard/task-detail-panel.tsx
@@ -254,7 +254,12 @@ export function TaskDetailPanel({
             {/* Verification & Reconciliation */}
             <div className="grid grid-cols-1 gap-4">
               <VerificationCard summary={task.verification_summary} />
-              <ReconciliationCard summary={task.reconciliation_summary} />
+              <ReconciliationCard
+                summary={task.reconciliation_summary}
+                evidence={task.evidence_summary}
+                timeline={task.timeline}
+                currentStatus={task.current_status}
+              />
             </div>
 
             {/* Evidence */}

--- a/components/dashboard/verification-card.tsx
+++ b/components/dashboard/verification-card.tsx
@@ -46,23 +46,23 @@ export function VerificationCard({ summary }: VerificationCardProps) {
           {/* Key indicators */}
           <div className="flex items-center gap-4 text-sm">
             <div className="flex items-center gap-1.5">
-              {summary.completion_accepted ? (
+              {(summary.verification_passed ?? summary.completion_accepted) ? (
                 <CheckCircle2 className="h-4 w-4 text-success" />
               ) : (
                 <XCircle className="h-4 w-4 text-destructive" />
               )}
               <span className="text-muted-foreground">
-                Completion {summary.completion_accepted ? "Accepted" : "Not Accepted"}
+                Completion {(summary.verification_passed ?? summary.completion_accepted) ? "Accepted" : "Not Accepted"}
               </span>
             </div>
             <div className="flex items-center gap-1.5">
-              {summary.evidence_sufficient ? (
+              {(summary.evidence_is_sufficient ?? summary.evidence_sufficient) ? (
                 <FileSearch className="h-4 w-4 text-success" />
               ) : (
                 <FileSearch className="h-4 w-4 text-warning" />
               )}
               <span className="text-muted-foreground">
-                Evidence {summary.evidence_sufficient ? "Sufficient" : "Insufficient"}
+                Evidence {(summary.evidence_is_sufficient ?? summary.evidence_sufficient) ? "Sufficient" : "Insufficient"}
               </span>
             </div>
           </div>

--- a/lib/harness-api.ts
+++ b/lib/harness-api.ts
@@ -37,24 +37,16 @@ function mapReconciliationStatus(summary: Record<string, unknown> | null): Recon
     return null;
   }
 
-  const categories = Array.isArray(summary.mismatch_categories)
-    ? summary.mismatch_categories.map(String)
-    : [];
-
-  if (categories.includes("wrong_repository") || categories.includes("wrong_branch")) {
-    return "wrong_target";
-  }
-
   switch (summary.outcome) {
     case "no_mismatch":
       return "no_mismatch";
+    case "missing_evidence":
+      return "stale_evidence";
     case "wrong_target":
       return "wrong_target";
     case "contradictory_facts":
     case "terminal_invalid":
       return "contradictory_facts";
-    case "missing_evidence":
-      return "stale_evidence";
     case "review_required":
     case "reconciliation_pending":
       return "pending";
@@ -189,9 +181,25 @@ function mapTask(readModel: Record<string, unknown>, timelineOverride?: Timeline
   const reasons = Array.isArray(verificationSummary?.reasons)
     ? verificationSummary.reasons.map(String)
     : [];
+  const mismatchCategories = Array.isArray(reconciliationSummary?.mismatch_categories)
+    ? reconciliationSummary.mismatch_categories.map(String)
+    : [];
   const mismatches = Array.isArray(reconciliationSummary?.reasons)
     ? reconciliationSummary.reasons.map(String)
     : [];
+  const artifactTypeCounts =
+    (evidenceSummary.artifact_type_counts as Record<string, number> | undefined) ?? {};
+  const githubArtifactCount =
+    Number(artifactTypeCounts.pull_request ?? 0) +
+    Number(artifactTypeCounts.commit ?? 0) +
+    Number(artifactTypeCounts.branch ?? 0) +
+    Number(artifactTypeCounts.changed_file ?? 0);
+  const githubState =
+    githubArtifactCount > 0
+      ? `${githubArtifactCount} artifact${githubArtifactCount === 1 ? "" : "s"}`
+      : null;
+  const reconciliationStatusText =
+    (reconciliationSummary?.status as string | undefined) ?? null;
 
   return {
     task_id: String(readModel.task_id ?? ""),
@@ -267,8 +275,12 @@ function mapTask(readModel: Record<string, unknown>, timelineOverride?: Timeline
     verification_summary: verificationSummary && mappedVerificationStatus
       ? {
           result: mappedVerificationStatus,
+          outcome: String(verificationSummary.outcome ?? ""),
           completion_accepted: Boolean(verificationSummary.accepted_completion),
+          verification_passed: Boolean(verificationSummary.verification_passed),
           evidence_sufficient: Boolean(verificationSummary.evidence_is_sufficient),
+          evidence_is_valid: Boolean(verificationSummary.evidence_is_valid),
+          evidence_is_sufficient: Boolean(verificationSummary.evidence_is_sufficient),
           reasons,
           evaluated_at:
             (evaluationSummary.latest_recorded_at as string | undefined) ??
@@ -278,14 +290,12 @@ function mapTask(readModel: Record<string, unknown>, timelineOverride?: Timeline
     reconciliation_summary: reconciliationSummary && mappedReconciliationStatus
       ? {
           result: mappedReconciliationStatus,
-          linear_state:
-            (reconciliationSummary.status as string | undefined) ??
-            null,
-          github_state:
-            Array.isArray(reconciliationSummary.mismatch_categories) &&
-            reconciliationSummary.mismatch_categories.length > 0
-              ? String((reconciliationSummary.mismatch_categories as unknown[])[0])
-              : null,
+          outcome: String(reconciliationSummary.outcome ?? ""),
+          status: reconciliationStatusText,
+          blocking: Boolean(reconciliationSummary.blocking),
+          mismatch_categories: mismatchCategories,
+          linear_state: reconciliationStatusText,
+          github_state: githubState,
           harness_state: String(readModel.current_status ?? ""),
           mismatches,
           evaluated_at:

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -81,14 +81,22 @@ export interface EvidenceSummary {
 
 export interface VerificationSummary {
   result: VerificationStatus;
+  outcome?: string | null;
   completion_accepted: boolean;
+  verification_passed?: boolean;
   evidence_sufficient: boolean;
+  evidence_is_valid?: boolean;
+  evidence_is_sufficient?: boolean;
   reasons: string[];
   evaluated_at: string;
 }
 
 export interface ReconciliationSummary {
   result: ReconciliationStatus;
+  outcome?: string | null;
+  status?: string | null;
+  blocking?: boolean;
+  mismatch_categories?: string[];
   linear_state: string | null;
   github_state: string | null;
   harness_state: string | null;


### PR DESCRIPTION
## Summary
- fix the dashboard detail projection so verification, reconciliation, and evidence panels trust the canonical read-model summaries instead of ad hoc fallbacks
- derive GitHub presence from canonical evidence artifacts when the read-model does not include a dedicated GitHub state string
- remove false mismatch and awaiting states caused by frontend-side reconstruction of reconciliation and completion-evidence status

## Validation
- `pnpm lint`
- `pnpm build`

## Notes
- no backend or API contract changes were made
- this is a frontend data-mapping fix only; the UI layout and component structure remain unchanged
