### PR TITLE
Implement completion-claim interception in evaluation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ See:
 - Canonical mutation surfaces:
   - `POST /tasks`
   - `POST /tasks/<task_id>/reevaluate`
+- Completion-claim interception helper (delegates into canonical reevaluation semantics):
+  - `POST /tasks/<task_id>/completion-claims`
 - Integration helper surface:
   - `POST /ingress/linear`
 

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -9,6 +9,13 @@ This document is the source-of-truth API usage guide for execution agents and do
 
 For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritative mutation path.
 
+### Completion Claim Interception Helper
+
+- `POST /tasks/<task_id>/completion-claims` is an executor-facing helper for advisory completion claims.
+- This helper persists the claim under `task_envelope.observability.execution_metadata.advisory_completion_claims` and then runs canonical reevaluation.
+- A completion claim is treated as `claimed_completion=true` advisory input; it does not directly authorize a lifecycle transition.
+- The canonical lifecycle outcome still comes from verification/reconciliation/review enforcement.
+
 - Existing-task reevaluation uses the stored task snapshot as the source of truth.
 - `POST /evaluate` may still be used as an evaluation surface for an existing task id, but Harness evaluates against the stored task snapshot and only reapplies the supported top-level overlays listed below.
 - Automatic callers must not rely on `POST /evaluate` to overwrite an existing task lifecycle state by supplying a different nested `request.task_envelope`.

