### PR TITLE
Define execution trace requirements for future HEE analysis

### DIFF
--- a/docs/architecture/harness-evolution-engine.md
+++ b/docs/architecture/harness-evolution-engine.md
@@ -110,6 +110,8 @@ Timeline remains canonical audit surface for task progression. HEE may reference
 
 Execution traces are descriptive evidence of what happened during attempts. HEE may use them for diagnosis but they never become authoritative completion proof by themselves.
 
+Trace minimum-field expectations for future HEE inputs are defined in `modules/evolution/contracts/execution-trace-requirements.contract.md`.
+
 ### Artifacts And Completion Evidence
 
 Artifacts and verification/reconciliation outcomes remain completion authority under policy. HEE can propose improvements to artifact requirements, but cannot grant completion.

--- a/modules/evolution/contracts/README.md
+++ b/modules/evolution/contracts/README.md
@@ -6,6 +6,7 @@ These contracts should describe:
 
 - what a failure diagnosis must contain
 - what an evolution candidate or proposal must contain
+- what execution trace records must contain for future diagnosis inputs
 - how provenance back to task, trace, artifact, and review records is preserved
 
 These files are intentionally non-executable and non-authoritative for runtime behavior until implemented through normal Harness review.

--- a/modules/evolution/contracts/execution-trace-requirements.contract.md
+++ b/modules/evolution/contracts/execution-trace-requirements.contract.md
@@ -1,0 +1,93 @@
+# Execution Trace Requirements Contract
+
+Planning scaffold only. This contract is not executable code.
+
+## Purpose
+
+Define the minimum execution-trace facts that future HEE analysis needs while preserving Harness completion and lifecycle authority boundaries.
+
+## Design Principles
+
+1. Execution traces describe what happened during execution attempts.
+2. Verification and reconciliation remain the authoritative source of trusted completion.
+3. Trace records must preserve provenance to canonical task, attempt, artifact, and evaluation records.
+4. Trace requirements are additive observability guidance, not a new submission or lifecycle path.
+
+## Minimum Fields
+
+```text
+ExecutionTraceRecord
+  trace_id: string
+  task_id: string
+  attempt_id: string
+  attempt_sequence: integer
+  event_time: timestamp
+  event_type: string
+  event_status: started | checkpoint | completed | failed | cancelled | timed_out
+  actor_type: executor | harness | external_system | human_reviewer
+  actor_id: string?
+  correlation_id: string?
+  step_key: string?
+  message: string?
+  artifact_refs: ArtifactRef[]
+  evidence_refs: EvidenceRef[]
+  evaluation_refs: EvaluationRef[]
+  timeline_ref: TimelineRef?
+  source_system: string
+  source_record_id: string
+  ingest_time: timestamp
+  schema_version: string
+```
+
+## Scope Requirements
+
+### Attempt-Scoped Requirements (required)
+
+Attempt-scoped trace records must capture:
+
+- the attempt identifier and sequence
+- ordered step or checkpoint events
+- terminal event and terminal reason when the attempt ends
+- references to attempt-produced artifacts and evidence
+- source provenance for every imported event
+
+### Task-Scoped Requirements (required)
+
+Task-scoped summaries may be derived from attempt traces, but must:
+
+- preserve references back to contributing attempt IDs
+- preserve ordering across attempts
+- keep failed/cancelled/timed-out attempts visible
+- avoid collapsing contradictory attempt outcomes into a single success claim
+
+## Provenance And Linkage Requirements
+
+Trace records must remain linkable to canonical control-plane records:
+
+- `TaskEnvelope` identity (`task_id`)
+- evaluation history entries (by explicit reference)
+- timeline events (via `timeline_ref` when available)
+- artifact and evidence records used for verification
+- review records when trace events are inspected during manual review
+
+Missing linkage should be represented as explicit unresolved provenance, not silently dropped.
+
+## Boundary Rules
+
+- Trace events are descriptive execution facts, not completion decisions.
+- A terminal `completed` trace status does not authorize lifecycle transition by itself.
+- Verification/reconciliation outcomes remain the trusted completion authority.
+- Trace ingestion or analysis failures must not bypass policy enforcement.
+
+## Non-Goals
+
+- specifying storage engine or indexing strategy
+- defining runtime logging library APIs
+- defining diagnosis or proposal scoring algorithms
+- replacing canonical evaluation history or timeline contracts
+
+## Open Questions
+
+- whether `event_type` should be normalized by a shared enum in v1
+- whether actor identity should support structured resolver metadata beyond `actor_id`
+- what retention windows should apply for full-fidelity trace events versus compacted summaries


### PR DESCRIPTION
## Summary
- add a new planning-stage execution trace requirements contract for future HEE analysis
- define minimum trace fields, attempt-scoped vs task-scoped requirements, and provenance/linkage expectations
- reinforce boundary rules that verification/reconciliation remain trusted completion authority
- link HEE architecture doc to the new trace requirements contract and update evolution contracts README

## Testing
- docs-only change; no runtime code paths changed
- validated by reviewing markdown content and repository diff
