### PR TITLE
Implement bounded retry and recovery policy for classified failures

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -22,6 +22,7 @@ from modules.connectors import (
     translate_linear_facts,
     translate_linear_submission_payload,
 )
+from modules.contracts.failure_classification import FailureCategory
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
 from modules.contracts.task_envelope_external_facts import ExternalFactValidationError, GitHubArtifactFacts, LinearFacts
 from modules.contracts.task_envelope_reconciliation import ExpectedCodeContext
@@ -55,6 +56,15 @@ LINEAR_WORKFLOW_CONTRACT_ERROR = (
     "Invalid external_facts.linear_facts.workflow: must be null/omitted when record_found=false, "
     "or an object with workflow_id and workflow_name when record_found=true"
 )
+_DEFAULT_CLASSIFIED_RETRY_BUDGET = 2
+_CLASSIFIED_RETRY_BUDGET_ENV = "HARNESS_CLASSIFIED_RETRY_BUDGET"
+_RETRYABLE_FAILURE_CATEGORIES = frozenset(
+    {
+        FailureCategory.ENVIRONMENT_BOOTSTRAP_FAILURE,
+        FailureCategory.EXECUTOR_RUNTIME_FAILURE,
+        FailureCategory.EXTERNAL_AVAILABILITY_FAILURE,
+    }
+)
 
 
 def _iso_now() -> str:
@@ -65,6 +75,17 @@ def _parse_iso_timestamp(value: str | None) -> datetime:
     if not value:
         return datetime.min.replace(tzinfo=timezone.utc)
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _classified_retry_budget() -> int:
+    raw_budget = os.getenv(_CLASSIFIED_RETRY_BUDGET_ENV)
+    if raw_budget is None:
+        return _DEFAULT_CLASSIFIED_RETRY_BUDGET
+    try:
+        parsed_budget = int(raw_budget)
+    except ValueError:
+        return _DEFAULT_CLASSIFIED_RETRY_BUDGET
+    return max(parsed_budget, 0)
 
 
 def _require_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
@@ -598,6 +619,72 @@ class HarnessApiService:
             return self.store.put_task(task_envelope)
         return self.store.update_task(task_envelope)
 
+    def _with_retry_provenance(
+        self,
+        request: HarnessEvaluationRequest,
+        *,
+        attempt_number: int,
+        max_retries: int,
+        retry_reason: str,
+        category: FailureCategory,
+    ) -> HarnessEvaluationRequest:
+        runtime_facts = request.runtime_facts
+        next_attempt_count = max(runtime_facts.attempt_count, 1) + 1
+        return replace(
+            request,
+            runtime_facts=replace(
+                runtime_facts,
+                attempt_count=next_attempt_count,
+                latest_attempt_outcome="retry_scheduled",
+            ),
+            retry_context={
+                "attempt_number": attempt_number,
+                "max_retries": max_retries,
+                "triggered_by_category": category.value,
+                "triggered_by_reason": retry_reason,
+                "scheduled_at": _iso_now(),
+            },
+        )
+
+    def _evaluate_with_classified_retries(
+        self,
+        request: HarnessEvaluationRequest,
+    ) -> tuple[int, dict[str, Any], HarnessEvaluationResult | None, tuple[tuple[HarnessEvaluationRequest, HarnessEvaluationResult], ...]]:
+        attempts: list[tuple[HarnessEvaluationRequest, HarnessEvaluationResult]] = []
+        max_retries = _classified_retry_budget()
+        active_request = request
+
+        for retry_index in range(max_retries + 1):
+            status, response_payload, result = _evaluate_request(active_request)
+            if result is None:
+                return status, response_payload, None, tuple(attempts)
+            attempts.append((active_request, result))
+
+            category = result.failure_classification.category
+            should_retry = (
+                status == HTTPStatus.OK
+                and not result.invalid_input
+                and result.failure_classification.retryable
+                and category in _RETRYABLE_FAILURE_CATEGORIES
+                and retry_index < max_retries
+            )
+            if not should_retry:
+                return status, response_payload, result, tuple(attempts)
+
+            active_request = self._with_retry_provenance(
+                request=active_request,
+                attempt_number=retry_index + 1,
+                max_retries=max_retries,
+                retry_reason=result.failure_classification.reason,
+                category=category,
+            )
+
+        status, response_payload, result = _evaluate_request(active_request)
+        if result is None:
+            return status, response_payload, None, tuple(attempts)
+        attempts.append((active_request, result))
+        return status, response_payload, result, tuple(attempts)
+
     def submit(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:
             request = parse_evaluation_request(payload)
@@ -617,7 +704,7 @@ class HarnessApiService:
         except TaskEnvelopeNotFoundError:
             pass
 
-        status, response_payload, result = _evaluate_request(request)
+        status, response_payload, result, attempts = self._evaluate_with_classified_retries(request)
         if result is None:
             return status, response_payload
 
@@ -632,9 +719,12 @@ class HarnessApiService:
                 "duplicate_task_id": True,
             }
 
