### PR TITLE
[codex] add planning scaffolds for HEE and OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ It does not trust agent-reported completion on its own. It accepts or blocks lif
 
 Harness is not a PM tool, an agent runtime, or a chatbot UI.
 
+## Planned Capabilities
+
+The repository also carries planning-only scaffolds for two future capabilities:
+
+- the Harness Evolution Engine (HEE), an advisory subsystem for diagnosing recurring failures and proposing reviewed improvements
+- an OpenClaw executor adapter, a future execution boundary that would keep completion truth, verification, and lifecycle enforcement inside Harness
+
+See:
+
+- [`docs/architecture/harness-evolution-engine.md`](docs/architecture/harness-evolution-engine.md)
+- [`docs/architecture/openclaw-executor-adapter.md`](docs/architecture/openclaw-executor-adapter.md)
+
 ## Current Architecture
 
 ### Frontend

--- a/docs/architecture/harness-evolution-engine.md
+++ b/docs/architecture/harness-evolution-engine.md
@@ -1,0 +1,100 @@
+# Harness Evolution Engine
+
+## Purpose
+
+Define the future advisory subsystem that learns from real Harness execution traces, evaluation outcomes, and manual review decisions to diagnose recurring failure modes and later propose improvements.
+
+This document is planning-only. It does not authorize runtime mutation, autonomous code changes, or any change to current end-to-end automation behavior.
+
+## Why It Exists
+
+Harness already records append-only task state, evaluation history, timelines, artifacts, and review outcomes.
+
+If those records remain structured and auditable, they can later support:
+
+- diagnosis of recurring failure patterns
+- operator-visible suggestions about weak contracts or missing evidence
+- evidence-backed proposals for improving Harness policy, adapters, or execution handling
+
+The goal is to turn observed outcomes into better future design inputs without changing the rule that Harness remains the control plane and source of lifecycle truth.
+
+## Responsibilities
+
+The future Harness Evolution Engine (HEE) should own only advisory work such as:
+
+- collecting or referencing canonical execution traces and outcomes
+- producing structured failure diagnoses from repeated task results
+- producing structured evolution candidates or proposals for human review
+- preserving provenance from traces, evaluations, artifacts, and review decisions
+- exposing advisory outputs for inspection without mutating task truth
+
+## Explicit Non-Responsibilities
+
+HEE must not:
+
+- change live task state or lifecycle semantics on its own
+- bypass `TaskEnvelope`, reevaluation, or canonical enforcement paths
+- act as an executor, planner, or ingress surface
+- auto-generate pull requests or merge code changes
+- auto-edit prompts, policies, schemas, or adapter behavior in production
+- treat executor self-report as completion truth
+- replace human review for high-risk control-plane changes
+
+## Inputs
+
+Future HEE inputs should come from canonical Harness records, not ad hoc side channels.
+
+Expected inputs:
+
+- `TaskEnvelope` snapshots and identifiers
+- evaluation history records
+- task timeline entries
+- normalized execution trace facts and attempt outcomes
+- artifact metadata and proof-of-completion evidence references
+- reconciliation results and mismatch records
+- manual review decisions and review notes
+
+## Outputs
+
+HEE outputs should be advisory artifacts that can be inspected and reviewed.
+
+Expected outputs:
+
+- structured failure diagnosis records
+- structured evolution candidate records
+- operator-facing summaries or recommendations
+- references to the evidence used to justify the diagnosis or proposal
+
+These outputs are not lifecycle decisions and do not authorize runtime behavior changes by themselves.
+
+## Relationship To Existing Harness Concepts
+
+### TaskEnvelope
+
+`TaskEnvelope` remains the canonical task contract. HEE may analyze completed or in-flight records derived from it, but it does not redefine task meaning.
+
+### Lifecycle States
+
+Lifecycle state remains policy-enforced by Harness core. HEE may reference outcomes such as `blocked`, `completed`, `failed`, or `in_review`, but it does not assign them.
+
+### Execution Traces
+
+Execution traces are a future evidence source for HEE. They should describe what happened during task attempts without being treated as correctness proof on their own.
+
+### Artifacts And Proof Of Completion
+
+Artifacts, verification summaries, reconciliation summaries, and review decisions remain the basis for trusted completion. HEE may learn from those results, but it cannot replace them.
+
+## Future Implementation Notes
+
+- Keep HEE outputs append-only and auditable, similar to evaluation history.
+- Separate diagnosis from proposal generation so observed failures and recommended changes do not collapse into one opaque step.
+- Prefer explicit contracts for diagnoses and proposals before building any model or scoring logic.
+- Start with operator-reviewed outputs before considering any workflow that could draft code or policy changes.
+- Use canonical inspection surfaces and stored facts where possible rather than introducing a parallel truth store.
+
+## Boundary Summary
+
+HEE is a future advisory subsystem for diagnosis and proposal generation.
+
+It is not a runtime mutation engine.

