### PR TITLE
Define evolution candidate and proposal contract

### DIFF
--- a/docs/architecture/harness-evolution-engine.md
+++ b/docs/architecture/harness-evolution-engine.md
@@ -117,6 +117,11 @@ Failure diagnosis shape and taxonomy expectations are defined in:
 - `modules/evolution/contracts/failure-diagnosis.contract.md`
 - `modules/evolution/diagnostics/failure-taxonomy.v1.md`
 
+Evolution candidate and proposal planning contracts are defined in:
+
+- `modules/evolution/contracts/evolution-candidate.contract.md`
+- `modules/evolution/contracts/evolution-proposal.contract.md`
+
 
 ### Artifacts And Completion Evidence
 
@@ -125,6 +130,14 @@ Artifacts and verification/reconciliation outcomes remain completion authority u
 ### Manual Review Decisions
 
 Manual review remains explicit human governance. HEE may suggest escalation patterns but cannot clear or resolve review gates.
+
+### Candidate And Proposal Governance
+
+Evolution candidates and proposals are planning artifacts only.
+
+- Candidate/proposal acceptance is a review/planning decision, not runtime mutation authority.
+- No candidate/proposal state may directly alter task lifecycle, verification, reconciliation, or completion outcomes.
+- Implementation must still flow through normal issue, PR, and release processes.
 
 ## Failure-Containment Requirements
 

--- a/modules/evolution/README.md
+++ b/modules/evolution/README.md
@@ -7,6 +7,7 @@ The intended role is advisory only:
 - analyze execution traces and task outcomes
 - produce structured failure diagnoses
 - produce structured evolution candidates for human review
+- produce structured evolution proposals that remain advisory until humans accept and implement through normal workflows
 
 This module does not currently implement:
 

--- a/modules/evolution/contracts/README.md
+++ b/modules/evolution/contracts/README.md
@@ -5,8 +5,16 @@ This directory holds planning-stage contracts for future HEE outputs.
 These contracts define:
 
 - what a failure diagnosis must contain, including strict observed-fact vs inferred-cause separation
-- what an evolution candidate or proposal must contain
+- what an evolution candidate must contain before a proposal is drafted
+- what an evolution proposal must contain for auditable human review and decision tracking
 - what execution trace records must contain for future diagnosis inputs
 - how taxonomy versioning and provenance back to task, trace, artifact, and review records are preserved
 
 Contracts here are non-executable and non-authoritative for runtime behavior until implemented through normal Harness review.
+
+## Current Planning Contracts
+
+- `failure-diagnosis.contract.md`
+- `evolution-candidate.contract.md`
+- `evolution-proposal.contract.md`
+- `execution-trace-requirements.contract.md`

--- a/modules/evolution/contracts/evolution-candidate.contract.md
+++ b/modules/evolution/contracts/evolution-candidate.contract.md
@@ -4,36 +4,64 @@ Planning scaffold only. This contract is not executable code.
 
 ## Purpose
 
-Describe the minimum shape of a future HEE proposal record for a possible Harness improvement derived from diagnoses and evidence.
+Define the minimum reviewable record for a possible Harness improvement discovered from diagnoses and evidence.
 
-## Sketch
+A candidate is an **advisory planning object**. It captures why a proposal may be needed and how a reviewer can inspect provenance before any implementation work is authorized.
+
+## Candidate Shape
 
 ```text
 EvolutionCandidate
   candidate_id: string
-  source_diagnosis_ids: string[]
   title: string
-  proposal_type: contract_change | policy_change | adapter_change | observability_change | documentation_change
-  target_surface: string
-  rationale: string
-  expected_benefit: string
-  risks: string[]
-  required_reviewers: string[]
-  supporting_evidence_refs: EvidenceRef[]
-  status: draft | under_review | accepted | rejected | parked
+  summary: string
+  source_diagnosis_ids: string[]
+  source_evidence_refs: EvidenceRef[]
+  hypothesis: string
+  proposal_type: contract_change | policy_change | adapter_change | observability_change | documentation_change | process_change
+  target_surfaces: TargetSurface[]
+  estimated_risk: low | medium | high
+  assumptions: string[]
+  open_questions: string[]
+  review_state: draft | under_review | approved_for_planning | rejected | parked
   created_at: timestamp
+  updated_at: timestamp
+```
+
+### Supporting Types
+
+```text
+TargetSurface
+  area: schema | evaluator_policy | lifecycle_enforcement | read_model | adapter | operator_runbook | docs
+  component: string
+
+EvidenceRef
+  evidence_type: task_timeline | evaluation_record | reconciliation_summary | verification_summary | artifact | manual_review_note | execution_trace
+  reference_id: string
+  note: string
 ```
 
 ## Required Semantics
 