--- a/modules/api.py
+++ b/modules/api.py
@@ -380,6 +380,88 @@ def _merge_completion_evidence(
     return merged_task
 
 
+def _parse_completion_claim(payload: dict[str, Any]) -> dict[str, Any]:
+    claim_payload = _require_mapping(payload.get("completion_claim"), field_name="completion_claim")
+    claim_id = _require_non_empty_string(claim_payload.get("claim_id"), field_name="completion_claim.claim_id")
+    reported_at = _require_non_empty_string(claim_payload.get("reported_at"), field_name="completion_claim.reported_at")
+    reported_by = _optional_non_empty_string(claim_payload.get("reported_by"), field_name="completion_claim.reported_by")
+    reason = _optional_non_empty_string(claim_payload.get("reason"), field_name="completion_claim.reason")
+    metadata = _optional_mapping(claim_payload.get("metadata"), field_name="completion_claim.metadata") or {}
+
+    return {
+        "claim_id": claim_id,
+        "reported_at": reported_at,
+        "reported_by": reported_by,
+        "reason": reason,
+        "metadata": dict(metadata),
+    }
+
+
+def _with_advisory_completion_claim(task_envelope: dict[str, Any], *, claim: dict[str, Any]) -> dict[str, Any]:
+    merged_task = deepcopy(task_envelope)
+    execution_metadata = dict(merged_task["observability"]["execution_metadata"] or {})
+    existing_claims = execution_metadata.get("advisory_completion_claims")
+    if existing_claims is None:
+        advisory_claims: list[dict[str, Any]] = []
+    elif isinstance(existing_claims, list):
+        advisory_claims = [deepcopy(item) for item in existing_claims]
+    else:
+        raise ApiRequestError("observability.execution_metadata.advisory_completion_claims must be an array")
+
+    advisory_claims.append(deepcopy(claim))
+    execution_metadata["advisory_completion_claims"] = advisory_claims
+    merged_task["observability"]["execution_metadata"] = execution_metadata
+    merged_task["timestamps"]["updated_at"] = _iso_now()
+    return merged_task
+
+
+def parse_completion_claim_request(task_envelope: dict[str, Any], payload: dict[str, Any]) -> HarnessEvaluationRequest:
+    """Parse an executor completion claim into canonical reevaluation input."""
+
+    request_payload = _require_mapping(payload.get("request"), field_name="request")
+    completion_claim = _parse_completion_claim(request_payload)
+    merged_task = _with_advisory_completion_claim(task_envelope, claim=completion_claim)
+
+    new_artifacts = _optional_object_list(request_payload.get("new_artifacts"), field_name="new_artifacts")
+    if new_artifacts:
+        merged_task = _merge_artifacts(merged_task, new_artifacts=new_artifacts)
+
+    completion_evidence_update = _optional_mapping(
+        request_payload.get("completion_evidence"),
+        field_name="completion_evidence",
+    )
+    if completion_evidence_update is not None:
+        merged_task = _merge_completion_evidence(
+            merged_task,
+            completion_evidence_update=completion_evidence_update,
+        )
+
+    review_request = _parse_review_request(_optional_mapping(request_payload.get("review_request"), field_name="review_request"))
+    review_decision = _parse_review_decision(
+        _optional_mapping(request_payload.get("review_decision"), field_name="review_decision")
+    )
+
+    if review_request is not None and review_request.task_id != merged_task["id"]:
+        raise ApiRequestError("review_request.task_id must match the stored task id")
+    if review_decision is not None and review_decision.record.task_id != merged_task["id"]:
+        raise ApiRequestError("review_decision.record.task_id must match the stored task id")
+
+    return HarnessEvaluationRequest(
+        task_envelope=merged_task,
+        external_facts=_parse_external_facts(_optional_mapping(request_payload.get("external_facts"), field_name="external_facts")),
+        claimed_completion=True,
+        acceptance_criteria_satisfied=bool(request_payload.get("acceptance_criteria_satisfied", False)),
+        runtime_facts=_parse_runtime_facts(_optional_mapping(request_payload.get("runtime_facts"), field_name="runtime_facts")),
+        unresolved_conditions=_optional_string_tuple(
+            request_payload.get("unresolved_conditions"),
+            field_name="unresolved_conditions",
+        ),
+        review_reasons=_optional_string_tuple(request_payload.get("review_reasons"), field_name="review_reasons"),
+        review_request=review_request,
+        review_decision=review_decision,
+    )
+
+
 def parse_reevaluation_request(task_envelope: dict[str, Any], payload: dict[str, Any]) -> HarnessEvaluationRequest:
     """Parse a reevaluation payload against an existing stored TaskEnvelope."""
 
@@ -725,6 +807,40 @@ class HarnessApiService:
         response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
+    def submit_completion_claim(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            stored_task = self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+
+        try:
+            request = parse_completion_claim_request(stored_task, payload)
+        except Exception as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        request = replace(
+            request,
+            review_is_active=_review_gate_is_active(
+                stored_task,
+                self.store.list_evaluation_records(task_id),
+            ),
+        )
+
+        status, response_payload, result = _evaluate_request(request)
+        if result is None:
+            return status, response_payload
+        if result.invalid_input:
+            return status, response_payload
+
+        stored_task = self.store.update_task(result.task_envelope)
+        record = self.store.put_evaluation_record(request=request, result=result)
+        response_payload["task_envelope"] = _to_jsonable(stored_task)
+        response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        return status, response_payload
+
     def get_task(self, task_id: str) -> tuple[int, dict[str, Any]]:
         try:
             task = self.store.get_task(task_id)
@@ -832,7 +948,9 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         request_path = urlparse(self.path).path
 
         if request_path not in {"/evaluate", "/tasks", "/ingress/linear"} and not (
-            len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "reevaluate"
+            len(path_components) == 3
+            and path_components[0] == "tasks"
+            and path_components[2] in {"reevaluate", "completion-claims"}
         ):
             self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
             return
@@ -852,6 +970,8 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             status, response_payload = service.submit_linear_ingress(payload)
         elif request_path == "/evaluate":
             status, response_payload = service.evaluate(payload)
+        elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "completion-claims":
+            status, response_payload = service.submit_completion_claim(path_components[1], payload)
         else:
             status, response_payload = service.reevaluate(path_components[1], payload)
         self._write_json(status, response_payload)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -253,6 +253,18 @@ def _manual_happy_path_overlay_payload() -> dict:
     }
 
 
+def _completion_claim_payload(*, claim_id: str = "claim-1") -> dict:
+    return {
+        "completion_claim": {
+            "claim_id": claim_id,
+            "reported_at": "2026-04-01T08:00:00Z",
+            "reported_by": "stub-executor",
+            "reason": "executor reported completion",
+            "metadata": {"attempt_id": "attempt-1"},
+        }
+    }
+
+
 def _schema_invalid_submission_payload() -> dict:
     payload = _request_payload("accepted_completion")
     completion_evidence = payload["request"]["task_envelope"]["artifacts"]["completion_evidence"]
@@ -680,6 +692,60 @@ class HarnessApiServiceTests(unittest.TestCase):
             reevaluation_response["enforcement_result"]["verification_result"]["evidence_is_sufficient"],
             True,
         )
