### PR TITLE
Add local OpenClaw bootstrap and config scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ coverage/
 .env.production.local
 .env.*.local
 !.env.example
+config/openclaw/.env.local
+config/openclaw/openclaw.local.json5
 
 # Docker and local app state
 .docker-store/

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Relevant supporting files:
 - [`.env.example`](.env.example)
 - [`sql/postgres/001_harness_store.sql`](sql/postgres/001_harness_store.sql)
 - [`docs/setup/local-development.md`](docs/setup/local-development.md)
+- [`docs/setup/openclaw-local.md`](docs/setup/openclaw-local.md)
 - [`docs/setup/render-supabase.md`](docs/setup/render-supabase.md)
 
 ## Local Development

--- a/config/openclaw/.env.example
+++ b/config/openclaw/.env.example
@@ -1,0 +1,9 @@
+OPENCLAW_INSTALLER_URL=https://openclaw.ai/install-cli.sh
+OPENCLAW_INSTALL_PREFIX=$HOME/.openclaw-harness
+OPENCLAW_VERSION=latest
+OPENCLAW_STATE_DIR=$HOME/.openclaw-harness-state
+OPENCLAW_CONFIG_PATH=/absolute/path/to/Harness/config/openclaw/openclaw.local.json5
+OPENCLAW_WORKSPACE_PATH=/absolute/path/to/Harness
+OPENCLAW_GATEWAY_BIND=loopback
+OPENCLAW_GATEWAY_PORT=18789
+OPENCLAW_AGENT_ID=harness-local

--- a/config/openclaw/openclaw.template.json5
+++ b/config/openclaw/openclaw.template.json5
@@ -1,0 +1,25 @@
+{
+  // Local-only starting point for deterministic Harness bring-up.
+  gateway: {
+    mode: "local",
+    bind: "__OPENCLAW_GATEWAY_BIND__",
+    port: __OPENCLAW_GATEWAY_PORT__,
+    auth: {
+      mode: "none",
+    },
+  },
+
+  // Keep one explicit local agent with a repo-scoped workspace.
+  agents: {
+    defaults: {
+      workspace: "__OPENCLAW_WORKSPACE_PATH__",
+      skipBootstrap: true,
+    },
+    list: [
+      {
+        id: "__OPENCLAW_AGENT_ID__",
+        workspace: "__OPENCLAW_WORKSPACE_PATH__",
+      },
+    ],
+  },
+}