-- Must link back to one or more diagnoses or equivalent evidence sources.
-- Must state the target surface explicitly instead of implying a hidden mutation path.
-- Must preserve review status separately from implementation status.
-- Must remain advisory until accepted through normal planning and delivery channels.
-- Must not authorize autonomous code changes, PR generation, or deployment.
+- Must link to at least one diagnosis (`source_diagnosis_ids`) and at least one evidence reference (`source_evidence_refs`).
+- Must explicitly identify impacted surfaces (`target_surfaces`) rather than implying hidden or broad mutation authority.
+- Must preserve review state independently from delivery/implementation state.
+- Must retain provenance to canonical Harness inspection surfaces and historical records.
+- Must remain advisory until accepted through normal planning and delivery workflows.
 
-## Open Questions
+## Explicit Prohibitions
 
-- whether candidate status belongs inside Harness storage or only in planning systems
-- whether proposal types should be broader or narrower
-- how candidate-to-GitHub-issue linkage should be represented
+An `EvolutionCandidate` must not be interpreted as authority to:
+
+- mutate runtime task state or policy decisions
+- create or apply code changes automatically
+- open pull requests automatically
+- deploy changes automatically
+
+Candidates are inputs to human review and planning only.
+
+## Relationship To Proposal Contract
+
+A candidate can be promoted into one or more `EvolutionProposal` records after review.
+
+Proposal-level structure is defined in `modules/evolution/contracts/evolution-proposal.contract.md`.

--- a/modules/evolution/contracts/evolution-proposal.contract.md
+++ b/modules/evolution/contracts/evolution-proposal.contract.md
@@ -1,0 +1,77 @@
+# Evolution Proposal Contract
+
+Planning scaffold only. This contract is not executable code.
+
+## Purpose
+
+Define the advisory proposal record generated from a reviewed evolution candidate.
+
+A proposal is still non-authoritative: it packages a concrete change recommendation, review requirements, and decision trail while preserving the rule that implementation must proceed through normal repository and governance workflows.
+
+## Proposal Shape
+
+```text
+EvolutionProposal
+  proposal_id: string
+  candidate_id: string
+  proposal_type: contract_change | policy_change | adapter_change | observability_change | documentation_change | process_change
+  target_surfaces: TargetSurface[]
+  problem_statement: string
+  recommendation: string
+  expected_benefits: string[]
+  potential_risks: string[]
+  mitigations: string[]
+  decision_inputs: DecisionInput[]
+  reviewers_required: string[]
+  decision_state: proposed | in_review | accepted | rejected | superseded | deferred
+  decision_notes: string
+  tracking_links: TrackingLink[]
+  created_at: timestamp
+  updated_at: timestamp
+```
+
+### Supporting Types
+
+```text
+TargetSurface
+  area: schema | evaluator_policy | lifecycle_enforcement | read_model | adapter | operator_runbook | docs
+  component: string
+
+DecisionInput
+  input_type: diagnosis | evidence | prior_decision | incident | operator_feedback
+  reference_id: string
+  rationale_excerpt: string
+
+TrackingLink
+  system: linear | github_issue | github_pr | doc
+  identifier: string
+  url: string
+```
+
+## Required Semantics
+
+- Must retain a direct lineage to its source candidate (`candidate_id`).
+- Must preserve evidence and diagnosis provenance via `decision_inputs`.
+- Must express proposal type and target surfaces at planning level before implementation begins.
+- Must keep decision status (`decision_state`) explicit and auditable.
+- Must keep acceptance of a proposal distinct from implementation completion.
+
+## Explicit Prohibitions
+
+An `EvolutionProposal` must not grant direct runtime mutation authority.
+
+Specifically, proposal acceptance alone must not:
+
+- modify `TaskEnvelope` instances in-flight
+- change evaluator, verifier, reconciliation, or lifecycle outcomes
+- bypass canonical API submission/reevaluation paths
+- auto-generate or auto-merge code changes
+- auto-deploy policy or runtime configuration
+
+Accepted proposals only authorize humans to begin normal planning/delivery work in external systems.
+
+## Review Transition Expectations
+
+- `proposed` -> `in_review` requires an explicit reviewer handoff.
+- `in_review` -> `accepted` or `rejected` requires an explicit decision record.
+- `accepted` proposals remain advisory artifacts until implemented through normal issue/PR/release workflows.


### PR DESCRIPTION
## Summary\n- define a fuller planning contract for  with explicit provenance, target-surface, review-state, and advisory-only semantics\n- add a dedicated  planning contract with lineage, decision inputs, state transitions, and explicit non-authority rules\n- update evolution contract docs and architecture references to codify candidate/proposal governance boundaries\n\n## Validation\n- modules/evolution/contracts/evolution-candidate.contract.md:67:Proposal-level structure is defined in `modules/evolution/contracts/evolution-proposal.contract.md`.
docs/architecture/harness-evolution-engine.md:122:- `modules/evolution/contracts/evolution-candidate.contract.md`
docs/architecture/harness-evolution-engine.md:123:- `modules/evolution/contracts/evolution-proposal.contract.md`
modules/evolution/contracts/README.md:18:- `evolution-candidate.contract.md`
modules/evolution/contracts/README.md:19:- `evolution-proposal.contract.md`