### PR TITLE
Implement manual execution attempt attachment and reevaluation linkage

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -332,6 +332,33 @@ def _parse_completion_claim(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _parse_execution_attempt(payload: dict[str, Any], *, completion_claim: dict[str, Any]) -> dict[str, Any] | None:
+    attempt_payload = _optional_mapping(payload.get("execution_attempt"), field_name="execution_attempt")
+    if attempt_payload is None:
+        return None
+
+    attempt_id = _require_non_empty_string(attempt_payload.get("attempt_id"), field_name="execution_attempt.attempt_id")
+    recorded_at = _optional_non_empty_string(attempt_payload.get("recorded_at"), field_name="execution_attempt.recorded_at")
+    status = _optional_non_empty_string(attempt_payload.get("status"), field_name="execution_attempt.status") or "reported"
+    reported_by = _optional_non_empty_string(attempt_payload.get("reported_by"), field_name="execution_attempt.reported_by")
+    artifact_references = _optional_object_list(
+        attempt_payload.get("artifact_references"),
+        field_name="execution_attempt.artifact_references",
+    )
+    metadata = _optional_mapping(attempt_payload.get("metadata"), field_name="execution_attempt.metadata") or {}
+
+    return {
+        "attempt_id": attempt_id,
+        "recorded_at": recorded_at or completion_claim["reported_at"],
+        "status": status,
+        "reported_by": reported_by or completion_claim.get("reported_by"),
+        "completion_claim_id": completion_claim["claim_id"],
+        "artifact_references": [deepcopy(artifact) for artifact in artifact_references],
+        "metadata": dict(metadata),
+        "reevaluation": {},
+    }
+
+
 def _with_advisory_completion_claim(task_envelope: dict[str, Any], *, claim: dict[str, Any]) -> dict[str, Any]:
     merged_task = deepcopy(task_envelope)
     execution_metadata = dict(merged_task["observability"]["execution_metadata"] or {})
@@ -350,12 +377,71 @@ def _with_advisory_completion_claim(task_envelope: dict[str, Any], *, claim: dic
     return merged_task
 
 
+def _with_execution_attempt_record(task_envelope: dict[str, Any], *, attempt: dict[str, Any]) -> dict[str, Any]:
+    merged_task = deepcopy(task_envelope)
+    execution_metadata = dict(merged_task["observability"]["execution_metadata"] or {})
+    existing_attempts = execution_metadata.get("execution_attempts")
+    if existing_attempts is None:
+        execution_attempts: list[dict[str, Any]] = []
+    elif isinstance(existing_attempts, list):
+        execution_attempts = [deepcopy(item) for item in existing_attempts]
+    else:
+        raise ApiRequestError("observability.execution_metadata.execution_attempts must be an array")
+
+    execution_attempts.append(deepcopy(attempt))
+    execution_metadata["execution_attempts"] = execution_attempts
+    merged_task["observability"]["execution_metadata"] = execution_metadata
+    merged_task["timestamps"]["updated_at"] = _iso_now()
+    return merged_task
+
+
+def _with_reevaluation_linked_execution_attempt(
+    task_envelope: dict[str, Any],
+    *,
+    completion_claim_id: str,
+    evaluation_record: EvaluationRecord | None,
+) -> dict[str, Any]:
+    if evaluation_record is None:
+        return task_envelope
+
+    merged_task = deepcopy(task_envelope)
+    execution_metadata = dict(merged_task["observability"]["execution_metadata"] or {})
+    existing_attempts = execution_metadata.get("execution_attempts")
+    if existing_attempts is None:
+        return merged_task
+    if not isinstance(existing_attempts, list):
+        raise ApiRequestError("observability.execution_metadata.execution_attempts must be an array")
+
+    updated_attempts: list[Any] = [deepcopy(item) for item in existing_attempts]
+    for attempt in reversed(updated_attempts):
+        if not isinstance(attempt, dict):
+            continue
+        if attempt.get("completion_claim_id") != completion_claim_id:
+            continue
+        reevaluation = dict(attempt.get("reevaluation") or {})
+        reevaluation["evaluation_id"] = evaluation_record.evaluation_id
+        reevaluation["linked_at"] = evaluation_record.recorded_at
+        reevaluation["action"] = (evaluation_record.result if isinstance(evaluation_record.result, dict) else {}).get("action")
+        attempt["reevaluation"] = reevaluation
+        break
+    else:
+        return merged_task
+
+    execution_metadata["execution_attempts"] = updated_attempts
+    merged_task["observability"]["execution_metadata"] = execution_metadata
+    merged_task["timestamps"]["updated_at"] = _iso_now()
+    return merged_task
+
+
 def parse_completion_claim_request(task_envelope: dict[str, Any], payload: dict[str, Any]) -> HarnessEvaluationRequest:
     """Parse an executor completion claim into canonical reevaluation input."""
 
     request_payload = _require_mapping(payload.get("request"), field_name="request")
     completion_claim = _parse_completion_claim(request_payload)
     merged_task = _with_advisory_completion_claim(task_envelope, claim=completion_claim)
+    execution_attempt = _parse_execution_attempt(request_payload, completion_claim=completion_claim)
+    if execution_attempt is not None:
+        merged_task = _with_execution_attempt_record(merged_task, attempt=execution_attempt)
 
     new_artifacts = _optional_object_list(request_payload.get("new_artifacts"), field_name="new_artifacts")
     if new_artifacts:
@@ -861,6 +947,20 @@ class HarnessApiService:
         record = None
         for attempt_request, attempt_result in attempts:
             record = self.store.put_evaluation_record(request=attempt_request, result=attempt_result)
+        latest_claim_id = (
+            request.task_envelope.get("observability", {})
+            .get("execution_metadata", {})
+            .get("advisory_completion_claims", [{}])[-1]
+            .get("claim_id")
+        )
+        if isinstance(latest_claim_id, str) and latest_claim_id:
+            stored_task = self.store.update_task(
+                _with_reevaluation_linked_execution_attempt(
+                    stored_task,
+                    completion_claim_id=latest_claim_id,
+                    evaluation_record=record,
+                )
+            )
         response_payload["task_envelope"] = _to_jsonable(stored_task)
         if record is not None:
             response_payload["evaluation_record"] = _serialize_evaluation_record(record)

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -164,6 +164,28 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
             }
         )
 