--- a/docs/architecture/openclaw-executor-adapter.md
+++ b/docs/architecture/openclaw-executor-adapter.md
@@ -1,0 +1,102 @@
+# OpenClaw Executor Adapter
+
+## Purpose
+
+Define the future adapter boundary that would allow Harness to use OpenClaw as an execution engine while keeping lifecycle truth, verification, and completion enforcement inside Harness.
+
+This document is planning-only. It does not add a working OpenClaw execution integration.
+
+## Why It Exists
+
+The repository already contains an ingress-side OpenClaw spike proving that OpenClaw can act as a thin client against Harness's public API.
+
+A future executor adapter is a different concern:
+
+- ingress answers how work enters Harness
+- executor adaptation answers how assigned work could later be executed by OpenClaw
+
+Keeping those concerns separate protects the core design:
+
+- Harness remains the control plane
+- OpenClaw remains replaceable
+- completion remains evidence-backed instead of executor-declared
+
+## Responsibilities
+
+The future OpenClaw executor adapter should own only execution-boundary concerns such as:
+
+- mapping canonical assigned-task data into an OpenClaw execution request
+- translating OpenClaw runtime events into canonical execution facts
+- normalizing produced artifacts, outputs, and trace references
+- returning completion claims to Harness for verification instead of accepting them directly
+- preserving provenance needed for audit and reevaluation
+
+## Explicit Non-Responsibilities
+
+The adapter must not:
+
+- define lifecycle policy or terminal state semantics
+- decide whether work is complete
+- bypass `POST /tasks/<task_id>/reevaluate` or canonical enforcement paths
+- replace Linear, GitHub, or other external fact sources
+- act as the system of record for task truth
+- absorb planning, decomposition, or verification responsibilities
+- couple Harness control-plane rules to OpenClaw-specific runtime internals
+
+## Inputs
+
+Expected adapter inputs:
+
+- canonical `TaskEnvelope` data for a task in an execution-ready state
+- assignment metadata identifying OpenClaw as the selected executor
+- execution attempt context from Harness runtime or dispatch layers
+- constraints, acceptance criteria, artifact expectations, and provenance metadata
+
+## Outputs
+
+Expected adapter outputs:
+
+- normalized execution start, progress, stall, failure, and completion events
+- references to produced outputs and artifacts
+- normalized trace or log references that later diagnostics can inspect
+- explicit completion claims returned for Harness-side validation
+
+The adapter output is execution telemetry and artifact references, not trusted completion.
+
+## Relationship To Existing Harness Concepts
+
+### TaskEnvelope
+
+`TaskEnvelope` remains canonical. The adapter may project a subset into an OpenClaw request, but OpenClaw-specific request shape must not become the source of truth.
+
+### Lifecycle States
+
+Harness remains responsible for `assigned`, `executing`, `in_review`, `completed`, `blocked`, and related transitions. The adapter only reports execution facts that Harness may later evaluate.
+
+### Execution Traces
+
+The adapter is a likely producer of normalized execution-trace references. Those traces should support later audit and diagnostics, including future HEE analysis.
+
+### Artifacts And Proof Of Completion
+
+Artifacts produced through OpenClaw remain subject to Harness verification, reconciliation, and manual review rules. An OpenClaw success report is advisory only.
+
+## Relationship To The Existing OpenClaw Spike
+
+The existing spike in [`modules/connectors/openclaw_harness_spike.py`](../../modules/connectors/openclaw_harness_spike.py) proves an ingress/client boundary using the public Harness API.
+
+This future adapter would be separate and executor-facing. It should not reuse the ingress spike as a runtime implementation shortcut.
+
+## Future Implementation Notes
+
+- Define a stable executor-adapter contract before any OpenClaw API wiring.
+- Intercept completion claims and route them through canonical Harness verification rather than accepting executor status as terminal truth.
+- Keep OpenClaw payload mapping explicit so executor-specific fields stay outside control-plane contracts.
+- Preserve replaceability by keeping the adapter contract generic enough for other executors.
+- Treat execution traces and artifact references as first-class outputs from the adapter boundary.
+
+## Boundary Summary
+
+OpenClaw may become a future execution backend.
+
+Harness still owns truth.

