### PR TITLE
Fix happy-path evidence evaluation

### DIFF
--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -12,6 +12,15 @@ For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritativ
 - Existing-task reevaluation uses the stored task snapshot as the source of truth.
 - Automatic callers must not rely on `POST /evaluate` to overwrite an existing task lifecycle state.
 
+For new-task submission and one-shot evaluation, the canonical contract remains `request.task_envelope`. Harness also accepts ingress-style top-level overlays for convenience on initial requests:
+
+- `request.task_status`
+- `request.assigned_executor`
+- `request.linked_artifacts`
+- `request.completion_evidence`
+
+Those overlays are merged into `request.task_envelope` before evaluation. They do not mutate existing stored tasks; use `POST /tasks/<task_id>/reevaluate` for that path.
+
 ## Review-Required Lifecycle Rule
 
 - If verification returns `requires_review=true`, Harness moves an active non-terminal task into `in_review`.

--- a/modules/api.py
+++ b/modules/api.py
@@ -90,6 +90,12 @@ def _optional_mapping(value: Any, *, field_name: str) -> dict[str, Any] | None:
     return _require_mapping(value, field_name=field_name)
 
 
+def _optional_non_empty_string(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return _require_non_empty_string(value, field_name=field_name)
+
+
 def _optional_string_tuple(value: Any, *, field_name: str) -> tuple[str, ...]:
     if value is None:
         return ()
@@ -287,12 +293,46 @@ def _parse_review_decision(payload: dict[str, Any] | None) -> ReviewDecisionResu
     )
 
 
+def _apply_submission_task_overlays(
+    task_envelope: dict[str, Any],
+    *,
+    request_payload: dict[str, Any],
+) -> dict[str, Any]:
+    merged_task = deepcopy(task_envelope)
+
+    task_status = _optional_non_empty_string(request_payload.get("task_status"), field_name="task_status")
+    if task_status is not None:
+        merged_task["status"] = task_status
+        merged_task["timestamps"]["completed_at"] = (
+            merged_task["timestamps"]["updated_at"] if task_status == "completed" else None
+        )
+
+    assigned_executor = _optional_mapping(request_payload.get("assigned_executor"), field_name="assigned_executor")
+    if assigned_executor is not None:
+        merged_task["assigned_executor"] = dict(assigned_executor)
+
+    linked_artifacts_payload = request_payload.get("linked_artifacts")
+    if linked_artifacts_payload is not None:
+        linked_artifacts = _optional_object_list(linked_artifacts_payload, field_name="linked_artifacts")
+        merged_task["artifacts"]["items"] = [deepcopy(artifact) for artifact in linked_artifacts]
+
+    completion_evidence_update = _optional_mapping(
+        request_payload.get("completion_evidence"),
+        field_name="completion_evidence",
+    )
+    if completion_evidence_update is not None:
+        merged_task["artifacts"]["completion_evidence"].update(dict(completion_evidence_update))
+
+    return merged_task
+
+
 def parse_evaluation_request(payload: dict[str, Any]) -> HarnessEvaluationRequest:
     """Parse a canonical HTTP evaluation request into the public evaluator input."""
 
     request_payload = _require_mapping(payload.get("request"), field_name="request")
     task_envelope = _require_mapping(request_payload.get("task_envelope"), field_name="task_envelope")
     _require_non_empty_string(task_envelope.get("id"), field_name="task_envelope.id")
