### PR TITLE
Implement OpenClaw canonical ingress submission path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It does not trust agent-reported completion on its own. It accepts or blocks lif
 - A Python control-plane backend that evaluates canonical `TaskEnvelope` submissions.
 - A read-only Next.js dashboard over canonical inspection APIs.
 - A persistence layer for task snapshots and append-only evaluation history.
-- A thin integration boundary around Linear-shaped ingress and GitHub/Linear fact inputs.
+- A thin integration boundary around Linear/manual/OpenClaw ingress and GitHub/Linear fact inputs.
 
 Harness is not a PM tool, an agent runtime, or a chatbot UI.
 
@@ -59,6 +59,7 @@ See:
 - Integration helper surface:
   - `POST /ingress/linear`
   - `POST /ingress/manual`
+  - `POST /ingress/openclaw`
 
 ### Persistence
 

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -7,6 +7,7 @@ This document is the source-of-truth API usage guide for execution agents and do
 - `POST /tasks`: submit a new canonical task payload
 - `POST /tasks/<task_id>/reevaluate`: submit new facts, artifacts, or review decisions for an existing task
 - `POST /ingress/manual`: submit a manually initiated task and let Harness intake assign a canonical `task_id` when one is not provided
+- `POST /ingress/openclaw`: submit an OpenClaw-shaped ingress payload that is normalized into canonical `TaskEnvelope` submission
 
 For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritative mutation path.
 

--- a/docs/integration/openclaw-harness-spike.md
+++ b/docs/integration/openclaw-harness-spike.md
@@ -78,6 +78,8 @@ Other observations:
 - inspection endpoints are already sufficient for operator and dashboard visibility
 - no API redesign was required for this spike
 
+Since the spike was written, Harness added a dedicated OpenClaw ingress adapter endpoint (`POST /ingress/openclaw`) that still delegates into canonical submission semantics (`POST /tasks`) rather than introducing a separate control-plane contract.
+
 ## Scope Limits
 
 This spike does not implement:
@@ -85,6 +87,5 @@ This spike does not implement:
 - OpenClaw plugin lifecycle integration
 - OpenClaw gateway runtime integration
 - live OpenClaw message/channel wiring
-- a new Harness ingress endpoint for OpenClaw
 
 It is intentionally a narrow proof that OpenClaw can remain a client and Harness can remain a standalone service.

--- a/docs/integrations/overview.md
+++ b/docs/integrations/overview.md
@@ -45,9 +45,12 @@ The existing spike demonstrated:
 - task creation verbosity was the main pain point
 - the right fix was a thin request-builder adapter, not a new control-plane shape
 
+Harness now includes an OpenClaw-shaped ingress endpoint (`POST /ingress/openclaw`) backed by a thin adapter that normalizes request content into canonical submission payloads.
+
 Relevant code and docs:
 
 - [modules/connectors/openclaw_harness_spike.py](../../modules/connectors/openclaw_harness_spike.py)
+- [modules/connectors/openclaw_ingress.py](../../modules/connectors/openclaw_ingress.py)
 - [modules/connectors/ingress_request_builder.py](../../modules/connectors/ingress_request_builder.py)
 - [docs/integration/openclaw-harness-spike.md](../integration/openclaw-harness-spike.md)
 
@@ -58,6 +61,7 @@ Real today:
 - canonical API submission and reevaluation
 - normalized fact models
 - Linear-shaped ingress adapter
+- OpenClaw-shaped ingress adapter
 - OpenClaw-informed thin client spike
 
 Not live today:

