### PR TITLE
Remove .venv assumptions and standardize on system Python

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ Final task completion must return concrete external artifact identifiers:
 Executor summaries are advisory only. External artifacts remain the proof of completion.
 If `Repository`, `Branch`, `Commit SHA`, and `PR URL` are not all present, the task is considered invalid and not executed (not partial and not completed with issues).
 
+Codex Cloud uses system Python. Do not assume `.venv` exists, do not create `.venv`, and write Python commands so they run as `python ...`.
+
 ## Rules For Modifying TaskEnvelope And Schema
 
 When changing `TaskEnvelope` or `schemas/task_envelope.schema.json`:
@@ -205,7 +207,7 @@ Do not add separate frontend-only truth sources for evidence, verification, reco
 At minimum, run the validation that matches your change:
 
 - docs-only: verify file paths, commands, and references
-- backend Python changes: `.venv/bin/python -m unittest discover -s tests`
+- backend Python changes: `python -m unittest discover -s tests`
 - frontend changes: `pnpm lint` and `pnpm build`
 - mixed changes: run both backend and frontend validation as relevant
 

--- a/README.md
+++ b/README.md
@@ -137,15 +137,15 @@ Relevant supporting files:
 Backend setup:
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
 pip install -r requirements.txt
 ```
+
+Harness and Codex Cloud assume system Python is available as `python`. Do not assume or require a `.venv`.
 
 Run the backend with the file store:
 
 ```bash
-.venv/bin/python -m modules.api --store-root .harness-store
+python -m modules.api --store-root .harness-store
 ```
 
 Run the backend with Postgres:
@@ -153,7 +153,7 @@ Run the backend with Postgres:
 ```bash
 export HARNESS_STORE_BACKEND=postgres
 export DATABASE_URL=postgresql://...
-.venv/bin/python -m modules.api
+python -m modules.api
 ```
 
 The API binds to `0.0.0.0` by default and honors `PORT` when set. Local default access is `http://127.0.0.1:8000`.
@@ -182,21 +182,20 @@ pnpm dev
 Install backend and frontend dependencies first:
 
 ```bash
-python3 -m venv .venv
-.venv/bin/pip install -r requirements.txt
+pip install -r requirements.txt
 pnpm install --frozen-lockfile
 ```
 
 Run only the dedicated end-to-end runtime scenario suite:
 
 ```bash
-.venv/bin/python -m unittest discover -s tests/e2e -p 'test_*.py'
+python -m unittest discover -s tests/e2e -p 'test_*.py'
 ```
 
 Run the full Python test suite:
 
 ```bash
-.venv/bin/python -m unittest discover -s tests
+python -m unittest discover -s tests
 ```
 
 Run frontend validation:
@@ -219,8 +218,7 @@ The runner reuses the same scenario builders used by the runtime E2E suite inste
 Expected environment:
 
 ```bash
-python3 -m venv .venv
-.venv/bin/pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 
 Optional configuration:
@@ -238,13 +236,13 @@ export HARNESS_DRYRUN_MAX_E2E_SUITE_RUNS=1
 Run once:
 
 ```bash
-.venv/bin/python scripts/run_unattended_dryruns.py --iterations 1
+python scripts/run_unattended_dryruns.py --iterations 1
 ```
 
 Run unattended in tmux:
 
 ```bash
-tmux new -s harness-dryruns '.venv/bin/python scripts/run_unattended_dryruns.py --interval-seconds 300'
+tmux new -s harness-dryruns 'python scripts/run_unattended_dryruns.py --interval-seconds 300'
 ```
 
 Stop or restart:
@@ -270,7 +268,7 @@ Self-heal behavior:
 Disable retry and diagnostics:
 
 ```bash
-.venv/bin/python scripts/run_unattended_dryruns.py --max-retries 0 --disable-diagnostics --max-e2e-suite-runs 0
+python scripts/run_unattended_dryruns.py --max-retries 0 --disable-diagnostics --max-e2e-suite-runs 0
 ```
 
 ## Demo And Canonical Scenarios

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -73,11 +73,11 @@ Generated source-of-truth payloads live under `examples/api/`:
 Regenerate them with:
 
 ```bash
-.venv/bin/python scripts/render_api_examples.py
+python scripts/render_api_examples.py
 ```
 
 If you also need the synced execution bundle under `exports/agent-contract/`, regenerate that with:
 
 ```bash
