### PR TITLE
Implement canonical Linear fact linkage capture

### DIFF
--- a/docs/architecture/task-envelope.md
+++ b/docs/architecture/task-envelope.md
@@ -66,6 +66,7 @@ At the top level, a TaskEnvelope contains:
 | `required_capabilities` | array | yes | executor capabilities needed for the task |
 | `priority` | enum | yes | relative scheduling priority |
 | `artifacts` | object | yes | canonical execution artifacts and completion evidence state |
+| `coordination` | object | yes | canonical linkage to external coordination records (for example Linear) |
 | `clarification` | object | no | canonical missing-information and clarification tracking state |
 | `observability` | object | yes | retries, errors, and execution metadata |
 | `extensions` | object | no | explicitly non-canonical extension surface for future modules |
@@ -286,6 +287,21 @@ Completion is not trusted purely because an executor claims success. `artifacts.
 Verification consumes this evidence state but remains a distinct control-plane decision layer. Evidence presence and completion acceptance must not collapse into one concept.
 
 Long-running support artifacts such as `progress_artifact`, `plan_artifact`, and `handoff_artifact` are first-class task artifacts. Harness preserves them for auditability and may use them as verification or review inputs, but they are not completion-bearing by default in the current contract.
+
+### Coordination
+
+`coordination` stores normalized linkage to external tracking systems while preserving Harness as the lifecycle truth authority.
+
+Current canonical linkage:
+
+- `coordination.linear`
+  - `record_found` shows whether a matching Linear record currently resolves
+  - `issue_id` / `issue_key` preserve normalized Linear identity
+  - `state`, `workflow`, `project`, and `task_reference` preserve normalized Linear metadata for inspection and reconciliation context
+  - `reasons` captures missing/stale/conflicting sync notes when provided
+  - `provenance` (`linked_at`, `linked_by`, `source`) keeps linkage creation/update auditable
+
+This linkage surface is advisory context for verification and reconciliation. It does not replace Harness ownership of lifecycle truth.
 
 ### Completion Trust Levels
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -263,6 +263,37 @@ def _apply_submission_task_overlays(
     return merged_task
 
 
+def _with_linear_coordination(
+    task_envelope: dict[str, Any],
+    *,
+    linear_facts: LinearFacts | None,
+    linked_by: str,
+    source: str,
+) -> dict[str, Any]:
+    if linear_facts is None:
+        return task_envelope
+
+    merged_task = deepcopy(task_envelope)
+    coordination = _optional_mapping(merged_task.get("coordination"), field_name="task_envelope.coordination") or {}
+    coordination["linear"] = {
+        "record_found": linear_facts.record_found,
+        "issue_id": linear_facts.issue_id,
+        "issue_key": linear_facts.issue_key,
+        "state": linear_facts.state,
+        "workflow": _to_jsonable(linear_facts.workflow),
+        "project": _to_jsonable(linear_facts.project),
+        "task_reference": _to_jsonable(linear_facts.task_reference),
+        "reasons": list(linear_facts.reasons),
+        "provenance": {
+            "linked_at": _iso_now(),
+            "linked_by": linked_by,
+            "source": source,
+        },
+    }
+    merged_task["coordination"] = coordination
+    return merged_task
+
+
 def parse_evaluation_request(payload: dict[str, Any]) -> HarnessEvaluationRequest:
     """Parse a canonical HTTP evaluation request into the public evaluator input."""
 
@@ -271,9 +302,19 @@ def parse_evaluation_request(payload: dict[str, Any]) -> HarnessEvaluationReques
     _require_non_empty_string(task_envelope.get("id"), field_name="task_envelope.id")
     task_envelope = _apply_submission_task_overlays(task_envelope, request_payload=request_payload)
 
+    external_facts = _parse_external_facts(
+        _optional_mapping(request_payload.get("external_facts"), field_name="external_facts")
+    )
+    task_envelope = _with_linear_coordination(
+        task_envelope,
+        linear_facts=external_facts.linear_facts if external_facts is not None else None,
+        linked_by=(task_envelope.get("origin") or {}).get("source_system") or "harness",
+        source="evaluation_request.external_facts",
+    )
+
     return HarnessEvaluationRequest(
         task_envelope=task_envelope,
-        external_facts=_parse_external_facts(_optional_mapping(request_payload.get("external_facts"), field_name="external_facts")),
+        external_facts=external_facts,
         claimed_completion=bool(request_payload.get("claimed_completion", False)),
         acceptance_criteria_satisfied=bool(request_payload.get("acceptance_criteria_satisfied", False)),
         runtime_facts=_parse_runtime_facts(_optional_mapping(request_payload.get("runtime_facts"), field_name="runtime_facts")),
@@ -469,9 +510,19 @@ def parse_completion_claim_request(task_envelope: dict[str, Any], payload: dict[
     if review_decision is not None and review_decision.record.task_id != merged_task["id"]:
         raise ApiRequestError("review_decision.record.task_id must match the stored task id")
 
+    external_facts = _parse_external_facts(
+        _optional_mapping(request_payload.get("external_facts"), field_name="external_facts")
+    )
+    merged_task = _with_linear_coordination(
+        merged_task,
+        linear_facts=external_facts.linear_facts if external_facts is not None else None,
+        linked_by="reevaluation",
+        source="completion_claim.external_facts",
+    )
+
     return HarnessEvaluationRequest(
         task_envelope=merged_task,
-        external_facts=_parse_external_facts(_optional_mapping(request_payload.get("external_facts"), field_name="external_facts")),
+        external_facts=external_facts,
         claimed_completion=True,
         acceptance_criteria_satisfied=bool(request_payload.get("acceptance_criteria_satisfied", False)),
         runtime_facts=_parse_runtime_facts(_optional_mapping(request_payload.get("runtime_facts"), field_name="runtime_facts")),
@@ -517,9 +568,19 @@ def parse_reevaluation_request(task_envelope: dict[str, Any], payload: dict[str,
     if review_decision is not None and review_decision.record.task_id != merged_task["id"]:
         raise ApiRequestError("review_decision.record.task_id must match the stored task id")
 
+    external_facts = _parse_external_facts(
+        _optional_mapping(request_payload.get("external_facts"), field_name="external_facts")
+    )
+    merged_task = _with_linear_coordination(
+        merged_task,
+        linear_facts=external_facts.linear_facts if external_facts is not None else None,
+        linked_by="reevaluation",
+        source="reevaluation_request.external_facts",
+    )
+
     return HarnessEvaluationRequest(
         task_envelope=merged_task,
-        external_facts=_parse_external_facts(_optional_mapping(request_payload.get("external_facts"), field_name="external_facts")),
+        external_facts=external_facts,
         claimed_completion=bool(request_payload.get("claimed_completion", False)),
         acceptance_criteria_satisfied=bool(request_payload.get("acceptance_criteria_satisfied", False)),
         runtime_facts=_parse_runtime_facts(_optional_mapping(request_payload.get("runtime_facts"), field_name="runtime_facts")),

--- a/modules/connectors/linear_ingress.py
+++ b/modules/connectors/linear_ingress.py
@@ -126,6 +126,25 @@ def _default_acceptance_criteria(issue_identifier: str | None) -> list[dict[str,
     ]
 
 
+def _build_linear_coordination_entry(*, linear_facts: Any, linked_at: str, linked_by: str, source: str) -> dict[str, Any]:
+    facts_payload = _to_jsonable(linear_facts)
+    return {
+        "record_found": bool(facts_payload.get("record_found", True)),
+        "issue_id": facts_payload.get("issue_id"),
+        "issue_key": facts_payload.get("issue_key"),
+        "state": facts_payload.get("state"),
+        "workflow": facts_payload.get("workflow"),
+        "project": facts_payload.get("project"),
+        "task_reference": facts_payload.get("task_reference"),
+        "reasons": list(facts_payload.get("reasons") or []),
+        "provenance": {
+            "linked_at": linked_at,
+            "linked_by": linked_by,
+            "source": source,
+        },
+    }
+
+
 def _build_task_envelope(payload: Mapping[str, Any]) -> dict[str, Any]:
     issue_payload = _require_mapping(payload.get("issue"), field_name="issue")
     issue_id = _require_string(issue_payload.get("id"), field_name="issue.id")
@@ -184,6 +203,17 @@ def _build_task_envelope(payload: Mapping[str, Any]) -> dict[str, Any]:
         labels = [label.strip() for label in labels]
     else:
         labels = []
+
+    linear_facts = translate_linear_facts(payload)
+
+    task_envelope["coordination"] = {
+        "linear": _build_linear_coordination_entry(
+            linear_facts=linear_facts,
+            linked_at=task_envelope["timestamps"]["updated_at"],
+            linked_by=_optional_string(payload.get("requested_by"), field_name="requested_by") or "linear-ingress",
+            source="linear_ingress_payload",
+        )
+    }
 
     task_envelope["extensions"] = {
         "linear": {

--- a/modules/intake/task_envelope.py
+++ b/modules/intake/task_envelope.py
@@ -181,6 +181,9 @@ def create_task_envelope(
                 "notes": None,
             },
         },
+        "coordination": {
+            "linear": None,
+        },
         "observability": {
             "errors": [],
             "retries": {

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -186,6 +186,20 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
             }
         )
 
+    linear_coordination = ((task_envelope.get("coordination") or {}).get("linear")) or None
+    if isinstance(linear_coordination, dict):
+        provenance = linear_coordination.get("provenance") if isinstance(linear_coordination.get("provenance"), dict) else {}
+        events.append(
+            {
+                "event_id": f"{task_envelope['id']}:linear_linkage",
+                "event_type": "linear_linkage_recorded",
+                "occurred_at": provenance.get("linked_at") or timestamps.get("updated_at"),
+                "summary": "Linear linkage recorded",
+                "source": provenance.get("linked_by") or "harness",
+                "details": dict(linear_coordination),
+            }
+        )
+
     for record in records:
         result_payload = record.result if isinstance(record.result, dict) else {}
         enforcement_result = dict(result_payload.get("enforcement_result") or {})
@@ -277,6 +291,7 @@ class TaskReadModel:
     relationships: dict[str, Any]
     assigned_executor: dict[str, Any] | None
     evidence_summary: dict[str, Any]
+    coordination_summary: dict[str, Any]
     verification_summary: dict[str, Any] | None
     reconciliation_summary: dict[str, Any] | None
     review_summary: dict[str, Any]
@@ -334,6 +349,11 @@ class HarnessReadModelService:
             },
             assigned_executor=dict(task.get("assigned_executor") or {}) if task.get("assigned_executor") is not None else None,
             evidence_summary=_build_evidence_summary(task),
+            coordination_summary={
+                "linear": dict(((task.get("coordination") or {}).get("linear") or {}))
+                if ((task.get("coordination") or {}).get("linear")) is not None
+                else None
+            },
             verification_summary=verification_summary,
             reconciliation_summary=reconciliation_summary,
             review_summary=review_summary,

--- a/schemas/task_envelope.schema.json
+++ b/schemas/task_envelope.schema.json
@@ -130,6 +130,9 @@
     "observability": {
       "$ref": "#/$defs/observability"
     },
+    "coordination": {
+      "$ref": "#/$defs/coordination"
+    },
     "extensions": {
       "type": "object",
       "description": "Explicit non-canonical extension surface for future modules.",
@@ -1319,6 +1322,184 @@
           }
         }
       ]
+    },
+    "coordination": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "linear"
+      ],
+      "properties": {
+        "linear": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/linearCoordination"
+            }
+          ],
+          "default": null
+        }
+      }
+    },
+    "linearCoordination": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "record_found",
+        "provenance"
+      ],
+      "properties": {
+        "record_found": {
+          "type": "boolean"
+        },
+        "issue_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "issue_key": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "state": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "workflow": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/linearWorkflowRef"
+            }
+          ],
+          "default": null
+        },
+        "project": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/linearProjectRef"
+            }
+          ],
+          "default": null
+        },
+        "task_reference": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/linearTaskReference"
+            }
+          ],
+          "default": null
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "provenance": {
+          "$ref": "#/$defs/linkProvenance"
+        }
+      }
+    },
+    "linearWorkflowRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workflow_id",
+        "workflow_name"
+      ],
+      "properties": {
+        "workflow_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "workflow_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "linearProjectRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "project_id"
+      ],
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "project_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "linearTaskReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "harness_task_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "linkProvenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "linked_at",
+        "linked_by",
+        "source"
+      ],
+      "properties": {
+        "linked_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "linked_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     }
   }
 }

--- a/tests/connectors/test_linear_ingress.py
+++ b/tests/connectors/test_linear_ingress.py
@@ -74,6 +74,8 @@ class LinearIngressTranslationTests(unittest.TestCase):
         self.assertEqual(task["origin"]["source_system"], "linear")
         self.assertEqual(task["origin"]["source_id"], "lin-ingress-1")
         self.assertEqual(task["priority"], "high")
+        self.assertTrue(task["coordination"]["linear"]["record_found"])
+        self.assertEqual(task["coordination"]["linear"]["provenance"]["source"], "linear_ingress_payload")
         self.assertEqual(task["extensions"]["linear"]["issue_identifier"], "HAR-901")
         self.assertEqual(len(task["artifacts"]["items"]), 2)
         self.assertEqual(linear_facts["issue_id"], "lin-ingress-1")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1720,6 +1720,46 @@ class HarnessHttpApiTests(unittest.TestCase):
         )
         self.assertEqual(reevaluation_status, 200)
         self.assertEqual(reevaluation_response["task_envelope"]["status"], "completed")
+        self.assertEqual(
+            reevaluation_response["task_envelope"]["coordination"]["linear"]["provenance"]["source"],
+            "reevaluation_request.external_facts",
+        )
+
+    def test_api_persists_linear_coordination_when_record_not_found_and_when_conflicting(self) -> None:
+        initial_payload = _request_payload("accepted_completion")
+        initial_status, initial_response = self._post_json("/evaluate", initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        missing_record_payload = {
+            "request": {
+                "external_facts": {
+                    "linear_facts": {
+                        "record_found": False,
+                        "reasons": ["Linear record was not found during sync."],
+                    }
+                },
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        }
+        missing_status, missing_response = self._post_json(f"/tasks/{task_id}/reevaluate", missing_record_payload)
+
+        stale_record_payload = {
+            "request": {
+                "external_facts": deepcopy(_request_payload("blocked_reconciliation_mismatch")["request"]["external_facts"]),
+                "claimed_completion": True,
+                "acceptance_criteria_satisfied": True,
+                "runtime_facts": deepcopy(initial_payload["request"]["runtime_facts"]),
+            }
+        }
+        stale_status, stale_response = self._post_json(f"/tasks/{task_id}/reevaluate", stale_record_payload)
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(missing_status, 200)
+        self.assertFalse(missing_response["task_envelope"]["coordination"]["linear"]["record_found"])
+        self.assertEqual(stale_status, 200)
+        self.assertEqual(stale_response["task_envelope"]["coordination"]["linear"]["state"], "in_progress")
 
     def test_api_appends_long_running_support_artifacts_across_reevaluations(self) -> None:
         initial_payload = _request_payload("blocked_insufficient_evidence")

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -118,6 +118,7 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertEqual(payload["task"]["verification_summary"]["outcome"], "accepted_completion")
         self.assertEqual(payload["task"]["reconciliation_summary"]["outcome"], "no_mismatch")
         self.assertEqual(payload["task"]["evidence_summary"]["artifact_count"], 2)
+        self.assertTrue(payload["task"]["coordination_summary"]["linear"]["record_found"])
         self.assertEqual(payload["task"]["evaluation_summary"]["count"], 1)
 
     def test_builds_read_model_for_blocked_insufficient_evidence(self) -> None:
@@ -155,6 +156,7 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertEqual(reevaluation_status, 200)
         self.assertEqual(status, 200)
         self.assertEqual(transition_targets[-2:], ["completed", "blocked"])
+        self.assertTrue(any(event["event_type"] == "linear_linkage_recorded" for event in payload["timeline"]))
 
     def test_review_summary_shows_request_then_resolution(self) -> None:
         accepted_payload = _request_payload("accepted_completion")


### PR DESCRIPTION
## Summary
- add canonical  linkage structure to TaskEnvelope schema and intake defaults
- persist normalized Linear linkage/provenance from linear ingress and reevaluation external facts
- surface linkage in read-model summaries and timeline events
- add coverage for linked, missing, and stale/contradictory Linear fact scenarios

## Validation
- python -m unittest discover -s tests