### PR TITLE
Implement minimal real OpenClaw executor adapter integration

### DIFF
--- a/modules/adapters/__init__.py
+++ b/modules/adapters/__init__.py
@@ -7,6 +7,7 @@ from .executor_adapter import (
     ExecutorDispatchOutput,
     StubExecutorAdapter,
 )
+from .openclaw import OpenClawAdapterError, OpenClawExecutorAdapter, OpenClawRuntimeClient
 
 __all__ = [
     "ExecutorAdapter",
@@ -14,4 +15,7 @@ __all__ = [
     "ExecutorDispatchInput",
     "ExecutorDispatchOutput",
     "StubExecutorAdapter",
+    "OpenClawAdapterError",
+    "OpenClawExecutorAdapter",
+    "OpenClawRuntimeClient",
 ]

--- a/modules/adapters/openclaw/README.md
+++ b/modules/adapters/openclaw/README.md
@@ -1,18 +1,20 @@
-# OpenClaw Executor Adapter Scaffold
+# OpenClaw Executor Adapter
 
-This directory reserves a future home for an execution adapter that lets Harness use OpenClaw as a worker backend.
+This directory contains a minimal real OpenClaw executor adapter path.
 
-Its intended boundary is executor-facing only:
+Current scope:
 
-- map assigned Harness work into an OpenClaw execution request
-- normalize OpenClaw execution events back into Harness execution facts
-- preserve artifact and trace references for later verification
+- project canonical `ExecutorDispatchInput` into a minimal OpenClaw request payload
+- call an OpenClaw runtime client through a thin transport protocol
+- normalize OpenClaw events/artifacts into canonical advisory execution models
+- preserve advisory-only completion semantics for Harness lifecycle enforcement
 
-This directory is distinct from the current ingress/client spike in `modules/connectors/openclaw_harness_spike.py`.
+The adapter intentionally keeps OpenClaw-specific request/response fields local to translation code in `executor_adapter.py`.
 
-It does not currently implement:
+This directory remains distinct from ingress/client code in `modules/connectors/openclaw_harness_spike.py`.
 
-- API wiring
-- runtime dispatch
-- execution logic
-- completion acceptance
+Non-goals for this module:
+
+- broad OpenClaw orchestration support
+- lifecycle mutation from executor output
+- bypassing canonical completion interception or reevaluation paths

--- a/modules/adapters/openclaw/__init__.py
+++ b/modules/adapters/openclaw/__init__.py
@@ -1,0 +1,5 @@
+"""OpenClaw executor adapter package."""
+
+from .executor_adapter import OpenClawAdapterError, OpenClawExecutorAdapter, OpenClawRuntimeClient
+
+__all__ = ["OpenClawAdapterError", "OpenClawExecutorAdapter", "OpenClawRuntimeClient"]

--- a/modules/adapters/openclaw/executor_adapter.py
+++ b/modules/adapters/openclaw/executor_adapter.py
@@ -1,0 +1,304 @@
+"""Minimal real OpenClaw executor adapter implementation.
+
+This module isolates OpenClaw request/response translation while returning canonical
+advisory execution facts consumed by Harness.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from modules.adapters.executor_adapter import ExecutorDispatchInput, ExecutorDispatchOutput
+from modules.contracts.execution_advisory import (
+    AdvisoryCompletionClaim,
+    ArtifactReference,
+    ExecutionEvent,
+    ExecutionEventType,
+    ExecutionProvenance,
+    validate_artifact_reference,
+    validate_execution_event,
+)
+
+
+class OpenClawAdapterError(ValueError):
+    """Raised when OpenClaw adapter inputs or outputs are invalid."""
+
+
+class OpenClawRuntimeClient(Protocol):
+    """Transport abstraction for a minimal OpenClaw execution call."""
+
+    def execute(self, request_payload: dict[str, Any]) -> dict[str, Any]:
+        """Execute an OpenClaw run and return raw OpenClaw response payload."""
+
+
+@dataclass(frozen=True)
+class OpenClawExecutorAdapter:
+    """Minimal real adapter that translates canonical input across the OpenClaw boundary."""
+
+    runtime_client: OpenClawRuntimeClient
+
+    adapter_name: str = "openclaw"
+
+    def dispatch(self, dispatch_input: ExecutorDispatchInput) -> ExecutorDispatchOutput:
+        request_payload = self._to_openclaw_request(dispatch_input)
+        response_payload = self.runtime_client.execute(request_payload)
+        return self._to_canonical_output(dispatch_input=dispatch_input, response_payload=response_payload)
+
+    def _to_openclaw_request(self, dispatch_input: ExecutorDispatchInput) -> dict[str, Any]:
+        return {
+            "task": {
+                "id": dispatch_input.task_id,
+                "attempt_id": dispatch_input.attempt_id,
+                "title": dispatch_input.title,
+                "description": dispatch_input.description,
+                "objective": dispatch_input.objective_summary,
+                "acceptance_criteria": list(dispatch_input.acceptance_criteria),
+                "constraints": list(dispatch_input.constraints),
+                "required_artifacts": list(dispatch_input.required_artifact_types),
+            },
+            "context": {
+                "references": list(dispatch_input.context_references),
+                "origin_source": dispatch_input.metadata.get("origin_source"),
+                "priority": dispatch_input.metadata.get("priority"),
+            },
+            "executor": {
+                "target": dispatch_input.assigned_executor,
+                "adapter": self.adapter_name,
+            },
+        }
+
+    def _to_canonical_output(
+        self,
+        *,
+        dispatch_input: ExecutorDispatchInput,
+        response_payload: dict[str, Any],
+    ) -> ExecutorDispatchOutput:
+        if not isinstance(response_payload, dict):
+            raise OpenClawAdapterError("OpenClaw response payload must be an object")
+
+        run_id = _require_non_empty(response_payload.get("run_id"), field_name="response.run_id")
+
+        artifacts = tuple(
+            self._normalize_artifact(
+                dispatch_input=dispatch_input,
+                run_id=run_id,
+                artifact_payload=artifact_payload,
+                index=index,
+            )
+            for index, artifact_payload in enumerate(_require_list(response_payload.get("artifacts"), "response.artifacts"))
+        )
+
+        raw_events = _require_list(response_payload.get("events"), "response.events")
+        if not raw_events:
+            raw_events = [
+                {
+                    "id": f"{run_id}:started",
+                    "type": "run_started",
+                    "timestamp": _utc_now(),
+                    "message": "OpenClaw run started",
+                },
+                {
+                    "id": f"{run_id}:completed",
+                    "type": "run_succeeded",
+                    "timestamp": _utc_now(),
+                    "message": "OpenClaw run completed",
+                },
+            ]
+
+        completion_payload = response_payload.get("completion")
+        completion_claim = self._normalize_completion_claim(completion_payload, run_id=run_id)
+
+        canonical_events: list[ExecutionEvent] = []
+        for index, event_payload in enumerate(raw_events):
+            canonical_events.append(
+                self._normalize_event(
+                    dispatch_input=dispatch_input,
+                    run_id=run_id,
+                    event_payload=event_payload,
+                    index=index,
+                    artifacts=artifacts,
+                    completion_claim=completion_claim,
+                )
+            )
+
+        return ExecutorDispatchOutput(
+            events=tuple(canonical_events),
+            artifact_references=artifacts,
+            metadata={
+                "adapter": self.adapter_name,
+                "openclaw_run_id": run_id,
+                "advisory_only": True,
+                "request_shape": "openclaw.execute.v1",
+            },
+        )
+
+    def _normalize_event(
+        self,
+        *,
+        dispatch_input: ExecutorDispatchInput,
+        run_id: str,
+        event_payload: Any,
+        index: int,
+        artifacts: tuple[ArtifactReference, ...],
+        completion_claim: AdvisoryCompletionClaim | None,
+    ) -> ExecutionEvent:
+        if not isinstance(event_payload, dict):
+            raise OpenClawAdapterError(f"response.events[{index}] must be an object")
+
+        raw_type = _require_non_empty(event_payload.get("type"), field_name=f"response.events[{index}].type")
+        event_type = _normalize_event_type(raw_type)
+
+        event_id = _require_non_empty(event_payload.get("id"), field_name=f"response.events[{index}].id")
+        occurred_at = _require_non_empty(
+            event_payload.get("timestamp"),
+            field_name=f"response.events[{index}].timestamp",
+        )
+
+        advisory_completion: AdvisoryCompletionClaim | None = None
+        if completion_claim is not None and event_type in {
+            ExecutionEventType.EXECUTION_SUCCEEDED,
+            ExecutionEventType.EXECUTION_FAILED,
+            ExecutionEventType.EXECUTION_TIMED_OUT,
+            ExecutionEventType.EXECUTION_CANCELED,
+        }:
+            advisory_completion = completion_claim
+
+        attached_artifacts: tuple[ArtifactReference, ...] = ()
+        if event_type in {
+            ExecutionEventType.ARTIFACT_ATTACHED,
+            ExecutionEventType.OUTPUT_ATTACHED,
+            ExecutionEventType.EXECUTION_SUCCEEDED,
+        }:
+            attached_artifacts = artifacts
+
+        return validate_execution_event(
+            ExecutionEvent(
+                event_id=f"{dispatch_input.attempt_id}:{event_id}",
+                task_id=dispatch_input.task_id,
+                attempt_id=dispatch_input.attempt_id,
+                event_type=event_type,
+                occurred_at=occurred_at,
+                provenance=ExecutionProvenance(
+                    source_system="openclaw",
+                    source_type="executor_event",
+                    source_id=f"{run_id}:{event_id}",
+                    captured_by="openclaw_adapter",
+                ),
+                artifact_references=attached_artifacts,
+                advisory_completion=advisory_completion,
+                metadata={
+                    "adapter": self.adapter_name,
+                    "openclaw_event_type": raw_type,
+                    "openclaw_run_id": run_id,
+                },
+            )
+        )
+
+    def _normalize_artifact(
+        self,
+        *,
+        dispatch_input: ExecutorDispatchInput,
+        run_id: str,
+        artifact_payload: Any,
+        index: int,
+    ) -> ArtifactReference:
+        if not isinstance(artifact_payload, dict):
+            raise OpenClawAdapterError(f"response.artifacts[{index}] must be an object")
+
+        artifact_type = _require_non_empty(
+            artifact_payload.get("type"),
+            field_name=f"response.artifacts[{index}].type",
+        )
+        artifact_id = _require_non_empty(
+            artifact_payload.get("id"),
+            field_name=f"response.artifacts[{index}].id",
+        )
+
+        location = artifact_payload.get("url")
+        external_id = artifact_payload.get("external_id")
+        commit_sha = artifact_payload.get("commit_sha")
+
+        return validate_artifact_reference(
+            ArtifactReference(
+                artifact_type=artifact_type,
+                reference_id=f"{dispatch_input.attempt_id}:{artifact_id}",
+                location=location if isinstance(location, str) and location.strip() else None,
+                external_id=external_id if isinstance(external_id, str) and external_id.strip() else None,
+                commit_sha=commit_sha if isinstance(commit_sha, str) and commit_sha.strip() else None,
+                provenance=ExecutionProvenance(
+                    source_system="openclaw",
+                    source_type="executor_artifact",
+                    source_id=f"{run_id}:{artifact_id}",
+                    captured_by="openclaw_adapter",
+                ),
+                metadata={
+                    "adapter": self.adapter_name,
+                },
+            )
+        )
+
+    def _normalize_completion_claim(
+        self,
+        completion_payload: Any,
+        *,
+        run_id: str,
+    ) -> AdvisoryCompletionClaim | None:
+        if completion_payload is None:
+            return None
+        if not isinstance(completion_payload, dict):
+            raise OpenClawAdapterError("response.completion must be an object")
+
+        reported_complete = bool(completion_payload.get("reported_complete"))
+        confidence = completion_payload.get("confidence")
+        reason = completion_payload.get("reason")
+
+        return AdvisoryCompletionClaim(
+            claim_id=f"{run_id}:completion",
+            reported_complete=reported_complete,
+            confidence=confidence if isinstance(confidence, str) and confidence.strip() else None,
+            reason=reason if isinstance(reason, str) and reason.strip() else None,
+            metadata={"advisory_only": True, "adapter": self.adapter_name},
+        )
+
+
+def _normalize_event_type(raw_type: str) -> ExecutionEventType:
+    mapping = {
+        "run_started": ExecutionEventType.EXECUTION_STARTED,
+        "progress": ExecutionEventType.PROGRESS_REPORTED,
+        "output": ExecutionEventType.OUTPUT_ATTACHED,
+        "artifact_attached": ExecutionEventType.ARTIFACT_ATTACHED,
+        "run_failed": ExecutionEventType.EXECUTION_FAILED,
+        "run_succeeded": ExecutionEventType.EXECUTION_SUCCEEDED,
+        "run_stalled": ExecutionEventType.EXECUTION_STALLED,
+        "run_timed_out": ExecutionEventType.EXECUTION_TIMED_OUT,
+        "retry_scheduled": ExecutionEventType.RETRY_SCHEDULED,
+        "retry_started": ExecutionEventType.RETRY_STARTED,
+        "run_canceled": ExecutionEventType.EXECUTION_CANCELED,
+    }
+    normalized = mapping.get(raw_type)
+    if normalized is None:
+        raise OpenClawAdapterError(f"Unsupported OpenClaw event type: {raw_type}")
+    return normalized
+
+
+def _require_non_empty(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OpenClawAdapterError(f"{field_name} is required")
+    return value.strip()
+
+
+def _require_list(value: Any, field_name: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise OpenClawAdapterError(f"{field_name} must be a list")
+    return value
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+__all__ = ["OpenClawAdapterError", "OpenClawExecutorAdapter", "OpenClawRuntimeClient"]

--- a/tests/adapters/test_openclaw_executor_adapter.py
+++ b/tests/adapters/test_openclaw_executor_adapter.py
@@ -1,0 +1,133 @@
+"""Tests for minimal real OpenClaw executor adapter translation and normalization."""
+
+from __future__ import annotations
+
+import unittest
+
+from modules.adapters.executor_adapter import ExecutorDispatchInput
+from modules.adapters.openclaw import OpenClawExecutorAdapter
+from modules.intake.task_envelope import create_task_envelope
+
+
+class _FakeOpenClawClient:
+    def __init__(self, response_payload: dict) -> None:
+        self.response_payload = response_payload
+        self.last_request: dict | None = None
+
+    def execute(self, request_payload: dict) -> dict:
+        self.last_request = request_payload
+        return self.response_payload
+
+
+class OpenClawExecutorAdapterTests(unittest.TestCase):
+    def _dispatch_input(self) -> ExecutorDispatchInput:
+        task_envelope = create_task_envelope(
+            {
+                "id": "task-oc-1",
+                "title": "Implement minimal adapter",
+                "description": "Map canonical task input to OpenClaw and normalize output",
+                "origin": {
+                    "source_system": "linear",
+                    "source_type": "issue",
+                    "source_id": "KNO-157",
+                },
+                "constraints": [
+                    {
+                        "type": "policy",
+                        "description": "Do not allow executor to mutate lifecycle directly",
+                    }
+                ],
+                "acceptance_criteria": [
+                    {
+                        "id": "ac-1",
+                        "description": "OpenClaw request shape is adapter-local",
+                    },
+                    {
+                        "id": "ac-2",
+                        "description": "Outputs are normalized into canonical execution advisory facts",
+                    },
+                ],
+            }
+        )
+        task_envelope["artifacts"]["completion_evidence"]["required_artifact_types"] = [
+            "pull_request",
+            "commit",
+        ]
+
+        return ExecutorDispatchInput.from_task_envelope(
+            task_envelope,
+            attempt_id="attempt-oc-1",
+            assigned_executor="openclaw-worker",
+            context_references=("https://example.test/context/1",),
+        )
+
+    def test_dispatch_projects_canonical_input_to_openclaw_request(self) -> None:
+        fake_client = _FakeOpenClawClient(
+            response_payload={
+                "run_id": "run-1",
+                "events": [
+                    {
+                        "id": "evt-1",
+                        "type": "run_started",
+                        "timestamp": "2026-04-02T10:00:00Z",
+                    },
+                    {
+                        "id": "evt-2",
+                        "type": "run_succeeded",
+                        "timestamp": "2026-04-02T10:05:00Z",
+                    },
+                ],
+                "artifacts": [
+                    {
+                        "type": "pull_request",
+                        "id": "pr-77",
+                        "url": "https://github.com/sfayka/Harness/pull/77",
+                    }
+                ],
+                "completion": {
+                    "reported_complete": True,
+                    "confidence": "medium",
+                    "reason": "OpenClaw finished execution",
+                },
+            }
+        )
+        adapter = OpenClawExecutorAdapter(runtime_client=fake_client)
+
+        dispatch_input = self._dispatch_input()
+        output = adapter.dispatch(dispatch_input)
+
+        assert fake_client.last_request is not None
+        self.assertEqual(fake_client.last_request["task"]["id"], "task-oc-1")
+        self.assertEqual(fake_client.last_request["task"]["attempt_id"], "attempt-oc-1")
+        self.assertEqual(fake_client.last_request["task"]["required_artifacts"], ["pull_request", "commit"])
+        self.assertEqual(fake_client.last_request["executor"]["target"], "openclaw-worker")
+
+        self.assertEqual(output.events[0].event_type.value, "execution_started")
+        self.assertEqual(output.events[1].event_type.value, "execution_succeeded")
+        self.assertEqual(output.events[1].advisory_completion.reported_complete, True)
+        self.assertEqual(output.events[1].provenance.source_system, "openclaw")
+        self.assertEqual(output.artifact_references[0].artifact_type, "pull_request")
+        self.assertTrue(output.metadata["advisory_only"])
+
+    def test_dispatch_rejects_unknown_openclaw_event_type(self) -> None:
+        fake_client = _FakeOpenClawClient(
+            response_payload={
+                "run_id": "run-2",
+                "events": [
+                    {
+                        "id": "evt-1",
+                        "type": "unknown",
+                        "timestamp": "2026-04-02T10:00:00Z",
+                    }
+                ],
+                "artifacts": [],
+            }
+        )
+        adapter = OpenClawExecutorAdapter(runtime_client=fake_client)
+
+        with self.assertRaisesRegex(ValueError, "Unsupported OpenClaw event type"):
+            adapter.dispatch(self._dispatch_input())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a minimal real `OpenClawExecutorAdapter` that projects canonical `ExecutorDispatchInput` into an adapter-local OpenClaw request payload
- normalize OpenClaw runtime events, artifacts, and completion signals back into canonical advisory execution facts
- expose OpenClaw adapter exports from `modules.adapters`
- add adapter-focused tests that verify request projection, output normalization, and invalid event-type rejection
- update the OpenClaw adapter README from scaffold language to implemented minimal-path behavior

## Validation
- `python -m unittest discover -s tests`

## Scope/Contract Notes
- preserves advisory-only completion semantics
- keeps OpenClaw request/response shape isolated inside adapter translation code
- does not authorize lifecycle completion from executor output