--- a/docs/setup/openclaw-local.md
+++ b/docs/setup/openclaw-local.md
@@ -1,0 +1,167 @@
+# OpenClaw Local Bootstrap
+
+This document defines a local-first, deterministic OpenClaw bring-up path for Harness.
+
+The goal is not broad Harness ↔ OpenClaw integration yet. The goal is a reproducible macOS-oriented install and config scaffold that avoids interactive onboarding, keeps config explicit, and gives future adapter work a stable base.
+
+## Why Local-First
+
+OpenClaw is not just a package import. It has installer behavior, state, config, and validation rules. That means an interactive happy-path install is not enough if we want repeatable Harness-side iteration.
+
+This setup path exists so we can:
+
+- install OpenClaw without a wizard
+- keep config under repo control
+- validate config strictly before future adapter work
+- iterate locally on macOS before deciding whether any of this belongs in Codex Cloud
+
+## What This Setup Includes
+
+- [`config/openclaw/openclaw.template.json5`](../../config/openclaw/openclaw.template.json5): minimal repo-owned config template
+- [`config/openclaw/.env.example`](../../config/openclaw/.env.example): optional local environment template
+- [`scripts/openclaw-bootstrap.sh`](../../scripts/openclaw-bootstrap.sh): non-interactive local bootstrap
+- [`scripts/openclaw-validate-local.sh`](../../scripts/openclaw-validate-local.sh): local validation helper
+
+## What This Setup Intentionally Does Not Configure
+
+- channel credentials or routing
+- model/provider authentication
+- daemon install or background service management
+- production network exposure
+- Harness runtime integration
+- Codex Cloud execution support
+
+This is a local bootstrap and validation scaffold only.
+
+## Bootstrap Flow
+
+The bootstrap script uses the documented OpenClaw CLI installer path and explicitly disables onboarding:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh | bash -s -- --prefix "$OPENCLAW_INSTALL_PREFIX" --version "$OPENCLAW_VERSION" --no-onboard
+```
+
+Why this path:
+
+- it is non-interactive
+- it installs into a caller-controlled prefix instead of relying on global npm state
+- it keeps onboarding out of the bring-up flow
+- it is easy to re-run during local iteration
+
+After install, the script renders a deterministic config file from the repo-owned template and validates it with:
+
+```bash
+openclaw --version
+openclaw config file
+openclaw config validate
+```
+
+## Local Setup On macOS
+
+1. Copy the example env file and replace the absolute paths:
+
+```bash
+cp config/openclaw/.env.example config/openclaw/.env.local
+```
+
+2. Edit `config/openclaw/.env.local` so `OPENCLAW_CONFIG_PATH` and `OPENCLAW_WORKSPACE_PATH` point at your local Harness checkout.
+
+3. Run the bootstrap:
+
+```bash
+bash scripts/openclaw-bootstrap.sh
+```
+
+4. Validate the install and config:
+
+```bash
+bash scripts/openclaw-validate-local.sh
+```
+
+If you want to run raw `openclaw ...` commands directly from the shell, add the install prefix to `PATH` first:
+
+```bash
+export PATH="$OPENCLAW_INSTALL_PREFIX/bin:$PATH"
+```
+
+## Config Location And Overrides
+
+The repo-owned source of truth is the template:
+
+- [`config/openclaw/openclaw.template.json5`](../../config/openclaw/openclaw.template.json5)
+
+The rendered local config defaults to:
+
+- `config/openclaw/openclaw.local.json5`
+
+You can override the rendered config location with:
+
+```bash
+export OPENCLAW_CONFIG_PATH=/absolute/path/to/openclaw.local.json5
+```
+
+The bootstrap and validation scripts both honor:
+
+- `OPENCLAW_ENV_FILE`
+- `OPENCLAW_INSTALL_PREFIX`
+- `OPENCLAW_VERSION`
+- `OPENCLAW_STATE_DIR`
+- `OPENCLAW_CONFIG_PATH`
+- `OPENCLAW_WORKSPACE_PATH`
+- `OPENCLAW_GATEWAY_BIND`
+- `OPENCLAW_GATEWAY_PORT`
+- `OPENCLAW_AGENT_ID`
+
+If `OPENCLAW_ENV_FILE` is not set, both scripts automatically load `config/openclaw/.env.local` when it exists.
+
+## Minimal Config Shape
+
+The template keeps the local surface intentionally small:
+
+- `gateway.mode: "local"`
+- `gateway.bind: "loopback"`
+- `gateway.auth.mode: "none"`
+- one explicit local agent
+- workspace path pointed at the local Harness repo
+- `skipBootstrap: true` to avoid implicit workspace bootstrap behavior during early setup work
+
+That gives us a deterministic local base without prematurely choosing channels, daemon install, or production auth.
+
+## Validation Commands
+
+The helper script runs:
+
+```bash
+openclaw --version
+openclaw doctor --non-interactive
+openclaw config file
+openclaw config validate --json
+openclaw status
+```
+
+If the gateway is already running, it also runs:
+
+```bash
+openclaw gateway status
+openclaw health
+```
+
+If the gateway is not running yet, the helper skips those runtime checks and reports that clearly.
+
+## Known Limitations
+
+- This path assumes internet access to fetch the OpenClaw installer.
+- The generated config is local-only and intentionally does not configure model credentials.
+- `gateway.auth.mode` is set to `none` because the target is same-host local iteration on loopback, not remote access.
+- The scripts validate install and config, but they do not install a background service or open any channels.
+- This setup does not prove Harness runtime integration. It only proves that a stable, non-interactive OpenClaw local base exists.
+
+## Manual Inputs Still Required Later
+
+Nothing extra is required to bootstrap and validate the config itself beyond editing local paths in `.env.local`.
+
+If you later want to do real agent execution rather than install/config validation, you will still need to supply:
+
+- model/provider authentication
+- any channel credentials
+- any future Harness adapter wiring

--- a/scripts/openclaw-bootstrap.sh
+++ b/scripts/openclaw-bootstrap.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+log() {
+  printf '[openclaw-bootstrap] %s\n' "$*"
+}
+
+die() {
+  printf '[openclaw-bootstrap][ERROR] %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+sed_escape() {
+  printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
+}
+
+load_env_file() {
+  local env_file="$1"
+
+  if [[ -z "${env_file}" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "${env_file}" ]]; then
+    die "env file not found: ${env_file}"
+  fi
+
+  log "loading environment from ${env_file}"
+  set -a
+  # shellcheck disable=SC1090
+  source "${env_file}"
+  set +a
+}
+
+render_config() {
+  local template_path="$1"
+  local output_path="$2"
+
+  [[ -f "${template_path}" ]] || die "config template not found: ${template_path}"
+  mkdir -p "$(dirname "${output_path}")"
+
+  sed \
+    -e "s/__OPENCLAW_GATEWAY_BIND__/$(sed_escape "${OPENCLAW_GATEWAY_BIND}")/g" \
+    -e "s/__OPENCLAW_GATEWAY_PORT__/$(sed_escape "${OPENCLAW_GATEWAY_PORT}")/g" \
+    -e "s#__OPENCLAW_WORKSPACE_PATH__#$(sed_escape "${OPENCLAW_WORKSPACE_PATH}")#g" \
+    -e "s/__OPENCLAW_AGENT_ID__/$(sed_escape "${OPENCLAW_AGENT_ID}")/g" \
+    "${template_path}" > "${output_path}"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_ENV_FILE="${REPO_ROOT}/config/openclaw/.env.local"
+
+if [[ -n "${OPENCLAW_ENV_FILE:-}" ]]; then
+  load_env_file "${OPENCLAW_ENV_FILE}"
+elif [[ -f "${DEFAULT_ENV_FILE}" ]]; then
+  load_env_file "${DEFAULT_ENV_FILE}"
+fi
+
+case "$(uname -s)" in
+  Darwin|Linux) ;;
+  *)
+    die "unsupported platform; this bootstrap currently targets macOS first and Linux second"
+    ;;
+esac
+
+require_command bash
+require_command curl
+require_command sed
+
+OPENCLAW_INSTALLER_URL="${OPENCLAW_INSTALLER_URL:-https://openclaw.ai/install-cli.sh}"
+OPENCLAW_INSTALL_PREFIX="${OPENCLAW_INSTALL_PREFIX:-${HOME}/.openclaw-harness}"
+OPENCLAW_VERSION="${OPENCLAW_VERSION:-latest}"
+OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-${HOME}/.openclaw-harness-state}"
+OPENCLAW_CONFIG_TEMPLATE="${OPENCLAW_CONFIG_TEMPLATE:-${REPO_ROOT}/config/openclaw/openclaw.template.json5}"
+OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-${REPO_ROOT}/config/openclaw/openclaw.local.json5}"
+OPENCLAW_WORKSPACE_PATH="${OPENCLAW_WORKSPACE_PATH:-${REPO_ROOT}}"
+OPENCLAW_GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"
+OPENCLAW_GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+OPENCLAW_AGENT_ID="${OPENCLAW_AGENT_ID:-harness-local}"
+
+mkdir -p "${OPENCLAW_INSTALL_PREFIX}" "${OPENCLAW_STATE_DIR}" "$(dirname "${OPENCLAW_CONFIG_PATH}")"
+
+log "installing OpenClaw into ${OPENCLAW_INSTALL_PREFIX}"
+install_args=(--prefix "${OPENCLAW_INSTALL_PREFIX}" --version "${OPENCLAW_VERSION}" --no-onboard)
+curl -fsSL --proto '=https' --tlsv1.2 "${OPENCLAW_INSTALLER_URL}" | bash -s -- "${install_args[@]}"
+
+OPENCLAW_BIN="${OPENCLAW_BIN:-${OPENCLAW_INSTALL_PREFIX}/bin/openclaw}"
+[[ -x "${OPENCLAW_BIN}" ]] || die "openclaw binary not found after install: ${OPENCLAW_BIN}"
+
+log "rendering config to ${OPENCLAW_CONFIG_PATH}"
+render_config "${OPENCLAW_CONFIG_TEMPLATE}" "${OPENCLAW_CONFIG_PATH}"
+
+export OPENCLAW_CONFIG_PATH
+export OPENCLAW_STATE_DIR
+
+log "validating installation"
+"${OPENCLAW_BIN}" --version
+"${OPENCLAW_BIN}" config file
+"${OPENCLAW_BIN}" config validate
+
+cat <<EOF
+[openclaw-bootstrap] bootstrap complete
+[openclaw-bootstrap] openclaw_bin=${OPENCLAW_BIN}
+[openclaw-bootstrap] config_path=${OPENCLAW_CONFIG_PATH}
+[openclaw-bootstrap] state_dir=${OPENCLAW_STATE_DIR}
+EOF

--- a/scripts/openclaw-validate-local.sh
+++ b/scripts/openclaw-validate-local.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+log() {
+  printf '[openclaw-validate] %s\n' "$*"
+}
+
+die() {
+  printf '[openclaw-validate][ERROR] %s\n' "$*" >&2
+  exit 1
+}
+
+load_env_file() {
+  local env_file="$1"
+
+  if [[ -z "${env_file}" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "${env_file}" ]]; then
+    die "env file not found: ${env_file}"
+  fi
+
+  set -a
+  # shellcheck disable=SC1090
+  source "${env_file}"
+  set +a
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_ENV_FILE="${REPO_ROOT}/config/openclaw/.env.local"
+
+if [[ -n "${OPENCLAW_ENV_FILE:-}" ]]; then
+  load_env_file "${OPENCLAW_ENV_FILE}"
+elif [[ -f "${DEFAULT_ENV_FILE}" ]]; then
+  load_env_file "${DEFAULT_ENV_FILE}"
+fi
+
+OPENCLAW_INSTALL_PREFIX="${OPENCLAW_INSTALL_PREFIX:-${HOME}/.openclaw-harness}"
+OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-${REPO_ROOT}/config/openclaw/openclaw.local.json5}"
+OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-${HOME}/.openclaw-harness-state}"
+OPENCLAW_BIN="${OPENCLAW_BIN:-${OPENCLAW_INSTALL_PREFIX}/bin/openclaw}"
+
+[[ -x "${OPENCLAW_BIN}" ]] || die "openclaw binary not found: ${OPENCLAW_BIN}"
+[[ -f "${OPENCLAW_CONFIG_PATH}" ]] || die "config file not found: ${OPENCLAW_CONFIG_PATH}"
+
+export OPENCLAW_CONFIG_PATH
+export OPENCLAW_STATE_DIR
+
+"${OPENCLAW_BIN}" --version
+"${OPENCLAW_BIN}" doctor --non-interactive
+"${OPENCLAW_BIN}" config file
+"${OPENCLAW_BIN}" config validate --json
+"${OPENCLAW_BIN}" status
+
+if "${OPENCLAW_BIN}" gateway status >/dev/null 2>&1; then
+  "${OPENCLAW_BIN}" gateway status
+  "${OPENCLAW_BIN}" health
+else
+  log "gateway is not running; skipping gateway status output and health check"
+fi


### PR DESCRIPTION
## Summary
- add a local-first OpenClaw bootstrap script that installs non-interactively with onboarding disabled
- add a repo-owned OpenClaw config template plus optional local env template
- add a local validation helper and setup doc for deterministic macOS bring-up before any Harness runtime integration work

## Validation
- bash -n scripts/openclaw-bootstrap.sh
- bash -n scripts/openclaw-validate-local.sh

## Scope
This PR intentionally does not implement Harness runtime integration, Codex Cloud support, or production OpenClaw deployment concerns.