### PR TITLE
Tighten Codex Cloud execution contract (preflight + completion semantics)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ Every real Codex Cloud task must begin by returning raw preflight output for:
 - `git remote -v`
 - `cat .codex-bootstrap-proof`
 
+No repository changes or execution steps may occur before preflight output is returned. Preflight output must be generated in the same execution session as the task; cached or prior-session preflight output is invalid.
+
 If preflight shows the wrong repo path, missing or incorrect `origin`, missing bootstrap proof, or incomplete fetch/auth/bootstrap state, the task must report `BLOCKED` and stop.
 
 Final task completion must return concrete external artifact identifiers:
@@ -81,6 +83,7 @@ Final task completion must return concrete external artifact identifiers:
 - `PR URL`
 
 Executor summaries are advisory only. External artifacts remain the proof of completion.
+If `Repository`, `Branch`, `Commit SHA`, and `PR URL` are not all present, the task is considered invalid and not executed (not partial and not completed with issues).
 
 ## Rules For Modifying TaskEnvelope And Schema
 

--- a/docs/architecture/codex-cloud-execution.md
+++ b/docs/architecture/codex-cloud-execution.md
@@ -45,11 +45,15 @@ git remote -v
 cat .codex-bootstrap-proof
 ```
 
+No repository changes or execution steps may occur before preflight output is returned. Preflight output must be generated within the same execution session as the task.
+
 This preflight is required because it proves:
 
 - the task is running in the expected repository root
 - the repository remote matches the canonical GitHub repository
 - repo-owned bootstrap completed and recorded the expected proof
+
+Preflight output from a previous session, cached output, or copied output is invalid. Each task run must independently prove its execution context before any repository-modifying action, including branch creation, file writes, commits, and pushes.
 
 A task must stop and report `BLOCKED` if any of the following are true:
 
@@ -61,6 +65,8 @@ A task must stop and report `BLOCKED` if any of the following are true:
 
 The preflight contract is intentionally strict. It prevents delegated work from proceeding on a sandbox that only looks plausible but is not actually connected to the external repository state Harness relies on.
 
+Successful preflight validation is a prerequisite for any lifecycle transition from `assigned` to `in_progress`.
+
 ## Completion Artifact Contract
 
 A Codex Cloud task is not complete unless it returns concrete external artifact identifiers:
@@ -71,6 +77,8 @@ A Codex Cloud task is not complete unless it returns concrete external artifact 
 - `PR URL`
 
 These identifiers are the minimum operator-facing proof that the claimed work exists outside the executor summary. If those identifiers do not exist, the task is not complete regardless of how confident the executor summary sounds.
+
+If `Repository`, `Branch`, `Commit SHA`, and `PR URL` are not all present, the task is considered invalid and not executed (not partial and not completed with issues).
 
 This is consistent with Harness architecture:
 


### PR DESCRIPTION
## Summary
- clarify that no repository-modifying action or execution step may occur before preflight output is returned
- require preflight output to be generated in the same execution session and explicitly reject prior-session/cached output
- add explicit lifecycle prerequisite language that successful preflight is required before `assigned -> in_progress`
- strengthen completion semantics so missing any of `Repository`, `Branch`, `Commit SHA`, or `PR URL` is invalid/not executed (not partial)
- mirror the strengthened completion semantics and preflight strictness in `AGENTS.md`

## Validation
- verified documentation updates in:
  - `docs/architecture/codex-cloud-execution.md`
  - `AGENTS.md`
- reviewed git diff for only the requested docs changes