--- a/docs/planning/issues/01-define-hee-architecture-and-boundaries.md
+++ b/docs/planning/issues/01-define-hee-architecture-and-boundaries.md
@@ -1,0 +1,35 @@
+# Title
+
+Define Harness Evolution Engine architecture and boundaries
+
+## Problem Statement
+
+Harness needs a clear planning-stage architecture for future evolution work so failure diagnosis and proposal generation do not drift into hidden runtime mutation or vague "self-improvement" language.
+
+## Scope
+
+- define HEE purpose, responsibilities, and non-responsibilities
+- define how HEE relates to `TaskEnvelope`, evaluation history, timelines, execution traces, artifacts, and review decisions
+- define advisory-only boundaries and review expectations
+
+## Non-Goals
+
+- implementing learning logic
+- implementing model selection or training
+- implementing automated code changes, PR generation, or deployment
+
+## Acceptance Criteria
+
+- architecture doc exists and is reviewed
+- boundary language makes HEE advisory-only
+- doc explicitly states that Harness lifecycle truth remains outside HEE
+
+## Dependencies
+
+- none
+
+## Suggested Labels
+
+- `planning`
+- `architecture`
+- `hee`

--- a/docs/planning/issues/02-define-execution-trace-requirements-for-future-learning.md
+++ b/docs/planning/issues/02-define-execution-trace-requirements-for-future-learning.md
@@ -1,0 +1,36 @@
+# Title
+
+Define execution trace requirements for future HEE analysis
+
+## Problem Statement
+
+HEE can only diagnose recurring failures if Harness preserves the right execution-trace facts, attempt boundaries, and provenance. Those requirements need to be defined before any future learning work starts.
+
+## Scope
+
+- define the minimum execution-trace fields HEE will need
+- distinguish execution facts from correctness or completion truth
+- define how traces relate to attempts, artifacts, evaluations, and timelines
+
+## Non-Goals
+
+- implementing trace storage
+- adding new runtime logging libraries
+- building analytics or model pipelines
+
+## Acceptance Criteria
+
+- a trace-requirements note or contract exists
+- attempt-scoped versus task-scoped expectations are explicit
+- trace requirements preserve the rule that verification still owns trusted completion
+
+## Dependencies
+
+- Define Harness Evolution Engine architecture and boundaries
+
+## Suggested Labels
+
+- `planning`
+- `architecture`
+- `hee`
+- `observability`

--- a/docs/planning/issues/03-define-failure-diagnosis-contract-and-taxonomy.md
+++ b/docs/planning/issues/03-define-failure-diagnosis-contract-and-taxonomy.md
@@ -1,0 +1,36 @@
+# Title
+
+Define failure diagnosis contract and taxonomy
+
+## Problem Statement
+
+Future HEE outputs need a stable, reviewable diagnosis shape so recurring failures can be described consistently and tied back to real evidence.
+
+## Scope
+
+- define a diagnosis contract
+- define the initial taxonomy shape for recurring failure modes
+- define provenance and confidence expectations
+
+## Non-Goals
+
+- implementing diagnosis generation
+- backfilling historical diagnoses
+- choosing a final machine-learning approach
+
+## Acceptance Criteria
+
+- failure diagnosis contract exists
+- diagnosis records distinguish observed facts from inferred causes
+- taxonomy design is explicit enough for future implementation work
+
+## Dependencies
+
+- Define Harness Evolution Engine architecture and boundaries
+- Define execution trace requirements for future HEE analysis
+
+## Suggested Labels
+
+- `planning`
+- `contracts`
+- `hee`