-.venv/bin/python scripts/export_agent_contract.py
+python scripts/export_agent_contract.py
 ```

--- a/docs/architecture/codex-cloud-execution.md
+++ b/docs/architecture/codex-cloud-execution.md
@@ -25,6 +25,8 @@ That script is responsible for:
 - installing likely-needed Node dependencies from the detected lockfile or `package.json`
 - writing `.codex-bootstrap-proof`
 
+Codex Cloud uses system Python for this bootstrap path. Repository scripts and operator commands must be runnable as `python ...` without assuming a `.venv` exists or activating one.
+
 The proof file is environment evidence, not task-completion evidence. It proves that bootstrap ran successfully in the expected repository context. It does not prove that a task produced an external commit or pull request.
 
 ## Why The Bootstrap Script Exists
@@ -34,6 +36,8 @@ The bootstrap script exists because interactive terminal success was not enough 
 Before this flow was verified, a human could be in a healthy local shell while a fresh Codex Cloud task sandbox still lacked the git remote, authentication, or fetch state needed to produce real external artifacts. That mismatch allowed task summaries to sound complete even when the repository context was not fully initialized for delegated execution.
 
 Harness cannot accept that kind of ambiguity. Delegated task execution needs explicit proof of execution context before any completion claim is trusted.
+
+That includes interpreter assumptions. A task that only works after manually activating `.venv` is not portable across Codex Cloud sandboxes, so Harness standardizes Python execution on the system `python` command and system-level dependency installation via `pip install -r requirements.txt`.
 
 ## Task Preflight Contract
 

--- a/docs/demo/operator-walkthrough.md
+++ b/docs/demo/operator-walkthrough.md
@@ -23,7 +23,7 @@ python -m modules.demo_walkthrough reset --store-root .demo-store --output-dir d
 2. Start the Harness API against the demo store:
 
 ```bash
-.venv/bin/python -m modules.api --host 127.0.0.1 --port 8000 --store-root .demo-store
+python -m modules.api --host 127.0.0.1 --port 8000 --store-root .demo-store
 ```
 
 3. Start the dashboard in a separate terminal:

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -6,7 +6,6 @@ This guide covers the practical local and container runbook for Harness.
 
 - Python 3
 - `pnpm`
-- a local virtual environment for backend work
 - Docker, if you want the containerized mode
 
 ## Native Local Development
@@ -14,21 +13,21 @@ This guide covers the practical local and container runbook for Harness.
 ### Backend Setup
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
 pip install -r requirements.txt
 ```
+
+Harness and Codex Cloud assume system Python is available as `python`. Do not assume or require a `.venv`.
 
 Run the dedicated runtime scenario suite:
 
 ```bash
-.venv/bin/python -m unittest discover -s tests/e2e -p 'test_*.py'
+python -m unittest discover -s tests/e2e -p 'test_*.py'
 ```
 
 Run the full backend test suite:
 
 ```bash
-.venv/bin/python -m unittest discover -s tests
+python -m unittest discover -s tests
 ```
 
 ### Frontend Setup
@@ -54,7 +53,7 @@ pnpm build
 ### Run The API
 
 ```bash
-.venv/bin/python -m modules.api --store-root .harness-store
+python -m modules.api --store-root .harness-store
 ```
 
 To run the same backend against Supabase Postgres instead of the file-backed store:
@@ -62,7 +61,7 @@ To run the same backend against Supabase Postgres instead of the file-backed sto
 ```bash
 export HARNESS_STORE_BACKEND=postgres
 export DATABASE_URL=postgresql://...
-.venv/bin/python -m modules.api
+python -m modules.api
 ```
 The API defaults to binding `0.0.0.0` and will honor the `PORT` environment variable when one is provided by a host such as Render. For local development, access it through `http://127.0.0.1:8000`.
 
@@ -97,7 +96,7 @@ python -m modules.demo_walkthrough reset --store-root .demo-store --output-dir d
 Start API:
 
 ```bash
-.venv/bin/python -m modules.api --host 127.0.0.1 --port 8000 --store-root .demo-store
+python -m modules.api --host 127.0.0.1 --port 8000 --store-root .demo-store
 ```
 
 Start dashboard:

--- a/exports/agent-contract/README.md
+++ b/exports/agent-contract/README.md
@@ -2,7 +2,7 @@
 
 This directory is generated from the canonical Harness repository for execution agents and sync consumers such as `HARNESS-DRYRUN`.
 
