### PR TITLE
Define completion interception and artifact validation boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See:
 
 - [`docs/architecture/harness-evolution-engine.md`](docs/architecture/harness-evolution-engine.md)
 - [`docs/architecture/openclaw-executor-adapter.md`](docs/architecture/openclaw-executor-adapter.md)
+- [`docs/architecture/completion-interception-and-artifact-validation-boundary.md`](docs/architecture/completion-interception-and-artifact-validation-boundary.md)
 
 ## Current Architecture
 

--- a/docs/architecture/completion-interception-and-artifact-validation-boundary.md
+++ b/docs/architecture/completion-interception-and-artifact-validation-boundary.md
@@ -1,0 +1,122 @@
+# Completion Interception And Artifact Validation Boundary
+
+## Purpose
+
+Define the control-plane boundary for executor-reported completion.
+
+This contract ensures that future executor adapters (including OpenClaw) cannot directly mark tasks complete, bypass canonical reevaluation, or relocate artifact-validation responsibility outside Harness.
+
+## Problem This Boundary Solves
+
+Executor runtimes can report "done" based on local process signals (exit codes, tool completion, emitted outputs). Those signals are useful execution facts, but they are not proof that policy-required completion conditions are satisfied.
+
+Without an explicit boundary:
+
+- executor status could be mistaken for lifecycle truth
+- artifact references could be treated as validated evidence
+- verification/reconciliation/manual-review gates could be unintentionally bypassed
+
+Harness must intercept completion claims and re-evaluate canonical task truth before any terminal lifecycle outcome is accepted.
+
+## Core Boundary Rule
+
+**Completion claims from an executor are advisory execution facts, not authoritative lifecycle decisions.**
+
+Harness remains the sole authority for:
+
+- lifecycle transitions
+- policy enforcement
+- evidence sufficiency decisions
+- reconciliation decisions
+- manual review gate enforcement
+
+## Responsibility Split
+
+### Executor Adapter Responsibilities
+
+The adapter may:
+
+- report execution state changes (started, progressed, failed, claimed-complete)
+- attach normalized artifact references (URIs, IDs, provenance pointers)
+- attach execution traces/log pointers
+- preserve provenance about how outputs were produced
+
+The adapter must not:
+
+- mark the task as canonically `completed`
+- clear a required review gate
+- decide evidence sufficiency
+- resolve reconciliation mismatches
+- bypass canonical submission/reevaluation APIs
+
+### Harness Responsibilities
+
+Harness must:
+
+- intercept every executor completion claim
+- persist claim + references as advisory facts
+- run canonical reevaluation (`POST /tasks/<task_id>/reevaluate` semantics)
+- enforce verification, reconciliation, lifecycle, and manual-review policies
+- keep evaluation history append-only and auditable
+- publish resulting canonical truth through read-model/timeline surfaces
+
+## Artifact Boundary
+
+Artifacts split across two phases:
+
+1. **Attachment phase (adapter-side):**
+   - Adapter submits references to produced artifacts and related provenance.
+   - These references are untrusted inputs.
+
+2. **Validation phase (Harness-side):**
+   - Harness evaluates artifact relevance/completeness under canonical policy.
+   - Harness combines artifact facts with verification/reconciliation/manual review state.
+   - Only then can lifecycle advance to canonical completion.
+
+Therefore:
+
+- adapter **attaches** artifact references
+- Harness **validates** artifact sufficiency and completion eligibility
+
+## Completion Interception Flow
+
+1. Task is in an execution-capable lifecycle state (for example `assigned`/`executing`).
+2. Executor adapter emits a completion claim with artifact + trace references.
+3. Harness records the claim as advisory execution input.
+4. Harness triggers canonical reevaluation.
+5. Reevaluation computes verification/reconciliation/evidence/manual-review outcomes.
+6. Harness enforces lifecycle transition rules from reevaluation output.
+7. Read-model and timeline expose the canonical result and audit trail.
+
+At no point does adapter-reported "success" directly become canonical `completed` state.
+
+## Policy Invariants Preserved
+
+This boundary preserves existing Harness invariants:
+
+- agent/executor success is advisory only
+- completion remains evidence-backed when policy requires evidence
+- reconciliation mismatches are not silently ignored
+- manual review is explicit and auditable
+- `requires_review=true` moves canonical state to `in_review`
+- active review gates remain sticky until explicit review resolution
+
+## API Surface Expectations
+
+Executor-facing integrations should continue to rely on canonical Harness paths:
+
+- submission: `POST /tasks`
+- reevaluation trigger: `POST /tasks/<task_id>/reevaluate`
+- inspection: `GET /tasks`, `GET /tasks/<task_id>/read-model`, `GET /tasks/<task_id>/timeline`
+
+No adapter-private shortcut may bypass canonical validation, persistence, or evaluation-history behavior.
+
+## Relationship To Existing Planning Docs
+
+This boundary document complements:
+
+- `openclaw-executor-adapter.md` (future executor adapter scope)
+- `task-envelope-openclaw-mapping.md` (canonical envelope mapping boundary)
+- `codex-cloud-execution.md` (execution artifact and completion-proof requirements)
+
+Together, these documents keep execution plumbing replaceable while preserving Harness as the control-plane authority.

--- a/docs/architecture/openclaw-executor-adapter.md
+++ b/docs/architecture/openclaw-executor-adapter.md
@@ -100,3 +100,10 @@ This future adapter would be separate and executor-facing. It should not reuse t
 OpenClaw may become a future execution backend.
 
 Harness still owns truth.
+
+## Related References
+
+- [`completion-interception-and-artifact-validation-boundary.md`](./completion-interception-and-artifact-validation-boundary.md)
+- [`task-envelope-openclaw-mapping.md`](./task-envelope-openclaw-mapping.md)
+- [`codex-cloud-execution.md`](./codex-cloud-execution.md)
+


### PR DESCRIPTION
## Summary\n- add architecture boundary doc defining completion interception and artifact-validation ownership\n- clarify that executor completion claims are advisory and must re-enter canonical reevaluation\n- link the new boundary doc from README planned capabilities and executor adapter references\n\n## Validation\n- python check confirming updated/new docs files exist