--- a/docs/planning/issues/04-define-evolution-candidate-proposal-contract.md
+++ b/docs/planning/issues/04-define-evolution-candidate-proposal-contract.md
@@ -1,0 +1,35 @@
+# Title
+
+Define evolution candidate and proposal contract
+
+## Problem Statement
+
+If HEE eventually proposes improvements, those proposals need a reviewable contract that preserves rationale, provenance, risk, and review status without implying autonomous execution.
+
+## Scope
+
+- define an evolution candidate contract
+- define proposal types and target surfaces at a planning level
+- define how proposals remain advisory until accepted through normal workflows
+
+## Non-Goals
+
+- implementing proposal ranking
+- generating GitHub pull requests
+- auto-applying accepted proposals
+
+## Acceptance Criteria
+
+- evolution candidate contract exists
+- contract links proposals back to diagnoses or evidence
+- contract explicitly forbids direct runtime mutation authority
+
+## Dependencies
+
+- Define failure diagnosis contract and taxonomy
+
+## Suggested Labels
+
+- `planning`
+- `contracts`
+- `hee`

--- a/docs/planning/issues/05-define-executor-adapter-contract.md
+++ b/docs/planning/issues/05-define-executor-adapter-contract.md
@@ -1,0 +1,36 @@
+# Title
+
+Define canonical ExecutorAdapter contract
+
+## Problem Statement
+
+Harness needs a generic executor-adapter contract before any specific OpenClaw execution work starts, otherwise executor behavior will leak into control-plane semantics.
+
+## Scope
+
+- define the generic executor-adapter boundary
+- define canonical inputs and outputs at the adapter layer
+- define how completion claims return to Harness verification
+
+## Non-Goals
+
+- implementing OpenClaw execution
+- adding dispatch wiring
+- choosing the final runtime transport
+
+## Acceptance Criteria
+
+- executor-adapter contract exists
+- contract keeps completion claims advisory-only
+- contract is framed as replaceable, not OpenClaw-exclusive
+
+## Dependencies
+
+- none
+
+## Suggested Labels
+
+- `planning`
+- `contracts`
+- `executors`
+- `openclaw`

--- a/docs/planning/issues/06-define-task-envelope-to-openclaw-mapping-spec.md
+++ b/docs/planning/issues/06-define-task-envelope-to-openclaw-mapping-spec.md
@@ -1,0 +1,35 @@
+# Title
+
+Define TaskEnvelope to OpenClaw mapping specification
+
+## Problem Statement
+
+The future OpenClaw adapter needs a clear projection from canonical `TaskEnvelope` data into executor payloads without turning OpenClaw request shape into Harness truth.
+
+## Scope
+
+- define which `TaskEnvelope` fields are projected into OpenClaw requests
+- define which fields remain Harness-only
+- define provenance expectations for outputs, traces, and artifacts
+
+## Non-Goals
+
+- implementing payload builders
+- implementing OpenClaw request validation
+- expanding `TaskEnvelope` just to match executor ergonomics
+
+## Acceptance Criteria
+
+- mapping spec exists
+- spec is explicit about fields that must not be treated as executor-owned truth
+- provenance and artifact expectations are documented
+
+## Dependencies
+
+- Define canonical ExecutorAdapter contract
+
+## Suggested Labels
+
+- `planning`
+- `contracts`
+- `openclaw`