+    task_envelope = _apply_submission_task_overlays(task_envelope, request_payload=request_payload)
 
     return HarnessEvaluationRequest(
         task_envelope=task_envelope,

--- a/modules/contracts/task_envelope_reconciliation.py
+++ b/modules/contracts/task_envelope_reconciliation.py
@@ -292,6 +292,7 @@ def evaluate_reconciliation(
     internal_status = str(task_envelope["status"])
     if linear_facts and linear_facts.state:
         linear_done_states = {"done", "completed", "canceled"}
+        linear_completed_states = {"done", "completed"}
         harness_done_states = {"completed", "canceled", "failed"}
         if internal_status == "completed" and linear_facts.state not in linear_done_states:
             _append_category(
@@ -300,7 +301,11 @@ def evaluate_reconciliation(
                 category=MismatchCategory.LINEAR_STATE_CONFLICT,
                 reason="Harness marks the task completed while Linear still reports active work",
             )
-        elif internal_status in {"executing", "assigned", "planned", "dispatch_ready", "blocked"} and linear_facts.state == "completed":
+        elif (
+            internal_status in {"intake_ready", "executing", "assigned", "planned", "dispatch_ready", "blocked"}
+            and linear_facts.state in linear_completed_states
+            and not reconciliation_input.claimed_completion
+        ):
             _append_category(
                 categories,
                 reasons,

--- a/modules/contracts/task_envelope_verification.py
+++ b/modules/contracts/task_envelope_verification.py
@@ -110,6 +110,33 @@ def _base_reasons(task_id: str, decision_input: VerificationDecisionInput) -> li
     return reasons
 
 
+def _evidence_insufficiency_reasons(
+    task_envelope: TaskEnvelope,
+    evidence_result: CompletionEvidenceValidationResult,
+) -> tuple[str, ...]:
+    evidence = dict(task_envelope.get("artifacts", {}).get("completion_evidence", {}) or {})
+    policy = evidence.get("policy")
+    status = evidence.get("status")
+
+    if evidence_result.missing_required_artifact_types:
+        missing = ", ".join(sorted(evidence_result.missing_required_artifact_types))
+        return (f"Completion evidence is missing required artifact types: {missing}",)
+
+    if policy == "deferred":
+        return ("Completion evidence policy is deferred and does not yet authorize completion",)
+
+    if policy == "required" and status != "satisfied":
+        return (f"Completion evidence uses required policy but status is {status!r}",)
+
+    if policy == "not_applicable":
+        return ("Completion evidence policy is not_applicable and does not authorize completion",)
+
+    if policy == "required" and not evidence_result.validated_artifact_ids:
+        return ("Required completion evidence does not cite any validated artifact ids",)
+
+    return ("Validated evidence is not sufficient for the declared evidence policy",)
+
+
 def evaluate_verification_decision(
     task_envelope: TaskEnvelope,
     *,
@@ -269,7 +296,7 @@ def evaluate_verification_decision(
         )
 
     if not evidence_result.is_sufficient:
-        reasons.append("Validated evidence is not sufficient for the declared evidence policy")
+        reasons.extend(_evidence_insufficiency_reasons(task_envelope, evidence_result))
         return VerificationDecisionResult(
             task_id=task_id,
             outcome=VerificationOutcome.INSUFFICIENT_EVIDENCE,

--- a/tests/contracts/test_task_envelope_reconciliation.py
+++ b/tests/contracts/test_task_envelope_reconciliation.py
@@ -202,6 +202,26 @@ class ReconciliationPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.status, ReconciliationStatus.MISMATCH)
         self.assertIn(MismatchCategory.LINEAR_STATE_CONFLICT, result.mismatch_categories)
 
+    def test_allows_linear_completed_state_when_claimed_completion_is_under_verification(self) -> None:
+        task_envelope = _base_task_envelope()
+        task_envelope["status"] = "executing"
+        task_envelope["timestamps"]["completed_at"] = None
+
+        result = _evaluate(
+            task_envelope,
+            claimed_completion=True,
+            linear_facts=LinearFacts(
+                record_found=True,
+                issue_id="lin-1",
+                state="completed",
+                workflow=LinearWorkflowFact(workflow_id="workflow-done", workflow_name="completed"),
+            ),
+        )
+
+        self.assertEqual(result.outcome, ReconciliationOutcome.NO_MISMATCH)
+        self.assertEqual(result.status, ReconciliationStatus.PASSED)
+        self.assertEqual(result.mismatch_categories, ())
+
     def test_returns_review_required_for_review_worthy_external_facts(self) -> None:
         result = _evaluate(
             _base_task_envelope(),

--- a/tests/contracts/test_task_envelope_verification.py
+++ b/tests/contracts/test_task_envelope_verification.py
@@ -209,6 +209,27 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.target_status, "blocked")
         self.assertFalse(result.accepted_completion)
 
+    def test_reports_concrete_reason_when_evidence_policy_is_deferred(self) -> None:
+        task_envelope = _base_task_envelope()
+        task_envelope["artifacts"]["completion_evidence"] = {
+            "policy": "deferred",
+            "status": "deferred",
+            "required_artifact_types": [],
+            "validated_artifact_ids": [],
+            "validation_method": "deferred",
+            "validated_at": None,
+            "validator": None,
+            "notes": None,
+        }
+
+        result = _evaluate(task_envelope)
+
+        self.assertEqual(result.outcome, VerificationOutcome.INSUFFICIENT_EVIDENCE)
+        self.assertIn(
+            "Completion evidence policy is deferred and does not yet authorize completion",
+            result.reasons,
+        )
+
     def test_returns_external_mismatch_when_reconciliation_conflicts(self) -> None:
         result = _evaluate(
             _base_task_envelope(),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,7 @@ from modules.contracts.task_envelope_review import (
     resolve_review_request,
 )
 from modules.demo_cases import build_demo_request
+from modules.intake import create_task_envelope
 from modules.store import FileBackedHarnessStore, PostgresHarnessStore
 
 
@@ -77,6 +78,179 @@ def _to_jsonable(value):
 
 def _request_payload(case_name: str) -> dict:
     return {"request": _to_jsonable(build_demo_request(case_name))}
+
+
+def _manual_happy_path_overlay_payload() -> dict:
+    task_envelope = create_task_envelope(
+        {
+            "id": "task-http-happy-overlay-1",
+            "title": "Dry-run happy path overlay",
+            "description": "Exercise /evaluate with top-level evidence overlays.",
+            "origin": {
+                "source_system": "openclaw",
+                "source_type": "ingress_request",
+                "source_id": "req-happy-overlay-1",
+            },
+            "acceptance_criteria": [
+                {
+                    "id": "ac-1",
+                    "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                    "required": True,
+                }
+            ],
+        },
+        now="2026-03-31T14:30:00Z",
+    )
+
+    return {
+        "request": {
+            "task_envelope": task_envelope,
+            "task_status": "executing",
+            "assigned_executor": {
+                "executor_type": "codex",
+                "executor_id": "executor-e2e-1",
+                "assignment_reason": "Manual dry-run overlay payload.",
+            },
+            "linked_artifacts": [
+                {
+                    "id": "artifact-pr-dryrun-1",
+                    "type": "pull_request",
+                    "title": "HARNESS-DRYRUN PR",
+                    "description": None,
+                    "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/2",
+                    "content_type": None,
+                    "external_id": "PR-2",
+                    "commit_sha": None,
+                    "pull_request_number": 2,
+                    "review_state": "approved",
+                    "provenance": {
+                        "source_system": "github",
+                        "source_type": "api",
+                        "source_id": "pull/2",
+                        "captured_by": "github-sync",
+                    },
+                    "verification_status": "verified",
+                    "repository": {
+                        "host": "github.com",
+                        "owner": "KnoxAnalytics",
+                        "name": "HARNESS-DRYRUN",
+                        "external_id": "repo-dryrun-1",
+                    },
+                    "branch": {
+                        "name": "codex/e2e-test",
+                        "base_branch": "main",
+                        "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    },
+                    "changed_files": [],
+                    "external_refs": [],
+                    "captured_at": "2026-03-31T14:31:00Z",
+                    "metadata": {},
+                },
+                {
+                    "id": "artifact-commit-dryrun-1",
+                    "type": "commit",
+                    "title": None,
+                    "description": None,
+                    "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "content_type": None,
+                    "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "pull_request_number": None,
+                    "review_state": None,
+                    "provenance": {
+                        "source_system": "github",
+                        "source_type": "api",
+                        "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "captured_by": "github-sync",
+                    },
+                    "verification_status": "verified",
+                    "repository": {
+                        "host": "github.com",
+                        "owner": "KnoxAnalytics",
+                        "name": "HARNESS-DRYRUN",
+                        "external_id": "repo-dryrun-1",
+                    },
+                    "branch": None,
+                    "changed_files": [],
+                    "external_refs": [],
+                    "captured_at": "2026-03-31T14:31:10Z",
+                    "metadata": {},
+                },
+            ],
+            "completion_evidence": {
+                "policy": "required",
+                "status": "satisfied",
+                "required_artifact_types": ["pull_request", "commit"],
+                "validated_artifact_ids": ["artifact-pr-dryrun-1", "artifact-commit-dryrun-1"],
+                "validation_method": "external_reconciliation",
+                "validated_at": "2026-03-31T14:31:30Z",
+                "validator": {
+                    "source_system": "harness",
+                    "source_type": "verification",
+                    "source_id": "verification-dryrun-1",
+                    "captured_by": "github-sync",
+                },
+            },
+            "external_facts": {
+                "expected_code_context": {
+                    "repository_host": "github.com",
+                    "repository_owner": "KnoxAnalytics",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "branch_name": "codex/e2e-test",
+                    "base_branch": "main",
+                },
+                "github_facts": {
+                    "artifact_found": True,
+                    "repository": {
+                        "host": "github.com",
+                        "owner": "KnoxAnalytics",
+                        "name": "HARNESS-DRYRUN",
+                        "external_id": "repo-dryrun-1",
+                    },
+                    "branch": {
+                        "name": "codex/e2e-test",
+                        "base_branch": "main",
+                        "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    },
+                    "commit": {
+                        "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    },
+                    "pull_request": {
+                        "number": 2,
+                        "review_state": "approved",
+                    },
+                    "changed_files": {
+                        "matches_expected_scope": True,
+                        "files": [
+                            {
+                                "path": "modules/api.py",
+                                "change_type": "modified",
+                            }
+                        ],
+                    },
+                    "reasons": [],
+                },
+                "linear_facts": {
+                    "record_found": True,
+                    "issue_id": "lin-dryrun-1",
+                    "issue_key": "HAR-2",
+                    "state": "completed",
+                    "workflow": {
+                        "workflow_id": "workflow-completed",
+                        "workflow_name": "completed",
+                        "state_type": "completed",
+                    },
+                    "reasons": [],
+                },
+            },
+            "claimed_completion": True,
+            "acceptance_criteria_satisfied": True,
+            "runtime_facts": {
+                "executor_reported_success": True,
+                "attempt_count": 1,
+            },
+        }
+    }
 
 
 def _schema_invalid_submission_payload() -> dict:
@@ -771,6 +945,21 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history_payload["evaluations"]), 1)
         self.assertEqual(history_payload["evaluations"][0]["result"]["task_envelope"]["status"], "completed")
+
+    def test_api_accepts_manual_happy_path_overlay_payload(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+
+        status, response = self._post_json("/evaluate", payload)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["action"], "transition_applied")
+        self.assertEqual(response["target_status"], "completed")
+        self.assertTrue(response["accepted_completion"])
+        self.assertEqual(response["task_envelope"]["status"], "completed")
+        self.assertEqual(
+            response["enforcement_result"]["verification_result"]["outcome"],
+            "accepted_completion",
+        )
 
     def test_api_persists_blocked_result(self) -> None:
         status, payload = self._post_json("/evaluate", _request_payload("blocked_insufficient_evidence"))


### PR DESCRIPTION
## Summary
- honor ingress-style top-level task/evidence overlays on initial evaluate requests
- allow Linear completed state to align with an active claimed-completion verification pass
- add explicit insufficient-evidence diagnostics and a real /evaluate happy-path regression

## Validation
- .venv/bin/python -m unittest tests.test_api tests.contracts.test_task_envelope_reconciliation tests.contracts.test_task_envelope_verification tests.test_evaluation
- .venv/bin/python -m unittest discover -s tests
- pnpm lint
- pnpm build