### PR TITLE
Add generated agent contract export bundle

### DIFF
--- a/exports/agent-contract/README.md
+++ b/exports/agent-contract/README.md
@@ -1,0 +1,37 @@
+# Harness Agent Contract Bundle
+
+This directory is generated from the canonical Harness repository for execution agents and sync consumers such as `HARNESS-DRYRUN`.
+
+Do not edit files in this directory manually. Re-run `.venv/bin/python scripts/export_agent_contract.py` from the Harness repo instead.
+
+## Canonical API Surface
+
+- `POST /tasks`: submit a new canonical task envelope
+- `POST /tasks/<task_id>/reevaluate`: submit new evidence, facts, or review actions for an existing task
+- `GET /tasks/<task_id>/read-model`: inspect current task truth
+- `GET /tasks/<task_id>/timeline`: inspect the auditable task timeline
+
+## Included Examples
+
+- `examples/create-task.json`: canonical `POST /tasks` submission example generated from the ingress/OpenClaw request builder
+- `examples/evaluate-happy-path.json`: canonical accepted-completion evaluation request
+- `examples/evaluate-mismatch.json`: canonical reconciliation-mismatch evaluation request
+- `examples/evaluate-review-required.json`: canonical review-required evaluation request
+
+## Source Of Truth
+
+This bundle was generated from these Harness source files:
+
+- `AGENTS.md`
+- `README.md`
+- `docs/architecture/runtime-execution-contract.md`
+- `docs/integration/openclaw-harness-spike.md`
+- `modules/connectors/ingress_request_builder.py`
+- `modules/connectors/openclaw_harness_spike.py`
+- `modules/demo_cases.py`
+
+## Provenance
+
+- source repo: `Harness`
+- source commit: `e46be111b793ea88f8ca0133f009c4f442931c59`
+- generated at: `2026-03-29T15:38:47Z`

--- a/exports/agent-contract/examples/create-task.json
+++ b/exports/agent-contract/examples/create-task.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "acceptance_criteria_satisfied": false,
+    "claimed_completion": false,
+    "external_facts": {},
+    "task_envelope": {
+      "acceptance_criteria": [
+        {
+          "description": "Harness accepts the canonical task envelope at POST /tasks.",
+          "id": "ac-1",
+          "required": true
+        },
+        {
+          "description": "The stored task preserves ingress provenance for later evaluation.",
+          "id": "ac-2",
+          "required": true
+        }
+      ],
+      "artifacts": {
+        "completion_evidence": {
+          "notes": null,
+          "policy": "deferred",
+          "required_artifact_types": [],
+          "status": "deferred",
+          "validated_artifact_ids": [],
+          "validated_at": null,
+          "validation_method": "deferred",
+          "validator": null
+        },
+        "items": []
+      },
+      "assigned_executor": null,
+      "child_task_ids": [],
+      "constraints": [],
+      "dependencies": [],
+      "description": "Submit a task through the canonical Harness API boundary.",
+      "extensions": {
+        "openclaw": {
+          "agent_id": "openclaw-assistant",
+          "channel": "cli",
+          "conversation_id": "conv-openclaw-spike-1",
+          "message_id": "msg-openclaw-spike-1",
+          "user_id": "operator@example.com",
+          "workspace_id": "workspace-openclaw-spike"
+        }
+      },
+      "id": "task-openclaw-spike-1",
+      "objective": {
+        "deliverable_type": "api_submission",
+        "success_signal": "Harness stores the task and returns the canonical inspection surfaces.",
+        "summary": "Prove that ingress clients can submit work through the canonical Harness API."
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {
+          "schema_required_deferred_fields": [
+            "parent_task_id",
+            "child_task_ids",
+            "dependencies",
+            "assigned_executor",
+            "required_capabilities",
+            "priority",
+            "artifacts.items",
+            "artifacts.completion_evidence",
+            "observability"
+          ]
+        },
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "origin": {
+        "ingress_id": "conv-openclaw-spike-1",
+        "ingress_name": "OpenClaw",
+        "requested_by": "operator@example.com",
+        "source_id": "msg-openclaw-spike-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "required_capabilities": [],
+      "status": "intake_ready",
+      "status_history": [],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-03-29T15:38:47.354685Z",
+        "updated_at": "2026-03-29T15:38:47.354685Z"
+      },
+      "title": "Validate Harness API boundary from OpenClaw"
+    }
+  }
+}

