### PR TITLE
Implement explicit failure classification for execution/evaluation outcomes

### DIFF
--- a/modules/contracts/failure_classification.py
+++ b/modules/contracts/failure_classification.py
@@ -1,0 +1,117 @@
+"""Failure classification primitives for execution and evaluation outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+class FailureCategory(StrEnum):
+    """Stable failure categories used by retry and diagnosis workflows."""
+
+    NONE = "none"
+    ENVIRONMENT_BOOTSTRAP_FAILURE = "environment_bootstrap_failure"
+    EXECUTOR_RUNTIME_FAILURE = "executor_runtime_failure"
+    CONTRACT_VIOLATION = "contract_violation"
+    ARTIFACT_VALIDATION_FAILURE = "artifact_validation_failure"
+    EVIDENCE_INSUFFICIENCY = "evidence_insufficiency"
+    RECONCILIATION_MISMATCH = "reconciliation_mismatch"
+    MANUAL_REVIEW_REQUIRED = "manual_review_required"
+
+
+class FailureNature(StrEnum):
+    """High-level class for retry and policy handling."""
+
+    NONE = "none"
+    TRANSIENT = "transient"
+    SEMANTIC = "semantic"
+    CONTRACT = "contract"
+
+
+@dataclass(frozen=True)
+class FailureClassification:
+    """Explicit, auditable failure classification output."""
+
+    category: FailureCategory
+    nature: FailureNature
+    retryable: bool
+    reason: str
+
+
+def classify_verification_outcome(
+    *,
+    outcome: str,
+    runtime_failure_observed: bool,
+    reason: str,
+) -> FailureClassification:
+    """Map verification outcomes to stable failure classes."""
+
+    if outcome == "accepted_completion":
+        return FailureClassification(
+            category=FailureCategory.NONE,
+            nature=FailureNature.NONE,
+            retryable=False,
+            reason=reason,
+        )
+
+    if outcome == "verification_deferred":
+        return FailureClassification(
+            category=FailureCategory.NONE,
+            nature=FailureNature.NONE,
+            retryable=False,
+            reason=reason,
+        )
+
+    if outcome == "review_required":
+        return FailureClassification(
+            category=FailureCategory.MANUAL_REVIEW_REQUIRED,
+            nature=FailureNature.SEMANTIC,
+            retryable=False,
+            reason=reason,
+        )
+
+    if outcome == "insufficient_evidence":
+        return FailureClassification(
+            category=FailureCategory.EVIDENCE_INSUFFICIENCY,
+            nature=FailureNature.SEMANTIC,
+            retryable=False,
+            reason=reason,
+        )
+
+    if outcome == "external_mismatch":
+        return FailureClassification(
+            category=FailureCategory.RECONCILIATION_MISMATCH,
+            nature=FailureNature.SEMANTIC,
+            retryable=False,
+            reason=reason,
+        )
+
+    if outcome == "terminal_invalid" and runtime_failure_observed:
+        return FailureClassification(
+            category=FailureCategory.EXECUTOR_RUNTIME_FAILURE,
+            nature=FailureNature.TRANSIENT,
+            retryable=True,
+            reason=reason,
+        )
+
+    if outcome in {"terminal_invalid", "blocked_unresolved_conditions"}:
+        return FailureClassification(
+            category=FailureCategory.CONTRACT_VIOLATION,
+            nature=FailureNature.CONTRACT,
+            retryable=False,
+            reason=reason,
+        )
+
+    return FailureClassification(
+        category=FailureCategory.CONTRACT_VIOLATION,
+        nature=FailureNature.CONTRACT,
+        retryable=False,
+        reason=reason,
+    )
+
+
+__all__ = [
+    "FailureCategory",
+    "FailureClassification",
+    "FailureNature",
+    "classify_verification_outcome",
+]

--- a/modules/contracts/task_envelope_enforcement.py
+++ b/modules/contracts/task_envelope_enforcement.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
+from modules.contracts.failure_classification import FailureCategory, FailureClassification, FailureNature
 from modules.contracts.task_envelope_evidence import (
     CompletionEvidenceValidationResult,
     validate_task_evidence,
@@ -80,6 +81,7 @@ class EnforcementResult:
     transition_result: TransitionResult | None
     target_status: str | None
     reasons: tuple[str, ...]
+    failure_classification: FailureClassification
     error: str | None = None
 
 
@@ -118,6 +120,19 @@ def _result_with_error(
     review_request: ReviewRequest | None = None,
     review_decision: ReviewDecisionResult | None = None,
 ) -> EnforcementResult:
+    message = str(error).lower()
+    if "bootstrap" in message or "environment" in message:
+        failure_category = FailureCategory.ENVIRONMENT_BOOTSTRAP_FAILURE
+        failure_nature = FailureNature.TRANSIENT
+        retryable = True
+    elif "evidence" in message or "artifact" in message:
+        failure_category = FailureCategory.ARTIFACT_VALIDATION_FAILURE
+        failure_nature = FailureNature.CONTRACT
+        retryable = False
+    else:
+        failure_category = FailureCategory.CONTRACT_VIOLATION
+        failure_nature = FailureNature.CONTRACT
+        retryable = False
     return EnforcementResult(
         action=action,
         task_envelope=task_envelope,
@@ -129,6 +144,12 @@ def _result_with_error(
         transition_result=None,
         target_status=None,
         reasons=(str(error),),
+        failure_classification=FailureClassification(
+            category=failure_category,
+            nature=failure_nature,
+            retryable=retryable,
+            reason=str(error),
+        ),
         error=str(error),
     )
 
@@ -180,6 +201,16 @@ def _apply_transition(
         transition_result=transition_result,
         target_status=to_status,
         reasons=(reason,),
+        failure_classification=(
+            verification_result.failure_classification
+            if verification_result is not None
+            else FailureClassification(
+                category=FailureCategory.NONE,
+                nature=FailureNature.NONE,
+                retryable=False,
+                reason=reason,
+            )
+        ),
     )
 
 
@@ -230,6 +261,12 @@ def enforce_task_envelope(
                 transition_result=None,
                 target_status=review_decision.recommended_target_status,
                 reasons=(reason,),
+                failure_classification=FailureClassification(
+                    category=FailureCategory.NONE,
+                    nature=FailureNature.NONE,
+                    retryable=False,
+                    reason=reason,
+                ),
             )
         review_transition_facts = {"terminal_failure": review_decision.record.outcome.value == "mark_failed"}
         if review_decision.recommended_target_status == "completed":
@@ -308,6 +345,7 @@ def enforce_task_envelope(
             transition_result=None,
             target_status=None,
             reasons=verification_result.reasons,
+            failure_classification=verification_result.failure_classification,
         )
 
     if verification_result.outcome == VerificationOutcome.REVIEW_REQUIRED:
@@ -358,6 +396,7 @@ def enforce_task_envelope(
             transition_result=transition_result,
             target_status=verification_result.target_status,
             reasons=verification_result.reasons,
+            failure_classification=verification_result.failure_classification,
         )
 
     target_status = verification_result.target_status
@@ -374,6 +413,7 @@ def enforce_task_envelope(
             transition_result=None,
             target_status=target_status,
             reasons=verification_result.reasons,
+            failure_classification=verification_result.failure_classification,
         )
 
     return _apply_transition(

--- a/modules/contracts/task_envelope_verification.py
+++ b/modules/contracts/task_envelope_verification.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from modules.contracts.failure_classification import FailureClassification, classify_verification_outcome
 from modules.contracts.task_envelope_evidence import CompletionEvidenceValidationResult
 from modules.contracts.task_envelope_validation import assert_valid_task_envelope
 
@@ -99,6 +100,7 @@ class VerificationDecisionResult:
     evidence_is_sufficient: bool
     reconciliation_status: ReconciliationStatus
     reasons: tuple[str, ...]
+    failure_classification: FailureClassification
 
 
 def _base_reasons(task_id: str, decision_input: VerificationDecisionInput) -> list[str]:
@@ -167,9 +169,10 @@ def evaluate_verification_decision(
         # a final completion-policy decision. This is deferred evaluation, not a
         # blocked control-plane outcome.
         reasons.append("No completion claim is currently being evaluated")
+        outcome = VerificationOutcome.VERIFICATION_DEFERRED
         return VerificationDecisionResult(
             task_id=task_id,
-            outcome=VerificationOutcome.VERIFICATION_DEFERRED,
+            outcome=outcome,
             target_status=None,
             claimed_completion=False,
             accepted_completion=False,
@@ -180,13 +183,19 @@ def evaluate_verification_decision(
             evidence_is_sufficient=evidence_result.is_sufficient,
             reconciliation_status=decision_input.reconciliation_facts.status,
             reasons=tuple(reasons),
+            failure_classification=classify_verification_outcome(
+                outcome=outcome,
+                runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+                reason=reasons[-1],
+            ),
         )
 
     if decision_input.runtime_facts.terminal_failure:
         reasons.append("Runtime facts indicate terminal execution failure")
+        outcome = VerificationOutcome.TERMINAL_INVALID
         return VerificationDecisionResult(
             task_id=task_id,
-            outcome=VerificationOutcome.TERMINAL_INVALID,
+            outcome=outcome,
             target_status="failed",
             claimed_completion=True,
             accepted_completion=False,
@@ -197,15 +206,21 @@ def evaluate_verification_decision(
             evidence_is_sufficient=evidence_result.is_sufficient,
             reconciliation_status=decision_input.reconciliation_facts.status,
             reasons=tuple(reasons),
+            failure_classification=classify_verification_outcome(
+                outcome=outcome,
+                runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+                reason=reasons[-1],
+            ),
         )
 
     if decision_input.review_reasons or decision_input.reconciliation_facts.status == ReconciliationStatus.REVIEW_REQUIRED:
         reasons.extend(decision_input.review_reasons)
         reasons.extend(decision_input.reconciliation_facts.reasons)
         reasons.append("Automatic verification cannot safely accept completion")
+        outcome = VerificationOutcome.REVIEW_REQUIRED
         return VerificationDecisionResult(
             task_id=task_id,
-            outcome=VerificationOutcome.REVIEW_REQUIRED,
+            outcome=outcome,
             target_status="in_review",
             claimed_completion=True,
             accepted_completion=False,
@@ -216,15 +231,21 @@ def evaluate_verification_decision(
             evidence_is_sufficient=evidence_result.is_sufficient,
             reconciliation_status=decision_input.reconciliation_facts.status,
             reasons=tuple(reasons),
+            failure_classification=classify_verification_outcome(
+                outcome=outcome,
+                runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+                reason=reasons[-1],
+            ),
         )
 
     if decision_input.reconciliation_facts.status == ReconciliationStatus.MISMATCH:
         reasons.extend(decision_input.reconciliation_facts.reasons)
         if decision_input.reconciliation_facts.terminal:
             reasons.append("External mismatch is terminal under verification policy")
+            outcome = VerificationOutcome.TERMINAL_INVALID
             return VerificationDecisionResult(
                 task_id=task_id,
-                outcome=VerificationOutcome.TERMINAL_INVALID,
+                outcome=outcome,
                 target_status="failed",
                 claimed_completion=True,
                 accepted_completion=False,
@@ -235,12 +256,18 @@ def evaluate_verification_decision(
                 evidence_is_sufficient=evidence_result.is_sufficient,
                 reconciliation_status=decision_input.reconciliation_facts.status,
                 reasons=tuple(reasons),
+                failure_classification=classify_verification_outcome(
+                    outcome=outcome,
+                    runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+                    reason=reasons[-1],
+                ),
             )
 
         reasons.append("External mismatch prevents completion from being preserved")
+        outcome = VerificationOutcome.EXTERNAL_MISMATCH
         return VerificationDecisionResult(
             task_id=task_id,
-            outcome=VerificationOutcome.EXTERNAL_MISMATCH,
+            outcome=outcome,
             target_status="blocked",
             claimed_completion=True,
             accepted_completion=False,
@@ -251,6 +278,11 @@ def evaluate_verification_decision(
             evidence_is_sufficient=evidence_result.is_sufficient,
             reconciliation_status=decision_input.reconciliation_facts.status,
             reasons=tuple(reasons),
+            failure_classification=classify_verification_outcome(
+                outcome=outcome,
+                runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+                reason=reasons[-1],
+            ),
         )
 
     unresolved_conditions = list(decision_input.unresolved_conditions)
@@ -263,9 +295,10 @@ def evaluate_verification_decision(
         # should therefore remain blocked rather than merely deferred.
         reasons.extend(unresolved_conditions)
         reasons.append("Verification is blocked by unresolved conditions")
+        outcome = VerificationOutcome.BLOCKED_UNRESOLVED_CONDITIONS
         return VerificationDecisionResult(
             task_id=task_id,
-            outcome=VerificationOutcome.BLOCKED_UNRESOLVED_CONDITIONS,
+            outcome=outcome,
             target_status="blocked",
             claimed_completion=True,
             accepted_completion=False,
@@ -276,13 +309,19 @@ def evaluate_verification_decision(
             evidence_is_sufficient=evidence_result.is_sufficient,
             reconciliation_status=decision_input.reconciliation_facts.status,
             reasons=tuple(reasons),
+            failure_classification=classify_verification_outcome(
+                outcome=outcome,
+                runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+                reason=reasons[-1],
+            ),
         )
 
     if not decision_input.acceptance_criteria_satisfied:
         reasons.append("Acceptance criteria are not yet satisfied strongly enough for completion")
+        outcome = VerificationOutcome.BLOCKED_UNRESOLVED_CONDITIONS
         return VerificationDecisionResult(
             task_id=task_id,
-            outcome=VerificationOutcome.BLOCKED_UNRESOLVED_CONDITIONS,
+            outcome=outcome,
             target_status="blocked",
             claimed_completion=True,
             accepted_completion=False,
@@ -293,13 +332,19 @@ def evaluate_verification_decision(
             evidence_is_sufficient=evidence_result.is_sufficient,
             reconciliation_status=decision_input.reconciliation_facts.status,
             reasons=tuple(reasons),
+            failure_classification=classify_verification_outcome(
+                outcome=outcome,
+                runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+                reason=reasons[-1],
+            ),
         )
 
     if not evidence_result.is_sufficient:
         reasons.extend(_evidence_insufficiency_reasons(task_envelope, evidence_result))
+        outcome = VerificationOutcome.INSUFFICIENT_EVIDENCE
         return VerificationDecisionResult(
             task_id=task_id,
-            outcome=VerificationOutcome.INSUFFICIENT_EVIDENCE,
+            outcome=outcome,
             target_status="blocked",
             claimed_completion=True,
             accepted_completion=False,
@@ -310,12 +355,18 @@ def evaluate_verification_decision(
             evidence_is_sufficient=False,
             reconciliation_status=decision_input.reconciliation_facts.status,
             reasons=tuple(reasons),
+            failure_classification=classify_verification_outcome(
+                outcome=outcome,
+                runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+                reason=reasons[-1],
+            ),
         )
 
     reasons.append("Acceptance criteria, evidence, and reconciliation all support completion")
+    outcome = VerificationOutcome.ACCEPTED_COMPLETION
     return VerificationDecisionResult(
         task_id=task_id,
-        outcome=VerificationOutcome.ACCEPTED_COMPLETION,
+        outcome=outcome,
         target_status="completed",
         claimed_completion=True,
         accepted_completion=True,
@@ -326,6 +377,11 @@ def evaluate_verification_decision(
         evidence_is_sufficient=evidence_result.is_sufficient,
         reconciliation_status=decision_input.reconciliation_facts.status,
         reasons=tuple(reasons),
+        failure_classification=classify_verification_outcome(
+            outcome=outcome,
+            runtime_failure_observed=decision_input.runtime_facts.executor_reported_failure,
+            reason=reasons[-1],
+        ),
     )
 
 

--- a/modules/evaluation.py
+++ b/modules/evaluation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from modules.contracts.failure_classification import FailureClassification
 from modules.contracts.task_envelope_end_to_end import (
     CanonicalCaseInput,
     CanonicalExternalFactBundle,
@@ -44,6 +45,7 @@ class HarnessEvaluationResult:
     accepted_completion: bool
     requires_review: bool
     invalid_input: bool
+    failure_classification: FailureClassification
     reasons: tuple[str, ...]
     error: str | None
 
@@ -80,6 +82,7 @@ class HarnessEvaluator:
             accepted_completion=bool(verification_result and verification_result.accepted_completion),
             requires_review=bool(verification_result and verification_result.requires_review),
             invalid_input=enforcement_result.action == EnforcementAction.INVALID_INPUT,
+            failure_classification=enforcement_result.failure_classification,
             reasons=enforcement_result.reasons,
             error=enforcement_result.error,
         )

--- a/tests/contracts/test_task_envelope_enforcement.py
+++ b/tests/contracts/test_task_envelope_enforcement.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 
+from modules.contracts.failure_classification import FailureCategory
 from modules.contracts.task_envelope_enforcement import (
     EnforcementAction,
     EnforcementInput,
@@ -227,6 +228,7 @@ class IntegratedEnforcementTests(unittest.TestCase):
         self.assertEqual(result.verification_result.outcome, VerificationOutcome.VERIFICATION_DEFERRED)
         self.assertIsNone(result.transition_result)
         self.assertIsNone(result.error)
+        self.assertEqual(result.failure_classification.category, FailureCategory.NONE)
 
     def test_claimed_completion_with_valid_evidence_transitions_to_completed(self) -> None:
         task = _base_task(status="executing")
@@ -264,6 +266,7 @@ class IntegratedEnforcementTests(unittest.TestCase):
         self.assertEqual(result.target_status, "blocked")
         self.assertEqual(result.task_envelope["status"], "blocked")
         self.assertEqual(result.verification_result.outcome, VerificationOutcome.INSUFFICIENT_EVIDENCE)
+        self.assertEqual(result.failure_classification.category, FailureCategory.EVIDENCE_INSUFFICIENCY)
 
     def test_reconciliation_mismatch_moves_completed_task_back_to_blocked(self) -> None:
         task = _base_task(status="completed")
@@ -282,6 +285,7 @@ class IntegratedEnforcementTests(unittest.TestCase):
         self.assertEqual(result.action, EnforcementAction.TRANSITION_APPLIED)
         self.assertEqual(result.target_status, "blocked")
         self.assertEqual(result.verification_result.outcome, VerificationOutcome.EXTERNAL_MISMATCH)
+        self.assertEqual(result.failure_classification.category, FailureCategory.RECONCILIATION_MISMATCH)
 
     def test_task_requiring_manual_review_returns_review_required(self) -> None:
         task = _base_task(status="intake_ready")
@@ -511,6 +515,7 @@ class IntegratedEnforcementTests(unittest.TestCase):
 
         self.assertEqual(result.action, EnforcementAction.INVALID_INPUT)
         self.assertIsNotNone(result.error)
+        self.assertEqual(result.failure_classification.category, FailureCategory.ARTIFACT_VALIDATION_FAILURE)
 
 
 if __name__ == "__main__":

--- a/tests/contracts/test_task_envelope_verification.py
+++ b/tests/contracts/test_task_envelope_verification.py
@@ -4,6 +4,7 @@ import copy
 import unittest
 
 from modules.contracts.task_envelope_evidence import validate_task_evidence
+from modules.contracts.failure_classification import FailureCategory, FailureNature
 from modules.contracts.task_envelope_verification import (
     ReconciliationFacts,
     ReconciliationStatus,
@@ -198,6 +199,8 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.target_status, "completed")
         self.assertTrue(result.accepted_completion)
         self.assertTrue(result.verification_passed)
+        self.assertEqual(result.failure_classification.category, FailureCategory.NONE)
+        self.assertEqual(result.failure_classification.nature, FailureNature.NONE)
 
     def test_returns_insufficient_evidence_when_validated_evidence_is_not_sufficient(self) -> None:
         task_envelope = _base_task_envelope()
@@ -208,6 +211,7 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.outcome, VerificationOutcome.INSUFFICIENT_EVIDENCE)
         self.assertEqual(result.target_status, "blocked")
         self.assertFalse(result.accepted_completion)
+        self.assertEqual(result.failure_classification.category, FailureCategory.EVIDENCE_INSUFFICIENCY)
 
     def test_reports_concrete_reason_when_evidence_policy_is_deferred(self) -> None:
         task_envelope = _base_task_envelope()
@@ -244,6 +248,7 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.outcome, VerificationOutcome.EXTERNAL_MISMATCH)
         self.assertEqual(result.target_status, "blocked")
         self.assertFalse(result.is_terminal)
+        self.assertEqual(result.failure_classification.category, FailureCategory.RECONCILIATION_MISMATCH)
 
     def test_returns_review_required_when_manual_review_is_needed(self) -> None:
         result = _evaluate(
@@ -254,6 +259,7 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.outcome, VerificationOutcome.REVIEW_REQUIRED)
         self.assertTrue(result.requires_review)
         self.assertEqual(result.target_status, "in_review")
+        self.assertEqual(result.failure_classification.category, FailureCategory.MANUAL_REVIEW_REQUIRED)
 
     def test_returns_blocked_when_verification_conditions_are_unresolved(self) -> None:
         result = _evaluate(
@@ -282,6 +288,8 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.outcome, VerificationOutcome.TERMINAL_INVALID)
         self.assertEqual(result.target_status, "failed")
         self.assertTrue(result.is_terminal)
+        self.assertEqual(result.failure_classification.category, FailureCategory.EXECUTOR_RUNTIME_FAILURE)
+        self.assertEqual(result.failure_classification.nature, FailureNature.TRANSIENT)
 
     def test_rejects_invalid_evidence_inputs_before_policy_evaluation(self) -> None:
         task_envelope = _base_task_envelope()
@@ -307,6 +315,7 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertIsNone(result.target_status)
         self.assertFalse(result.verification_passed)
         self.assertIn("No completion claim is currently being evaluated", result.reasons)
+        self.assertEqual(result.failure_classification.category, FailureCategory.NONE)
 
     def test_distinguishes_deferred_verification_from_blocked_control_plane_outcome(self) -> None:
         deferred = _evaluate(_base_task_envelope(), claimed_completion=False)


### PR DESCRIPTION
## Summary
- add first-class failure classification primitives with stable categories (, , , , , , )
- integrate classification into verification decisions so each evaluation outcome now carries auditable failure metadata
- propagate classification through enforcement and top-level evaluation results
- add contract tests that verify representative classifications for accepted, insufficient evidence, reconciliation mismatch, manual review required, runtime terminal failure, and invalid artifact evidence paths

## Validation
- 