### PR TITLE
Normalize GitHub and Linear external facts for reevaluation

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -15,26 +15,15 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from modules.connectors import (
+    GitHubConnectorInputError,
     LinearConnectorInputError,
     LinearIngressInputError,
+    translate_github_artifact_facts,
+    translate_linear_facts,
     translate_linear_submission_payload,
 )
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
-from modules.contracts.task_envelope_external_facts import (
-    BranchFact,
-    ChangedFileFact,
-    ChangedFilesSummary,
-    CommitFact,
-    ExternalFactValidationError,
-    GitHubArtifactFacts,
-    LinearFacts,
-    LinearProjectFact,
-    LinearTaskReference,
-    LinearWorkflowFact,
-    PullRequestFact,
-    RepositoryFact,
-    validate_linear_facts,
-)
+from modules.contracts.task_envelope_external_facts import ExternalFactValidationError, GitHubArtifactFacts, LinearFacts
 from modules.contracts.task_envelope_reconciliation import ExpectedCodeContext
 from modules.contracts.task_envelope_review import (
     ReviewDecisionResult,
@@ -121,100 +110,23 @@ def _require_non_empty_string(value: Any, *, field_name: str) -> str:
     return value.strip()
 
 
-def _parse_repository(payload: dict[str, Any] | None) -> RepositoryFact | None:
-    if payload is None:
-        return None
-    return RepositoryFact(**_require_mapping(payload, field_name="external_facts.github_facts.repository"))
-
-
-def _parse_branch(payload: dict[str, Any] | None) -> BranchFact | None:
-    if payload is None:
-        return None
-    return BranchFact(**_require_mapping(payload, field_name="external_facts.github_facts.branch"))
-
-
-def _parse_commit(payload: dict[str, Any] | None) -> CommitFact | None:
-    if payload is None:
-        return None
-    return CommitFact(**_require_mapping(payload, field_name="external_facts.github_facts.commit"))
-
-
-def _parse_pull_request(payload: dict[str, Any] | None) -> PullRequestFact | None:
-    if payload is None:
-        return None
-    return PullRequestFact(**_require_mapping(payload, field_name="external_facts.github_facts.pull_request"))
-
-
-def _parse_changed_files(payload: dict[str, Any] | None) -> ChangedFilesSummary | None:
-    if payload is None:
-        return None
-    changed_files_payload = _require_mapping(payload, field_name="external_facts.github_facts.changed_files")
-    files = tuple(ChangedFileFact(**item) for item in changed_files_payload.get("files", []))
-    return ChangedFilesSummary(
-        files=files,
-        matches_expected_scope=changed_files_payload.get("matches_expected_scope"),
-    )
-
-
 def _parse_github_facts(payload: dict[str, Any] | None) -> GitHubArtifactFacts | None:
     if payload is None:
         return None
     github_payload = _require_mapping(payload, field_name="external_facts.github_facts")
-    return GitHubArtifactFacts(
-        artifact_found=github_payload.get("artifact_found", True),
-        repository=_parse_repository(_optional_mapping(github_payload.get("repository"), field_name="repository")),
-        branch=_parse_branch(_optional_mapping(github_payload.get("branch"), field_name="branch")),
-        commit=_parse_commit(_optional_mapping(github_payload.get("commit"), field_name="commit")),
-        pull_request=_parse_pull_request(_optional_mapping(github_payload.get("pull_request"), field_name="pull_request")),
-        changed_files=_parse_changed_files(_optional_mapping(github_payload.get("changed_files"), field_name="changed_files")),
-        artifact_refs=tuple(),
-        reasons=_optional_string_tuple(github_payload.get("reasons"), field_name="external_facts.github_facts.reasons"),
-    )
+    try:
+        return translate_github_artifact_facts(github_payload)
+    except (GitHubConnectorInputError, ExternalFactValidationError) as error:
+        raise ApiRequestError(str(error)) from error
 
 
 def _parse_linear_facts(payload: dict[str, Any] | None) -> LinearFacts | None:
     if payload is None:
         return None
     linear_payload = _require_mapping(payload, field_name="external_facts.linear_facts")
-    record_found = linear_payload.get("record_found", True)
-    if not isinstance(record_found, bool):
-        raise ApiRequestError("external_facts.linear_facts.record_found must be a boolean")
-
-    raw_workflow_payload = linear_payload.get("workflow")
-    workflow = None
-    if record_found:
-        workflow_payload = _optional_mapping(raw_workflow_payload, field_name="external_facts.linear_facts.workflow")
-        if workflow_payload is None:
-            raise ApiRequestError(LINEAR_WORKFLOW_CONTRACT_ERROR)
-        workflow_id = workflow_payload.get("workflow_id")
-        workflow_name = workflow_payload.get("workflow_name")
-        if not isinstance(workflow_id, str) or not workflow_id.strip():
-            raise ApiRequestError(LINEAR_WORKFLOW_CONTRACT_ERROR)
-        if not isinstance(workflow_name, str) or not workflow_name.strip():
-            raise ApiRequestError(LINEAR_WORKFLOW_CONTRACT_ERROR)
-        workflow = LinearWorkflowFact(
-            workflow_id=workflow_id.strip(),
-            workflow_name=workflow_name.strip(),
-            state_type=workflow_payload.get("state_type"),
-        )
-    elif raw_workflow_payload is not None:
-        raise ApiRequestError(LINEAR_WORKFLOW_CONTRACT_ERROR)
-
-    project_payload = _optional_mapping(linear_payload.get("project"), field_name="project")
-    task_reference_payload = _optional_mapping(linear_payload.get("task_reference"), field_name="task_reference")
-    linear_facts = LinearFacts(
-        record_found=record_found,
-        issue_id=linear_payload.get("issue_id"),
-        issue_key=linear_payload.get("issue_key"),
-        state=linear_payload.get("state"),
-        workflow=workflow,
-        project=LinearProjectFact(**project_payload) if project_payload is not None else None,
-        task_reference=LinearTaskReference(**task_reference_payload) if task_reference_payload is not None else None,
-        reasons=_optional_string_tuple(linear_payload.get("reasons"), field_name="external_facts.linear_facts.reasons"),
-    )
     try:
-        return validate_linear_facts(linear_facts)
-    except ExternalFactValidationError as error:
+        return translate_linear_facts(linear_payload)
+    except (LinearConnectorInputError, ExternalFactValidationError) as error:
         if "workflow" in str(error):
             raise ApiRequestError(LINEAR_WORKFLOW_CONTRACT_ERROR) from error
         raise ApiRequestError(str(error)) from error

--- a/modules/connectors/github_facts.py
+++ b/modules/connectors/github_facts.py
@@ -196,11 +196,42 @@ def translate_github_changed_files(files_payload: Sequence[Mapping[str, Any]] | 
     return ChangedFilesSummary(files=tuple(files))
 
 
+def _translate_changed_files_summary(payload: Any) -> ChangedFilesSummary | None:
+    if payload is None:
+        return None
+    if isinstance(payload, Mapping):
+        changed_files_payload = _require_mapping(payload, field_name="changed_files")
+        files = translate_github_changed_files(changed_files_payload.get("files"))
+        matches_expected_scope = _optional_bool(changed_files_payload.get("matches_expected_scope"))
+        if files is None:
+            return ChangedFilesSummary(matches_expected_scope=matches_expected_scope)
+        return ChangedFilesSummary(
+            files=files.files,
+            matches_expected_scope=matches_expected_scope,
+        )
+    return translate_github_changed_files(payload)
+
+
 def translate_github_artifact_references(payload: Mapping[str, Any]) -> tuple[ArtifactReferenceFact, ...]:
     """Translate GitHub-shaped commit/PR references into normalized artifact refs."""
 
     payload = _require_mapping(payload, field_name="github_payload")
     refs: list[ArtifactReferenceFact] = []
+
+    raw_artifact_refs = payload.get("artifact_refs")
+    if raw_artifact_refs is not None:
+        if not isinstance(raw_artifact_refs, Sequence) or isinstance(raw_artifact_refs, (str, bytes, bytearray)):
+            raise GitHubConnectorInputError("artifact_refs must be a sequence of mappings")
+        for index, raw_ref in enumerate(raw_artifact_refs):
+            ref_payload = _require_mapping(raw_ref, field_name=f"artifact_refs[{index}]")
+            refs.append(
+                ArtifactReferenceFact(
+                    artifact_type=_require_string(ref_payload.get("artifact_type"), field_name=f"artifact_refs[{index}].artifact_type"),
+                    external_id=_require_string(ref_payload.get("external_id"), field_name=f"artifact_refs[{index}].external_id"),
+                    url=_optional_string(ref_payload.get("url")),
+                )
+            )
+        return tuple(refs)
 
     pull_request_payload = _optional_mapping(payload.get("pull_request"), field_name="pull_request")
     if pull_request_payload is not None:
@@ -239,7 +270,9 @@ def translate_github_artifact_facts(payload: Mapping[str, Any]) -> GitHubArtifac
     branch_payload = _optional_mapping(payload.get("branch"), field_name="branch")
     commit_payload = _optional_mapping(payload.get("commit"), field_name="commit")
     pull_request_payload = _optional_mapping(payload.get("pull_request"), field_name="pull_request")
-    changed_files_payload = payload.get("files")
+    changed_files_payload = payload.get("changed_files")
+    if changed_files_payload is None:
+        changed_files_payload = payload.get("files")
 
     github_facts = GitHubArtifactFacts(
         artifact_found=artifact_found,
@@ -247,7 +280,7 @@ def translate_github_artifact_facts(payload: Mapping[str, Any]) -> GitHubArtifac
         branch=translate_github_branch(branch_payload) if branch_payload is not None else None,
         commit=translate_github_commit(commit_payload) if commit_payload is not None else None,
         pull_request=translate_github_pull_request(pull_request_payload) if pull_request_payload is not None else None,
-        changed_files=translate_github_changed_files(changed_files_payload),
+        changed_files=_translate_changed_files_summary(changed_files_payload),
         artifact_refs=translate_github_artifact_references(payload),
         reasons=tuple(payload.get("reasons", ())),
     )

--- a/modules/connectors/linear_facts.py
+++ b/modules/connectors/linear_facts.py
@@ -73,9 +73,12 @@ def translate_linear_workflow(workflow_payload: Mapping[str, Any]) -> LinearWork
 
     workflow_payload = _require_mapping(workflow_payload, field_name="workflow")
     return LinearWorkflowFact(
-        workflow_id=_require_string(workflow_payload.get("id"), field_name="workflow.id"),
+        workflow_id=_require_string(
+            workflow_payload.get("workflow_id") or workflow_payload.get("id"),
+            field_name="workflow.id",
+        ),
         workflow_name=_require_string(
-            workflow_payload.get("name") or workflow_payload.get("label"),
+            workflow_payload.get("workflow_name") or workflow_payload.get("name") or workflow_payload.get("label"),
             field_name="workflow.name",
         ),
         state_type=_optional_string(
@@ -91,7 +94,7 @@ def translate_linear_project(project_payload: Mapping[str, Any]) -> LinearProjec
 
     project_payload = _require_mapping(project_payload, field_name="project")
     return LinearProjectFact(
-        project_id=_require_string(project_payload.get("id"), field_name="project.id"),
+        project_id=_require_string(project_payload.get("project_id") or project_payload.get("id"), field_name="project.id"),
         project_name=_optional_string(project_payload.get("name")),
     )
 
@@ -132,10 +135,16 @@ def translate_linear_facts(payload: Mapping[str, Any]) -> LinearFacts:
             or issue_payload.get("key")
             or issue_payload.get("issueKey")
         )
+    issue_id = issue_id or _optional_string(payload.get("issue_id"))
+    issue_key = issue_key or _optional_string(payload.get("issue_key"))
 
     state_name = _optional_string(payload.get("state_name"))
     workflow = None
-    if isinstance(raw_state_payload, Mapping):
+    canonical_workflow_payload = _optional_mapping(payload.get("workflow"), field_name="workflow")
+    if canonical_workflow_payload is not None:
+        workflow = translate_linear_workflow(canonical_workflow_payload)
+        state_name = _optional_string(payload.get("state")) or workflow.workflow_name
+    elif isinstance(raw_state_payload, Mapping):
         workflow = translate_linear_workflow(raw_state_payload)
         state_name = workflow.workflow_name
     elif raw_state_payload is not None:

--- a/tests/connectors/test_github_facts.py
+++ b/tests/connectors/test_github_facts.py
@@ -186,6 +186,30 @@ class GitHubConnectorScaffoldingTests(unittest.TestCase):
 
         self.assertEqual(result.outcome, ReconciliationOutcome.NO_MISMATCH)
 
+    def test_accepts_canonical_changed_files_and_artifact_refs(self) -> None:
+        github_facts = translate_github_artifact_facts(
+            {
+                "repository": {"host": "github.com", "owner": "sfayka", "name": "Harness"},
+                "branch": {"name": "codex/github-connector"},
+                "changed_files": {
+                    "files": [{"path": "modules/api.py", "change_type": "modified", "additions": 10, "deletions": 2}],
+                    "matches_expected_scope": True,
+                },
+                "artifact_refs": [
+                    {
+                        "artifact_type": "pull_request",
+                        "external_id": "PR-111",
+                        "url": "https://github.com/sfayka/Harness/pull/111",
+                    }
+                ],
+            }
+        )
+
+        self.assertTrue(github_facts.changed_files_match)
+        self.assertEqual(len(github_facts.changed_files.files), 1)
+        self.assertEqual(len(github_facts.artifact_refs), 1)
+        self.assertEqual(github_facts.artifact_refs[0].external_id, "PR-111")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/connectors/test_linear_facts.py
+++ b/tests/connectors/test_linear_facts.py
@@ -124,6 +124,25 @@ class LinearConnectorTranslationTests(unittest.TestCase):
         self.assertEqual(facts.project.project_id, "project_1")
         self.assertEqual(facts.task_reference.harness_task_id, "task-linear-1")
 
+    def test_accepts_canonical_linear_payload_identifiers(self) -> None:
+        facts = translate_linear_facts(
+            {
+                "issue_id": "lin_910",
+                "issue_key": "HAR-910",
+                "state": "completed",
+                "workflow": {
+                    "workflow_id": "wf_done",
+                    "workflow_name": "completed",
+                    "state_type": "completed",
+                },
+            }
+        )
+
+        self.assertEqual(facts.issue_id, "lin_910")
+        self.assertEqual(facts.issue_key, "HAR-910")
+        self.assertEqual(facts.workflow.workflow_id, "wf_done")
+        self.assertEqual(facts.state, "completed")
+
     def test_rejects_string_state_without_workflow_object(self) -> None:
         with self.assertRaisesRegex(LinearConnectorInputError, "record_found=true requires workflow/state"):
             translate_linear_facts(

--- a/tests/e2e/test_task_evaluation_pipeline.py
+++ b/tests/e2e/test_task_evaluation_pipeline.py
@@ -115,6 +115,35 @@ class TaskEvaluationRuntimeScenarioTests(RuntimeApiTestCase):
         self.assertTrue(flow.reevaluate_response["accepted_completion"])
         self.assertEqual(flow.final_fetch_response["task"]["status"], "completed")
 
+    def test_reevaluate_normalizes_github_and_linear_vendor_shaped_facts(self) -> None:
+        create_payload = build_create_task_payload("e2e-reevaluate-normalized-facts")
+        happy_overlays = build_happy_path_overlays()
+        flow = self.run_create_fetch_reevaluate_fetch(
+            create_payload=create_payload,
+            reevaluate_payload_builder=lambda _task: build_reevaluate_payload(
+                new_artifacts=happy_overlays["linked_artifacts"],
+                completion_evidence=happy_overlays["completion_evidence"],
+                external_facts={
+                    "expected_code_context": build_expected_code_context(),
+                    "github_facts": {
+                        "repository": {"full_name": "KnoxAnalytics/HARNESS-DRYRUN"},
+                        "branch": {"ref": "codex/e2e-test", "baseRefName": "main"},
+                        "commit": {"sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"},
+                        "pull_request": {"number": 2, "reviewDecision": "approved"},
+                    },
+                    "linear_facts": {
+                        "issue": {"id": "lin_42", "identifier": "HAR-42"},
+                        "state": {"id": "workflow_done", "name": "completed", "type": "completed"},
+                    },
+                },
+                runtime_facts=happy_overlays["runtime_facts"],
+            ),
+        )
+
+        self.assertEqual(flow.reevaluate_status, 200)
+        self.assertTrue(flow.reevaluate_response["accepted_completion"])
+        self.assertEqual(flow.final_fetch_response["task"]["status"], "completed")
+
     def test_valid_but_insufficient_evidence_emits_concrete_reason(self) -> None:
         create_payload = build_create_task_payload("e2e-insufficient-valid")
 


### PR DESCRIPTION
## Summary\n- route API external fact parsing through connector translators so reevaluation accepts both canonical and vendor-shaped GitHub/Linear payloads\n- extend GitHub normalization for canonical changed file summaries and explicit artifact_refs\n- extend Linear normalization for canonical identifiers (/, /, and )\n- add regression coverage for connector canonical payload support and reevaluation with vendor-shaped facts\n\n## Validation\n- python -m unittest discover -s tests