### PR TITLE
[codex] Batch /tasks read-model loading

### DIFF
--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -281,8 +281,18 @@ class HarnessReadModelService:
         )
         return task, records
 
-    def build_task_read_model(self, task_id: str) -> TaskReadModel:
-        task, records = self._load_task_and_records(task_id)
+    def _build_task_read_model_from_loaded(
+        self,
+        *,
+        task: TaskEnvelope,
+        records: tuple[EvaluationRecord, ...],
+    ) -> TaskReadModel:
+        records = tuple(
+            sorted(
+                records,
+                key=lambda record: (_parse_iso_timestamp(record.recorded_at), record.evaluation_id),
+            )
+        )
         verification_summary = _latest_mapping(records, ("enforcement_result", "verification_result"))
         reconciliation_summary = _latest_mapping(records, ("enforcement_result", "reconciliation_result"))
         review_summary = _build_review_summary(records)
@@ -326,6 +336,10 @@ class HarnessReadModelService:
             timeline=timeline,
         )
 
+    def build_task_read_model(self, task_id: str) -> TaskReadModel:
+        task, records = self._load_task_and_records(task_id)
+        return self._build_task_read_model_from_loaded(task=task, records=records)
+
     def build_task_timeline(self, task_id: str) -> dict[str, Any]:
         task, records = self._load_task_and_records(task_id)
         timeline = _build_timeline(task, records)
@@ -337,7 +351,16 @@ class HarnessReadModelService:
         }
 
     def list_task_read_models(self) -> tuple[TaskReadModel, ...]:
-        return tuple(self.build_task_read_model(str(task["id"])) for task in self.store.list_tasks())
+        tasks = self.store.list_tasks()
+        task_ids = tuple(str(task["id"]) for task in tasks)
+        records_by_task_id = self.store.list_evaluation_records_for_tasks(task_ids)
+        return tuple(
+            self._build_task_read_model_from_loaded(
+                task=task,
+                records=records_by_task_id.get(str(task["id"]), ()),
+            )
+            for task in tasks
+        )
 
 
 __all__ = [

--- a/modules/store.py
+++ b/modules/store.py
@@ -96,6 +96,10 @@ class EvaluationRecordStore(Protocol):
 
     def list_evaluation_records(self, task_id: str) -> tuple[EvaluationRecord, ...]: ...
 
+    def list_evaluation_records_for_tasks(
+        self, task_ids: tuple[str, ...]
+    ) -> dict[str, tuple[EvaluationRecord, ...]]: ...
+
 
 class HarnessStore(TaskEnvelopeStore, EvaluationRecordStore, Protocol):
     """Combined persistence boundary for canonical task and evaluation state."""
@@ -209,6 +213,12 @@ class FileBackedHarnessStore(TaskEnvelopeStore, EvaluationRecordStore):
             )
         records.sort(key=lambda record: (record.recorded_at, record.evaluation_id))
         return tuple(records)
+
+    def list_evaluation_records_for_tasks(self, task_ids: tuple[str, ...]) -> dict[str, tuple[EvaluationRecord, ...]]:
+        grouped_records: dict[str, tuple[EvaluationRecord, ...]] = {}
+        for task_id in task_ids:
+            grouped_records[task_id] = self.list_evaluation_records(task_id)
+        return grouped_records
 
 
 def _parse_iso_timestamp(value: str | None) -> datetime:
@@ -381,6 +391,39 @@ class PostgresHarnessStore(HarnessStore):
             )
             for row in rows
         )
+
+    def list_evaluation_records_for_tasks(self, task_ids: tuple[str, ...]) -> dict[str, tuple[EvaluationRecord, ...]]:
+        if not task_ids:
+            return {}
+
+        grouped_records: dict[str, list[EvaluationRecord]] = {task_id: [] for task_id in task_ids}
+
+        with self._connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT evaluation_id, task_id, recorded_at, request_json, result_json
+                    FROM evaluation_records
+                    WHERE task_id = ANY(%s)
+                    ORDER BY task_id ASC, recorded_at ASC, evaluation_id ASC
+                    """,
+                    (list(task_ids),),
+                )
+                rows = cursor.fetchall()
+
+        for row in rows:
+            task_id = str(row[1])
+            grouped_records.setdefault(task_id, []).append(
+                EvaluationRecord(
+                    evaluation_id=str(row[0]),
+                    task_id=task_id,
+                    recorded_at=cast(datetime, row[2]).astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    request=cast(dict[str, Any], row[3]),
+                    result=cast(dict[str, Any], row[4]),
+                )
+            )
+
+        return {task_id: tuple(records) for task_id, records in grouped_records.items()}
 
 
 def build_harness_store(


### PR DESCRIPTION
## What changed
- batched `/tasks` read-model loading instead of rebuilding each task through per-task store calls
- added bulk evaluation-record loading support to the store layer for the dashboard list path
- preserved the `/tasks` response shape while removing the worst `1 + 2N` query pattern

## Why it changed
The hosted backend at `https://harness-qeav.onrender.com/tasks` was hanging while `/health` remained healthy. The Vercel frontend proxy at `https://harness-umber.vercel.app/api/harness/tasks` timed out waiting on that backend call, which surfaced as a 502 in the tasks UI.

The root cause was the backend list path building a full read model for every task by reloading each task and its evaluation history individually. On Postgres this created too many synchronous round trips for the hosted dataset.

## Impact
- `GET /tasks` should return promptly again for the hosted Postgres deployment
- the Vercel tasks page should recover once this is merged to `main` and redeployed
- task detail and timeline contracts remain unchanged

## Validation
- live investigation confirmed `/health` returned 200 while `/tasks` timed out on Render
- `.venv/bin/python -m unittest tests.test_read_model tests.test_api`
- `.venv/bin/python -m unittest discover -s tests`
- local smoke check: seeded temp server returned `GET /tasks` 200 with expected tasks after the batching change
