### PR TITLE
Handle evaluator-side invalid TaskEnvelope errors in API

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -365,9 +365,8 @@ def evaluate_http_payload(payload: dict[str, Any]) -> tuple[int, dict[str, Any]]
             "invalid_input": True,
         }
 
-    result = evaluate_task_case(request)
-    status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
-    return status, _to_jsonable(result)
+    status, response_payload, _ = _evaluate_request(request)
+    return status, response_payload
 
 
 def _task_path_components(path: str) -> tuple[str, ...]:
@@ -379,6 +378,19 @@ def _task_path_components(path: str) -> tuple[str, ...]:
 
 def _serialize_evaluation_record(record: EvaluationRecord) -> dict[str, Any]:
     return _to_jsonable(record)
+
+
+def _evaluate_request(request: HarnessEvaluationRequest) -> tuple[int, dict[str, Any], HarnessEvaluationResult | None]:
+    try:
+        result = evaluate_task_case(request)
+    except (ApiRequestError, ValueError) as error:
+        return HTTPStatus.BAD_REQUEST, {
+            "error": str(error),
+            "invalid_input": True,
+        }, None
+
+    status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
+    return status, _to_jsonable(result), result
 
 
 class HarnessApiService:
@@ -415,9 +427,9 @@ class HarnessApiService:
         except TaskEnvelopeNotFoundError:
             pass
 
-        result = evaluate_task_case(request)
-        status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
-        response_payload = _to_jsonable(result)
+        status, response_payload, result = _evaluate_request(request)
+        if result is None:
+            return status, response_payload
 
         if result.invalid_input:
             return status, response_payload
@@ -455,9 +467,9 @@ class HarnessApiService:
                 "invalid_input": True,
             }
 
-        result = evaluate_task_case(request)
-        status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
-        response_payload = _to_jsonable(result)
+        status, response_payload, result = _evaluate_request(request)
+        if result is None:
+            return status, response_payload
 
         if result.invalid_input:
             return status, response_payload
@@ -482,9 +494,9 @@ class HarnessApiService:
                 "invalid_input": True,
             }
 
-        result = evaluate_task_case(request)
-        status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
-        response_payload = _to_jsonable(result)
+        status, response_payload, result = _evaluate_request(request)
+        if result is None:
+            return status, response_payload
 
         if result.invalid_input:
             return status, response_payload

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,15 @@ def _request_payload(case_name: str) -> dict:
     return {"request": _to_jsonable(build_demo_request(case_name))}
 
 
+def _schema_invalid_submission_payload() -> dict:
+    payload = _request_payload("accepted_completion")
+    completion_evidence = payload["request"]["task_envelope"]["artifacts"]["completion_evidence"]
+    del completion_evidence["validated_at"]
+    del completion_evidence["validation_method"]
+    del completion_evidence["validator"]
+    return payload
+
+
 def _linear_ingress_payload(case_name: str, *, task_id: str | None = None) -> dict:
     canonical_request = _request_payload(case_name)["request"]
     task = deepcopy(canonical_request["task_envelope"])
@@ -223,6 +232,13 @@ class HarnessApiPayloadTests(unittest.TestCase):
         self.assertEqual(payload["action"], "invalid_input")
         self.assertTrue(payload["invalid_input"])
 
+    def test_rejects_schema_invalid_payload(self) -> None:
+        status, payload = evaluate_http_payload(_schema_invalid_submission_payload())
+
+        self.assertEqual(status, 400)
+        self.assertTrue(payload["invalid_input"])
+        self.assertIn("Invalid TaskEnvelope:", payload["error"])
+
 
 class HarnessApiServiceTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -302,6 +318,13 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(status, 400)
         self.assertTrue(payload["invalid_input"])
         self.assertIn("task_envelope.id is required", payload["error"])
+
+    def test_service_submit_rejects_schema_invalid_task_envelope_without_crashing(self) -> None:
+        status, payload = self.service.submit(_schema_invalid_submission_payload())
+
+        self.assertEqual(status, 400)
+        self.assertTrue(payload["invalid_input"])
+        self.assertIn("Invalid TaskEnvelope:", payload["error"])
 
     def test_service_can_submit_linear_ingress_payload_via_canonical_submission_path(self) -> None:
         status, payload = self.service.submit_linear_ingress(_linear_ingress_payload("accepted_completion"))
@@ -465,6 +488,13 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(status, 400)
         self.assertTrue(payload["invalid_input"])
         self.assertIn("task_envelope.id is required", payload["error"])
+
+    def test_api_submit_rejects_schema_invalid_task_envelope_with_structured_400(self) -> None:
+        status, payload = self._post_json("/tasks", _schema_invalid_submission_payload())
+
+        self.assertEqual(status, 400)
+        self.assertTrue(payload["invalid_input"])
+        self.assertIn("Invalid TaskEnvelope:", payload["error"])
 
     def test_api_submit_rejects_duplicate_task_id_with_conflict(self) -> None:
         initial_status, initial_payload = self._post_json("/tasks", _request_payload("accepted_completion"))


### PR DESCRIPTION
## Summary
- catch evaluator-side schema validation failures and convert them into structured `400` invalid-input responses
- reuse the same guarded evaluator path for `POST /tasks`, direct payload evaluation, and reevaluation-backed API flows
- add regressions for malformed `completion_evidence` payloads that previously raised `ValueError: Invalid TaskEnvelope`

## Validation
- `.venv/bin/python -m unittest tests.test_api`
- `.venv/bin/python -m unittest discover -s tests`