### PR TITLE
[codex] Add optional gh CLI support to Codex Cloud bootstrap

### DIFF
--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -19,6 +19,14 @@ have_command() {
   command -v "$1" >/dev/null 2>&1
 }
 
+run_install_command() {
+  if "$@" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  return 1
+}
+
 resolve_python() {
   if have_command python3; then
     printf '%s\n' "python3"
@@ -94,6 +102,48 @@ install_node_dependencies() {
   fi
 }
 
+install_gh_cli() {
+  if have_command gh; then
+    return 0
+  fi
+
+  if have_command apt-get; then
+    if run_install_command apt-get update; then
+      if run_install_command apt-get install -y gh; then
+        return 0
+      fi
+    fi
+  fi
+
+  if have_command apk; then
+    if run_install_command apk add --no-cache gh; then
+      return 0
+    fi
+  fi
+
+  if have_command brew; then
+    if run_install_command brew install gh; then
+      return 0
+    fi
+  fi
+
+  log "gh install skipped or failed"
+  return 1
+}
+
+authenticate_gh_cli() {
+  if ! have_command gh; then
+    return 1
+  fi
+
+  if gh auth login --with-token >/dev/null 2>&1 <<<"${GH_AUTH}"; then
+    return 0
+  fi
+
+  log "gh authentication failed; continuing"
+  return 1
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
@@ -164,6 +214,8 @@ fi
 node_available=false
 pnpm_available=false
 npm_available=false
+gh_available=false
+gh_authenticated=false
 
 if have_command node; then
   node_available=true
@@ -175,6 +227,13 @@ fi
 
 if have_command npm; then
   npm_available=true
+fi
+
+if have_command gh || install_gh_cli; then
+  gh_available=true
+  if authenticate_gh_cli; then
+    gh_authenticated=true
+  fi
 fi
 
 install_python_dependencies "${python_bin}"
@@ -189,6 +248,8 @@ python_available=${python_available}
 node_available=${node_available}
 pnpm_available=${pnpm_available}
 npm_available=${npm_available}
+gh_available=${gh_available}
+gh_authenticated=${gh_authenticated}
 fetched_origin=true
 bootstrap_complete=true
 EOF


### PR DESCRIPTION
## What changed
- added optional `gh` CLI detection to `scripts/codex-cloud-setup.sh`
- added best-effort `gh` installation using `apt-get`, `apk`, or `brew` when available
- added non-interactive `gh auth login --with-token` using `GH_AUTH` when `gh` is present
- recorded `gh_available` and `gh_authenticated` in `.codex-bootstrap-proof`

## Why it changed
Harness now needs `gh` to be a first-class but optional PR creation path in Codex Cloud. The bootstrap script should provision and authenticate it when possible without weakening the existing git plus GitHub API auth flow or turning `gh` into a bootstrap requirement.

## Impact
- bootstrap still blocks on the canonical repo, origin, and git/API auth checks
- bootstrap still succeeds if `gh` is absent or `gh` auth fails
- environments that can support `gh` now advertise that capability in the bootstrap proof for downstream tasks

## Validation
- `bash -n scripts/codex-cloud-setup.sh`
- full end-to-end script execution was not run from this checkout because the script correctly enforces `/workspace/Harness` as the repo root
