### PR TITLE
Skip OpenClaw health check when gateway is unreachable

### DIFF
--- a/scripts/openclaw-validate-local.sh
+++ b/scripts/openclaw-validate-local.sh
@@ -57,7 +57,12 @@ export OPENCLAW_STATE_DIR
 
 if "${OPENCLAW_BIN}" gateway status >/dev/null 2>&1; then
   "${OPENCLAW_BIN}" gateway status
-  "${OPENCLAW_BIN}" health
+
+  if "${OPENCLAW_BIN}" gateway probe >/dev/null 2>&1; then
+    "${OPENCLAW_BIN}" health
+  else
+    log "gateway is configured but unreachable; skipping health check"
+  fi
 else
   log "gateway is not running; skipping gateway status output and health check"
 fi


### PR DESCRIPTION
## Summary
- stop the local OpenClaw validator from calling  when the gateway is configured but not actually reachable
- keep  output for visibility
- replace the misleading end-of-run stack trace with an explicit skip message for the expected local-only bootstrap state

## Validation
- bash -n scripts/openclaw-validate-local.sh
- bash scripts/openclaw-validate-local.sh against a local install with no running gateway

## Scope
This PR only improves validator behavior for the local bootstrap path. It does not change OpenClaw runtime integration scope or gateway configuration.