### PR TITLE
Implement canonical manual-task ingestion into Harness store

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See:
   - `POST /tasks/<task_id>/completion-claims`
 - Integration helper surface:
   - `POST /ingress/linear`
+  - `POST /ingress/manual`
 
 ### Persistence
 

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -6,6 +6,7 @@ This document is the source-of-truth API usage guide for execution agents and do
 
 - `POST /tasks`: submit a new canonical task payload
 - `POST /tasks/<task_id>/reevaluate`: submit new facts, artifacts, or review decisions for an existing task
+- `POST /ingress/manual`: submit a manually initiated task and let Harness intake assign a canonical `task_id` when one is not provided
 
 For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritative mutation path.
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -18,9 +18,11 @@ from modules.connectors import (
     GitHubConnectorInputError,
     LinearConnectorInputError,
     LinearIngressInputError,
+    ManualIngressInputError,
     translate_github_artifact_facts,
     translate_linear_facts,
     translate_linear_submission_payload,
+    translate_manual_submission_payload,
 )
 from modules.contracts.failure_classification import FailureCategory
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
@@ -738,6 +740,18 @@ class HarnessApiService:
 
         return self.submit(canonical_payload)
 
+
+    def submit_manual_ingress(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            canonical_payload = translate_manual_submission_payload(payload)
+        except (ManualIngressInputError, ValueError) as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        return self.submit(canonical_payload)
+
     def evaluate(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:
             request = parse_evaluation_request(payload)
@@ -958,7 +972,7 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         path_components = _task_path_components(self.path)
         request_path = urlparse(self.path).path
 
-        if request_path not in {"/evaluate", "/tasks", "/ingress/linear"} and not (
+        if request_path not in {"/evaluate", "/tasks", "/ingress/linear", "/ingress/manual"} and not (
             len(path_components) == 3
             and path_components[0] == "tasks"
             and path_components[2] in {"reevaluate", "completion-claims"}
@@ -979,6 +993,8 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             status, response_payload = service.submit(payload)
         elif request_path == "/ingress/linear":
             status, response_payload = service.submit_linear_ingress(payload)
+        elif request_path == "/ingress/manual":
+            status, response_payload = service.submit_manual_ingress(payload)
         elif request_path == "/evaluate":
             status, response_payload = service.evaluate(payload)
         elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "completion-claims":

--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -30,6 +30,10 @@ from .linear_ingress import (
     LinearIngressInputError,
     translate_linear_submission_payload,
 )
+from .manual_ingress import (
+    ManualIngressInputError,
+    translate_manual_submission_payload,
+)
 from .ingress_request_builder import (
     IngressRequestBuilderError,
     IngressSourceContext,
@@ -59,6 +63,7 @@ __all__ = [
     "IngressTaskIntent",
     "LinearConnectorInputError",
     "LinearIngressInputError",
+    "ManualIngressInputError",
     "OpenClawHarnessSpikeClient",
     "OpenClawHarnessSpikeError",
     "OpenClawHarnessSpikeResult",
@@ -76,6 +81,7 @@ __all__ = [
     "translate_github_pull_request",
     "translate_github_repository",
     "translate_linear_facts",
+    "translate_manual_submission_payload",
     "translate_linear_submission_payload",
     "translate_linear_project",
     "translate_linear_task_reference",

--- a/modules/connectors/manual_ingress.py
+++ b/modules/connectors/manual_ingress.py
@@ -1,0 +1,165 @@
+"""Manual ingress adapter that translates operator-provided task intent into canonical submission payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from typing import Any
+
+from modules.intake.task_envelope import create_task_envelope
+
+
+class ManualIngressInputError(ValueError):
+    """Raised when a manual-ingress payload cannot be translated into canonical submission input."""
+
+
+def _require_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ManualIngressInputError(f"{field_name} must be a mapping")
+    return payload
+
+
+def _optional_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any] | None:
+    if payload is None:
+        return None
+    return _require_mapping(payload, field_name=field_name)
+
+
+def _require_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ManualIngressInputError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_string(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ManualIngressInputError(f"{field_name} must be a string when provided")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _optional_mapping_list(value: Any, *, field_name: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ManualIngressInputError(f"{field_name} must be a list of objects")
+
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        normalized.append(dict(_require_mapping(item, field_name=f"{field_name}[{index}]")))
+    return normalized
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _build_task_envelope(payload: Mapping[str, Any]) -> dict[str, Any]:
+    task_payload = _require_mapping(payload.get("task"), field_name="task")
+
+    intake_input: dict[str, Any] = {
+        "id": _optional_string(payload.get("task_id"), field_name="task_id"),
+        "title": _require_string(task_payload.get("title"), field_name="task.title"),
+        "description": _require_string(task_payload.get("description"), field_name="task.description"),
+        "origin": {
+            "source_system": "manual",
+            "source_type": _optional_string(task_payload.get("source_type"), field_name="task.source_type")
+            or "manual",
+            "source_id": _optional_string(task_payload.get("source_id"), field_name="task.source_id")
+            or _require_string(task_payload.get("title"), field_name="task.title"),
+            "ingress_name": _optional_string(task_payload.get("ingress_name"), field_name="task.ingress_name"),
+            "ingress_id": _optional_string(task_payload.get("ingress_id"), field_name="task.ingress_id"),
+            "requested_by": _optional_string(task_payload.get("requested_by"), field_name="task.requested_by"),
+        },
+        "objective": task_payload.get("objective"),
+        "constraints": task_payload.get("constraints"),
+        "acceptance_criteria": task_payload.get("acceptance_criteria"),
+    }
+
+    intake_input = {key: value for key, value in intake_input.items() if value is not None}
+    task_envelope = create_task_envelope(intake_input)
+
+    task_status = _optional_string(payload.get("task_status"), field_name="task_status")
+    if task_status is not None:
+        task_envelope["status"] = task_status
+        if task_status == "completed":
+            task_envelope["timestamps"]["completed_at"] = task_envelope["timestamps"]["updated_at"]
+
+    assigned_executor = _optional_mapping(payload.get("assigned_executor"), field_name="assigned_executor")
+    if assigned_executor is not None:
+        task_envelope["assigned_executor"] = dict(assigned_executor)
+
+    priority = _optional_string(payload.get("priority"), field_name="priority")
+    if priority is not None:
+        task_envelope["priority"] = priority
+
+    linked_artifacts = _optional_mapping_list(payload.get("linked_artifacts"), field_name="linked_artifacts")
+    if linked_artifacts:
+        task_envelope["artifacts"]["items"] = deepcopy(linked_artifacts)
+
+    completion_evidence = _optional_mapping(payload.get("completion_evidence"), field_name="completion_evidence")
+    if completion_evidence is not None:
+        task_envelope["artifacts"]["completion_evidence"].update(dict(completion_evidence))
+
+    task_envelope["extensions"] = {
+        "manual": {
+            "submission": {
+                "metadata": _to_jsonable(payload.get("metadata") or {}),
+            }
+        }
+    }
+
+    return task_envelope
+
+
+def translate_manual_submission_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate a manual-ingress payload into a canonical ``POST /tasks`` request body."""
+
+    payload = _require_mapping(payload, field_name="manual_ingress_payload")
+    task_envelope = _build_task_envelope(payload)
+
+    external_facts_payload = _optional_mapping(payload.get("external_facts"), field_name="external_facts")
+    canonical_external_facts = (
+        {str(key): _to_jsonable(value) for key, value in external_facts_payload.items()}
+        if external_facts_payload is not None
+        else {}
+    )
+
+    request_payload: dict[str, Any] = {
+        "task_envelope": task_envelope,
+        "external_facts": canonical_external_facts,
+        "claimed_completion": bool(payload.get("claimed_completion", False)),
+        "acceptance_criteria_satisfied": bool(payload.get("acceptance_criteria_satisfied", False)),
+    }
+
+    runtime_facts = _optional_mapping(payload.get("runtime_facts"), field_name="runtime_facts")
+    if runtime_facts is not None:
+        request_payload["runtime_facts"] = dict(runtime_facts)
+
+    unresolved_conditions = payload.get("unresolved_conditions")
+    if unresolved_conditions is not None:
+        if not isinstance(unresolved_conditions, list) or not all(
+            isinstance(item, str) and item.strip() for item in unresolved_conditions
+        ):
+            raise ManualIngressInputError("unresolved_conditions must be a list of non-empty strings")
+        request_payload["unresolved_conditions"] = [item.strip() for item in unresolved_conditions]
+
+    return {"request": request_payload}
+
+
+__all__ = [
+    "ManualIngressInputError",
+    "translate_manual_submission_payload",
+]

--- a/tests/connectors/test_manual_ingress.py
+++ b/tests/connectors/test_manual_ingress.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.connectors import ManualIngressInputError, translate_manual_submission_payload
+
+
+class ManualIngressConnectorTests(unittest.TestCase):
+    def _payload(self) -> dict:
+        return {
+            "task": {
+                "title": "Verify canonical manual ingestion",
+                "description": "Ensure manual task ingestion persists in Harness store.",
+                "requested_by": "operator@example.com",
+                "acceptance_criteria": [
+                    {
+                        "id": "ac-1",
+                        "description": "Manual task is persisted in store-backed task list.",
+                        "required": True,
+                    }
+                ],
+            },
+            "metadata": {"source": "manual-test"},
+            "claimed_completion": False,
+            "acceptance_criteria_satisfied": False,
+        }
+
+    def test_translate_manual_submission_payload_generates_task_id_when_omitted(self) -> None:
+        payload = translate_manual_submission_payload(self._payload())
+        task = payload["request"]["task_envelope"]
+
+        self.assertIsInstance(task["id"], str)
+        self.assertTrue(task["id"])
+        self.assertEqual(task["origin"]["source_system"], "manual")
+        self.assertEqual(task["extensions"]["manual"]["submission"]["metadata"]["source"], "manual-test")
+
+    def test_translate_manual_submission_payload_requires_task_shape(self) -> None:
+        with self.assertRaises(ManualIngressInputError):
+            translate_manual_submission_payload({"task": "invalid"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -329,6 +329,30 @@ def _linear_ingress_payload(case_name: str, *, task_id: str | None = None) -> di
     return payload
 
 
+
+
+def _manual_ingress_payload(*, task_id: str | None = None) -> dict:
+    payload: dict[str, object] = {
+        "task": {
+            "title": "Manual canonical ingestion task",
+            "description": "Create and persist a manual task through canonical submission.",
+            "requested_by": "operator@example.com",
+            "ingress_name": "Manual",
+            "ingress_id": "KNO-162",
+            "acceptance_criteria": [
+                {
+                    "id": "ac-1",
+                    "description": "Task is persisted and queryable via canonical inspection surfaces.",
+                    "required": True,
+                }
+            ],
+        },
+        "metadata": {"mode": "manual"},
+    }
+    if task_id is not None:
+        payload["task_id"] = task_id
+    return payload
+
 def _review_note_artifact(artifact_id: str = "artifact-review-note-1") -> dict:
     return {
         "id": artifact_id,
@@ -611,6 +635,29 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(payload["task_envelope"]["status"], "completed")
         self.assertEqual(task_status, 200)
         self.assertEqual(task_payload["task"]["extensions"]["linear"]["issue_id"], f"lin-{payload['task_envelope']['id']}")
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
+
+    def test_service_can_submit_manual_ingress_payload_and_expose_canonical_read_surfaces(self) -> None:
+        status, payload = self.service.submit_manual_ingress(_manual_ingress_payload())
+
+        task_id = payload["task_envelope"]["id"]
+        list_status, list_payload = self.service.list_tasks()
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+        timeline_status, timeline_payload = self.service.get_task_timeline(task_id)
+        history_status, history_payload = self.service.get_evaluation_history(task_id)
+
+        self.assertEqual(status, 200)
+        self.assertTrue(task_id)
+        self.assertEqual(payload["task_envelope"]["origin"]["source_system"], "manual")
+        self.assertEqual(list_status, 200)
+        self.assertEqual(list_payload["tasks"][0]["task_id"], task_id)
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["task_id"], task_id)
+        self.assertEqual(timeline_status, 200)
+        self.assertEqual(timeline_payload["task_id"], task_id)
+        self.assertGreaterEqual(timeline_payload["event_count"], 1)
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history_payload["evaluations"]), 1)
 
@@ -1119,6 +1166,15 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history_payload["evaluations"]), 1)
         self.assertEqual(history_payload["evaluations"][0]["result"]["task_envelope"]["status"], "completed")
+
+
+    def test_api_accepts_manual_ingress_submission_endpoint(self) -> None:
+        status, payload = self._post_json("/ingress/manual", _manual_ingress_payload())
+
+        self.assertEqual(status, 200)
+        self.assertIn("task_envelope", payload)
+        self.assertEqual(payload["task_envelope"]["origin"]["source_system"], "manual")
+        self.assertTrue(payload["task_envelope"]["id"])
 
     def test_api_accepts_manual_happy_path_overlay_payload(self) -> None:
         payload = _manual_happy_path_overlay_payload()


### PR DESCRIPTION
## Summary
- add a canonical manual-ingress translation path that converts operator-provided task intent into a schema-valid TaskEnvelope
- add POST /ingress/manual and delegate to canonical submission/evaluation persistence flow
- add tests proving generated task IDs and store-backed task/read-model/timeline visibility
- document manual ingress endpoint in README and API usage docs

## Validation
- python -m unittest discover -s tests