--- a/docs/planning/issues/07-define-completion-interception-and-artifact-validation-boundary.md
+++ b/docs/planning/issues/07-define-completion-interception-and-artifact-validation-boundary.md
@@ -1,0 +1,36 @@
+# Title
+
+Define completion interception and artifact validation boundary
+
+## Problem Statement
+
+A future executor adapter must not let OpenClaw completion claims bypass Harness verification, reconciliation, or manual review rules. That interception boundary needs to be specified before implementation begins.
+
+## Scope
+
+- define how executor completion claims re-enter Harness
+- define where artifact references are attached versus validated
+- define which parts of completion handling remain core Harness responsibilities
+
+## Non-Goals
+
+- implementing completion hooks
+- implementing artifact verification logic changes
+- changing lifecycle semantics
+
+## Acceptance Criteria
+
+- boundary doc or contract exists
+- completion interception is explicit
+- artifact validation responsibility remains in Harness, not in the executor adapter
+
+## Dependencies
+
+- Define canonical ExecutorAdapter contract
+- Define TaskEnvelope to OpenClaw mapping specification
+
+## Suggested Labels
+
+- `planning`
+- `verification`
+- `openclaw`

--- a/docs/planning/issues/08-define-openclaw-adapter-architecture-and-non-goals.md
+++ b/docs/planning/issues/08-define-openclaw-adapter-architecture-and-non-goals.md
@@ -1,0 +1,36 @@
+# Title
+
+Define OpenClaw executor adapter architecture and non-goals
+
+## Problem Statement
+
+The repository already has an ingress-side OpenClaw spike. A future executor adapter needs a separate architecture definition so ingress, execution, validation, and control-plane truth do not get conflated.
+
+## Scope
+
+- define the purpose and boundary of the future OpenClaw executor adapter
+- distinguish it from the current ingress/client spike
+- document explicit non-goals and replaceability constraints
+
+## Non-Goals
+
+- implementing API wiring
+- implementing a working OpenClaw runtime integration
+- making OpenClaw the source of lifecycle truth
+
+## Acceptance Criteria
+
+- architecture doc exists
+- ingress/client spike and executor adapter roles are clearly separated
+- doc states that Harness remains the control plane and lifecycle authority
+
+## Dependencies
+
+- Define canonical ExecutorAdapter contract
+- Define TaskEnvelope to OpenClaw mapping specification
+
+## Suggested Labels
+
+- `planning`
+- `architecture`
+- `openclaw`

--- a/modules/adapters/openclaw/README.md
+++ b/modules/adapters/openclaw/README.md
@@ -1,0 +1,18 @@
+# OpenClaw Executor Adapter Scaffold
+
+This directory reserves a future home for an execution adapter that lets Harness use OpenClaw as a worker backend.
+
+Its intended boundary is executor-facing only:
+
+- map assigned Harness work into an OpenClaw execution request
+- normalize OpenClaw execution events back into Harness execution facts
+- preserve artifact and trace references for later verification
+
+This directory is distinct from the current ingress/client spike in `modules/connectors/openclaw_harness_spike.py`.
+
+It does not currently implement:
+
+- API wiring
+- runtime dispatch
+- execution logic
+- completion acceptance

--- a/modules/adapters/openclaw/contracts/README.md
+++ b/modules/adapters/openclaw/contracts/README.md
@@ -1,0 +1,11 @@
+# OpenClaw Adapter Contracts Scaffold
+
+This directory holds planning-stage contracts for the future OpenClaw executor adapter.
+
+The contract work here should define:
+
+- the generic executor-adapter interface Harness expects
+- the allowed projection from `TaskEnvelope` into OpenClaw request payloads
+- the normalized event and artifact outputs that return to Harness
+
+These files are intentionally documentation-only until a later implementation phase.

--- a/modules/adapters/openclaw/contracts/executor-adapter.contract.md
+++ b/modules/adapters/openclaw/contracts/executor-adapter.contract.md
@@ -1,0 +1,33 @@
+# Executor Adapter Contract
+
+Planning scaffold only. This contract is not executable code.
+
+## Purpose
+
+Define the intended boundary between Harness execution coordination and a replaceable executor adapter such as OpenClaw.
+
+## Sketch
+
+```text
+ExecutorAdapter
+  prepare_execution(task_envelope, assignment_context) -> executor_request
+  start_execution(executor_request) -> execution_start_fact
+  poll_or_receive_events(execution_handle) -> ExecutionEvent[]
+  collect_outputs(execution_handle) -> OutputRef[]
+  collect_artifacts(execution_handle) -> ArtifactRef[]
+  claim_completion(execution_handle) -> CompletionClaim
+```
+
+## Required Semantics
+
+- Input task data must come from canonical Harness state, not executor-owned truth.
+- `claim_completion` is advisory and must return to Harness verification paths.
+- Event outputs must be normalized into canonical execution facts.
+- The contract must support replaceable executors, not only OpenClaw.
+- Adapter-specific transport or auth details must stay outside the canonical contract.
+
+## Open Questions
+
+- whether the adapter boundary is synchronous, event-driven, or both
+- how attempt and retry identifiers are assigned and preserved
+- which event families are required at minimum for later diagnostics