-        record = self.store.put_evaluation_record(request=request, result=result)
+        record = None
+        for attempt_request, attempt_result in attempts:
+            record = self.store.put_evaluation_record(request=attempt_request, result=attempt_result)
         response_payload["task_envelope"] = _to_jsonable(stored_task)
-        response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        if record is not None:
+            response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
     def submit_linear_ingress(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
@@ -671,7 +761,7 @@ class HarnessApiService:
                 review_is_active=_review_gate_is_active(stored_task, existing_records),
             )
 
-        status, response_payload, result = _evaluate_request(request)
+        status, response_payload, result, attempts = self._evaluate_with_classified_retries(request)
         if result is None:
             return status, response_payload
 
@@ -679,9 +769,12 @@ class HarnessApiService:
             return status, response_payload
 
         stored_task = self._upsert_task(result.task_envelope)
-        record = self.store.put_evaluation_record(request=request, result=result)
+        record = None
+        for attempt_request, attempt_result in attempts:
+            record = self.store.put_evaluation_record(request=attempt_request, result=attempt_result)
         response_payload["task_envelope"] = _to_jsonable(stored_task)
-        response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        if record is not None:
+            response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
     def reevaluate(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
@@ -706,7 +799,7 @@ class HarnessApiService:
             ),
         )
 
-        status, response_payload, result = _evaluate_request(request)
+        status, response_payload, result, attempts = self._evaluate_with_classified_retries(request)
         if result is None:
             return status, response_payload
 
@@ -714,9 +807,12 @@ class HarnessApiService:
             return status, response_payload
 
         stored_task = self.store.update_task(result.task_envelope)
-        record = self.store.put_evaluation_record(request=request, result=result)
+        record = None
+        for attempt_request, attempt_result in attempts:
+            record = self.store.put_evaluation_record(request=attempt_request, result=attempt_result)
         response_payload["task_envelope"] = _to_jsonable(stored_task)
-        response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        if record is not None:
+            response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
     def submit_completion_claim(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
@@ -741,16 +837,19 @@ class HarnessApiService:
             ),
         )
 
-        status, response_payload, result = _evaluate_request(request)
+        status, response_payload, result, attempts = self._evaluate_with_classified_retries(request)
         if result is None:
             return status, response_payload
         if result.invalid_input:
             return status, response_payload
 
         stored_task = self.store.update_task(result.task_envelope)
-        record = self.store.put_evaluation_record(request=request, result=result)
+        record = None
+        for attempt_request, attempt_result in attempts:
+            record = self.store.put_evaluation_record(request=attempt_request, result=attempt_result)
         response_payload["task_envelope"] = _to_jsonable(stored_task)
-        response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        if record is not None:
+            response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
     def get_task(self, task_id: str) -> tuple[int, dict[str, Any]]:

--- a/modules/contracts/failure_classification.py
+++ b/modules/contracts/failure_classification.py
@@ -11,6 +11,7 @@ class FailureCategory(StrEnum):
     NONE = "none"
     ENVIRONMENT_BOOTSTRAP_FAILURE = "environment_bootstrap_failure"
     EXECUTOR_RUNTIME_FAILURE = "executor_runtime_failure"
+    EXTERNAL_AVAILABILITY_FAILURE = "external_availability_failure"
     CONTRACT_VIOLATION = "contract_violation"
     ARTIFACT_VALIDATION_FAILURE = "artifact_validation_failure"
     EVIDENCE_INSUFFICIENCY = "evidence_insufficiency"

