### PR TITLE
Define failure diagnosis contract and taxonomy v1

### DIFF
--- a/docs/architecture/harness-evolution-engine.md
+++ b/docs/architecture/harness-evolution-engine.md
@@ -110,7 +110,13 @@ Timeline remains canonical audit surface for task progression. HEE may reference
 
 Execution traces are descriptive evidence of what happened during attempts. HEE may use them for diagnosis but they never become authoritative completion proof by themselves.
 
-Trace minimum-field expectations for future HEE inputs are defined in `modules/evolution/contracts/execution-trace-requirements.contract.md`.
+Trace minimum-field expectations for future HEE inputs are defined in `modules/evolution/contracts/execution-trace-requirements.contract.md`
+
+Failure diagnosis shape and taxonomy expectations are defined in:
+
+- `modules/evolution/contracts/failure-diagnosis.contract.md`
+- `modules/evolution/diagnostics/failure-taxonomy.v1.md`
+
 
 ### Artifacts And Completion Evidence
 

--- a/modules/evolution/contracts/README.md
+++ b/modules/evolution/contracts/README.md
@@ -2,11 +2,11 @@
 
 This directory holds planning-stage contracts for future HEE outputs.
 
-These contracts should describe:
+These contracts define:
 
-- what a failure diagnosis must contain
+- what a failure diagnosis must contain, including strict observed-fact vs inferred-cause separation
 - what an evolution candidate or proposal must contain
 - what execution trace records must contain for future diagnosis inputs
-- how provenance back to task, trace, artifact, and review records is preserved
+- how taxonomy versioning and provenance back to task, trace, artifact, and review records are preserved
 
-These files are intentionally non-executable and non-authoritative for runtime behavior until implemented through normal Harness review.
+Contracts here are non-executable and non-authoritative for runtime behavior until implemented through normal Harness review.

--- a/modules/evolution/contracts/failure-diagnosis.contract.md
+++ b/modules/evolution/contracts/failure-diagnosis.contract.md
@@ -1,40 +1,108 @@
 # Failure Diagnosis Contract
 
-Planning scaffold only. This contract is not executable code.
+Planning contract only. This document defines a reviewable, non-runtime shape for future HEE diagnosis records.
 
 ## Purpose
 
-Describe the minimum shape of a future HEE diagnosis record for recurring failures or degraded outcomes.
+Define a stable diagnosis record that captures:
 
-## Sketch
+- what was observed in canonical Harness outcomes
+- what is inferred as likely causal explanation
+- which concrete records support each claim
+- how confident HEE is in each inferred cause
+
+The diagnosis contract is advisory. It cannot mutate task lifecycle, verification outcomes, reconciliation outcomes, or completion authority.
+
+## Record Shape (v1 draft)
 
 ```text
-FailureDiagnosis
+FailureDiagnosisV1
   diagnosis_id: string
-  task_ids: string[]
-  attempt_ids: string[]
-  observed_outcome: string
-  diagnosis_taxonomy_key: string
-  summary: string
-  evidence_refs: EvidenceRef[]
-  trace_refs: TraceRef[]
-  contributing_factors: string[]
+  taxonomy_version: string            # e.g. "failure-taxonomy.v1"
+  diagnosis_taxonomy_key: string      # leaf key from taxonomy version above
+  status: draft | needs_review | accepted | rejected | superseded
+
+  scope:
+    task_ids: string[]                # canonical task ids
+    attempt_ids: string[]             # optional canonical attempt ids
+    cluster_key: string | null        # optional recurring-pattern grouping key
+
+  observed_facts: ObservedFact[]      # direct, source-backed facts only
+  inferred_causes: InferredCause[]    # hypotheses derived from observed facts
   unresolved_questions: string[]
-  confidence: low | medium | high
+
+  summary:
+    headline: string
+    detail: string
+
+  provenance: ProvenanceRef[]         # task/read-model/timeline/evaluation/trace/review refs
+
+  confidence:
+    overall: low | medium | high
+    scoring_notes: string
+
   created_at: timestamp
   created_from: diagnosis_run_id | review_id
+  supersedes_diagnosis_id: string | null
+
+ObservedFact
+  fact_id: string
+  category: lifecycle | verification | reconciliation | evidence | runtime | review
+  statement: string
+  source_refs: ProvenanceRef[]
+
+InferredCause
+  cause_id: string
+  statement: string
+  cause_type: process | policy | contract | adapter | environment | external_dependency | unknown
+  supporting_fact_ids: string[]
+  contradicting_fact_ids: string[]
+  confidence: low | medium | high
+
+ProvenanceRef
+  ref_id: string
+  source_type: task_envelope | task_read_model | timeline_event | evaluation_record | trace_record | artifact_record | review_record
+  source_identifier: string
+  captured_at: timestamp
+  notes: string | null
 ```
 
 ## Required Semantics
 
-- Must reference canonical task or attempt identifiers.
-- Must preserve which evidence and traces support the diagnosis.
-- Must distinguish observed facts from inferred causes.
-- Must remain advisory and reviewable.
-- Must not mutate lifecycle state or task truth directly.
+1. **Observed vs inferred separation is mandatory.**
+   - `observed_facts` may only contain source-backed statements.
+   - `inferred_causes` may only reference facts by ID; they must not be presented as observed truth.
 
-## Open Questions
+2. **Taxonomy binding is explicit.**
+   - Every diagnosis must include both `taxonomy_version` and `diagnosis_taxonomy_key`.
+   - Keys must resolve to a known taxonomy entry for that version.
 