--- a/modules/adapters/openclaw/contracts/task-envelope-mapping.contract.md
+++ b/modules/adapters/openclaw/contracts/task-envelope-mapping.contract.md
@@ -1,0 +1,42 @@
+# TaskEnvelope To OpenClaw Mapping Contract
+
+Planning scaffold only. This contract is not executable code.
+
+## Purpose
+
+Describe the future projection from canonical `TaskEnvelope` fields into an OpenClaw execution request without making OpenClaw payload shape canonical inside Harness.
+
+## Mapping Principles
+
+- `TaskEnvelope` remains the source of truth.
+- Only execution-relevant fields should be projected.
+- OpenClaw-specific request fields must stay adapter-local.
+- Provenance needed for audit, artifacts, and reevaluation must be preserved.
+
+## Initial Field Sketch
+
+```text
+TaskEnvelope.id -> openclaw_request.task_id
+TaskEnvelope.objective -> openclaw_request.objective
+TaskEnvelope.constraints -> openclaw_request.constraints
+TaskEnvelope.acceptance_criteria -> openclaw_request.acceptance_criteria
+TaskEnvelope.artifacts -> openclaw_request.expected_artifacts
+TaskEnvelope.origin -> openclaw_request.provenance.origin
+TaskEnvelope.extensions -> openclaw_request.provenance.extensions_subset
+AssignmentContext.executor -> openclaw_request.executor_target
+AttemptContext.attempt_id -> openclaw_request.attempt_id
+```
+
+## Must Not Be Mapped As Truth
+
+- lifecycle authority
+- verification outcomes
+- reconciliation decisions
+- manual review resolution
+- terminal completion acceptance
+
+## Open Questions
+
+- whether OpenClaw needs a richer intermediate task spec than the current `TaskEnvelope` projection
+- which extensions are safe to pass through versus retain inside Harness only
+- how artifact expectations should be represented for executor ergonomics without weakening verification rules

--- a/modules/evolution/README.md
+++ b/modules/evolution/README.md
@@ -1,0 +1,21 @@
+# Evolution Module Scaffold
+
+This directory reserves a future home for the Harness Evolution Engine (HEE).
+
+The intended role is advisory only:
+
+- analyze execution traces and task outcomes
+- produce structured failure diagnoses
+- produce structured evolution candidates for human review
+
+This module does not currently implement:
+
+- learning logic
+- runtime mutation
+- automatic policy changes
+- pull request generation
+
+Current subdirectories:
+
+- `contracts/` for planning-stage diagnosis and proposal contracts
+- `diagnostics/` for future diagnosis logic and taxonomy material

--- a/modules/evolution/contracts/README.md
+++ b/modules/evolution/contracts/README.md
@@ -1,0 +1,11 @@
+# Evolution Contracts Scaffold
+
+This directory holds planning-stage contracts for future HEE outputs.
+
+These contracts should describe:
+
+- what a failure diagnosis must contain
+- what an evolution candidate or proposal must contain
+- how provenance back to task, trace, artifact, and review records is preserved
+
+These files are intentionally non-executable and non-authoritative for runtime behavior until implemented through normal Harness review.