--- a/modules/contracts/task_envelope_enforcement.py
+++ b/modules/contracts/task_envelope_enforcement.py
@@ -125,6 +125,10 @@ def _result_with_error(
         failure_category = FailureCategory.ENVIRONMENT_BOOTSTRAP_FAILURE
         failure_nature = FailureNature.TRANSIENT
         retryable = True
+    elif "timeout" in message or "temporarily unavailable" in message or "connection" in message:
+        failure_category = FailureCategory.EXTERNAL_AVAILABILITY_FAILURE
+        failure_nature = FailureNature.TRANSIENT
+        retryable = True
     elif "evidence" in message or "artifact" in message:
         failure_category = FailureCategory.ARTIFACT_VALIDATION_FAILURE
         failure_nature = FailureNature.CONTRACT

--- a/modules/evaluation.py
+++ b/modules/evaluation.py
@@ -32,6 +32,7 @@ class HarnessEvaluationRequest:
     review_request: ReviewRequest | None = None
     review_decision: ReviewDecisionResult | None = None
     review_is_active: bool = False
+    retry_context: dict[str, object] | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -848,6 +848,66 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(payload["database_host"], "db.internal.example")
         self.assertFalse(payload["database_schema_ready"])
 
+    def test_service_retries_retryable_transient_failure_with_bounded_budget(self) -> None:
+        payload = _request_payload("accepted_completion")
+        payload["request"]["runtime_facts"] = {
+            "executor_reported_success": True,
+            "executor_reported_failure": True,
+            "terminal_failure": True,
+            "attempt_count": 1,
+            "latest_attempt_outcome": "failed",
+        }
+
+        with patch.dict(os.environ, {"HARNESS_CLASSIFIED_RETRY_BUDGET": "2"}):
+            status, response = self.service.submit(payload)
+        history_status, history = self.service.get_evaluation_history(response["task_envelope"]["id"])
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["failure_classification"]["category"], "executor_runtime_failure")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history["evaluations"]), 3)
+        retry_requests = [item["request"].get("retry_context") for item in history["evaluations"]]
+        self.assertIsNone(retry_requests[0])
+        self.assertEqual(retry_requests[1]["triggered_by_category"], "executor_runtime_failure")
+        self.assertEqual(retry_requests[2]["triggered_by_category"], "executor_runtime_failure")
+
+    def test_service_does_not_retry_non_retryable_contract_violation(self) -> None:
+        payload = _request_payload("accepted_completion")
+        payload["request"]["unresolved_conditions"] = ["Execution checkpoint is missing."]
+
+        with patch.dict(os.environ, {"HARNESS_CLASSIFIED_RETRY_BUDGET": "2"}):
+            status, response = self.service.submit(payload)
+        history_status, history = self.service.get_evaluation_history(response["task_envelope"]["id"])
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["failure_classification"]["category"], "contract_violation")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history["evaluations"]), 1)
+
+    def test_service_does_not_retry_non_retryable_evidence_insufficiency(self) -> None:
+        payload = _request_payload("blocked_insufficient_evidence")
+
+        with patch.dict(os.environ, {"HARNESS_CLASSIFIED_RETRY_BUDGET": "2"}):
+            status, response = self.service.submit(payload)
+        history_status, history = self.service.get_evaluation_history(response["task_envelope"]["id"])
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["failure_classification"]["category"], "evidence_insufficiency")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history["evaluations"]), 1)
+
+    def test_service_does_not_retry_non_retryable_reconciliation_mismatch(self) -> None:
+        payload = _request_payload("blocked_reconciliation_mismatch")
+
+        with patch.dict(os.environ, {"HARNESS_CLASSIFIED_RETRY_BUDGET": "2"}):
+            status, response = self.service.submit(payload)
+        history_status, history = self.service.get_evaluation_history(response["task_envelope"]["id"])
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["failure_classification"]["category"], "reconciliation_mismatch")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history["evaluations"]), 1)
+
 
 class HarnessHttpApiTests(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary\n- add a bounded classified-retry loop for submit/evaluate/reevaluate/completion paths in the API service\n- retry only explicitly retryable transient classifications (environment bootstrap, executor runtime, external availability)\n- persist each retry attempt as its own append-only evaluation record with retry provenance context\n- add external availability failure category support and tests for retryable/non-retryable classes\n\n## Testing\n- python -m unittest tests.test_api.HarnessApiServiceTests\n- python -m unittest discover -s tests