-Do not edit files in this directory manually. Re-run `.venv/bin/python scripts/export_agent_contract.py` from the Harness repo instead.
+Do not edit files in this directory manually. Re-run `python scripts/export_agent_contract.py` from the Harness repo instead.
 
 ## Canonical API Surface
 

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -28,13 +28,27 @@ run_install_command() {
 }
 
 resolve_python() {
+  if have_command python; then
+    printf '%s\n' "python"
+    return 0
+  fi
+
   if have_command python3; then
     printf '%s\n' "python3"
     return 0
   fi
 
-  if have_command python; then
-    printf '%s\n' "python"
+  return 1
+}
+
+resolve_pip() {
+  if have_command pip; then
+    printf '%s\n' "pip"
+    return 0
+  fi
+
+  if have_command pip3; then
+    printf '%s\n' "pip3"
     return 0
   fi
 
@@ -43,15 +57,24 @@ resolve_python() {
 
 install_python_dependencies() {
   local python_bin="$1"
+  local pip_bin="${2:-}"
 
   if [[ -f requirements.txt ]]; then
-    if ! "$python_bin" -m pip install -q -r requirements.txt >/dev/null 2>&1; then
+    if [[ -n "${pip_bin}" ]]; then
+      if ! "${pip_bin}" install -q -r requirements.txt >/dev/null 2>&1; then
+        log "requirements.txt installation failed; continuing"
+      fi
+    elif ! "$python_bin" -m pip install -q -r requirements.txt >/dev/null 2>&1; then
       log "requirements.txt installation failed; continuing"
     fi
   fi
 
   if [[ -f requirements-dev.txt ]]; then
-    if ! "$python_bin" -m pip install -q -r requirements-dev.txt >/dev/null 2>&1; then
+    if [[ -n "${pip_bin}" ]]; then
+      if ! "${pip_bin}" install -q -r requirements-dev.txt >/dev/null 2>&1; then
+        log "requirements-dev.txt installation failed; continuing"
+      fi
+    elif ! "$python_bin" -m pip install -q -r requirements-dev.txt >/dev/null 2>&1; then
       log "requirements-dev.txt installation failed; continuing"
     fi
   fi
@@ -190,6 +213,11 @@ else
   blocked "python is required to configure GitHub authentication"
 fi
 
+pip_bin=""
+if ! pip_bin="$(resolve_pip 2>/dev/null)"; then
+  pip_bin=""
+fi
+
 github_extraheader="$("${python_bin}" - <<'PY'
 import base64
 import os
@@ -236,7 +264,7 @@ if have_command gh || install_gh_cli; then
   fi
 fi
 
-install_python_dependencies "${python_bin}"
+install_python_dependencies "${python_bin}" "${pip_bin}"
 install_node_dependencies
 
 cat > "${PROOF_FILE}" <<EOF

--- a/scripts/export_agent_contract.py
+++ b/scripts/export_agent_contract.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Generate the minimal execution-facing contract bundle for sync consumers."""
 
 from __future__ import annotations
@@ -52,7 +52,7 @@ def _bundle_readme(*, commit_sha: str, generated_at: str) -> str:
 
 This directory is generated from the canonical Harness repository for execution agents and sync consumers such as `HARNESS-DRYRUN`.
 
-Do not edit files in this directory manually. Re-run `.venv/bin/python scripts/export_agent_contract.py` from the Harness repo instead.
+Do not edit files in this directory manually. Re-run `python scripts/export_agent_contract.py` from the Harness repo instead.
 
 ## Canonical API Surface
 

--- a/scripts/render_api_examples.py
+++ b/scripts/render_api_examples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Render canonical API examples from Harness source-of-truth builders."""
 
 from __future__ import annotations

--- a/scripts/run_unattended_dryruns.py
+++ b/scripts/run_unattended_dryruns.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Run unattended dry-run scenarios against the deployed Harness backend.
 
 Tmux:
-  tmux new -s harness-dryruns '.venv/bin/python scripts/run_unattended_dryruns.py --interval-seconds 300'
+  tmux new -s harness-dryruns 'python scripts/run_unattended_dryruns.py --interval-seconds 300'
 
 Environment:
   HARNESS_DRYRUN_BASE_URL=https://harness-qeav.onrender.com


### PR DESCRIPTION
Summary:
- remove repo guidance that assumes a local .venv exists
- standardize documented Python execution on the system python command
- update Codex Cloud bootstrap and docs to prefer system Python and system-level pip installs without creating a virtualenv

Validation:
- pwd
- git remote -v
- cat .codex-bootstrap-proof -> cat: .codex-bootstrap-proof: No such file or directory
- python -m unittest discover -s tests -> zsh:1: command not found: python

This branch intentionally standardizes the repository on python, but the current local desktop environment does not have a python executable on PATH, so the required test command could not run here.