--- a/modules/api.py
+++ b/modules/api.py
@@ -19,6 +19,8 @@ from modules.connectors import (
     LinearConnectorInputError,
     LinearIngressInputError,
     ManualIngressInputError,
+    OpenClawIngressInputError,
+    translate_openclaw_submission_payload,
     translate_github_artifact_facts,
     translate_linear_facts,
     translate_linear_submission_payload,
@@ -838,6 +840,17 @@ class HarnessApiService:
 
         return self.submit(canonical_payload)
 
+    def submit_openclaw_ingress(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            canonical_payload = translate_openclaw_submission_payload(payload)
+        except (OpenClawIngressInputError, ValueError) as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        return self.submit(canonical_payload)
+
     def evaluate(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:
             request = parse_evaluation_request(payload)
@@ -1072,7 +1085,7 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         path_components = _task_path_components(self.path)
         request_path = urlparse(self.path).path
 
-        if request_path not in {"/evaluate", "/tasks", "/ingress/linear", "/ingress/manual"} and not (
+        if request_path not in {"/evaluate", "/tasks", "/ingress/linear", "/ingress/manual", "/ingress/openclaw"} and not (
             len(path_components) == 3
             and path_components[0] == "tasks"
             and path_components[2] in {"reevaluate", "completion-claims"}
@@ -1095,6 +1108,8 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             status, response_payload = service.submit_linear_ingress(payload)
         elif request_path == "/ingress/manual":
             status, response_payload = service.submit_manual_ingress(payload)
+        elif request_path == "/ingress/openclaw":
+            status, response_payload = service.submit_openclaw_ingress(payload)
         elif request_path == "/evaluate":
             status, response_payload = service.evaluate(payload)
         elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "completion-claims":

--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -34,6 +34,10 @@ from .manual_ingress import (
     ManualIngressInputError,
     translate_manual_submission_payload,
 )
+from .openclaw_ingress import (
+    OpenClawIngressInputError,
+    translate_openclaw_submission_payload,
+)
 from .ingress_request_builder import (
     IngressRequestBuilderError,
     IngressSourceContext,
@@ -67,6 +71,7 @@ __all__ = [
     "OpenClawHarnessSpikeClient",
     "OpenClawHarnessSpikeError",
     "OpenClawHarnessSpikeResult",
+    "OpenClawIngressInputError",
     "OpenClawSourceContext",
     "OpenClawTaskIntent",
     "build_task_reevaluation_payload",
@@ -82,6 +87,7 @@ __all__ = [
     "translate_github_repository",
     "translate_linear_facts",
     "translate_manual_submission_payload",
+    "translate_openclaw_submission_payload",
     "translate_linear_submission_payload",
     "translate_linear_project",
     "translate_linear_task_reference",

--- a/modules/connectors/openclaw_ingress.py
+++ b/modules/connectors/openclaw_ingress.py
@@ -1,0 +1,162 @@
+"""OpenClaw-shaped ingress adapter for canonical Harness task submission."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from typing import Any
+
+from .ingress_request_builder import (
+    IngressRequestBuilderError,
+    IngressSourceContext,
+    IngressTaskIntent,
+    build_task_submission_payload,
+)
+
+
+class OpenClawIngressInputError(ValueError):
+    """Raised when an OpenClaw-shaped ingress payload cannot be normalized canonically."""
+
+
+def _require_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise OpenClawIngressInputError(f"{field_name} must be a mapping")
+    return payload
+
+
+def _optional_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any] | None:
+    if payload is None:
+        return None
+    return _require_mapping(payload, field_name=field_name)
+
+
+def _require_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OpenClawIngressInputError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_string(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise OpenClawIngressInputError(f"{field_name} must be a string when provided")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _optional_non_empty_string_list(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
+        raise OpenClawIngressInputError(f"{field_name} must be a list of non-empty strings")
+    return tuple(item.strip() for item in value)
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _build_openclaw_context(payload: Mapping[str, Any]) -> IngressSourceContext:
+    context = _require_mapping(payload.get("context"), field_name="context")
+    conversation_id = _require_string(context.get("conversation_id"), field_name="context.conversation_id")
+    message_id = _require_string(context.get("message_id"), field_name="context.message_id")
+
+    extension_payload = {
+        "conversation_id": conversation_id,
+        "message_id": message_id,
+        "channel": _require_string(context.get("channel"), field_name="context.channel"),
+        "workspace_id": _optional_string(context.get("workspace_id"), field_name="context.workspace_id"),
+        "user_id": _optional_string(context.get("user_id"), field_name="context.user_id"),
+        "agent_id": _optional_string(context.get("agent_id"), field_name="context.agent_id"),
+    }
+
+    return IngressSourceContext(
+        source_system="openclaw",
+        source_id=message_id,
+        ingress_name="OpenClaw",
+        ingress_id=conversation_id,
+        requested_by=_optional_string(payload.get("requested_by"), field_name="requested_by")
+        or extension_payload["user_id"],
+        extension_namespace="openclaw",
+        extension_payload=extension_payload,
+    )
+
+
+def _build_task_intent(payload: Mapping[str, Any]) -> IngressTaskIntent:
+    task = _require_mapping(payload.get("task"), field_name="task")
+    context = _require_mapping(payload.get("context"), field_name="context")
+    task_id = _optional_string(payload.get("task_id"), field_name="task_id") or _require_string(
+        context.get("message_id"),
+        field_name="context.message_id",
+    )
+    constraints = tuple(
+        {
+            "type": "ingress_constraint",
+            "description": item,
+            "required": True,
+        }
+        for item in _optional_non_empty_string_list(task.get("constraints"), field_name="task.constraints")
+    )
+    return IngressTaskIntent(
+        task_id=task_id,
+        title=_require_string(task.get("title"), field_name="task.title"),
+        description=_require_string(task.get("description"), field_name="task.description"),
+        acceptance_criteria=_optional_non_empty_string_list(task.get("acceptance_criteria"), field_name="task.acceptance_criteria"),
+        objective_summary=_optional_string(task.get("objective_summary"), field_name="task.objective_summary"),
+        deliverable_type=_optional_string(
+            task.get("objective_deliverable_type"),
+            field_name="task.objective_deliverable_type",
+        )
+        or "unspecified",
+        success_signal=_optional_string(task.get("objective_success_signal"), field_name="task.objective_success_signal")
+        or "Task satisfies declared acceptance criteria.",
+        constraints=constraints,
+        priority=_optional_string(task.get("priority"), field_name="task.priority") or "normal",
+        status=_optional_string(task.get("status"), field_name="task.status") or "intake_ready",
+    )
+
+
+def translate_openclaw_submission_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate an OpenClaw ingress payload into canonical ``POST /tasks`` input."""
+
+    payload = _require_mapping(payload, field_name="openclaw_ingress_payload")
+    try:
+        canonical_payload = build_task_submission_payload(
+            intent=_build_task_intent(payload),
+            context=_build_openclaw_context(payload),
+            external_facts=_to_jsonable(_optional_mapping(payload.get("external_facts"), field_name="external_facts")),
+            claimed_completion=bool(payload.get("claimed_completion", False)),
+            acceptance_criteria_satisfied=bool(payload.get("acceptance_criteria_satisfied", False)),
+            runtime_facts=_to_jsonable(_optional_mapping(payload.get("runtime_facts"), field_name="runtime_facts")),
+            unresolved_conditions=_optional_non_empty_string_list(
+                payload.get("unresolved_conditions"),
+                field_name="unresolved_conditions",
+            ),
+        )
+    except IngressRequestBuilderError as error:
+        raise OpenClawIngressInputError(str(error)) from error
+
+    metadata = _to_jsonable(_optional_mapping(payload.get("metadata"), field_name="metadata") or {})
+    if metadata:
+        request_payload = canonical_payload["request"]
+        task_envelope = request_payload["task_envelope"]
+        openclaw_extension = dict(task_envelope.get("extensions", {}).get("openclaw") or {})
+        openclaw_extension["metadata"] = metadata
+        task_envelope["extensions"] = {"openclaw": openclaw_extension}
+    return canonical_payload
+
+
+__all__ = [
+    "OpenClawIngressInputError",
+    "translate_openclaw_submission_payload",
+]

--- a/tests/connectors/test_openclaw_ingress.py
+++ b/tests/connectors/test_openclaw_ingress.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.connectors import OpenClawIngressInputError, translate_openclaw_submission_payload
+
+
+class OpenClawIngressTranslationTests(unittest.TestCase):
+    def _payload(self) -> dict:
+        return {
+            "task_id": "task-openclaw-ingress-1",
+            "requested_by": "operator@example.com",
+            "context": {
+                "conversation_id": "conv-123",
+                "message_id": "msg-456",
+                "channel": "cli",
+                "workspace_id": "workspace-1",
+                "user_id": "operator@example.com",
+                "agent_id": "openclaw-assistant",
+            },
+            "task": {
+                "title": "Implement OpenClaw ingress path",
+                "description": "Submit work from OpenClaw via a canonical Harness ingress endpoint.",
+                "acceptance_criteria": [
+                    "Harness persists the task.",
+                    "OpenClaw provenance remains auditable.",
+                ],
+                "constraints": ["Keep canonical POST /tasks semantics."],
+                "priority": "high",
+                "status": "intake_ready",
+            },
+            "metadata": {"source": "openclaw-integration-test"},
+            "external_facts": {"expected_code_context": {"repository_owner": "sfayka"}},
+            "runtime_facts": {"attempt_count": 1},
+            "claimed_completion": False,
+            "acceptance_criteria_satisfied": False,
+            "unresolved_conditions": ["Awaiting external evidence."],
+        }
+
+    def test_translate_openclaw_submission_payload_generates_canonical_request(self) -> None:
+        payload = translate_openclaw_submission_payload(self._payload())
+        request = payload["request"]
+        task = request["task_envelope"]
+
+        self.assertEqual(task["id"], "task-openclaw-ingress-1")
+        self.assertEqual(task["origin"]["source_system"], "openclaw")
+        self.assertEqual(task["origin"]["source_id"], "msg-456")
+        self.assertEqual(task["origin"]["ingress_id"], "conv-123")
+        self.assertEqual(task["extensions"]["openclaw"]["conversation_id"], "conv-123")
+        self.assertEqual(task["extensions"]["openclaw"]["metadata"]["source"], "openclaw-integration-test")
+        self.assertEqual(request["runtime_facts"]["attempt_count"], 1)
+        self.assertEqual(request["unresolved_conditions"], ["Awaiting external evidence."])
+
+    def test_translate_openclaw_submission_payload_requires_context_shape(self) -> None:
+        payload = self._payload()
+        payload["context"] = "invalid"
+
+        with self.assertRaises(OpenClawIngressInputError):
+            translate_openclaw_submission_payload(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -372,6 +372,36 @@ def _manual_ingress_payload(*, task_id: str | None = None) -> dict:
         payload["task_id"] = task_id
     return payload
 
+
+def _openclaw_ingress_payload(*, task_id: str | None = None) -> dict:
+    payload: dict[str, object] = {
+        "context": {
+            "conversation_id": "conv-kno-164",
+            "message_id": "msg-kno-164-1",
+            "channel": "cli",
+            "workspace_id": "workspace-harness",
+            "user_id": "operator@example.com",
+            "agent_id": "openclaw-assistant",
+        },
+        "task": {
+            "title": "OpenClaw canonical ingress task",
+            "description": "Create a task through OpenClaw ingress that is persisted by canonical submission.",
+            "acceptance_criteria": [
+                "Task is persisted in Harness store.",
+                "OpenClaw provenance is visible in canonical read surfaces.",
+            ],
+            "constraints": ["Keep OpenClaw request shape non-canonical."],
+            "priority": "high",
+        },
+        "metadata": {"request_kind": "openclaw"},
+        "runtime_facts": {"attempt_count": 1},
+        "claimed_completion": False,
+        "acceptance_criteria_satisfied": False,
+    }
+    if task_id is not None:
+        payload["task_id"] = task_id
+    return payload
+
 def _review_note_artifact(artifact_id: str = "artifact-review-note-1") -> dict:
     return {
         "id": artifact_id,
@@ -677,6 +707,22 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(timeline_status, 200)
         self.assertEqual(timeline_payload["task_id"], task_id)
         self.assertGreaterEqual(timeline_payload["event_count"], 1)
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
+
+    def test_service_can_submit_openclaw_ingress_payload_and_persist_openclaw_provenance(self) -> None:
+        status, payload = self.service.submit_openclaw_ingress(_openclaw_ingress_payload())
+
+        task_id = payload["task_envelope"]["id"]
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+        history_status, history_payload = self.service.get_evaluation_history(task_id)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task_envelope"]["origin"]["source_system"], "openclaw")
+        self.assertEqual(payload["task_envelope"]["origin"]["source_id"], "msg-kno-164-1")
+        self.assertEqual(payload["task_envelope"]["extensions"]["openclaw"]["conversation_id"], "conv-kno-164")
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["extensions"]["openclaw"]["metadata"]["request_kind"], "openclaw")
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history_payload["evaluations"]), 1)
 
@@ -1230,6 +1276,29 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertIn("task_envelope", payload)
         self.assertEqual(payload["task_envelope"]["origin"]["source_system"], "manual")
         self.assertTrue(payload["task_envelope"]["id"])
+
+    def test_api_accepts_openclaw_ingress_submission_endpoint(self) -> None:
+        status, payload = self._post_json("/ingress/openclaw", _openclaw_ingress_payload())
+        task_id = payload["task_envelope"]["id"]
+
+        read_status, read_payload = self._get_json(f"/tasks/{task_id}/read-model")
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task_envelope"]["origin"]["source_system"], "openclaw")
+        self.assertEqual(payload["task_envelope"]["origin"]["ingress_name"], "OpenClaw")
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["extensions"]["openclaw"]["metadata"]["request_kind"], "openclaw")
+
+    def test_api_openclaw_ingress_rejects_invalid_payload_without_persisting_state(self) -> None:
+        payload = _openclaw_ingress_payload(task_id="task-openclaw-invalid-1")
+        payload["context"] = "invalid"
+
+        status, response_payload = self._post_json("/ingress/openclaw", payload)
+        task_status, task_payload = self._get_json("/tasks/task-openclaw-invalid-1")
+
+        self.assertEqual(status, 400)
+        self.assertTrue(response_payload["invalid_input"])
+        self.assertEqual(task_status, 404)
+        self.assertIn("not found", task_payload["error"].lower())
 
     def test_api_accepts_manual_happy_path_overlay_payload(self) -> None:
         payload = _manual_happy_path_overlay_payload()


### PR DESCRIPTION
## Summary
- add a new  adapter that translates OpenClaw-shaped ingress payloads into canonical  requests via the ingress request builder
- wire the adapter into  and expose a new  endpoint
- add connector and API tests proving canonical normalization, persistence, and invalid-input handling for OpenClaw-origin submissions
- update README and integration/API docs to document the new OpenClaw ingress path

## Validation
- python -m unittest discover -s tests