### PR TITLE
Add shared outcome severity styling

### DIFF
--- a/components/dashboard/reconciliation-card.tsx
+++ b/components/dashboard/reconciliation-card.tsx
@@ -1,4 +1,5 @@
 import type { EvidenceSummary, ReconciliationSummary, TimelineEvent } from "@/lib/types";
+import { getSeverityClasses } from "@/lib/outcome-severity";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { ReconciliationBadge } from "@/components/ui/status-badge";
 import { formatDateTime } from "@/lib/utils";
@@ -105,10 +106,10 @@ export function ReconciliationCard({
 
   const statusStyles = {
     ok: {
-      bg: "bg-success/10 border-success/30",
+      bg: getSeverityClasses("success").border,
       icon: CheckCircle2,
-      iconColor: "text-success",
-      stateColor: "text-success",
+      iconColor: getSeverityClasses("success").text,
+      stateColor: getSeverityClasses("success").text,
     },
     missing: {
       bg: "bg-muted/50 border-border",
@@ -117,10 +118,10 @@ export function ReconciliationCard({
       stateColor: "text-muted-foreground",
     },
     mismatch: {
-      bg: "bg-warning/10 border-warning/30",
+      bg: getSeverityClasses("warning").border,
       icon: AlertCircle,
-      iconColor: "text-warning",
-      stateColor: "text-warning",
+      iconColor: getSeverityClasses("warning").text,
+      stateColor: getSeverityClasses("warning").text,
     },
     unknown: {
       bg: "bg-muted/50 border-border",
@@ -130,16 +131,14 @@ export function ReconciliationCard({
     },
   } as const;
 
+  const cardSeverity = isContradictory
+    ? getSeverityClasses("failure").border
+    : hasMismatches
+      ? getSeverityClasses("warning").border
+      : "";
+
   return (
-    <Card
-      className={
-        isContradictory
-          ? "border-destructive/50 bg-destructive/5"
-          : hasMismatches
-            ? "border-warning/50 bg-warning/5"
-            : ""
-      }
-    >
+    <Card className={cardSeverity}>
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2">
@@ -176,15 +175,15 @@ export function ReconciliationCard({
 
           {/* Contradiction Banner */}
           {isContradictory && (
-            <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/20 border border-destructive/40">
+            <div className={`flex items-center gap-2 rounded-lg border p-3 ${getSeverityClasses("failure").border}`}>
               <div className="flex h-8 w-8 items-center justify-center rounded-full bg-destructive/30">
-                <AlertTriangle className="h-4 w-4 text-destructive" />
+                <AlertTriangle className={`h-4 w-4 ${getSeverityClasses("failure").text}`} />
               </div>
               <div>
-                <p className="text-sm font-semibold text-destructive">
+                <p className={`text-sm font-semibold ${getSeverityClasses("failure").text}`}>
                   Systems Disagree
                 </p>
-                <p className="text-xs text-destructive/80">
+                <p className={`text-xs ${getSeverityClasses("failure").text}/80`}>
                   Truth cannot be established - human review required
                 </p>
               </div>
@@ -193,10 +192,10 @@ export function ReconciliationCard({
 
           {/* Mismatch Details */}
           {hasMismatches && !isContradictory && (
-            <div className="p-2.5 rounded-lg bg-warning/10 border border-warning/30">
+            <div className={`rounded-lg border p-2.5 ${getSeverityClasses("warning").border}`}>
               <div className="flex items-center gap-1.5 mb-1.5">
-                <AlertTriangle className="h-3.5 w-3.5 text-warning" />
-                <span className="text-xs font-semibold text-warning">
+                <AlertTriangle className={`h-3.5 w-3.5 ${getSeverityClasses("warning").text}`} />
+                <span className={`text-xs font-semibold ${getSeverityClasses("warning").text}`}>
                   Mismatches Detected
                 </span>
               </div>
@@ -206,7 +205,7 @@ export function ReconciliationCard({
                     key={index}
                     className="text-xs text-foreground flex items-start gap-1.5"
                   >
-                    <span className="text-warning mt-0.5">-</span>
+                    <span className={`mt-0.5 ${getSeverityClasses("warning").text}`}>-</span>
                     {mismatch}
                   </li>
                 ))}
@@ -216,9 +215,9 @@ export function ReconciliationCard({
 
           {/* All Aligned Banner */}
           {!hasMismatches && summary.outcome === "no_mismatch" && !summary.blocking && (
-            <div className="flex items-center gap-2 p-2.5 rounded-lg bg-success/10 border border-success/30">
-              <CheckCircle2 className="h-4 w-4 text-success" />
-              <span className="text-sm font-medium text-success">
+            <div className={`flex items-center gap-2 rounded-lg border p-2.5 ${getSeverityClasses("success").border}`}>
+              <CheckCircle2 className={`h-4 w-4 ${getSeverityClasses("success").text}`} />
+              <span className={`text-sm font-medium ${getSeverityClasses("success").text}`}>
                 All systems aligned
               </span>
             </div>

--- a/components/dashboard/review-panel.tsx
+++ b/components/dashboard/review-panel.tsx
@@ -1,4 +1,5 @@
 import type { ReviewSummary } from "@/lib/types";
+import { getSeverityClasses } from "@/lib/outcome-severity";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { formatDateTime } from "@/lib/utils";
@@ -68,9 +69,9 @@ export function ReviewPanel({ review }: ReviewPanelProps) {
 
           {/* Latest Request */}
           {review.latest_request && (
-            <div className="p-3 rounded-md bg-warning/10 border border-warning/20">
+            <div className={`rounded-md border p-3 ${getSeverityClasses("warning").border}`}>
               <div className="flex items-center gap-2 mb-2">
-                <AlertCircle className="h-4 w-4 text-warning" />
+                <AlertCircle className={`h-4 w-4 ${getSeverityClasses("warning").text}`} />
                 <span className="text-sm font-medium text-foreground">
                   Review Requested
                 </span>
@@ -88,19 +89,19 @@ export function ReviewPanel({ review }: ReviewPanelProps) {
           {/* Latest Decision */}
           {review.latest_decision && (
             <div
-              className={`p-3 rounded-md border ${
+              className={`rounded-md border p-3 ${
                 review.latest_decision.outcome === "approved"
-                  ? "bg-success/10 border-success/20"
+                  ? getSeverityClasses("success").border
                   : review.latest_decision.outcome === "rejected"
-                    ? "bg-destructive/10 border-destructive/20"
-                    : "bg-muted border-border"
+                    ? getSeverityClasses("failure").border
+                    : getSeverityClasses("neutral").border
               }`}
             >
               <div className="flex items-center gap-2 mb-2">
                 {review.latest_decision.outcome === "approved" ? (
-                  <CheckCircle2 className="h-4 w-4 text-success" />
+                  <CheckCircle2 className={`h-4 w-4 ${getSeverityClasses("success").text}`} />
                 ) : review.latest_decision.outcome === "rejected" ? (
-                  <XCircle className="h-4 w-4 text-destructive" />
+                  <XCircle className={`h-4 w-4 ${getSeverityClasses("failure").text}`} />
                 ) : (
                   <Clock className="h-4 w-4 text-muted-foreground" />
                 )}

--- a/components/dashboard/stats-cards.tsx
+++ b/components/dashboard/stats-cards.tsx
@@ -1,4 +1,5 @@
 import type { Task } from "@/lib/types";
+import { OutcomeSeverity, getSeverityClasses } from "@/lib/outcome-severity";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   ShieldCheck,
@@ -77,7 +78,7 @@ export function StatsCards({ tasks }: StatsCardsProps) {
         label="Invalid"
         value={stats.invalidContradicted}
         icon={XOctagon}
-        variant="destructive"
+        variant="failure"
         sublabel="Contradicted"
       />
       <StatCard
@@ -90,7 +91,7 @@ export function StatsCards({ tasks }: StatsCardsProps) {
         label="Pending Verification"
         value={stats.pendingVerification}
         icon={Clock}
-        variant="info"
+        variant="warning"
         className="col-span-2 md:col-span-1"
       />
     </div>
@@ -101,7 +102,7 @@ interface StatCardProps {
   label: string;
   value: number;
   icon: React.ElementType;
-  variant: "success" | "warning" | "destructive" | "info";
+  variant: OutcomeSeverity;
   sublabel?: string;
   className?: string;
 }
@@ -114,12 +115,7 @@ function StatCard({
   sublabel,
   className,
 }: StatCardProps) {
-  const variantStyles = {
-    success: "text-success",
-    warning: "text-warning",
-    destructive: "text-destructive",
-    info: "text-info",
-  };
+  const severity = getSeverityClasses(variant);
 
   return (
     <Card className={className}>
@@ -133,7 +129,7 @@ function StatCard({
             <p className="text-2xl font-semibold mt-1">{value}</p>
           </div>
           <div
-            className={`flex h-10 w-10 items-center justify-center rounded-md bg-muted ${variantStyles[variant]}`}
+            className={`flex h-10 w-10 items-center justify-center rounded-md bg-muted ${severity.text}`}
           >
             <Icon className="h-5 w-5" />
           </div>

--- a/components/dashboard/task-browser.tsx
+++ b/components/dashboard/task-browser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { startTransition, useEffect, useMemo, useState } from "react";
+import { OutcomeSeverity } from "@/lib/outcome-severity";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -31,7 +32,7 @@ interface FocusStat {
   label: string;
   value: number;
   icon: React.ElementType;
-  tone: "success" | "warning" | "destructive" | "info";
+  tone: OutcomeSeverity;
 }
 
 interface ViewConfig {
@@ -48,8 +49,8 @@ interface ViewConfig {
 const toneClassNames: Record<FocusStat["tone"], string> = {
   success: "text-success",
   warning: "text-warning",
-  destructive: "text-destructive",
-  info: "text-info",
+  failure: "text-destructive",
+  neutral: "text-muted-foreground",
 };
 
 const viewConfig: Record<DashboardView, ViewConfig> = {
@@ -127,13 +128,13 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
             !task.verification_summary.completion_accepted,
         ).length,
         icon: XCircle,
-        tone: "destructive",
+        tone: "failure",
       },
       {
         label: "Evaluated",
         value: tasks.filter((task) => task.verification_summary !== null).length,
         icon: ShieldCheck,
-        tone: "info",
+        tone: "neutral",
       },
       {
         label: "Evidence Insufficient",
@@ -154,7 +155,7 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
           (task) => task.verification_summary?.evidence_is_valid === false,
         ).length,
         icon: XCircle,
-        tone: "destructive",
+        tone: "failure",
       },
     ],
   },
@@ -215,7 +216,7 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
         label: "Blocking",
         value: tasks.filter((task) => task.reconciliation_summary?.blocking).length,
         icon: AlertTriangle,
-        tone: "warning",
+        tone: "failure",
       },
       {
         label: "Contradictions",
@@ -224,13 +225,13 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
           return result === "contradictory_facts" || result === "wrong_target";
         }).length,
         icon: GitCompare,
-        tone: "destructive",
+        tone: "warning",
       },
       {
         label: "Blocks Completion",
         value: tasks.filter((task) => task.reconciliation_summary?.blocking).length,
         icon: Clock3,
-        tone: "info",
+        tone: "failure",
       },
     ],
   },
@@ -292,7 +293,7 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
           0,
         ),
         icon: Search,
-        tone: "info",
+        tone: "neutral",
       },
       {
         label: "Decisions",
@@ -301,7 +302,7 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
           0,
         ),
         icon: CheckCircle2,
-        tone: "info",
+        tone: "neutral",
       },
     ],
   },

--- a/components/dashboard/task-table.tsx
+++ b/components/dashboard/task-table.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import type { Task } from "@/lib/types";
+import {
+  getBlockingSeverity,
+  getBooleanOutcomeSeverity,
+  getEvidenceSeverity,
+  getMismatchSeverity,
+  getReviewSeverity,
+  getSeverityClasses,
+  getVerificationSeverity,
+} from "@/lib/outcome-severity";
 import { formatDateTime, formatRelativeTime } from "@/lib/utils";
 import { StatusBadge, TruthStateBadge } from "@/components/ui/status-badge";
 import {
@@ -164,17 +173,20 @@ function renderCells(task: Task, view: DashboardView) {
             </div>
           </td>
           <td className="hidden px-4 py-3 md:table-cell">
-            <span
-              className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ${
-                task.reconciliation_summary?.blocking
-                  ? "bg-warning/15 text-warning"
-                  : "bg-muted text-muted-foreground"
-              }`}
-            >
-              {task.reconciliation_summary?.blocking
-                ? "Blocks completion"
-                : "No completion block"}
-            </span>
+            {(() => {
+              const severity = getSeverityClasses(
+                getBlockingSeverity(task.reconciliation_summary?.blocking ?? null),
+              );
+              return (
+                <span
+                  className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ${severity.soft}`}
+                >
+                  {task.reconciliation_summary?.blocking
+                    ? "Blocks completion"
+                    : "No completion block"}
+                </span>
+              );
+            })()}
           </td>
           <td className="hidden px-4 py-3 lg:table-cell">
             <TextList
@@ -194,7 +206,7 @@ function renderCells(task: Task, view: DashboardView) {
           />
           <td className="px-4 py-3">
             <div className="space-y-2">
-              <StatusBadge status={task.review_summary.status} variant="review" />
+              <StrictReviewBadge task={task} />
               <p className="text-xs text-muted-foreground">
                 {task.review_summary.status === "requested"
                   ? "Requires explicit manual decision"
@@ -328,22 +340,15 @@ function StrictVerificationBadge({ task }: { task: Task }) {
   const summary = task.verification_summary;
   const isAccepted = summary?.completion_accepted ?? false;
   const label = summary ? (isAccepted ? "Accepted" : "Rejected") : "Not evaluated";
+  const severity = getSeverityClasses(
+    summary ? getVerificationSeverity(isAccepted ? "accepted" : "rejected") : "neutral",
+  );
 
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${
-        !summary
-          ? "bg-muted text-muted-foreground"
-          : isAccepted
-          ? "bg-success/15 text-success"
-          : "bg-destructive/15 text-destructive"
-      }`}
+      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${severity.soft}`}
     >
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${
-          !summary ? "bg-muted-foreground" : isAccepted ? "bg-success" : "bg-destructive"
-        }`}
-      />
+      <span className={`h-1.5 w-1.5 rounded-full ${severity.dot}`} />
       {label}
     </span>
   );
@@ -352,9 +357,10 @@ function StrictVerificationBadge({ task }: { task: Task }) {
 function StrictReconciliationBadge({ task }: { task: Task }) {
   const summary = task.reconciliation_summary;
   if (!summary) {
+    const severity = getSeverityClasses("neutral");
     return (
-      <span className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground" />
+      <span className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${severity.soft}`}>
+        <span className={`h-1.5 w-1.5 rounded-full ${severity.dot}`} />
         Not reconciled
       </span>
     );
@@ -363,20 +369,13 @@ function StrictReconciliationBadge({ task }: { task: Task }) {
     summary?.result === "no_mismatch" &&
     !summary.blocking &&
     (summary.mismatch_categories?.length ?? 0) === 0;
+  const severity = getSeverityClasses(getMismatchSeverity(!isAligned));
 
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${
-        isAligned
-          ? "bg-success/15 text-success"
-          : "bg-warning/15 text-warning"
-      }`}
+      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${severity.soft}`}
     >
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${
-          isAligned ? "bg-success" : "bg-warning"
-        }`}
-      />
+      <span className={`h-1.5 w-1.5 rounded-full ${severity.dot}`} />
       {isAligned ? "Aligned" : "Mismatch"}
     </span>
   );
@@ -386,27 +385,35 @@ function StrictEvidenceBadge({ task }: { task: Task }) {
   const summary = task.verification_summary;
   const isSufficient =
     summary?.evidence_is_sufficient ?? summary?.evidence_sufficient ?? false;
+  const severity = getSeverityClasses(
+    getEvidenceSeverity(summary ? isSufficient : null),
+  );
 
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${
-        !summary
-          ? "bg-muted text-muted-foreground"
-          : isSufficient
-            ? "bg-success/15 text-success"
-            : "bg-warning/15 text-warning"
-      }`}
+      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${severity.soft}`}
     >
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${
-          !summary
-            ? "bg-muted-foreground"
-            : isSufficient
-              ? "bg-success"
-              : "bg-warning"
-        }`}
-      />
+      <span className={`h-1.5 w-1.5 rounded-full ${severity.dot}`} />
       {!summary ? "No evidence status" : isSufficient ? "Sufficient" : "Insufficient"}
+    </span>
+  );
+}
+
+function StrictReviewBadge({ task }: { task: Task }) {
+  const severity = getSeverityClasses(getReviewSeverity(task.review_summary.status));
+  const label =
+    task.review_summary.status === "requested"
+      ? "Review Required"
+      : task.review_summary.status === "resolved"
+        ? "Reviewed"
+        : "No Review";
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${severity.soft}`}
+    >
+      <span className={`h-1.5 w-1.5 rounded-full ${severity.dot}`} />
+      {label}
     </span>
   );
 }
@@ -418,13 +425,10 @@ function BooleanState({
   label: string;
   value: boolean;
 }) {
+  const severity = getSeverityClasses(getBooleanOutcomeSeverity(value));
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ${
-        value
-          ? "bg-success/15 text-success"
-          : "bg-muted text-muted-foreground"
-      }`}
+      className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ${severity.soft}`}
     >
       {value ? (
         <CheckCircle2 className="h-3.5 w-3.5" />
@@ -437,11 +441,10 @@ function BooleanState({
 }
 
 function InlineBoolean({ value }: { value: boolean }) {
+  const severity = getSeverityClasses(getBooleanOutcomeSeverity(value));
   return (
     <span
-      className={`inline-flex items-center gap-1 font-medium ${
-        value ? "text-success" : "text-muted-foreground"
-      }`}
+      className={`inline-flex items-center gap-1 font-medium ${severity.text}`}
     >
       {value ? (
         <CheckCircle2 className="h-3.5 w-3.5" />
@@ -466,8 +469,8 @@ function TextList({
 
   return (
     <div className="space-y-1">
-      {items.slice(0, 2).map((item) => (
-        <div key={item} className="text-xs text-foreground">
+      {items.slice(0, 2).map((item, index) => (
+        <div key={`${item}-${index}`} className="text-xs text-foreground">
           {item}
         </div>
       ))}

--- a/components/dashboard/verification-card.tsx
+++ b/components/dashboard/verification-card.tsx
@@ -1,4 +1,5 @@
 import type { VerificationSummary } from "@/lib/types";
+import { getEvidenceSeverity, getSeverityClasses, getVerificationSeverity } from "@/lib/outcome-severity";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { VerificationBadge } from "@/components/ui/status-badge";
 import { formatDateTime } from "@/lib/utils";
@@ -30,6 +31,13 @@ export function VerificationCard({ summary }: VerificationCardProps) {
     );
   }
 
+  const decisionSeverity = getSeverityClasses(getVerificationSeverity(summary.result));
+  const evidenceSeverity = getSeverityClasses(
+    getEvidenceSeverity(
+      summary.evidence_is_sufficient ?? summary.evidence_sufficient ?? null,
+    ),
+  );
+
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -47,9 +55,9 @@ export function VerificationCard({ summary }: VerificationCardProps) {
           <div className="flex items-center gap-4 text-sm">
             <div className="flex items-center gap-1.5">
               {(summary.verification_passed ?? summary.completion_accepted) ? (
-                <CheckCircle2 className="h-4 w-4 text-success" />
+                <CheckCircle2 className={`h-4 w-4 ${decisionSeverity.text}`} />
               ) : (
-                <XCircle className="h-4 w-4 text-destructive" />
+                <XCircle className={`h-4 w-4 ${decisionSeverity.text}`} />
               )}
               <span className="text-muted-foreground">
                 Completion {(summary.verification_passed ?? summary.completion_accepted) ? "Accepted" : "Not Accepted"}
@@ -57,9 +65,9 @@ export function VerificationCard({ summary }: VerificationCardProps) {
             </div>
             <div className="flex items-center gap-1.5">
               {(summary.evidence_is_sufficient ?? summary.evidence_sufficient) ? (
-                <FileSearch className="h-4 w-4 text-success" />
+                <FileSearch className={`h-4 w-4 ${evidenceSeverity.text}`} />
               ) : (
-                <FileSearch className="h-4 w-4 text-warning" />
+                <FileSearch className={`h-4 w-4 ${evidenceSeverity.text}`} />
               )}
               <span className="text-muted-foreground">
                 Evidence {(summary.evidence_is_sufficient ?? summary.evidence_sufficient) ? "Sufficient" : "Insufficient"}

--- a/components/ui/status-badge.tsx
+++ b/components/ui/status-badge.tsx
@@ -1,4 +1,12 @@
 import { cn } from "@/lib/utils";
+import {
+  getPrioritySeverity,
+  getReconciliationSeverity,
+  getReviewSeverity,
+  getSeverityClasses,
+  getTaskStatusSeverity,
+  getVerificationSeverity,
+} from "@/lib/outcome-severity";
 import type {
   TaskStatus,
   VerificationStatus,
@@ -16,136 +24,109 @@ interface StatusBadgeProps {
 
 const taskStatusConfig: Record<
   TaskStatus,
-  { label: string; className: string }
+  { label: string }
 > = {
   intake_ready: {
     label: "Intake Ready",
-    className: "bg-muted text-muted-foreground",
   },
   planned: {
     label: "Planned",
-    className: "bg-info/15 text-info",
   },
   dispatch_ready: {
     label: "Dispatch Ready",
-    className: "bg-info/15 text-info",
   },
   assigned: {
     label: "Assigned",
-    className: "bg-info/15 text-info",
   },
   executing: {
     label: "Executing",
-    className: "bg-warning/15 text-warning",
   },
   blocked: {
     label: "Blocked",
-    className: "bg-destructive/15 text-destructive",
   },
   completed: {
     label: "Completed",
-    className: "bg-success/15 text-success",
   },
   failed: {
     label: "Failed",
-    className: "bg-destructive/15 text-destructive",
   },
   canceled: {
     label: "Canceled",
-    className: "bg-muted text-muted-foreground",
   },
 };
 
 const verificationStatusConfig: Record<
   VerificationStatus,
-  { label: string; className: string }
+  { label: string }
 > = {
   accepted: {
     label: "Accepted",
-    className: "bg-success/15 text-success",
   },
   insufficient_evidence: {
     label: "Insufficient",
-    className: "bg-warning/15 text-warning",
   },
   deferred: {
     label: "Deferred",
-    className: "bg-muted text-muted-foreground",
   },
   pending: {
     label: "Pending",
-    className: "bg-info/15 text-info",
   },
   rejected: {
     label: "Rejected",
-    className: "bg-destructive/15 text-destructive",
   },
 };
 
 const reconciliationStatusConfig: Record<
   ReconciliationStatus,
-  { label: string; className: string }
+  { label: string }
 > = {
   no_mismatch: {
     label: "Aligned",
-    className: "bg-success/15 text-success",
   },
   wrong_target: {
     label: "Wrong Target",
-    className: "bg-destructive/15 text-destructive",
   },
   contradictory_facts: {
     label: "Contradictory",
-    className: "bg-destructive/15 text-destructive",
   },
   stale_evidence: {
     label: "Stale",
-    className: "bg-warning/15 text-warning",
   },
   pending: {
     label: "Pending",
-    className: "bg-info/15 text-info",
   },
 };
 
 const reviewStatusConfig: Record<
   ReviewStatus,
-  { label: string; className: string }
+  { label: string }
 > = {
   none: {
     label: "No Review",
-    className: "bg-muted text-muted-foreground",
   },
   requested: {
     label: "Review Required",
-    className: "bg-warning/15 text-warning",
   },
   resolved: {
     label: "Reviewed",
-    className: "bg-success/15 text-success",
   },
 };
 
-const priorityConfig: Record<Priority, { label: string; className: string }> = {
+const priorityConfig: Record<Priority, { label: string }> = {
   critical: {
     label: "Critical",
-    className: "bg-destructive/15 text-destructive",
   },
   high: {
     label: "High",
-    className: "bg-warning/15 text-warning",
   },
   normal: {
     label: "Normal",
-    className: "bg-muted text-muted-foreground",
   },
   low: {
     label: "Low",
-    className: "bg-muted text-muted-foreground",
   },
   backlog: {
     label: "Backlog",
-    className: "bg-muted text-muted-foreground",
   },
 };
 
@@ -155,28 +136,39 @@ export function StatusBadge({
   size = "sm",
   className,
 }: StatusBadgeProps) {
-  let config: { label: string; className: string } | undefined;
+  let config: { label: string } | undefined;
+  let severity = getSeverityClasses("neutral");
 
   switch (variant) {
     case "task":
       config = taskStatusConfig[status as TaskStatus];
+      severity = getSeverityClasses(getTaskStatusSeverity(status as TaskStatus));
       break;
     case "verification":
       config = verificationStatusConfig[status as VerificationStatus];
+      severity = getSeverityClasses(
+        getVerificationSeverity(status as VerificationStatus),
+      );
       break;
     case "reconciliation":
       config = reconciliationStatusConfig[status as ReconciliationStatus];
+      severity = getSeverityClasses(
+        getReconciliationSeverity(status as ReconciliationStatus),
+      );
       break;
     case "review":
       config = reviewStatusConfig[status as ReviewStatus];
+      severity = getSeverityClasses(getReviewSeverity(status as ReviewStatus));
       break;
     case "priority":
       config = priorityConfig[status as Priority];
+      severity = getSeverityClasses(getPrioritySeverity(status as Priority));
       break;
   }
 
   if (!config) {
-    config = { label: status, className: "bg-muted text-muted-foreground" };
+    config = { label: status };
+    severity = getSeverityClasses("neutral");
   }
 
   return (
@@ -184,7 +176,7 @@ export function StatusBadge({
       className={cn(
         "inline-flex items-center rounded-md font-medium",
         size === "sm" ? "px-2 py-0.5 text-xs" : "px-2.5 py-1 text-sm",
-        config.className,
+        severity.soft,
         className
       )}
     >
@@ -202,38 +194,33 @@ export function VerificationBadge({
   className?: string;
 }) {
   if (!status) {
+    const severity = getSeverityClasses("neutral");
     return (
       <span
         className={cn(
-          "inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium bg-muted text-muted-foreground",
+          "inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium",
+          severity.soft,
           className
         )}
       >
-        <span className="h-1.5 w-1.5 rounded-full bg-current opacity-50" />
+        <span className={cn("h-1.5 w-1.5 rounded-full opacity-50", severity.dot)} />
         Not Evaluated
       </span>
     );
   }
 
   const config = verificationStatusConfig[status];
-  const dotColor =
-    status === "accepted"
-      ? "bg-success"
-      : status === "rejected" || status === "insufficient_evidence"
-        ? "bg-destructive"
-        : status === "pending"
-          ? "bg-info"
-          : "bg-muted-foreground";
+  const severity = getSeverityClasses(getVerificationSeverity(status));
 
   return (
     <span
       className={cn(
         "inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium",
-        config.className,
+        severity.soft,
         className
       )}
     >
-      <span className={cn("h-1.5 w-1.5 rounded-full", dotColor)} />
+      <span className={cn("h-1.5 w-1.5 rounded-full", severity.dot)} />
       {config.label}
     </span>
   );
@@ -248,38 +235,33 @@ export function ReconciliationBadge({
   className?: string;
 }) {
   if (!status) {
+    const severity = getSeverityClasses("neutral");
     return (
       <span
         className={cn(
-          "inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium bg-muted text-muted-foreground",
+          "inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium",
+          severity.soft,
           className
         )}
       >
-        <span className="h-1.5 w-1.5 rounded-full bg-current opacity-50" />
+        <span className={cn("h-1.5 w-1.5 rounded-full opacity-50", severity.dot)} />
         Not Reconciled
       </span>
     );
   }
 
   const config = reconciliationStatusConfig[status];
-  const dotColor =
-    status === "no_mismatch"
-      ? "bg-success"
-      : status === "wrong_target" || status === "contradictory_facts"
-        ? "bg-destructive"
-        : status === "stale_evidence"
-          ? "bg-warning"
-          : "bg-info";
+  const severity = getSeverityClasses(getReconciliationSeverity(status));
 
   return (
     <span
       className={cn(
         "inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium",
-        config.className,
+        severity.soft,
         className
       )}
     >
-      <span className={cn("h-1.5 w-1.5 rounded-full", dotColor)} />
+      <span className={cn("h-1.5 w-1.5 rounded-full", severity.dot)} />
       {config.label}
     </span>
   );
@@ -303,23 +285,26 @@ export function TruthStateBadge({
     : null;
 
   // Determine overall truth state
-  const isVerified = verificationStatus === "accepted";
-  const isAligned = reconciliationStatus === "no_mismatch";
-  const hasIssue =
-    verificationStatus === "rejected" ||
-    reconciliationStatus === "wrong_target" ||
-    reconciliationStatus === "contradictory_facts";
-  const needsAttention =
-    verificationStatus === "insufficient_evidence" ||
-    reconciliationStatus === "stale_evidence";
+  const verificationSeverity = getSeverityClasses(
+    getVerificationSeverity(verificationStatus),
+  );
+  const reconciliationSeverity = getSeverityClasses(
+    getReconciliationSeverity(reconciliationStatus),
+  );
 
-  const containerClass = hasIssue
-    ? "border-destructive/30 bg-destructive/5"
-    : needsAttention
-      ? "border-warning/30 bg-warning/5"
-      : isVerified && isAligned
-        ? "border-success/30 bg-success/5"
-        : "border-border bg-muted/30";
+  const containerSeverity =
+    verificationStatus === "accepted" && reconciliationStatus === "no_mismatch"
+      ? "success"
+      : verificationStatus === "rejected"
+        ? "failure"
+        : verificationStatus === "insufficient_evidence" ||
+            reconciliationStatus === "wrong_target" ||
+            reconciliationStatus === "contradictory_facts" ||
+            reconciliationStatus === "stale_evidence" ||
+            reconciliationStatus === "pending"
+          ? "warning"
+          : "neutral";
+  const containerClass = getSeverityClasses(containerSeverity).border;
 
   return (
     <div
@@ -333,21 +318,13 @@ export function TruthStateBadge({
       <span
         className={cn(
           "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium",
-          verificationConfig?.className ?? "bg-muted text-muted-foreground"
+          verificationConfig ? verificationSeverity.soft : getSeverityClasses("neutral").soft
         )}
       >
         <span
           className={cn(
             "h-1.5 w-1.5 rounded-full",
-            verificationStatus === "accepted"
-              ? "bg-success"
-              : verificationStatus === "rejected"
-                ? "bg-destructive"
-                : verificationStatus === "insufficient_evidence"
-                  ? "bg-warning"
-                  : verificationStatus === "pending"
-                    ? "bg-info"
-                    : "bg-muted-foreground/50"
+            verificationConfig ? verificationSeverity.dot : "bg-muted-foreground/50"
           )}
         />
         {verificationConfig?.label ?? "Unverified"}
@@ -359,22 +336,17 @@ export function TruthStateBadge({
       <span
         className={cn(
           "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium",
-          reconciliationConfig?.className ?? "bg-muted text-muted-foreground"
+          reconciliationConfig
+            ? reconciliationSeverity.soft
+            : getSeverityClasses("neutral").soft
         )}
       >
         <span
           className={cn(
             "h-1.5 w-1.5 rounded-full",
-            reconciliationStatus === "no_mismatch"
-              ? "bg-success"
-              : reconciliationStatus === "wrong_target" ||
-                  reconciliationStatus === "contradictory_facts"
-                ? "bg-destructive"
-                : reconciliationStatus === "stale_evidence"
-                  ? "bg-warning"
-                  : reconciliationStatus === "pending"
-                    ? "bg-info"
-                    : "bg-muted-foreground/50"
+            reconciliationConfig
+              ? reconciliationSeverity.dot
+              : "bg-muted-foreground/50"
           )}
         />
         {reconciliationConfig?.label ?? "Unreconciled"}

--- a/lib/harness-api.ts
+++ b/lib/harness-api.ts
@@ -372,10 +372,17 @@ export async function fetchDashboardTasks(): Promise<{
   const payload = (await fetchJson("/tasks")) as {
     tasks?: Record<string, unknown>[];
   };
+  const mappedTasks = Array.isArray(payload.tasks)
+    ? payload.tasks.map((task) => mapTask(task))
+    : [];
+  const uniqueTasks = new Map<string, Task>();
+
+  for (const task of mappedTasks) {
+    uniqueTasks.set(task.task_id, task);
+  }
+
   return {
-    tasks: Array.isArray(payload.tasks)
-      ? payload.tasks.map((task) => mapTask(task))
-      : [],
+    tasks: Array.from(uniqueTasks.values()),
   };
 }
 

--- a/lib/outcome-severity.ts
+++ b/lib/outcome-severity.ts
@@ -1,0 +1,148 @@
+import type {
+  Priority,
+  ReconciliationStatus,
+  ReviewStatus,
+  TaskStatus,
+  VerificationStatus,
+} from "@/lib/types";
+
+export type OutcomeSeverity = "success" | "warning" | "failure" | "neutral";
+
+const severityClassMap: Record<
+  OutcomeSeverity,
+  { soft: string; text: string; dot: string; border: string }
+> = {
+  success: {
+    soft: "bg-success/15 text-success",
+    text: "text-success",
+    dot: "bg-success",
+    border: "border-success/30 bg-success/5",
+  },
+  warning: {
+    soft: "bg-warning/15 text-warning",
+    text: "text-warning",
+    dot: "bg-warning",
+    border: "border-warning/30 bg-warning/5",
+  },
+  failure: {
+    soft: "bg-destructive/15 text-destructive",
+    text: "text-destructive",
+    dot: "bg-destructive",
+    border: "border-destructive/30 bg-destructive/5",
+  },
+  neutral: {
+    soft: "bg-muted text-muted-foreground",
+    text: "text-muted-foreground",
+    dot: "bg-muted-foreground",
+    border: "border-border bg-muted/30",
+  },
+};
+
+export function getSeverityClasses(severity: OutcomeSeverity) {
+  return severityClassMap[severity];
+}
+
+export function getTaskStatusSeverity(status: TaskStatus): OutcomeSeverity {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "blocked":
+    case "failed":
+      return "failure";
+    case "executing":
+      return "warning";
+    case "intake_ready":
+    case "planned":
+    case "dispatch_ready":
+    case "assigned":
+    case "canceled":
+    default:
+      return "neutral";
+  }
+}
+
+export function getVerificationSeverity(
+  status: VerificationStatus | null,
+): OutcomeSeverity {
+  switch (status) {
+    case "accepted":
+      return "success";
+    case "insufficient_evidence":
+    case "pending":
+      return "warning";
+    case "rejected":
+      return "failure";
+    case "deferred":
+    default:
+      return "neutral";
+  }
+}
+
+export function getReconciliationSeverity(
+  status: ReconciliationStatus | null,
+): OutcomeSeverity {
+  switch (status) {
+    case "no_mismatch":
+      return "success";
+    case "wrong_target":
+    case "contradictory_facts":
+      return "warning";
+    case "stale_evidence":
+    case "pending":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}
+
+export function getReviewSeverity(status: ReviewStatus): OutcomeSeverity {
+  switch (status) {
+    case "requested":
+      return "warning";
+    case "resolved":
+    case "none":
+    default:
+      return "neutral";
+  }
+}
+
+export function getPrioritySeverity(priority: Priority): OutcomeSeverity {
+  switch (priority) {
+    case "critical":
+      return "failure";
+    case "high":
+      return "warning";
+    case "normal":
+    case "low":
+    case "backlog":
+    default:
+      return "neutral";
+  }
+}
+
+export function getBooleanOutcomeSeverity(value: boolean): OutcomeSeverity {
+  return value ? "success" : "neutral";
+}
+
+export function getEvidenceSeverity(
+  isSufficient: boolean | null,
+): OutcomeSeverity {
+  if (isSufficient === null) {
+    return "neutral";
+  }
+  return isSufficient ? "success" : "warning";
+}
+
+export function getBlockingSeverity(isBlocking: boolean | null): OutcomeSeverity {
+  if (isBlocking === null) {
+    return "neutral";
+  }
+  return isBlocking ? "failure" : "success";
+}
+
+export function getMismatchSeverity(hasMismatch: boolean | null): OutcomeSeverity {
+  if (hasMismatch === null) {
+    return "neutral";
+  }
+  return hasMismatch ? "warning" : "success";
+}


### PR DESCRIPTION
## Summary
- add a shared outcome severity utility for success, warning, failure, and neutral states
- refactor status badges and dashboard cards/tables to consume the shared severity mapping instead of per-view color rules
- deduplicate repeated task IDs in the dashboard task adapter so live route views render cleanly against the current backend payload

## Validation
- pnpm lint
- pnpm build
- ran the local API and Next dev server with HARNESS_API_BASE_URL=http://127.0.0.1:8000
- verified /tasks, /verification, /reconciliation, and /reviews in-browser against live backend data