+
+    def test_service_completion_claim_is_intercepted_and_cannot_directly_complete_task(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+        submit_payload = {"request": {"task_envelope": deepcopy(payload["request"]["task_envelope"])}}
+        submit_status, submit_response = self.service.submit(submit_payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        claim_status, claim_response = self.service.submit_completion_claim(
+            task_id,
+            {
+                "request": {
+                    **_completion_claim_payload(claim_id="claim-intercepted-1"),
+                    "runtime_facts": {"executor_reported_success": True, "attempt_count": 1},
+                }
+            },
+        )
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(claim_status, 200)
+        self.assertFalse(claim_response["accepted_completion"])
+        self.assertNotEqual(claim_response["task_envelope"]["status"], "completed")
+        claims = claim_response["task_envelope"]["observability"]["execution_metadata"]["advisory_completion_claims"]
+        self.assertEqual(claims[-1]["claim_id"], "claim-intercepted-1")
+
+    def test_service_completion_claim_routes_into_canonical_evaluation_and_can_complete_when_evidence_aligns(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+        submit_payload = {"request": {"task_envelope": deepcopy(payload["request"]["task_envelope"])}}
+        submit_status, submit_response = self.service.submit(submit_payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        claim_status, claim_response = self.service.submit_completion_claim(
+            task_id,
+            {
+                "request": {
+                    **_completion_claim_payload(claim_id="claim-complete-1"),
+                    "new_artifacts": deepcopy(payload["request"]["linked_artifacts"]),
+                    "completion_evidence": deepcopy(payload["request"]["completion_evidence"]),
+                    "external_facts": deepcopy(payload["request"]["external_facts"]),
+                    "acceptance_criteria_satisfied": True,
+                    "runtime_facts": deepcopy(payload["request"]["runtime_facts"]),
+                }
+            },
+        )
+        history_status, history_payload = self.service.get_evaluation_history(task_id)
+        latest_request = history_payload["evaluations"][-1]["request"]
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(claim_status, 200)
+        self.assertTrue(claim_response["accepted_completion"])
+        self.assertEqual(claim_response["task_envelope"]["status"], "completed")
+        self.assertEqual(history_status, 200)
+        self.assertTrue(latest_request["claimed_completion"])
+        claims = latest_request["task_envelope"]["observability"]["execution_metadata"]["advisory_completion_claims"]
+        self.assertEqual(claims[-1]["claim_id"], "claim-complete-1")
 
     def test_service_evaluate_existing_review_required_task_cannot_be_overwritten_to_completed(self) -> None:
         initial_status, initial_response = self.service.evaluate(_request_payload("review_required"))
@@ -1210,6 +1276,33 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(reevaluation_response["action"], "transition_applied")
         self.assertTrue(reevaluation_response["accepted_completion"])
         self.assertEqual(reevaluation_response["task_envelope"]["status"], "completed")
+
+    def test_api_completion_claim_endpoint_intercepts_claim_and_routes_to_evaluation(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+        submit_payload = {"request": {"task_envelope": deepcopy(payload["request"]["task_envelope"])}}
+        submit_status, submit_response = self._post_json("/tasks", submit_payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        claim_status, claim_response = self._post_json(
+            f"/tasks/{task_id}/completion-claims",
+            {
+                "request": {
+                    **_completion_claim_payload(claim_id="claim-api-1"),
+                    "runtime_facts": {"executor_reported_success": True, "attempt_count": 1},
+                }
+            },
+        )
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(claim_status, 200)
+        self.assertFalse(claim_response["accepted_completion"])
+        self.assertNotEqual(claim_response["task_envelope"]["status"], "completed")
+        self.assertEqual(history_status, 200)
+        claims = history_payload["evaluations"][-1]["request"]["task_envelope"]["observability"]["execution_metadata"][
+            "advisory_completion_claims"
+        ]
+        self.assertEqual(claims[-1]["claim_id"], "claim-api-1")
 
     def test_api_can_reevaluate_completed_task_back_to_blocked_for_contradictory_facts(self) -> None:
         initial_payload = _request_payload("accepted_completion")


### PR DESCRIPTION
## Summary
- add a completion-claim interception parser that stores advisory executor claims under task observability metadata
- add a dedicated service/API path () that routes claims through canonical evaluation
- add service and HTTP tests proving claims are auditable and do not directly complete tasks without policy-backed evidence
- document the new completion-claim helper while preserving reevaluate as canonical mutation semantics

## Testing
- python -m unittest discover -s tests