--- a/exports/agent-contract/examples/evaluate-happy-path.json
+++ b/exports/agent-contract/examples/evaluate-happy-path.json
@@ -1,0 +1,208 @@
+{
+  "request": {
+    "acceptance_criteria_satisfied": true,
+    "claimed_completion": true,
+    "external_facts": {
+      "expected_code_context": {
+        "base_branch": "main",
+        "branch_name": "codex/demo",
+        "repository_host": "github.com",
+        "repository_name": "Harness",
+        "repository_owner": "sfayka"
+      },
+      "github_facts": {
+        "artifact_found": true,
+        "artifact_refs": [],
+        "branch": {
+          "base_branch": "main",
+          "head_commit_sha": "abcdef1234567890",
+          "name": "codex/demo"
+        },
+        "changed_files": {
+          "files": [],
+          "matches_expected_scope": true
+        },
+        "commit": {
+          "message_summary": null,
+          "sha": "abcdef1234567890",
+          "url": null
+        },
+        "pull_request": {
+          "merged": null,
+          "number": 300,
+          "review_state": "approved",
+          "state": null,
+          "url": null
+        },
+        "reasons": [],
+        "repository": {
+          "external_id": null,
+          "host": "github.com",
+          "name": "Harness",
+          "owner": "sfayka"
+        }
+      },
+      "linear_facts": {
+        "issue_id": "lin-demo-1",
+        "issue_key": "HAR-300",
+        "project": null,
+        "reasons": [],
+        "record_found": true,
+        "state": "in_progress",
+        "task_reference": null,
+        "workflow": null
+      }
+    },
+    "review_decision": null,
+    "review_reasons": [],
+    "review_request": null,
+    "runtime_facts": {
+      "attempt_count": 1,
+      "executor_reported_failure": false,
+      "executor_reported_success": true,
+      "latest_attempt_outcome": null,
+      "terminal_failure": false
+    },
+    "task_envelope": {
+      "acceptance_criteria": [
+        {
+          "description": "Completion is backed by valid evidence and normalized external facts.",
+          "id": "ac-1",
+          "required": true
+        }
+      ],
+      "artifacts": {
+        "completion_evidence": {
+          "policy": "required",
+          "required_artifact_types": [
+            "pull_request",
+            "commit"
+          ],
+          "status": "satisfied",
+          "validated_artifact_ids": [
+            "artifact-pr-1",
+            "artifact-commit-1"
+          ],
+          "validated_at": "2026-03-24T20:14:00Z",
+          "validation_method": "external_reconciliation",
+          "validator": {
+            "captured_by": "github-sync",
+            "source_id": "verification-run-demo-1",
+            "source_system": "harness",
+            "source_type": "verification"
+          }
+        },
+        "items": [
+          {
+            "branch": {
+              "base_branch": "main",
+              "head_commit_sha": "abcdef1234567890",
+              "name": "codex/demo"
+            },
+            "captured_at": "2026-03-24T20:10:00Z",
+            "changed_files": [],
+            "commit_sha": null,
+            "content_type": null,
+            "description": null,
+            "external_id": "PR-300",
+            "external_refs": [],
+            "id": "artifact-pr-1",
+            "location": "https://github.com/example/harness/pull/300",
+            "metadata": {},
+            "provenance": {
+              "captured_by": "github-sync",
+              "source_id": "pull/300",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": 300,
+            "repository": {
+              "external_id": "repo-123",
+              "host": "github.com",
+              "name": "Harness",
+              "owner": "sfayka"
+            },
+            "review_state": "approved",
+            "title": "Harness demo case",
+            "type": "pull_request",
+            "verification_status": "verified"
+          },
+          {
+            "branch": null,
+            "captured_at": "2026-03-24T20:11:00Z",
+            "changed_files": [],
+            "commit_sha": "abcdef1234567890",
+            "content_type": null,
+            "description": null,
+            "external_id": "commit-abcdef1234567890",
+            "external_refs": [],
+            "id": "artifact-commit-1",
+            "location": "https://github.com/example/harness/commit/abcdef1234567890",
+            "metadata": {},
+            "provenance": {
+              "captured_by": "github-sync",
+              "source_id": "commit/abcdef1234567890",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": null,
+            "repository": {
+              "external_id": "repo-123",
+              "host": "github.com",
+              "name": "Harness",
+              "owner": "sfayka"
+            },
+            "review_state": null,
+            "title": null,
+            "type": "commit",
+            "verification_status": "verified"
+          }
+        ]
+      },
+      "assigned_executor": {
+        "assignment_reason": "Capability match.",
+        "executor_id": "executor-1",
+        "executor_type": "codex"
+      },
+      "child_task_ids": [],
+      "constraints": [],
+      "dependencies": [],
+      "description": "Task used to demonstrate the Harness evaluation entry point.",
+      "id": "task-demo-executing-1",
+      "objective": {
+        "deliverable_type": "code_change",
+        "success_signal": "The evaluator returns a structured control-plane result.",
+        "summary": "Demonstrate the Harness evaluation path."
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {},
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": "OpenClaw",
+        "requested_by": null,
+        "source_id": "req-demo-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "required_capabilities": [],
+      "status": "executing",
+      "status_history": [],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-03-24T20:00:00Z",
+        "updated_at": "2026-03-24T20:05:00Z"
+      },
+      "title": "Harness demo task"
+    },
+    "unresolved_conditions": []
+  }
+}

--- a/exports/agent-contract/examples/evaluate-mismatch.json
+++ b/exports/agent-contract/examples/evaluate-mismatch.json
@@ -1,0 +1,204 @@
+{
+  "request": {
+    "acceptance_criteria_satisfied": true,
+    "claimed_completion": true,
+    "external_facts": {
+      "expected_code_context": {
+        "base_branch": "main",
+        "branch_name": "codex/demo",
+        "repository_host": "github.com",
+        "repository_name": "Harness",
+        "repository_owner": "sfayka"
+      },
+      "github_facts": {
+        "artifact_found": true,
+        "artifact_refs": [],
+        "branch": {
+          "base_branch": "main",
+          "head_commit_sha": "abcdef1234567890",
+          "name": "codex/demo"
+        },
+        "changed_files": {
+          "files": [],
+          "matches_expected_scope": true
+        },
+        "commit": {
+          "message_summary": null,
+          "sha": "abcdef1234567890",
+          "url": null
+        },
+        "pull_request": {
+          "merged": null,
+          "number": 300,
+          "review_state": "approved",
+          "state": null,
+          "url": null
+        },
+        "reasons": [],
+        "repository": {
+          "external_id": null,
+          "host": "github.com",
+          "name": "Harness",
+          "owner": "sfayka"
+        }
+      },
+      "linear_facts": {
+        "issue_id": "lin-demo-1",
+        "issue_key": "HAR-300",
+        "project": null,
+        "reasons": [],
+        "record_found": true,
+        "state": "in_progress",
+        "task_reference": null,
+        "workflow": null
+      }
+    },
+    "review_decision": null,
+    "review_reasons": [],
+    "review_request": null,
+    "runtime_facts": {
+      "attempt_count": 0,
+      "executor_reported_failure": false,
+      "executor_reported_success": true,
+      "latest_attempt_outcome": null,
+      "terminal_failure": false
+    },
+    "task_envelope": {
+      "acceptance_criteria": [
+        {
+          "description": "Completion is backed by valid evidence and normalized external facts.",
+          "id": "ac-1",
+          "required": true
+        }
+      ],
+      "artifacts": {
+        "completion_evidence": {
+          "policy": "required",
+          "required_artifact_types": [
+            "pull_request",
+            "commit"
+          ],
+          "status": "satisfied",
+          "validated_artifact_ids": [
+            "artifact-pr-1",
+            "artifact-commit-1"
+          ],
+          "validated_at": "2026-03-24T20:14:00Z",
+          "validation_method": "external_reconciliation",
+          "validator": {
+            "captured_by": "github-sync",
+            "source_id": "verification-run-demo-1",
+            "source_system": "harness",
+            "source_type": "verification"
+          }
+        },
+        "items": [
+          {
+            "branch": {
+              "base_branch": "main",
+              "head_commit_sha": "abcdef1234567890",
+              "name": "codex/demo"
+            },
+            "captured_at": "2026-03-24T20:10:00Z",
+            "changed_files": [],
+            "commit_sha": null,
+            "content_type": null,
+            "description": null,
+            "external_id": "PR-300",
+            "external_refs": [],
+            "id": "artifact-pr-1",
+            "location": "https://github.com/example/harness/pull/300",
+            "metadata": {},
+            "provenance": {
+              "captured_by": "github-sync",
+              "source_id": "pull/300",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": 300,
+            "repository": {
+              "external_id": "repo-123",
+              "host": "github.com",
+              "name": "Harness",
+              "owner": "sfayka"
+            },
+            "review_state": "approved",
+            "title": "Harness demo case",
+            "type": "pull_request",
+            "verification_status": "verified"
+          },
+          {
+            "branch": null,
+            "captured_at": "2026-03-24T20:11:00Z",
+            "changed_files": [],
+            "commit_sha": "abcdef1234567890",
+            "content_type": null,
+            "description": null,
+            "external_id": "commit-abcdef1234567890",
+            "external_refs": [],
+            "id": "artifact-commit-1",
+            "location": "https://github.com/example/harness/commit/abcdef1234567890",
+            "metadata": {},
+            "provenance": {
+              "captured_by": "github-sync",
+              "source_id": "commit/abcdef1234567890",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": null,
+            "repository": {
+              "external_id": "repo-123",
+              "host": "github.com",
+              "name": "Harness",
+              "owner": "sfayka"
+            },
+            "review_state": null,
+            "title": null,
+            "type": "commit",
+            "verification_status": "verified"
+          }
+        ]
+      },
+      "assigned_executor": null,
+      "child_task_ids": [],
+      "constraints": [],
+      "dependencies": [],
+      "description": "Task used to demonstrate the Harness evaluation entry point.",
+      "id": "task-demo-completed-1",
+      "objective": {
+        "deliverable_type": "code_change",
+        "success_signal": "The evaluator returns a structured control-plane result.",
+        "summary": "Demonstrate the Harness evaluation path."
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {},
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": "OpenClaw",
+        "requested_by": null,
+        "source_id": "req-demo-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "required_capabilities": [],
+      "status": "completed",
+      "status_history": [],
+      "timestamps": {
+        "completed_at": "2026-03-24T20:15:00Z",
+        "created_at": "2026-03-24T20:00:00Z",
+        "updated_at": "2026-03-24T20:05:00Z"
+      },
+      "title": "Harness demo task"
+    },
+    "unresolved_conditions": []
+  }
+}

--- a/exports/agent-contract/examples/evaluate-review-required.json
+++ b/exports/agent-contract/examples/evaluate-review-required.json
@@ -1,0 +1,224 @@
+{
+  "request": {
+    "acceptance_criteria_satisfied": true,
+    "claimed_completion": true,
+    "external_facts": {
+      "expected_code_context": {
+        "base_branch": "main",
+        "branch_name": "codex/demo",
+        "repository_host": "github.com",
+        "repository_name": "Harness",
+        "repository_owner": "sfayka"
+      },
+      "github_facts": {
+        "artifact_found": true,
+        "artifact_refs": [],
+        "branch": {
+          "base_branch": "main",
+          "head_commit_sha": "abcdef1234567890",
+          "name": "codex/demo"
+        },
+        "changed_files": {
+          "files": [],
+          "matches_expected_scope": true
+        },
+        "commit": {
+          "message_summary": null,
+          "sha": "abcdef1234567890",
+          "url": null
+        },
+        "pull_request": {
+          "merged": null,
+          "number": 300,
+          "review_state": "approved",
+          "state": null,
+          "url": null
+        },
+        "reasons": [],
+        "repository": {
+          "external_id": null,
+          "host": "github.com",
+          "name": "Harness",
+          "owner": "sfayka"
+        }
+      },
+      "linear_facts": {
+        "issue_id": null,
+        "issue_key": null,
+        "project": null,
+        "reasons": [
+          "Linear record is not yet resolvable."
+        ],
+        "record_found": false,
+        "state": null,
+        "task_reference": null,
+        "workflow": null
+      }
+    },
+    "review_decision": null,
+    "review_reasons": [],
+    "review_request": {
+      "allowed_outcomes": [
+        "accept_completion",
+        "keep_blocked"
+      ],
+      "metadata": {},
+      "presented_sections": [
+        "task_state",
+        "evidence",
+        "reconciliation"
+      ],
+      "prior_review_ids": [],
+      "requested_at": "2026-03-24T20:20:00Z",
+      "requested_by": "verification",
+      "review_request_id": "review-request-demo-1",
+      "summary": "Linear record needs manual judgment.",
+      "task_id": "task-demo-completed-1",
+      "trigger": "reconciliation"
+    },
+    "runtime_facts": {
+      "attempt_count": 0,
+      "executor_reported_failure": false,
+      "executor_reported_success": true,
+      "latest_attempt_outcome": null,
+      "terminal_failure": false
+    },
+    "task_envelope": {
+      "acceptance_criteria": [
+        {
+          "description": "Completion is backed by valid evidence and normalized external facts.",
+          "id": "ac-1",
+          "required": true
+        }
+      ],
+      "artifacts": {
+        "completion_evidence": {
+          "policy": "required",
+          "required_artifact_types": [
+            "pull_request",
+            "commit"
+          ],
+          "status": "satisfied",
+          "validated_artifact_ids": [
+            "artifact-pr-1",
+            "artifact-commit-1"
+          ],
+          "validated_at": "2026-03-24T20:14:00Z",
+          "validation_method": "external_reconciliation",
+          "validator": {
+            "captured_by": "github-sync",
+            "source_id": "verification-run-demo-1",
+            "source_system": "harness",
+            "source_type": "verification"
+          }
+        },
+        "items": [
+          {
+            "branch": {
+              "base_branch": "main",
+              "head_commit_sha": "abcdef1234567890",
+              "name": "codex/demo"
+            },
+            "captured_at": "2026-03-24T20:10:00Z",
+            "changed_files": [],
+            "commit_sha": null,
+            "content_type": null,
+            "description": null,
+            "external_id": "PR-300",
+            "external_refs": [],
+            "id": "artifact-pr-1",
+            "location": "https://github.com/example/harness/pull/300",
+            "metadata": {},
+            "provenance": {
+              "captured_by": "github-sync",
+              "source_id": "pull/300",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": 300,
+            "repository": {
+              "external_id": "repo-123",
+              "host": "github.com",
+              "name": "Harness",
+              "owner": "sfayka"
+            },
+            "review_state": "approved",
+            "title": "Harness demo case",
+            "type": "pull_request",
+            "verification_status": "verified"
+          },
+          {
+            "branch": null,
+            "captured_at": "2026-03-24T20:11:00Z",
+            "changed_files": [],
+            "commit_sha": "abcdef1234567890",
+            "content_type": null,
+            "description": null,
+            "external_id": "commit-abcdef1234567890",
+            "external_refs": [],
+            "id": "artifact-commit-1",
+            "location": "https://github.com/example/harness/commit/abcdef1234567890",
+            "metadata": {},
+            "provenance": {
+              "captured_by": "github-sync",
+              "source_id": "commit/abcdef1234567890",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": null,
+            "repository": {
+              "external_id": "repo-123",
+              "host": "github.com",
+              "name": "Harness",
+              "owner": "sfayka"
+            },
+            "review_state": null,
+            "title": null,
+            "type": "commit",
+            "verification_status": "verified"
+          }
+        ]
+      },
+      "assigned_executor": null,
+      "child_task_ids": [],
+      "constraints": [],
+      "dependencies": [],
+      "description": "Task used to demonstrate the Harness evaluation entry point.",
+      "id": "task-demo-completed-1",
+      "objective": {
+        "deliverable_type": "code_change",
+        "success_signal": "The evaluator returns a structured control-plane result.",
+        "summary": "Demonstrate the Harness evaluation path."
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {},
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": "OpenClaw",
+        "requested_by": null,
+        "source_id": "req-demo-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "required_capabilities": [],
+      "status": "completed",
+      "status_history": [],
+      "timestamps": {
+        "completed_at": "2026-03-24T20:15:00Z",
+        "created_at": "2026-03-24T20:00:00Z",
+        "updated_at": "2026-03-24T20:05:00Z"
+      },
+      "title": "Harness demo task"
+    },
+    "unresolved_conditions": []
+  }
+}

--- a/exports/agent-contract/provenance.json
+++ b/exports/agent-contract/provenance.json
@@ -1,0 +1,15 @@
+{
+  "generated_at": "2026-03-29T15:38:47Z",
+  "generator": "scripts/export_agent_contract.py",
+  "source_commit_sha": "e46be111b793ea88f8ca0133f009c4f442931c59",
+  "source_paths": [
+    "AGENTS.md",
+    "README.md",
+    "docs/architecture/runtime-execution-contract.md",
+    "docs/integration/openclaw-harness-spike.md",
+    "modules/connectors/ingress_request_builder.py",
+    "modules/connectors/openclaw_harness_spike.py",
+    "modules/demo_cases.py"
+  ],
+  "source_repo": "Harness"
+}

--- a/scripts/export_agent_contract.py
+++ b/scripts/export_agent_contract.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Generate the minimal execution-facing contract bundle for sync consumers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from modules.connectors.openclaw_harness_spike import (  # noqa: E402
+    OpenClawSourceContext,
+    OpenClawTaskIntent,
+    build_task_submission_payload,
+)
+from modules.demo_cases import build_demo_request  # noqa: E402
+
+
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "exports" / "agent-contract"
+SOURCE_PATHS = (
+    "AGENTS.md",
+    "README.md",
+    "docs/architecture/runtime-execution-contract.md",
+    "docs/integration/openclaw-harness-spike.md",
+    "modules/connectors/ingress_request_builder.py",
+    "modules/connectors/openclaw_harness_spike.py",
+    "modules/demo_cases.py",
+)
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(item) for key, item in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _repo_head_sha(repo_root: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _build_create_task_example() -> dict[str, Any]:
+    return build_task_submission_payload(
+        intent=OpenClawTaskIntent(
+            task_id="task-openclaw-spike-1",
+            title="Validate Harness API boundary from OpenClaw",
+            description="Submit a task through the canonical Harness API boundary.",
+            acceptance_criteria=(
+                "Harness accepts the canonical task envelope at POST /tasks.",
+                "The stored task preserves ingress provenance for later evaluation.",
+            ),
+            objective_summary="Prove that ingress clients can submit work through the canonical Harness API.",
+            deliverable_type="api_submission",
+            success_signal="Harness stores the task and returns the canonical inspection surfaces.",
+            requested_by="operator@example.com",
+        ),
+        context=OpenClawSourceContext(
+            conversation_id="conv-openclaw-spike-1",
+            message_id="msg-openclaw-spike-1",
+            channel="cli",
+            workspace_id="workspace-openclaw-spike",
+            user_id="operator@example.com",
+            agent_id="openclaw-assistant",
+        ),
+    )
+
+
+def _bundle_readme(*, commit_sha: str, generated_at: str) -> str:
+    source_docs = "\n".join(f"- `{path}`" for path in SOURCE_PATHS)
+    return f"""# Harness Agent Contract Bundle
+
+This directory is generated from the canonical Harness repository for execution agents and sync consumers such as `HARNESS-DRYRUN`.
+
+Do not edit files in this directory manually. Re-run `.venv/bin/python scripts/export_agent_contract.py` from the Harness repo instead.
+
+## Canonical API Surface
+
+- `POST /tasks`: submit a new canonical task envelope
+- `POST /tasks/<task_id>/reevaluate`: submit new evidence, facts, or review actions for an existing task
+- `GET /tasks/<task_id>/read-model`: inspect current task truth
+- `GET /tasks/<task_id>/timeline`: inspect the auditable task timeline
+
+## Included Examples
+
+- `examples/create-task.json`: canonical `POST /tasks` submission example generated from the ingress/OpenClaw request builder
+- `examples/evaluate-happy-path.json`: canonical accepted-completion evaluation request
+- `examples/evaluate-mismatch.json`: canonical reconciliation-mismatch evaluation request
+- `examples/evaluate-review-required.json`: canonical review-required evaluation request
+
+## Source Of Truth
+
+This bundle was generated from these Harness source files:
+
+{source_docs}
+
+## Provenance
+
+- source repo: `Harness`
+- source commit: `{commit_sha}`
+- generated at: `{generated_at}`
+"""
+
+
+def export_agent_contract(output_dir: Path) -> Path:
+    commit_sha = _repo_head_sha(REPO_ROOT)
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+
+    examples_dir = output_dir / "examples"
+    examples_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_json(
+        output_dir / "provenance.json",
+        {
+            "generated_at": generated_at,
+            "generator": "scripts/export_agent_contract.py",
+            "source_commit_sha": commit_sha,
+            "source_paths": list(SOURCE_PATHS),
+            "source_repo": "Harness",
+        },
+    )
+    (output_dir / "README.md").write_text(
+        _bundle_readme(commit_sha=commit_sha, generated_at=generated_at),
+        encoding="utf-8",
+    )
+
+    _write_json(examples_dir / "create-task.json", _build_create_task_example())
+    _write_json(examples_dir / "evaluate-happy-path.json", {"request": _to_jsonable(build_demo_request("accepted_completion"))})
+    _write_json(
+        examples_dir / "evaluate-mismatch.json",
+        {"request": _to_jsonable(build_demo_request("blocked_reconciliation_mismatch"))},
+    )
+    _write_json(
+        examples_dir / "evaluate-review-required.json",
+        {"request": _to_jsonable(build_demo_request("review_required"))},
+    )
+
+    return output_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export the minimal Harness agent contract bundle.")
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory where the generated bundle should be written.",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    export_agent_contract(output_dir)
+    print(output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a generated execution-facing contract bundle under exports/agent-contract
- derive the bundle from canonical Harness docs and example payload builders
- include provenance metadata for source repo, commit SHA, and generation timestamp

## Validation
- .venv/bin/python scripts/export_agent_contract.py