### PR TITLE
[codex] Document verified Codex Cloud execution chain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,29 @@ Do not casually turn this repo into:
 11. `requires_review=true` must move the task into the explicit `in_review` lifecycle state; it must not remain `completed`.
 12. An active manual review gate is sticky until an explicit review decision resolves it; automatic reevaluation must not clear it.
 
+## Codex Cloud Execution Requirements
+
+Codex Cloud tasks for Harness must run in the Harness environment and that environment must execute the repo-owned bootstrap script:
+
+- `bash /workspace/Harness/scripts/codex-cloud-setup.sh`
+
+Every real Codex Cloud task must begin by returning raw preflight output for:
+
+- `pwd`
+- `git remote -v`
+- `cat .codex-bootstrap-proof`
+
+If preflight shows the wrong repo path, missing or incorrect `origin`, missing bootstrap proof, or incomplete fetch/auth/bootstrap state, the task must report `BLOCKED` and stop.
+
+Final task completion must return concrete external artifact identifiers:
+
+- `Repository`
+- `Branch`
+- `Commit SHA`
+- `PR URL`
+
+Executor summaries are advisory only. External artifacts remain the proof of completion.
+
 ## Rules For Modifying TaskEnvelope And Schema
 
 When changing `TaskEnvelope` or `schemas/task_envelope.schema.json`:
@@ -211,6 +234,7 @@ Rules:
 
 - [README.md](README.md)
 - [docs/setup/local-development.md](docs/setup/local-development.md)
+- [docs/architecture/codex-cloud-execution.md](docs/architecture/codex-cloud-execution.md)
 - [docs/architecture/system-context.md](docs/architecture/system-context.md)
 - [docs/architecture/task-envelope.md](docs/architecture/task-envelope.md)
 - [docs/architecture/module-boundaries.md](docs/architecture/module-boundaries.md)

--- a/docs/architecture/codex-cloud-execution.md
+++ b/docs/architecture/codex-cloud-execution.md
@@ -1,0 +1,109 @@
+# Codex Cloud Execution
+
+## Purpose
+
+Document the verified Codex Cloud execution path for Harness.
+
+Harness treats executor summaries as advisory. Real completion depends on externally verifiable artifacts and explicit control-plane evaluation. The Codex Cloud execution contract exists so delegated execution starts from a known repository state and produces inspectable proof about both environment readiness and completion artifacts.
+
+## Verified Execution Chain
+
+The verified Harness Codex Cloud environment starts with the repo-owned bootstrap command:
+
+```bash
+bash /workspace/Harness/scripts/codex-cloud-setup.sh
+```
+
+That script is responsible for:
+
+- validating that the repository root is `/workspace/Harness`
+- ensuring `origin` exists and points to `https://github.com/sfayka/Harness.git`
+- setting local git identity for Codex
+- configuring non-interactive GitHub authentication from `GH_AUTH`
+- verifying that `git fetch origin` succeeds
+- installing likely-needed Python dependencies from `requirements.txt` and `requirements-dev.txt` when present
+- installing likely-needed Node dependencies from the detected lockfile or `package.json`
+- writing `.codex-bootstrap-proof`
+
+The proof file is environment evidence, not task-completion evidence. It proves that bootstrap ran successfully in the expected repository context. It does not prove that a task produced an external commit or pull request.
+
+## Why The Bootstrap Script Exists
+
+The bootstrap script exists because interactive terminal success was not enough to prove delegated execution correctness.
+
+Before this flow was verified, a human could be in a healthy local shell while a fresh Codex Cloud task sandbox still lacked the git remote, authentication, or fetch state needed to produce real external artifacts. That mismatch allowed task summaries to sound complete even when the repository context was not fully initialized for delegated execution.
+
+Harness cannot accept that kind of ambiguity. Delegated task execution needs explicit proof of execution context before any completion claim is trusted.
+
+## Task Preflight Contract
+
+Every real Codex Cloud task for Harness must begin by returning raw output for:
+
+```bash
+pwd
+git remote -v
+cat .codex-bootstrap-proof
+```
+
+This preflight is required because it proves:
+
+- the task is running in the expected repository root
+- the repository remote matches the canonical GitHub repository
+- repo-owned bootstrap completed and recorded the expected proof
+
+A task must stop and report `BLOCKED` if any of the following are true:
+
+- the repo path is wrong
+- `origin` is missing
+- `origin` points anywhere other than `https://github.com/sfayka/Harness.git`
+- `.codex-bootstrap-proof` is missing
+- fetch, authentication, or bootstrap completion has not succeeded
+
+The preflight contract is intentionally strict. It prevents delegated work from proceeding on a sandbox that only looks plausible but is not actually connected to the external repository state Harness relies on.
+
+## Completion Artifact Contract
+
+A Codex Cloud task is not complete unless it returns concrete external artifact identifiers:
+
+- `Repository`
+- `Branch`
+- `Commit SHA`
+- `PR URL`
+
+These identifiers are the minimum operator-facing proof that the claimed work exists outside the executor summary. If those identifiers do not exist, the task is not complete regardless of how confident the executor summary sounds.
+
+This is consistent with Harness architecture:
+
+- executor summaries are advisory
+- external artifacts are completion evidence
+- control-plane truth depends on evidence and reconciliation, not on claims alone
+
+## Relationship To Harness Control-Plane Truth
+
+This execution contract reinforces the core Harness distinction between execution claims and canonical truth.
+
+Bootstrap proof answers the question, "did this delegated task start in the expected execution context?"
+
+Completion artifacts answer the question, "what externally verifiable repository evidence exists for the claimed work?"
+
+Harness still owns the final control-plane judgment. Even with a correct bootstrap and concrete repository artifacts, lifecycle acceptance remains evidence-backed and policy-enforced rather than inferred from executor confidence.
+
+## Known Failure Mode
+
+The previously observed failure mode was:
+
+- fresh Codex Cloud task sandboxes contained repository contents but no `origin`
+- task summaries overstated completion when external artifacts did not actually exist
+- interactive terminal success did not prove delegated task sandboxes were correctly bootstrapped
+
+The fix was to make repository bootstrap repo-owned and explicit, then require task-level preflight output before work continues:
+
+- `scripts/codex-cloud-setup.sh` establishes the repository, auth, and fetch prerequisites
+- `.codex-bootstrap-proof` records that bootstrap completed in the expected environment
+- raw preflight output proves the delegated task is running in that verified context
+- completion remains tied to repository and GitHub artifacts rather than executor narrative
+
+## Related Documents
+
+- [runtime-execution-contract.md](runtime-execution-contract.md)
+- [artifact-and-completion-evidence.md](artifact-and-completion-evidence.md)


### PR DESCRIPTION
## What changed
- added Codex Cloud execution requirements to `AGENTS.md`
- added `docs/architecture/codex-cloud-execution.md` documenting the verified bootstrap, preflight, blocking, and completion-artifact contracts
- linked the new architecture doc from the `AGENTS.md` starting points list

## Why it changed
We validated the real Codex Cloud execution chain for Harness after fixing environment bootstrap and preflight. The repository docs now need to state that operating model explicitly so delegated execution is reproducible and grounded in external evidence.

## Impact
- future agents have an explicit Codex Cloud preflight contract
- documentation now describes the repo-owned bootstrap path and the conditions that require a task to stop as `BLOCKED`
- completion reporting remains tied to repository artifacts instead of executor summaries

## Validation
- docs-only validation: verified file paths, commands, and cross-references