--- a/modules/evolution/contracts/evolution-candidate.contract.md
+++ b/modules/evolution/contracts/evolution-candidate.contract.md
@@ -1,0 +1,39 @@
+# Evolution Candidate Contract
+
+Planning scaffold only. This contract is not executable code.
+
+## Purpose
+
+Describe the minimum shape of a future HEE proposal record for a possible Harness improvement derived from diagnoses and evidence.
+
+## Sketch
+
+```text
+EvolutionCandidate
+  candidate_id: string
+  source_diagnosis_ids: string[]
+  title: string
+  proposal_type: contract_change | policy_change | adapter_change | observability_change | documentation_change
+  target_surface: string
+  rationale: string
+  expected_benefit: string
+  risks: string[]
+  required_reviewers: string[]
+  supporting_evidence_refs: EvidenceRef[]
+  status: draft | under_review | accepted | rejected | parked
+  created_at: timestamp
+```
+
+## Required Semantics
+
+- Must link back to one or more diagnoses or equivalent evidence sources.
+- Must state the target surface explicitly instead of implying a hidden mutation path.
+- Must preserve review status separately from implementation status.
+- Must remain advisory until accepted through normal planning and delivery channels.
+- Must not authorize autonomous code changes, PR generation, or deployment.
+
+## Open Questions
+
+- whether candidate status belongs inside Harness storage or only in planning systems
+- whether proposal types should be broader or narrower
+- how candidate-to-GitHub-issue linkage should be represented

--- a/modules/evolution/contracts/failure-diagnosis.contract.md
+++ b/modules/evolution/contracts/failure-diagnosis.contract.md
@@ -1,0 +1,40 @@
+# Failure Diagnosis Contract
+
+Planning scaffold only. This contract is not executable code.
+
+## Purpose
+
+Describe the minimum shape of a future HEE diagnosis record for recurring failures or degraded outcomes.
+
+## Sketch
+
+```text
+FailureDiagnosis
+  diagnosis_id: string
+  task_ids: string[]
+  attempt_ids: string[]
+  observed_outcome: string
+  diagnosis_taxonomy_key: string
+  summary: string
+  evidence_refs: EvidenceRef[]
+  trace_refs: TraceRef[]
+  contributing_factors: string[]
+  unresolved_questions: string[]
+  confidence: low | medium | high
+  created_at: timestamp
+  created_from: diagnosis_run_id | review_id
+```
+
+## Required Semantics
+
+- Must reference canonical task or attempt identifiers.
+- Must preserve which evidence and traces support the diagnosis.
+- Must distinguish observed facts from inferred causes.
+- Must remain advisory and reviewable.
+- Must not mutate lifecycle state or task truth directly.
+
+## Open Questions
+
+- whether diagnoses are task-scoped, attempt-scoped, or cluster-scoped by default
+- how much taxonomy should be enum-driven versus free-form
+- whether confidence is qualitative, numeric, or both

--- a/modules/evolution/diagnostics/README.md
+++ b/modules/evolution/diagnostics/README.md
@@ -1,0 +1,11 @@
+# Evolution Diagnostics Scaffold
+
+This directory is reserved for future failure-diagnosis logic, taxonomies, and supporting notes.
+
+Future work here should focus on:
+
+- recurring failure pattern identification
+- taxonomy definitions grounded in canonical outcomes
+- diagnosis generation backed by trace and evaluation evidence
+
+It should not become a hidden policy engine or a place where lifecycle truth is reassigned outside Harness core.


### PR DESCRIPTION
## What changed

- added architecture docs for the future Harness Evolution Engine (HEE) and OpenClaw executor adapter
- added lightweight module scaffolds under `modules/evolution/` and `modules/adapters/openclaw/`
- added planning-only contract sketches for failure diagnosis, evolution candidates, executor adaptation, and `TaskEnvelope` mapping
- added issue-ready markdown artifacts under `docs/planning/issues/`
- added a brief top-level README pointer to these planned capabilities

## Why

This keeps two future capabilities visible and reviewable in the repository without diluting the current end-to-end automation effort or blurring control-plane boundaries.

The PR makes the intended architecture concrete while preserving the core rules that Harness owns lifecycle truth, verification, reconciliation, and proof-of-completion.

## Intentionally not implemented

- no HEE learning or mutation logic
- no autonomous proposal execution or PR generation
- no OpenClaw API wiring or runtime execution integration
- no lifecycle, verification, or reconciliation behavior changes
- no new dependencies or fake tests for unimplemented behavior

## Validation

- `git diff --check`
- verified the new scaffold file set and README pointers