+    execution_attempts = ((task_envelope.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []
+    for index, attempt in enumerate(execution_attempts):
+        if not isinstance(attempt, dict):
+            continue
+        reevaluation = attempt.get("reevaluation") if isinstance(attempt.get("reevaluation"), dict) else {}
+        events.append(
+            {
+                "event_id": f"{task_envelope['id']}:execution_attempt:{attempt.get('attempt_id') or index}",
+                "event_type": "execution_attempt_recorded",
+                "occurred_at": attempt.get("recorded_at") or timestamps.get("updated_at"),
+                "summary": f"Execution attempt recorded: {attempt.get('attempt_id')}",
+                "source": attempt.get("reported_by") or "executor",
+                "details": {
+                    "attempt_id": attempt.get("attempt_id"),
+                    "status": attempt.get("status"),
+                    "completion_claim_id": attempt.get("completion_claim_id"),
+                    "artifact_references": list(attempt.get("artifact_references") or []),
+                    "reevaluation": dict(reevaluation or {}),
+                },
+            }
+        )
+
     for record in records:
         result_payload = record.result if isinstance(record.result, dict) else {}
         enforcement_result = dict(result_payload.get("enforcement_result") or {})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -265,6 +265,25 @@ def _completion_claim_payload(*, claim_id: str = "claim-1") -> dict:
     }
 
 
+def _execution_attempt_payload(*, attempt_id: str = "attempt-1") -> dict:
+    return {
+        "execution_attempt": {
+            "attempt_id": attempt_id,
+            "recorded_at": "2026-04-01T08:00:05Z",
+            "status": "succeeded",
+            "reported_by": "stub-executor",
+            "artifact_references": [
+                {
+                    "reference_id": f"{attempt_id}:log",
+                    "artifact_type": "execution_log",
+                    "location": "stub://attempts/log",
+                }
+            ],
+            "metadata": {"executor_run_id": f"stub-run-{attempt_id}"},
+        }
+    }
+
+
 def _schema_invalid_submission_payload() -> dict:
     payload = _request_payload("accepted_completion")
     completion_evidence = payload["request"]["task_envelope"]["artifacts"]["completion_evidence"]
@@ -793,6 +812,42 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertTrue(latest_request["claimed_completion"])
         claims = latest_request["task_envelope"]["observability"]["execution_metadata"]["advisory_completion_claims"]
         self.assertEqual(claims[-1]["claim_id"], "claim-complete-1")
+
+    def test_service_completion_claim_can_attach_execution_attempt_and_link_reevaluation(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+        submit_payload = {"request": {"task_envelope": deepcopy(payload["request"]["task_envelope"])}}
+        submit_status, submit_response = self.service.submit(submit_payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        claim_status, claim_response = self.service.submit_completion_claim(
+            task_id,
+            {
+                "request": {
+                    **_completion_claim_payload(claim_id="claim-with-attempt-1"),
+                    **_execution_attempt_payload(attempt_id="attempt-linked-1"),
+                    "new_artifacts": deepcopy(payload["request"]["linked_artifacts"]),
+                    "completion_evidence": deepcopy(payload["request"]["completion_evidence"]),
+                    "external_facts": deepcopy(payload["request"]["external_facts"]),
+                    "acceptance_criteria_satisfied": True,
+                    "runtime_facts": deepcopy(payload["request"]["runtime_facts"]),
+                }
+            },
+        )
+        timeline_status, timeline_payload = self.service.get_task_timeline(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(claim_status, 200)
+        self.assertTrue(claim_response["accepted_completion"])
+        execution_attempts = claim_response["task_envelope"]["observability"]["execution_metadata"]["execution_attempts"]
+        latest_attempt = execution_attempts[-1]
+        self.assertEqual(latest_attempt["attempt_id"], "attempt-linked-1")
+        self.assertEqual(latest_attempt["completion_claim_id"], "claim-with-attempt-1")
+        self.assertEqual(latest_attempt["reevaluation"]["evaluation_id"], claim_response["evaluation_record"]["evaluation_id"])
+        self.assertEqual(timeline_status, 200)
+        execution_events = [
+            event for event in timeline_payload["timeline"] if event["event_type"] == "execution_attempt_recorded"
+        ]
+        self.assertTrue(execution_events)
 
     def test_service_evaluate_existing_review_required_task_cannot_be_overwritten_to_completed(self) -> None:
         initial_status, initial_response = self.service.evaluate(_request_payload("review_required"))


### PR DESCRIPTION
## Summary
- add completion-claim request support for optional  attachment data
- persist execution attempt records under task observability metadata and keep advisory completion claims append-only
- link the latest completion-claim attempt record to the resulting reevaluation record id after canonical evaluation persists
- expose execution-attempt events in task timeline read-model output
- add API coverage proving task/attempt/claim linkage plus timeline visibility

## Validation
- python -m unittest tests.test_api tests.test_read_model
- python -m unittest discover -s tests