-- whether diagnoses are task-scoped, attempt-scoped, or cluster-scoped by default
-- how much taxonomy should be enum-driven versus free-form
-- whether confidence is qualitative, numeric, or both
+3. **Provenance is required and auditable.**
+   - Every observed fact must include at least one provenance reference.
+   - Inferred causes must link to supporting and/or contradicting observed fact IDs.
+
+4. **Confidence is explanatory, not authoritative.**
+   - Confidence expresses uncertainty of inference quality.
+   - Confidence never authorizes lifecycle changes or completion decisions.
+
+5. **Advisory-only boundary is preserved.**
+   - Diagnosis status reflects review workflow only.
+   - No diagnosis record can directly mutate canonical task truth.
+
+## Lifecycle For Diagnosis Records (advisory)
+
+- `draft`: generated, not yet reviewed.
+- `needs_review`: explicitly queued for human review.
+- `accepted`: human accepted diagnosis as useful advisory interpretation.
+- `rejected`: human rejected diagnosis.
+- `superseded`: replaced by newer diagnosis via `supersedes_diagnosis_id` linkage.
+
+This lifecycle governs diagnosis records only; it is separate from task lifecycle state.
+
+## Initial Taxonomy Requirement
+
+The initial taxonomy is defined in:
+
+- `modules/evolution/diagnostics/failure-taxonomy.v1.md`
+
+Diagnosis records using this contract must reference taxonomy keys from that document until a new version is explicitly introduced.

--- a/modules/evolution/diagnostics/README.md
+++ b/modules/evolution/diagnostics/README.md
@@ -2,10 +2,14 @@
 
 This directory is reserved for future failure-diagnosis logic, taxonomies, and supporting notes.
 
+Current planning artifacts:
+
+- `failure-taxonomy.v1.md` defines the initial diagnosis taxonomy contract surface.
+
 Future work here should focus on:
 
 - recurring failure pattern identification
 - taxonomy definitions grounded in canonical outcomes
 - diagnosis generation backed by trace and evaluation evidence
 
-It should not become a hidden policy engine or a place where lifecycle truth is reassigned outside Harness core.
+It must not become a hidden policy engine or a place where lifecycle truth is reassigned outside Harness core.

--- a/modules/evolution/diagnostics/failure-taxonomy.v1.md
+++ b/modules/evolution/diagnostics/failure-taxonomy.v1.md
@@ -1,0 +1,76 @@
+# Failure Taxonomy v1 (Planning)
+
+Status: planning taxonomy for future HEE diagnosis outputs.
+
+Taxonomy keys classify likely failure modes for recurring analysis. They do not decide task lifecycle state or completion outcomes.
+
+## Design Rules
+
+- Keys are stable and versioned.
+- Keys describe inferred causal class, not raw lifecycle status.
+- Keys are advisory labels and must be supported by observed facts + provenance.
+- New keys must preserve backward-readable history by bumping taxonomy version when semantics change.
+
+## Key Format
+
+`<domain>.<category>.<specific_mode>`
+
+Example: `verification.evidence.missing_required_artifact`
+
+## Domains and Initial Keys
+
+### 1) `verification`
+
+- `verification.evidence.missing_required_artifact`
+- `verification.evidence.artifact_unreadable`
+- `verification.evidence.artifact_nonconforming`
+- `verification.proof.insufficient_completion_evidence`
+
+### 2) `reconciliation`
+
+- `reconciliation.external_fact.contradiction_with_github`
+- `reconciliation.external_fact.contradiction_with_linear`
+- `reconciliation.external_fact.record_not_found`
+- `reconciliation.mapping.identifier_mismatch`
+
+### 3) `execution`
+
+- `execution.runtime.timeout`
+- `execution.runtime.crash_or_unhandled_error`
+- `execution.runtime.stall_without_progress`
+- `execution.environment.dependency_or_tool_unavailable`
+- `execution.environment.infrastructure_instability`
+
+### 4) `workflow`
+
+- `workflow.spec.requirements_ambiguous`
+- `workflow.spec.scope_conflict`
+- `workflow.review.manual_review_required_unresolved`
+- `workflow.review.repeated_rejections`
+
+### 5) `policy`
+
+- `policy.enforcement.invalid_lifecycle_transition_attempt`
+- `policy.enforcement.unauthorized_completion_claim`
+- `policy.enforcement.reconciliation_gate_not_satisfied`
+
+### 6) `ingress`
+
+- `ingress.contract.task_envelope_validation_failed`
+- `ingress.contract.missing_required_fields`
+- `ingress.adapter.vendor_payload_translation_error`
+
+## Required Pairing With Diagnosis Contract
+
+For each diagnosis:
+
+1. Choose exactly one primary taxonomy key.
+2. Keep observed facts independent from key selection.
+3. Represent uncertainty through inferred-cause confidence and unresolved questions.
+4. If no key fits, use `workflow.spec.scope_conflict` only as temporary fallback and mark taxonomy extension needed.
+
+## Non-Goals
+
+- defining automated remediation policies
+- implementing key-assignment algorithms
+- replacing human review decisions


### PR DESCRIPTION
## Summary
- expand the planning-stage failure diagnosis contract with explicit structure for scope, observed facts, inferred causes, provenance, confidence, and advisory diagnosis lifecycle states
- add an initial versioned taxonomy (`failure-taxonomy.v1`) with stable key naming and domain-based failure classes
- update evolution contract/diagnostics scaffolding docs and HEE architecture doc to reference the diagnosis contract and taxonomy artifacts

## Validation
- `git diff --check`

## Scope Notes
- docs/contracts only; no runtime behavior changes
- preserves advisory-only boundary and does not introduce lifecycle mutation paths
