### PR TITLE
Add self-heal policy to unattended dry runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ export HARNESS_DRYRUN_BASE_URL=https://harness-qeav.onrender.com
 export HARNESS_DRYRUN_OUTPUT_DIR=runs
 export HARNESS_DRYRUN_INTERVAL_SECONDS=300
 export HARNESS_DRYRUN_ITERATIONS=0
+export HARNESS_DRYRUN_MAX_RETRIES=2
+export HARNESS_DRYRUN_DIAGNOSTICS_ENABLED=true
+export HARNESS_DRYRUN_MAX_E2E_SUITE_RUNS=1
 ```
 
 Run once:
@@ -238,7 +241,21 @@ Inspect logs and raw responses:
 
 ```bash
 tail -f runs/log.jsonl
+find runs/reports -type f | sort
 find runs/raw -type f | sort
+```
+
+Self-heal behavior:
+
+- each scenario compares its actual outcome to the canonical expected outcome
+- transient transport and backend availability failures are retried up to the bounded retry limit
+- runtime regressions can trigger the local E2E suite once per runner session
+- unexpected failures write structured reports under `runs/reports/`
+
+Disable retry and diagnostics:
+
+```bash
+.venv/bin/python scripts/run_unattended_dryruns.py --max-retries 0 --disable-diagnostics --max-e2e-suite-runs 0
 ```
 
 ## Demo And Canonical Scenarios

--- a/modules/runtime_scenario_builders.py
+++ b/modules/runtime_scenario_builders.py
@@ -25,6 +25,7 @@ class RuntimeScenarioDefinition:
 
     name: str
     description: str
+    expected_outcome: dict[str, Any]
     build_evaluate_payload: Callable[[dict[str, Any]], dict[str, Any]]
 
 
@@ -473,16 +474,31 @@ CANONICAL_UNATTENDED_SCENARIOS: tuple[RuntimeScenarioDefinition, ...] = (
     RuntimeScenarioDefinition(
         name="happy_path",
         description="Evidence-backed completion should be accepted.",
+        expected_outcome={
+            "accepted_completion": True,
+            "final_status": "completed",
+            "requires_review": False,
+        },
         build_evaluate_payload=build_happy_path_evaluate_payload,
     ),
     RuntimeScenarioDefinition(
         name="mismatch",
         description="Wrong-target reconciliation mismatch should fail terminally.",
+        expected_outcome={
+            "accepted_completion": False,
+            "final_status": "failed",
+            "requires_review": False,
+        },
         build_evaluate_payload=build_mismatch_evaluate_payload,
     ),
     RuntimeScenarioDefinition(
         name="review_required",
         description="Unresolved external truth should require manual review.",
+        expected_outcome={
+            "accepted_completion": False,
+            "final_status": "in_review",
+            "requires_review": True,
+        },
         build_evaluate_payload=build_review_required_payload,
     ),
 )

--- a/modules/unattended_dryruns.py
+++ b/modules/unattended_dryruns.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import random
 import string
+import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -21,6 +23,16 @@ from modules.runtime_scenario_builders import (
 
 
 DEFAULT_BASE_URL = "https://harness-qeav.onrender.com"
+E2E_SUITE_COMMAND = [
+    sys.executable,
+    "-m",
+    "unittest",
+    "discover",
+    "-s",
+    "tests/e2e",
+    "-p",
+    "test_*.py",
+]
 
 
 @dataclass(frozen=True)
@@ -28,6 +40,27 @@ class RequestResult:
     status: int | None
     payload: dict[str, Any]
     error: str | None = None
+
+
+@dataclass(frozen=True)
+class FailureClassification:
+    category: str
+    retryable: bool
+    suggested_action: str
+    confidence: float | None = None
+
+
+@dataclass
+class RunnerSessionState:
+    e2e_suite_runs: int = 0
+
+
+@dataclass(frozen=True)
+class E2ESuiteResult:
+    ran: bool
+    passed: bool | None
+    exit_code: int | None
+    output_path: str | None
 
 
 def utc_now() -> datetime:
@@ -132,6 +165,159 @@ def warm_backend(
     return False, raw_files
 
 
+def actual_outcome_from_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "accepted_completion": entry.get("accepted_completion"),
+        "final_status": entry.get("final_status"),
+        "requires_review": entry.get("requires_review"),
+    }
+
+
+def classify_outcome(
+    expected_outcome: dict[str, Any],
+    actual_outcome: dict[str, Any],
+) -> tuple[bool, str]:
+    matched = all(actual_outcome.get(key) == value for key, value in expected_outcome.items())
+    if not matched:
+        return False, "unexpected_failure"
+    if expected_outcome.get("accepted_completion") is True:
+        return True, "expected_success"
+    return True, "expected_semantic_failure"
+
+
+def _contains_any(text: str, fragments: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(fragment in lowered for fragment in fragments)
+
+
+def classify_unexpected_failure(entry: dict[str, Any]) -> FailureClassification:
+    stage = entry.get("attempt_error_stage")
+    error_text = str(entry.get("error") or "")
+    statuses = [
+        entry.get("create_http_status"),
+        entry.get("evaluate_http_status"),
+        entry.get("fetch_http_status"),
+    ]
+
+    if stage == "payload_build":
+        return FailureClassification(
+            category="payload_build_failure",
+            retryable=False,
+            suggested_action="Inspect the scenario builder or payload overlay assembly for this scenario.",
+            confidence=0.98,
+        )
+
+    if _contains_any(error_text, ("timed out", "timeout")):
+        return FailureClassification(
+            category="render_cold_start_timeout",
+            retryable=True,
+            suggested_action="Warm /health and retry within the capped retry budget.",
+            confidence=0.9,
+        )
+
+    if any(status in {502, 503, 504} for status in statuses if status is not None):
+        return FailureClassification(
+            category="backend_unavailable",
+            retryable=True,
+            suggested_action="Warm /health and retry; the hosted backend appears unavailable.",
+            confidence=0.9,
+        )
+
+    if any(status is None for status in statuses):
+        if _contains_any(
+            error_text,
+            (
+                "connection refused",
+                "connection reset",
+                "temporarily unavailable",
+                "temporary failure",
+                "remote end closed",
+                "name or service not known",
+                "nodename nor servname",
+            ),
+        ):
+            return FailureClassification(
+                category="transient_transport",
+                retryable=True,
+                suggested_action="Retry this scenario within bounds; transport failed before a stable API response arrived.",
+                confidence=0.85,
+            )
+        return FailureClassification(
+            category="backend_unavailable",
+            retryable=True,
+            suggested_action="Warm /health and retry; the backend did not return a usable response.",
+            confidence=0.75,
+        )
+
+    if any(status is not None and 400 <= status < 500 for status in statuses):
+        return FailureClassification(
+            category="unexpected_runtime_regression",
+            retryable=False,
+            suggested_action="Inspect the raw API artifacts and compare them to the canonical runtime E2E suite.",
+            confidence=0.8,
+        )
+
+    if entry.get("evaluate_http_status") == 200 and not entry.get("expected_outcome_matched", False):
+        return FailureClassification(
+            category="unexpected_runtime_regression",
+            retryable=False,
+            suggested_action="Inspect the raw API artifacts and run the runtime E2E suite locally.",
+            confidence=0.9,
+        )
+
+    return FailureClassification(
+        category="unknown",
+        retryable=False,
+        suggested_action="Inspect the raw artifacts and run the runtime E2E suite once for comparison.",
+        confidence=0.4,
+    )
+
+
+def should_run_e2e_suite(classification: FailureClassification) -> bool:
+    return classification.category in {"unexpected_runtime_regression", "unknown"}
+
+
+def run_e2e_suite(*, output_dir: Path, session_state: RunnerSessionState, max_runs: int) -> E2ESuiteResult:
+    if max_runs <= 0 or session_state.e2e_suite_runs >= max_runs:
+        return E2ESuiteResult(ran=False, passed=None, exit_code=None, output_path=None)
+
+    session_state.e2e_suite_runs += 1
+    timestamp = compact_utc(utc_now())
+    report_path = output_dir / "reports" / f"e2e-suite-{timestamp}.txt"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    completed = subprocess.run(
+        E2E_SUITE_COMMAND,
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+    )
+    report_path.write_text(
+        f"$ {' '.join(E2E_SUITE_COMMAND)}\n\n{completed.stdout}\n{completed.stderr}",
+        encoding="utf-8",
+    )
+    return E2ESuiteResult(
+        ran=True,
+        passed=completed.returncode == 0,
+        exit_code=completed.returncode,
+        output_path=str(report_path),
+    )
+
+
+def write_diagnostic_report(
+    *,
+    output_dir: Path,
+    scenario: str,
+    task_id: str | None,
+    payload: dict[str, Any],
+) -> str:
+    timestamp = compact_utc(utc_now())
+    normalized_task_id = task_id or "no-task-id"
+    report_path = output_dir / "reports" / f"{timestamp}-{scenario}-{normalized_task_id}.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return str(report_path)
+
+
 def summarize_run(
     *,
     timestamp: str,
@@ -141,7 +327,8 @@ def summarize_run(
     evaluate_result: RequestResult,
     fetch_result: RequestResult,
     duration_ms: int,
-    raw_files: dict[str, str],
+    raw_files: dict[str, Any],
+    attempt_error_stage: str | None = None,
 ) -> dict[str, Any]:
     verification = ((evaluate_result.payload.get("enforcement_result") or {}).get("verification_result") or {})
     reconciliation = ((evaluate_result.payload.get("enforcement_result") or {}).get("reconciliation_result") or {})
@@ -170,6 +357,7 @@ def summarize_run(
         "mismatch_categories": reconciliation.get("mismatch_categories", []),
         "duration_ms": duration_ms,
         "raw_files": raw_files,
+        "attempt_error_stage": attempt_error_stage,
     }
 
 
@@ -185,7 +373,7 @@ def run_scenario_once(
     timestamp = isoformat_utc(started_at)
     task_id = build_task_id(scenario.name, at=started_at)
     scenario_dir = output_dir / "raw" / compact_utc(started_at) / scenario.name / task_id
-    raw_files: dict[str, str] = {}
+    raw_files: dict[str, Any] = {}
 
     create_payload = build_create_task_payload(
         task_id,
@@ -219,10 +407,17 @@ def run_scenario_once(
         )
 
     evaluate_result = RequestResult(status=None, payload={}, error="evaluate_skipped")
+    attempt_error_stage: str | None = None
     if initial_fetch_result.status == 200 and isinstance(initial_fetch_result.payload.get("task"), dict):
-        evaluate_payload = scenario.build_evaluate_payload(initial_fetch_result.payload["task"])
+        try:
+            evaluate_payload = scenario.build_evaluate_payload(initial_fetch_result.payload["task"])
+        except Exception as error:
+            attempt_error_stage = "payload_build"
+            evaluate_payload = {"error": str(error)}
+            evaluate_result = RequestResult(status=None, payload={}, error=str(error))
         raw_files["evaluate_request"] = _write_json(scenario_dir / "evaluate-request.json", evaluate_payload)
-        evaluate_result = client.post_json("/evaluate", evaluate_payload)
+        if attempt_error_stage is None:
+            evaluate_result = client.post_json("/evaluate", evaluate_payload)
         raw_files["evaluate_response"] = _write_json(
             scenario_dir / "evaluate-response.json",
             {"status": evaluate_result.status, "payload": evaluate_result.payload, "error": evaluate_result.error},
@@ -259,17 +454,184 @@ def run_scenario_once(
         fetch_result=final_fetch_result,
         duration_ms=round((time.monotonic() - scenario_started) * 1000),
         raw_files=raw_files,
+        attempt_error_stage=attempt_error_stage,
     )
+
+
+def enrich_entry_with_expectations(entry: dict[str, Any], scenario: RuntimeScenarioDefinition) -> dict[str, Any]:
+    expected_outcome = dict(scenario.expected_outcome)
+    actual_outcome = actual_outcome_from_entry(entry)
+    matched, outcome_class = classify_outcome(expected_outcome, actual_outcome)
+    enriched = dict(entry)
+    enriched.update(
+        {
+            "expected_outcome": expected_outcome,
+            "actual_outcome": actual_outcome,
+            "outcome_class": outcome_class,
+            "expected_outcome_matched": matched,
+        }
+    )
+    return enriched
 
 
 def _scenario_line(entry: dict[str, Any]) -> str:
     return (
         f"[{entry['timestamp']}] scenario={entry['scenario']} task_id={entry['task_id']} "
+        f"outcome={entry.get('outcome_class')} classification={entry.get('classification')} "
         f"create={entry['create_http_status']} evaluate={entry['evaluate_http_status']} "
         f"fetch={entry['fetch_http_status']} final_status={entry['final_status']} "
         f"accepted={entry['accepted_completion']} requires_review={entry['requires_review']} "
-        f"action={entry['action']} duration_ms={entry['duration_ms']}"
+        f"retry_count={entry.get('retry_count')} retry_result={entry.get('retry_result')}"
     )
+
+
+def execute_scenario_with_policy(
+    client: HarnessRemoteClient,
+    *,
+    scenario: RuntimeScenarioDefinition,
+    output_dir: Path,
+    session_state: RunnerSessionState,
+    health_retries: int,
+    health_backoff_seconds: float,
+    max_retries: int,
+    diagnostics_enabled: bool,
+    max_e2e_suite_runs: int,
+) -> dict[str, Any]:
+    attempts: list[dict[str, Any]] = []
+    warmup_files: list[str] = []
+
+    for retry_index in range(max_retries + 1):
+        if retry_index > 0 and warmup_files:
+            warm_key = f"retry_health_attempt_{retry_index}"
+        else:
+            warm_key = None
+
+        entry = enrich_entry_with_expectations(
+            run_scenario_once(
+                client,
+                scenario=scenario,
+                output_dir=output_dir,
+                now=utc_now(),
+            ),
+            scenario,
+        )
+        attempts.append(entry)
+
+        if entry["expected_outcome_matched"]:
+            entry["classification"] = "none"
+            entry["retryable"] = False
+            entry["suggested_action"] = "No action required."
+            entry["confidence"] = None
+            entry["retry_count"] = retry_index
+            entry["retry_result"] = "not_needed" if retry_index == 0 else "succeeded_after_retry"
+            entry["e2e_suite_run"] = False
+            entry["e2e_suite_passed"] = None
+            entry["e2e_suite_exit_code"] = None
+            entry["e2e_suite_output_path"] = None
+            entry["report_path"] = None
+            if warm_key:
+                entry["raw_files"][warm_key] = warmup_files
+            return entry
+
+        classification = classify_unexpected_failure(entry)
+        should_retry = classification.retryable and retry_index < max_retries
+        if should_retry:
+            warmed, health_files = warm_backend(
+                client,
+                raw_dir=output_dir / "raw" / compact_utc(utc_now()) / "_retry_health" / scenario.name,
+                retries=health_retries,
+                backoff_seconds=health_backoff_seconds,
+            )
+            warmup_files = health_files
+            if not warmed:
+                classification = FailureClassification(
+                    category="backend_unavailable",
+                    retryable=False,
+                    suggested_action="Hosted backend stayed unavailable after warmup retries.",
+                    confidence=0.9,
+                )
+                should_retry = False
+
+        if should_retry:
+            continue
+
+        e2e_result = E2ESuiteResult(ran=False, passed=None, exit_code=None, output_path=None)
+        if diagnostics_enabled and should_run_e2e_suite(classification):
+            e2e_result = run_e2e_suite(
+                output_dir=output_dir,
+                session_state=session_state,
+                max_runs=max_e2e_suite_runs,
+            )
+
+        retry_result = "retry_exhausted" if classification.retryable and retry_index >= max_retries else "not_retryable"
+        final_entry = dict(entry)
+        final_entry.update(
+            {
+                "classification": classification.category,
+                "retryable": classification.retryable,
+                "suggested_action": classification.suggested_action,
+                "confidence": classification.confidence,
+                "retry_count": retry_index,
+                "retry_result": retry_result,
+                "e2e_suite_run": e2e_result.ran,
+                "e2e_suite_passed": e2e_result.passed,
+                "e2e_suite_exit_code": e2e_result.exit_code,
+                "e2e_suite_output_path": e2e_result.output_path,
+            }
+        )
+        if warmup_files:
+            final_entry["raw_files"][f"retry_health_attempt_{retry_index}"] = warmup_files
+
+        if diagnostics_enabled:
+            final_entry["report_path"] = write_diagnostic_report(
+                output_dir=output_dir,
+                scenario=scenario.name,
+                task_id=final_entry.get("task_id"),
+                payload={
+                    "scenario": scenario.name,
+                    "expected_outcome": final_entry["expected_outcome"],
+                    "actual_outcome": final_entry["actual_outcome"],
+                    "classification": classification.category,
+                    "retry_attempts": retry_index,
+                    "retryable": classification.retryable,
+                    "retry_result": retry_result,
+                    "suggested_action": classification.suggested_action,
+                    "confidence": classification.confidence,
+                    "e2e_suite": {
+                        "ran": e2e_result.ran,
+                        "passed": e2e_result.passed,
+                        "exit_code": e2e_result.exit_code,
+                        "output_path": e2e_result.output_path,
+                    },
+                    "attempts": attempts,
+                    "raw_files": final_entry["raw_files"],
+                },
+            )
+        else:
+            final_entry["report_path"] = None
+        return final_entry
+
+    # Defensive fallback: the loop above should always return.
+    fallback = enrich_entry_with_expectations(
+        run_scenario_once(client, scenario=scenario, output_dir=output_dir, now=utc_now()),
+        scenario,
+    )
+    fallback.update(
+        {
+            "classification": "unknown",
+            "retryable": False,
+            "suggested_action": "Inspect the raw artifacts for this scenario.",
+            "confidence": 0.1,
+            "retry_count": max_retries,
+            "retry_result": "retry_exhausted",
+            "e2e_suite_run": False,
+            "e2e_suite_passed": None,
+            "e2e_suite_exit_code": None,
+            "e2e_suite_output_path": None,
+            "report_path": None,
+        }
+    )
+    return fallback
 
 
 def run_unattended_loop(
@@ -281,11 +643,15 @@ def run_unattended_loop(
     timeout_seconds: float = 45.0,
     health_retries: int = 6,
     health_backoff_seconds: float = 5.0,
+    max_retries: int = 2,
+    diagnostics_enabled: bool = True,
+    max_e2e_suite_runs: int = 1,
 ) -> int:
     client = HarnessRemoteClient(base_url, timeout_seconds=timeout_seconds)
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
     log_path = output_path / "log.jsonl"
+    session_state = RunnerSessionState()
 
     loop_count = 0
     try:
@@ -300,7 +666,7 @@ def run_unattended_loop(
                 backoff_seconds=health_backoff_seconds,
             )
             if not warmed:
-                failure_entry = {
+                health_entry = {
                     "timestamp": isoformat_utc(loop_started_at),
                     "scenario": "_health",
                     "task_id": None,
@@ -317,39 +683,57 @@ def run_unattended_loop(
                     "mismatch_categories": [],
                     "duration_ms": None,
                     "raw_files": {"health": health_files},
+                    "attempt_error_stage": "health",
+                    "expected_outcome": None,
+                    "actual_outcome": None,
+                    "outcome_class": "unexpected_failure",
+                    "expected_outcome_matched": False,
+                    "classification": "backend_unavailable",
+                    "retryable": False,
+                    "suggested_action": "Inspect Render availability or rerun once the backend becomes healthy.",
+                    "confidence": 0.95,
+                    "retry_count": 0,
+                    "retry_result": "not_retryable",
+                    "e2e_suite_run": False,
+                    "e2e_suite_passed": None,
+                    "e2e_suite_exit_code": None,
+                    "e2e_suite_output_path": None,
+                    "report_path": None,
                 }
-                append_jsonl(log_path, failure_entry)
-                print(_scenario_line(failure_entry))
+                if diagnostics_enabled:
+                    health_entry["report_path"] = write_diagnostic_report(
+                        output_dir=output_path,
+                        scenario="_health",
+                        task_id=None,
+                        payload={
+                            "scenario": "_health",
+                            "classification": health_entry["classification"],
+                            "retry_attempts": 0,
+                            "e2e_suite": {
+                                "ran": False,
+                                "passed": None,
+                                "exit_code": None,
+                                "output_path": None,
+                            },
+                            "raw_files": health_entry["raw_files"],
+                            "suggested_action": health_entry["suggested_action"],
+                        },
+                    )
+                append_jsonl(log_path, health_entry)
+                print(_scenario_line(health_entry))
             else:
                 for scenario in CANONICAL_UNATTENDED_SCENARIOS:
-                    scenario_started = time.monotonic()
-                    try:
-                        entry = run_scenario_once(
-                            client,
-                            scenario=scenario,
-                            output_dir=output_path,
-                            now=utc_now(),
-                        )
-                    except Exception as error:
-                        failure_time = utc_now()
-                        entry = {
-                            "timestamp": isoformat_utc(failure_time),
-                            "scenario": scenario.name,
-                            "task_id": None,
-                            "create_http_status": None,
-                            "evaluate_http_status": None,
-                            "fetch_http_status": None,
-                            "accepted_completion": None,
-                            "verification_passed": None,
-                            "reconciliation_status": None,
-                            "requires_review": None,
-                            "final_status": None,
-                            "action": None,
-                            "error": str(error),
-                            "mismatch_categories": [],
-                            "duration_ms": round((time.monotonic() - scenario_started) * 1000),
-                            "raw_files": {},
-                        }
+                    entry = execute_scenario_with_policy(
+                        client,
+                        scenario=scenario,
+                        output_dir=output_path,
+                        session_state=session_state,
+                        health_retries=health_retries,
+                        health_backoff_seconds=health_backoff_seconds,
+                        max_retries=max_retries,
+                        diagnostics_enabled=diagnostics_enabled,
+                        max_e2e_suite_runs=max_e2e_suite_runs,
+                    )
                     append_jsonl(log_path, entry)
                     print(_scenario_line(entry))
 
@@ -373,6 +757,12 @@ def default_config_from_env() -> dict[str, Any]:
         value = os.environ.get(name)
         return int(value) if value else default
 
+    def _bool(name: str, default: bool) -> bool:
+        value = os.environ.get(name)
+        if value is None:
+            return default
+        return value.lower() not in {"0", "false", "no", "off"}
+
     return {
         "base_url": os.environ.get("HARNESS_DRYRUN_BASE_URL", DEFAULT_BASE_URL),
         "output_dir": os.environ.get("HARNESS_DRYRUN_OUTPUT_DIR", "runs"),
@@ -381,18 +771,31 @@ def default_config_from_env() -> dict[str, Any]:
         "timeout_seconds": _float("HARNESS_DRYRUN_TIMEOUT_SECONDS", 45.0),
         "health_retries": _int("HARNESS_DRYRUN_HEALTH_RETRIES", 6),
         "health_backoff_seconds": _float("HARNESS_DRYRUN_HEALTH_BACKOFF_SECONDS", 5.0),
+        "max_retries": _int("HARNESS_DRYRUN_MAX_RETRIES", 2),
+        "diagnostics_enabled": _bool("HARNESS_DRYRUN_DIAGNOSTICS_ENABLED", True),
+        "max_e2e_suite_runs": _int("HARNESS_DRYRUN_MAX_E2E_SUITE_RUNS", 1),
     }
 
 
 __all__ = [
     "CANONICAL_UNATTENDED_SCENARIOS",
     "DEFAULT_BASE_URL",
+    "E2ESuiteResult",
+    "FailureClassification",
     "HarnessRemoteClient",
     "RequestResult",
+    "RunnerSessionState",
+    "actual_outcome_from_entry",
     "append_jsonl",
     "build_task_id",
+    "classify_outcome",
+    "classify_unexpected_failure",
     "default_config_from_env",
+    "execute_scenario_with_policy",
+    "run_e2e_suite",
     "run_scenario_once",
     "run_unattended_loop",
+    "should_run_e2e_suite",
     "summarize_run",
+    "write_diagnostic_report",
 ]

--- a/scripts/run_unattended_dryruns.py
+++ b/scripts/run_unattended_dryruns.py
@@ -12,12 +12,16 @@ Environment:
   HARNESS_DRYRUN_TIMEOUT_SECONDS=45
   HARNESS_DRYRUN_HEALTH_RETRIES=6
   HARNESS_DRYRUN_HEALTH_BACKOFF_SECONDS=5
+  HARNESS_DRYRUN_MAX_RETRIES=2
+  HARNESS_DRYRUN_DIAGNOSTICS_ENABLED=true
+  HARNESS_DRYRUN_MAX_E2E_SUITE_RUNS=1
 
 Stop / restart:
   Stop with Ctrl-C in the tmux pane. Restart by rerunning the same command.
 
 Inspect logs:
   tail -f runs/log.jsonl
+  find runs/reports -type f | sort
   find runs/raw -type f | sort
 """
 
@@ -45,6 +49,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--timeout-seconds", type=float, default=defaults["timeout_seconds"], help="HTTP timeout for health and scenario requests")
     parser.add_argument("--health-retries", type=int, default=defaults["health_retries"], help="Maximum health-check retries before a loop is recorded as failed")
     parser.add_argument("--health-backoff-seconds", type=float, default=defaults["health_backoff_seconds"], help="Base backoff between health retries; multiplied by attempt number")
+    parser.add_argument("--max-retries", type=int, default=defaults["max_retries"], help="Maximum bounded retries for retryable unexpected failures")
+    parser.add_argument("--max-e2e-suite-runs", type=int, default=defaults["max_e2e_suite_runs"], help="Maximum times to run the local E2E suite per unattended session")
+    parser.add_argument(
+        "--disable-diagnostics",
+        action="store_true",
+        help="Disable diagnostic report writing and the optional E2E regression hook",
+    )
     return parser
 
 
@@ -59,6 +70,9 @@ def main(argv: list[str] | None = None) -> int:
         timeout_seconds=args.timeout_seconds,
         health_retries=args.health_retries,
         health_backoff_seconds=args.health_backoff_seconds,
+        max_retries=args.max_retries,
+        diagnostics_enabled=not args.disable_diagnostics,
+        max_e2e_suite_runs=args.max_e2e_suite_runs,
     )
 
 

--- a/tests/test_unattended_dryruns.py
+++ b/tests/test_unattended_dryruns.py
@@ -1,17 +1,40 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
+import tempfile
 import unittest
+from unittest.mock import patch
 
 from modules.runtime_scenario_builders import CANONICAL_UNATTENDED_SCENARIOS
-from modules.unattended_dryruns import RequestResult, build_task_id, summarize_run
+from modules.unattended_dryruns import (
+    E2ESuiteResult,
+    RequestResult,
+    RunnerSessionState,
+    build_task_id,
+    classify_outcome,
+    classify_unexpected_failure,
+    execute_scenario_with_policy,
+    summarize_run,
+)
 
 
 class UnattendedDryRunTests(unittest.TestCase):
-    def test_canonical_unattended_scenarios_match_expected_names(self) -> None:
+    def test_canonical_unattended_scenarios_match_expected_names_and_outcomes(self) -> None:
+        scenarios = {scenario.name: scenario.expected_outcome for scenario in CANONICAL_UNATTENDED_SCENARIOS}
+
+        self.assertEqual(list(scenarios), ["happy_path", "mismatch", "review_required"])
         self.assertEqual(
-            [scenario.name for scenario in CANONICAL_UNATTENDED_SCENARIOS],
-            ["happy_path", "mismatch", "review_required"],
+            scenarios["happy_path"],
+            {"accepted_completion": True, "final_status": "completed", "requires_review": False},
+        )
+        self.assertEqual(
+            scenarios["mismatch"],
+            {"accepted_completion": False, "final_status": "failed", "requires_review": False},
+        )
+        self.assertEqual(
+            scenarios["review_required"],
+            {"accepted_completion": False, "final_status": "in_review", "requires_review": True},
         )
 
     def test_build_task_id_includes_scenario_timestamp_and_suffix(self) -> None:
@@ -22,6 +45,55 @@ class UnattendedDryRunTests(unittest.TestCase):
         )
 
         self.assertEqual(task_id, "dryrun-review-required-20260401T123000Z-abc123")
+
+    def test_classify_outcome_distinguishes_expected_success_and_semantic_failure(self) -> None:
+        matched, outcome_class = classify_outcome(
+            {"accepted_completion": True, "final_status": "completed", "requires_review": False},
+            {"accepted_completion": True, "final_status": "completed", "requires_review": False},
+        )
+        self.assertTrue(matched)
+        self.assertEqual(outcome_class, "expected_success")
+
+        matched, outcome_class = classify_outcome(
+            {"accepted_completion": False, "final_status": "in_review", "requires_review": True},
+            {"accepted_completion": False, "final_status": "in_review", "requires_review": True},
+        )
+        self.assertTrue(matched)
+        self.assertEqual(outcome_class, "expected_semantic_failure")
+
+        matched, outcome_class = classify_outcome(
+            {"accepted_completion": True, "final_status": "completed", "requires_review": False},
+            {"accepted_completion": False, "final_status": "blocked", "requires_review": False},
+        )
+        self.assertFalse(matched)
+        self.assertEqual(outcome_class, "unexpected_failure")
+
+    def test_classify_unexpected_failure_detects_transient_and_regression_cases(self) -> None:
+        transient = classify_unexpected_failure(
+            {
+                "create_http_status": None,
+                "evaluate_http_status": None,
+                "fetch_http_status": None,
+                "error": "Connection refused",
+                "expected_outcome_matched": False,
+                "attempt_error_stage": None,
+            }
+        )
+        self.assertEqual(transient.category, "transient_transport")
+        self.assertTrue(transient.retryable)
+
+        regression = classify_unexpected_failure(
+            {
+                "create_http_status": 200,
+                "evaluate_http_status": 200,
+                "fetch_http_status": 200,
+                "error": None,
+                "expected_outcome_matched": False,
+                "attempt_error_stage": None,
+            }
+        )
+        self.assertEqual(regression.category, "unexpected_runtime_regression")
+        self.assertFalse(regression.retryable)
 
     def test_summarize_run_extracts_required_log_fields(self) -> None:
         summary = summarize_run(
@@ -65,6 +137,127 @@ class UnattendedDryRunTests(unittest.TestCase):
         self.assertEqual(summary["mismatch_categories"], [])
         self.assertEqual(summary["duration_ms"], 1420)
         self.assertEqual(summary["raw_files"], {"create_response": "runs/raw/create.json"})
+
+    def test_execute_scenario_with_policy_retries_transient_failure_then_succeeds(self) -> None:
+        scenario = CANONICAL_UNATTENDED_SCENARIOS[0]
+        transient_entry = {
+            "timestamp": "2026-04-01T12:30:00Z",
+            "scenario": scenario.name,
+            "task_id": "task-1",
+            "create_http_status": None,
+            "evaluate_http_status": None,
+            "fetch_http_status": None,
+            "accepted_completion": None,
+            "verification_passed": None,
+            "reconciliation_status": None,
+            "requires_review": None,
+            "final_status": None,
+            "action": None,
+            "error": "Connection refused",
+            "mismatch_categories": [],
+            "duration_ms": 1000,
+            "raw_files": {},
+            "attempt_error_stage": None,
+        }
+        success_entry = {
+            "timestamp": "2026-04-01T12:30:05Z",
+            "scenario": scenario.name,
+            "task_id": "task-1",
+            "create_http_status": 200,
+            "evaluate_http_status": 200,
+            "fetch_http_status": 200,
+            "accepted_completion": True,
+            "verification_passed": True,
+            "reconciliation_status": "passed",
+            "requires_review": False,
+            "final_status": "completed",
+            "action": "transition_applied",
+            "error": None,
+            "mismatch_categories": [],
+            "duration_ms": 900,
+            "raw_files": {},
+            "attempt_error_stage": None,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("modules.unattended_dryruns.run_scenario_once", side_effect=[transient_entry, success_entry]):
+                with patch("modules.unattended_dryruns.warm_backend", return_value=(True, ["runs/raw/retry-health.json"])):
+                    with patch("modules.unattended_dryruns.run_e2e_suite") as run_e2e_suite:
+                        result = execute_scenario_with_policy(
+                            client=object(),
+                            scenario=scenario,
+                            output_dir=Path(temp_dir),
+                            session_state=RunnerSessionState(),
+                            health_retries=2,
+                            health_backoff_seconds=0.01,
+                            max_retries=2,
+                            diagnostics_enabled=True,
+                            max_e2e_suite_runs=1,
+                        )
+
+        self.assertEqual(result["outcome_class"], "expected_success")
+        self.assertEqual(result["classification"], "none")
+        self.assertEqual(result["retry_count"], 1)
+        self.assertEqual(result["retry_result"], "succeeded_after_retry")
+        self.assertFalse(result["e2e_suite_run"])
+        run_e2e_suite.assert_not_called()
+
+    def test_execute_scenario_with_policy_runs_e2e_and_report_for_runtime_regression(self) -> None:
+        scenario = CANONICAL_UNATTENDED_SCENARIOS[0]
+        regression_entry = {
+            "timestamp": "2026-04-01T12:30:00Z",
+            "scenario": scenario.name,
+            "task_id": "task-1",
+            "create_http_status": 200,
+            "evaluate_http_status": 200,
+            "fetch_http_status": 200,
+            "accepted_completion": False,
+            "verification_passed": False,
+            "reconciliation_status": "passed",
+            "requires_review": False,
+            "final_status": "blocked",
+            "action": "transition_applied",
+            "error": None,
+            "mismatch_categories": [],
+            "duration_ms": 1000,
+            "raw_files": {},
+            "attempt_error_stage": None,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("modules.unattended_dryruns.run_scenario_once", return_value=regression_entry):
+                with patch(
+                    "modules.unattended_dryruns.run_e2e_suite",
+                    return_value=E2ESuiteResult(
+                        ran=True,
+                        passed=False,
+                        exit_code=1,
+                        output_path="runs/reports/e2e-suite.txt",
+                    ),
+                ):
+                    with patch(
+                        "modules.unattended_dryruns.write_diagnostic_report",
+                        return_value="runs/reports/happy-path-report.json",
+                    ):
+                        result = execute_scenario_with_policy(
+                            client=object(),
+                            scenario=scenario,
+                            output_dir=Path(temp_dir),
+                            session_state=RunnerSessionState(),
+                            health_retries=2,
+                            health_backoff_seconds=0.01,
+                            max_retries=2,
+                            diagnostics_enabled=True,
+                            max_e2e_suite_runs=1,
+                        )
+
+        self.assertEqual(result["outcome_class"], "unexpected_failure")
+        self.assertEqual(result["classification"], "unexpected_runtime_regression")
+        self.assertEqual(result["retry_count"], 0)
+        self.assertEqual(result["retry_result"], "not_retryable")
+        self.assertTrue(result["e2e_suite_run"])
+        self.assertFalse(result["e2e_suite_passed"])
+        self.assertEqual(result["report_path"], "runs/reports/happy-path-report.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- encode expected semantic outcomes on the canonical unattended scenarios so mismatch and review-required runs are treated as expected results
- add bounded failure classification, retry, diagnostic reporting, and a one-per-session E2E regression hook around the existing unattended runner
- document the new self-heal controls and how to disable retry or diagnostics when needed

## Validation
- `python3 -m py_compile modules/runtime_scenario_builders.py modules/unattended_dryruns.py scripts/run_unattended_dryruns.py`
- `.venv/bin/python -m unittest tests.test_unattended_dryruns`
- `.venv/bin/python -m unittest discover -s tests/e2e -p 'test_*.py'`
- `.venv/bin/python -m unittest discover -s tests`
- `pnpm lint`
- `pnpm build`
- `.venv/bin/python scripts/run_unattended_dryruns.py --iterations 1 --timeout-seconds 90 --health-retries 8 --health-backoff-seconds 5`
