### PR TITLE
Add KNO-166 persisted OpenClaw ingress bridge proof artifacts

### DIFF
--- a/docs/demo/kno-166-openclaw-bridge/README.md
+++ b/docs/demo/kno-166-openclaw-bridge/README.md
@@ -1,0 +1,57 @@
+# KNO-166 persisted OpenClaw ingress bridge proof
+
+This run records one real persisted bridge from OpenClaw-shaped ingress into Harness canonical task truth, through reevaluation, and into dashboard-facing inspection surfaces.
+
+## Canonical task definition
+
+- Linear issue: `KNO-166`
+- GitHub issue: https://github.com/sfayka/Harness/issues/127
+- Harness task id: `kno-166-openclaw-bridge-2026-04-03`
+
+## Canonical flow executed
+
+1. Start API with isolated store:
+   - `python -m modules.api --host 127.0.0.1 --port 8010 --store-root .tmp/kno166/store`
+2. Submit OpenClaw ingress payload:
+   - `POST /ingress/openclaw` with `create-request.json`
+3. Confirm persistence + inspection visibility:
+   - `GET /tasks`
+   - `GET /tasks/kno-166-openclaw-bridge-2026-04-03/read-model`
+   - `GET /tasks/kno-166-openclaw-bridge-2026-04-03/timeline`
+4. Submit governed reevaluation with external completion evidence:
+   - `POST /tasks/kno-166-openclaw-bridge-2026-04-03/reevaluate` with `reevaluate-request.json`
+5. Re-check canonical read surfaces used by dashboard task views:
+   - `GET /tasks`
+   - `GET /tasks/kno-166-openclaw-bridge-2026-04-03/read-model`
+   - `GET /tasks/kno-166-openclaw-bridge-2026-04-03/timeline`
+
+## Outcome summary
+
+- Ingress provenance persisted with `source_system=openclaw` and OpenClaw extension metadata.
+- Initial evaluation state is deferred until a completion claim is submitted.
+- Reevaluation with external artifacts transitions the task to `completed`.
+- Dashboard-facing surfaces (`/tasks`, `/tasks/<id>/read-model`, `/tasks/<id>/timeline`) all include this task after ingress and after reevaluation.
+
+## External artifacts used for completion evidence
+
+- Repository: `sfayka/Harness`
+- Branch: `codex/real-task-proof`
+- Commit SHA: `04d9da2b7d8add29e33f8c98bf558e2d145b0f95`
+- PR URL: `https://github.com/sfayka/Harness/pull/121`
+
+## Captured payloads and responses
+
+- `create-request.json`
+- `create-response.json`
+- `read-model-initial.json`
+- `timeline-initial.json`
+- `tasks-after-create.json`
+- `reevaluate-request.json`
+- `reevaluate-response.json`
+- `read-model-final.json`
+- `timeline-final.json`
+- `tasks-after-reevaluate.json`
+
+## Honest remaining gap
+
+This proof demonstrates persisted ingress, evaluation, and dashboard visibility via canonical Harness surfaces. It does **not** claim that all execution is human-free; manual artifact collection/reconciliation inputs may still be required depending on policy and external fact availability.

--- a/docs/demo/kno-166-openclaw-bridge/create-request.json
+++ b/docs/demo/kno-166-openclaw-bridge/create-request.json
@@ -1,0 +1,34 @@
+{
+  "context": {
+    "conversation_id": "conv-kno-166-bridge-1",
+    "message_id": "msg-kno-166-bridge-1",
+    "channel": "cli",
+    "workspace_id": "workspace-harness",
+    "user_id": "operator@example.com",
+    "agent_id": "openclaw-assistant"
+  },
+  "task_id": "kno-166-openclaw-bridge-2026-04-03",
+  "task": {
+    "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle",
+    "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+    "acceptance_criteria": [
+      "Task persists in Harness with OpenClaw provenance.",
+      "Execution and evaluation records are appended in canonical history.",
+      "Task is visible in read-model, timeline, and task list surfaces used by the dashboard."
+    ],
+    "constraints": [
+      "Use canonical Harness submission and reevaluation paths.",
+      "Keep OpenClaw metadata in ingress extensions without making it canonical truth."
+    ],
+    "priority": "high"
+  },
+  "metadata": {
+    "request_kind": "kno-166-bridge-proof",
+    "linear_issue": "KNO-166"
+  },
+  "runtime_facts": {
+    "attempt_count": 1
+  },
+  "claimed_completion": false,
+  "acceptance_criteria_satisfied": false
+}

--- a/docs/demo/kno-166-openclaw-bridge/create-response.json
+++ b/docs/demo/kno-166-openclaw-bridge/create-response.json
@@ -1,0 +1,742 @@
+{
+    "accepted_completion": false,
+    "action": "no_op",
+    "enforcement_result": {
+        "action": "no_op",
+        "error": null,
+        "evidence_result": {
+            "artifact_results": [],
+            "is_sufficient": false,
+            "is_valid": true,
+            "issues": [],
+            "missing_required_artifact_types": [],
+            "unknown_validated_artifact_ids": [],
+            "validated_artifact_ids": []
+        },
+        "failure_classification": {
+            "category": "none",
+            "nature": "none",
+            "reason": "No completion claim is currently being evaluated",
+            "retryable": false
+        },
+        "reasons": [
+            "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+            "No completion claim is currently being evaluated"
+        ],
+        "reconciliation_result": {
+            "blocking": false,
+            "mismatch_categories": [],
+            "outcome": "no_mismatch",
+            "reasons": [
+                "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                "No blocking reconciliation mismatch was detected"
+            ],
+            "status": "passed",
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "terminal": false
+        },
+        "review_decision": null,
+        "review_request": null,
+        "target_status": null,
+        "task_envelope": {
+            "acceptance_criteria": [
+                {
+                    "description": "Task persists in Harness with OpenClaw provenance.",
+                    "id": "ac-1",
+                    "required": true
+                },
+                {
+                    "description": "Execution and evaluation records are appended in canonical history.",
+                    "id": "ac-2",
+                    "required": true
+                },
+                {
+                    "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                    "id": "ac-3",
+                    "required": true
+                }
+            ],
+            "artifacts": {
+                "completion_evidence": {
+                    "notes": null,
+                    "policy": "deferred",
+                    "required_artifact_types": [],
+                    "status": "deferred",
+                    "validated_artifact_ids": [],
+                    "validated_at": null,
+                    "validation_method": "deferred",
+                    "validator": null
+                },
+                "items": []
+            },
+            "assigned_executor": null,
+            "child_task_ids": [],
+            "constraints": [
+                {
+                    "description": "Use canonical Harness submission and reevaluation paths.",
+                    "required": true,
+                    "type": "ingress_constraint"
+                },
+                {
+                    "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                    "required": true,
+                    "type": "ingress_constraint"
+                }
+            ],
+            "coordination": {
+                "linear": null
+            },
+            "dependencies": [],
+            "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+            "extensions": {
+                "openclaw": {
+                    "agent_id": "openclaw-assistant",
+                    "channel": "cli",
+                    "conversation_id": "conv-kno-166-bridge-1",
+                    "message_id": "msg-kno-166-bridge-1",
+                    "metadata": {
+                        "linear_issue": "KNO-166",
+                        "request_kind": "kno-166-bridge-proof"
+                    },
+                    "user_id": "operator@example.com",
+                    "workspace_id": "workspace-harness"
+                }
+            },
+            "id": "kno-166-openclaw-bridge-2026-04-03",
+            "objective": {
+                "deliverable_type": "unspecified",
+                "success_signal": "Task satisfies declared acceptance criteria.",
+                "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+            },
+            "observability": {
+                "errors": [],
+                "execution_metadata": {
+                    "schema_required_deferred_fields": [
+                        "parent_task_id",
+                        "child_task_ids",
+                        "dependencies",
+                        "assigned_executor",
+                        "required_capabilities",
+                        "priority",
+                        "artifacts.items",
+                        "artifacts.completion_evidence",
+                        "observability"
+                    ]
+                },
+                "retries": {
+                    "attempt_count": 0,
+                    "last_retry_at": null,
+                    "max_attempts": 0
+                }
+            },
+            "origin": {
+                "ingress_id": "conv-kno-166-bridge-1",
+                "ingress_name": "OpenClaw",
+                "requested_by": "operator@example.com",
+                "source_id": "msg-kno-166-bridge-1",
+                "source_system": "openclaw",
+                "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "high",
+            "required_capabilities": [],
+            "status": "intake_ready",
+            "status_history": [],
+            "timestamps": {
+                "completed_at": null,
+                "created_at": "2026-04-03T19:05:43.822495Z",
+                "updated_at": "2026-04-03T19:05:43.822495Z"
+            },
+            "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+        },
+        "transition_result": null,
+        "verification_result": {
+            "accepted_completion": false,
+            "claimed_completion": false,
+            "evidence_is_sufficient": false,
+            "evidence_is_valid": true,
+            "failure_classification": {
+                "category": "none",
+                "nature": "none",
+                "reason": "No completion claim is currently being evaluated",
+                "retryable": false
+            },
+            "is_terminal": false,
+            "outcome": "verification_deferred",
+            "reasons": [
+                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                "No completion claim is currently being evaluated"
+            ],
+            "reconciliation_status": "passed",
+            "requires_review": false,
+            "target_status": null,
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "verification_passed": false
+        }
+    },
+    "error": null,
+    "evaluation_record": {
+        "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+        "recorded_at": "2026-04-03T19:05:43.862477Z",
+        "request": {
+            "acceptance_criteria_satisfied": false,
+            "claimed_completion": false,
+            "external_facts": {
+                "expected_code_context": null,
+                "github_facts": null,
+                "linear_facts": null
+            },
+            "retry_context": null,
+            "review_decision": null,
+            "review_is_active": false,
+            "review_reasons": [],
+            "review_request": null,
+            "runtime_facts": {
+                "attempt_count": 1,
+                "executor_reported_failure": false,
+                "executor_reported_success": false,
+                "latest_attempt_outcome": null,
+                "terminal_failure": false
+            },
+            "task_envelope": {
+                "acceptance_criteria": [
+                    {
+                        "description": "Task persists in Harness with OpenClaw provenance.",
+                        "id": "ac-1",
+                        "required": true
+                    },
+                    {
+                        "description": "Execution and evaluation records are appended in canonical history.",
+                        "id": "ac-2",
+                        "required": true
+                    },
+                    {
+                        "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                        "id": "ac-3",
+                        "required": true
+                    }
+                ],
+                "artifacts": {
+                    "completion_evidence": {
+                        "notes": null,
+                        "policy": "deferred",
+                        "required_artifact_types": [],
+                        "status": "deferred",
+                        "validated_artifact_ids": [],
+                        "validated_at": null,
+                        "validation_method": "deferred",
+                        "validator": null
+                    },
+                    "items": []
+                },
+                "assigned_executor": null,
+                "child_task_ids": [],
+                "constraints": [
+                    {
+                        "description": "Use canonical Harness submission and reevaluation paths.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    },
+                    {
+                        "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    }
+                ],
+                "coordination": {
+                    "linear": null
+                },
+                "dependencies": [],
+                "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+                "extensions": {
+                    "openclaw": {
+                        "agent_id": "openclaw-assistant",
+                        "channel": "cli",
+                        "conversation_id": "conv-kno-166-bridge-1",
+                        "message_id": "msg-kno-166-bridge-1",
+                        "metadata": {
+                            "linear_issue": "KNO-166",
+                            "request_kind": "kno-166-bridge-proof"
+                        },
+                        "user_id": "operator@example.com",
+                        "workspace_id": "workspace-harness"
+                    }
+                },
+                "id": "kno-166-openclaw-bridge-2026-04-03",
+                "objective": {
+                    "deliverable_type": "unspecified",
+                    "success_signal": "Task satisfies declared acceptance criteria.",
+                    "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+                },
+                "observability": {
+                    "errors": [],
+                    "execution_metadata": {
+                        "schema_required_deferred_fields": [
+                            "parent_task_id",
+                            "child_task_ids",
+                            "dependencies",
+                            "assigned_executor",
+                            "required_capabilities",
+                            "priority",
+                            "artifacts.items",
+                            "artifacts.completion_evidence",
+                            "observability"
+                        ]
+                    },
+                    "retries": {
+                        "attempt_count": 0,
+                        "last_retry_at": null,
+                        "max_attempts": 0
+                    }
+                },
+                "origin": {
+                    "ingress_id": "conv-kno-166-bridge-1",
+                    "ingress_name": "OpenClaw",
+                    "requested_by": "operator@example.com",
+                    "source_id": "msg-kno-166-bridge-1",
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request"
+                },
+                "parent_task_id": null,
+                "priority": "high",
+                "required_capabilities": [],
+                "status": "intake_ready",
+                "status_history": [],
+                "timestamps": {
+                    "completed_at": null,
+                    "created_at": "2026-04-03T19:05:43.822495Z",
+                    "updated_at": "2026-04-03T19:05:43.822495Z"
+                },
+                "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+            },
+            "unresolved_conditions": []
+        },
+        "result": {
+            "accepted_completion": false,
+            "action": "no_op",
+            "enforcement_result": {
+                "action": "no_op",
+                "error": null,
+                "evidence_result": {
+                    "artifact_results": [],
+                    "is_sufficient": false,
+                    "is_valid": true,
+                    "issues": [],
+                    "missing_required_artifact_types": [],
+                    "unknown_validated_artifact_ids": [],
+                    "validated_artifact_ids": []
+                },
+                "failure_classification": {
+                    "category": "none",
+                    "nature": "none",
+                    "reason": "No completion claim is currently being evaluated",
+                    "retryable": false
+                },
+                "reasons": [
+                    "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                    "No completion claim is currently being evaluated"
+                ],
+                "reconciliation_result": {
+                    "blocking": false,
+                    "mismatch_categories": [],
+                    "outcome": "no_mismatch",
+                    "reasons": [
+                        "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                        "No blocking reconciliation mismatch was detected"
+                    ],
+                    "status": "passed",
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "terminal": false
+                },
+                "review_decision": null,
+                "review_request": null,
+                "target_status": null,
+                "task_envelope": {
+                    "acceptance_criteria": [
+                        {
+                            "description": "Task persists in Harness with OpenClaw provenance.",
+                            "id": "ac-1",
+                            "required": true
+                        },
+                        {
+                            "description": "Execution and evaluation records are appended in canonical history.",
+                            "id": "ac-2",
+                            "required": true
+                        },
+                        {
+                            "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                            "id": "ac-3",
+                            "required": true
+                        }
+                    ],
+                    "artifacts": {
+                        "completion_evidence": {
+                            "notes": null,
+                            "policy": "deferred",
+                            "required_artifact_types": [],
+                            "status": "deferred",
+                            "validated_artifact_ids": [],
+                            "validated_at": null,
+                            "validation_method": "deferred",
+                            "validator": null
+                        },
+                        "items": []
+                    },
+                    "assigned_executor": null,
+                    "child_task_ids": [],
+                    "constraints": [
+                        {
+                            "description": "Use canonical Harness submission and reevaluation paths.",
+                            "required": true,
+                            "type": "ingress_constraint"
+                        },
+                        {
+                            "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                            "required": true,
+                            "type": "ingress_constraint"
+                        }
+                    ],
+                    "coordination": {
+                        "linear": null
+                    },
+                    "dependencies": [],
+                    "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+                    "extensions": {
+                        "openclaw": {
+                            "agent_id": "openclaw-assistant",
+                            "channel": "cli",
+                            "conversation_id": "conv-kno-166-bridge-1",
+                            "message_id": "msg-kno-166-bridge-1",
+                            "metadata": {
+                                "linear_issue": "KNO-166",
+                                "request_kind": "kno-166-bridge-proof"
+                            },
+                            "user_id": "operator@example.com",
+                            "workspace_id": "workspace-harness"
+                        }
+                    },
+                    "id": "kno-166-openclaw-bridge-2026-04-03",
+                    "objective": {
+                        "deliverable_type": "unspecified",
+                        "success_signal": "Task satisfies declared acceptance criteria.",
+                        "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+                    },
+                    "observability": {
+                        "errors": [],
+                        "execution_metadata": {
+                            "schema_required_deferred_fields": [
+                                "parent_task_id",
+                                "child_task_ids",
+                                "dependencies",
+                                "assigned_executor",
+                                "required_capabilities",
+                                "priority",
+                                "artifacts.items",
+                                "artifacts.completion_evidence",
+                                "observability"
+                            ]
+                        },
+                        "retries": {
+                            "attempt_count": 0,
+                            "last_retry_at": null,
+                            "max_attempts": 0
+                        }
+                    },
+                    "origin": {
+                        "ingress_id": "conv-kno-166-bridge-1",
+                        "ingress_name": "OpenClaw",
+                        "requested_by": "operator@example.com",
+                        "source_id": "msg-kno-166-bridge-1",
+                        "source_system": "openclaw",
+                        "source_type": "ingress_request"
+                    },
+                    "parent_task_id": null,
+                    "priority": "high",
+                    "required_capabilities": [],
+                    "status": "intake_ready",
+                    "status_history": [],
+                    "timestamps": {
+                        "completed_at": null,
+                        "created_at": "2026-04-03T19:05:43.822495Z",
+                        "updated_at": "2026-04-03T19:05:43.822495Z"
+                    },
+                    "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+                },
+                "transition_result": null,
+                "verification_result": {
+                    "accepted_completion": false,
+                    "claimed_completion": false,
+                    "evidence_is_sufficient": false,
+                    "evidence_is_valid": true,
+                    "failure_classification": {
+                        "category": "none",
+                        "nature": "none",
+                        "reason": "No completion claim is currently being evaluated",
+                        "retryable": false
+                    },
+                    "is_terminal": false,
+                    "outcome": "verification_deferred",
+                    "reasons": [
+                        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                        "No completion claim is currently being evaluated"
+                    ],
+                    "reconciliation_status": "passed",
+                    "requires_review": false,
+                    "target_status": null,
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "verification_passed": false
+                }
+            },
+            "error": null,
+            "failure_classification": {
+                "category": "none",
+                "nature": "none",
+                "reason": "No completion claim is currently being evaluated",
+                "retryable": false
+            },
+            "invalid_input": false,
+            "reasons": [
+                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                "No completion claim is currently being evaluated"
+            ],
+            "requires_review": false,
+            "target_status": null,
+            "task_envelope": {
+                "acceptance_criteria": [
+                    {
+                        "description": "Task persists in Harness with OpenClaw provenance.",
+                        "id": "ac-1",
+                        "required": true
+                    },
+                    {
+                        "description": "Execution and evaluation records are appended in canonical history.",
+                        "id": "ac-2",
+                        "required": true
+                    },
+                    {
+                        "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                        "id": "ac-3",
+                        "required": true
+                    }
+                ],
+                "artifacts": {
+                    "completion_evidence": {
+                        "notes": null,
+                        "policy": "deferred",
+                        "required_artifact_types": [],
+                        "status": "deferred",
+                        "validated_artifact_ids": [],
+                        "validated_at": null,
+                        "validation_method": "deferred",
+                        "validator": null
+                    },
+                    "items": []
+                },
+                "assigned_executor": null,
+                "child_task_ids": [],
+                "constraints": [
+                    {
+                        "description": "Use canonical Harness submission and reevaluation paths.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    },
+                    {
+                        "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    }
+                ],
+                "coordination": {
+                    "linear": null
+                },
+                "dependencies": [],
+                "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+                "extensions": {
+                    "openclaw": {
+                        "agent_id": "openclaw-assistant",
+                        "channel": "cli",
+                        "conversation_id": "conv-kno-166-bridge-1",
+                        "message_id": "msg-kno-166-bridge-1",
+                        "metadata": {
+                            "linear_issue": "KNO-166",
+                            "request_kind": "kno-166-bridge-proof"
+                        },
+                        "user_id": "operator@example.com",
+                        "workspace_id": "workspace-harness"
+                    }
+                },
+                "id": "kno-166-openclaw-bridge-2026-04-03",
+                "objective": {
+                    "deliverable_type": "unspecified",
+                    "success_signal": "Task satisfies declared acceptance criteria.",
+                    "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+                },
+                "observability": {
+                    "errors": [],
+                    "execution_metadata": {
+                        "schema_required_deferred_fields": [
+                            "parent_task_id",
+                            "child_task_ids",
+                            "dependencies",
+                            "assigned_executor",
+                            "required_capabilities",
+                            "priority",
+                            "artifacts.items",
+                            "artifacts.completion_evidence",
+                            "observability"
+                        ]
+                    },
+                    "retries": {
+                        "attempt_count": 0,
+                        "last_retry_at": null,
+                        "max_attempts": 0
+                    }
+                },
+                "origin": {
+                    "ingress_id": "conv-kno-166-bridge-1",
+                    "ingress_name": "OpenClaw",
+                    "requested_by": "operator@example.com",
+                    "source_id": "msg-kno-166-bridge-1",
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request"
+                },
+                "parent_task_id": null,
+                "priority": "high",
+                "required_capabilities": [],
+                "status": "intake_ready",
+                "status_history": [],
+                "timestamps": {
+                    "completed_at": null,
+                    "created_at": "2026-04-03T19:05:43.822495Z",
+                    "updated_at": "2026-04-03T19:05:43.822495Z"
+                },
+                "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+            }
+        },
+        "task_id": "kno-166-openclaw-bridge-2026-04-03"
+    },
+    "failure_classification": {
+        "category": "none",
+        "nature": "none",
+        "reason": "No completion claim is currently being evaluated",
+        "retryable": false
+    },
+    "invalid_input": false,
+    "reasons": [
+        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+        "No completion claim is currently being evaluated"
+    ],
+    "requires_review": false,
+    "target_status": null,
+    "task_envelope": {
+        "acceptance_criteria": [
+            {
+                "description": "Task persists in Harness with OpenClaw provenance.",
+                "id": "ac-1",
+                "required": true
+            },
+            {
+                "description": "Execution and evaluation records are appended in canonical history.",
+                "id": "ac-2",
+                "required": true
+            },
+            {
+                "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                "id": "ac-3",
+                "required": true
+            }
+        ],
+        "artifacts": {
+            "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+            },
+            "items": []
+        },
+        "assigned_executor": null,
+        "child_task_ids": [],
+        "constraints": [
+            {
+                "description": "Use canonical Harness submission and reevaluation paths.",
+                "required": true,
+                "type": "ingress_constraint"
+            },
+            {
+                "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                "required": true,
+                "type": "ingress_constraint"
+            }
+        ],
+        "coordination": {
+            "linear": null
+        },
+        "dependencies": [],
+        "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+        "extensions": {
+            "openclaw": {
+                "agent_id": "openclaw-assistant",
+                "channel": "cli",
+                "conversation_id": "conv-kno-166-bridge-1",
+                "message_id": "msg-kno-166-bridge-1",
+                "metadata": {
+                    "linear_issue": "KNO-166",
+                    "request_kind": "kno-166-bridge-proof"
+                },
+                "user_id": "operator@example.com",
+                "workspace_id": "workspace-harness"
+            }
+        },
+        "id": "kno-166-openclaw-bridge-2026-04-03",
+        "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+        },
+        "observability": {
+            "errors": [],
+            "execution_metadata": {
+                "schema_required_deferred_fields": [
+                    "parent_task_id",
+                    "child_task_ids",
+                    "dependencies",
+                    "assigned_executor",
+                    "required_capabilities",
+                    "priority",
+                    "artifacts.items",
+                    "artifacts.completion_evidence",
+                    "observability"
+                ]
+            },
+            "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+            }
+        },
+        "origin": {
+            "ingress_id": "conv-kno-166-bridge-1",
+            "ingress_name": "OpenClaw",
+            "requested_by": "operator@example.com",
+            "source_id": "msg-kno-166-bridge-1",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "high",
+        "required_capabilities": [],
+        "status": "intake_ready",
+        "status_history": [],
+        "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-04-03T19:05:43.822495Z",
+            "updated_at": "2026-04-03T19:05:43.822495Z"
+        },
+        "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+    }
+}

--- a/docs/demo/kno-166-openclaw-bridge/read-model-final.json
+++ b/docs/demo/kno-166-openclaw-bridge/read-model-final.json
@@ -1,0 +1,383 @@
+{
+    "task": {
+        "assigned_executor": null,
+        "coordination_summary": {
+            "linear": {
+                "issue_id": "KNO-166",
+                "issue_key": "KNO-166",
+                "project": null,
+                "provenance": {
+                    "linked_at": "2026-04-03T19:05:46.803444Z",
+                    "linked_by": "reevaluation",
+                    "source": "reevaluation_request.external_facts"
+                },
+                "reasons": [],
+                "record_found": true,
+                "state": "in_progress",
+                "task_reference": null,
+                "workflow": {
+                    "state_type": "in_progress",
+                    "workflow_id": "workflow-in_progress",
+                    "workflow_name": "In Progress"
+                }
+            }
+        },
+        "current_status": "completed",
+        "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+        "evaluation_summary": {
+            "count": 2,
+            "history": [
+                {
+                    "action": "no_op",
+                    "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                    "recorded_at": "2026-04-03T19:05:43.862477Z",
+                    "target_status": null
+                },
+                {
+                    "action": "transition_applied",
+                    "evaluation_id": "83eaac42-491c-4984-a28f-a058e4f89c79",
+                    "recorded_at": "2026-04-03T19:05:46.857295Z",
+                    "target_status": "completed"
+                }
+            ],
+            "latest_action": "transition_applied",
+            "latest_recorded_at": "2026-04-03T19:05:46.857295Z",
+            "latest_target_status": "completed"
+        },
+        "evidence_summary": {
+            "artifact_count": 2,
+            "artifact_type_counts": {
+                "commit": 1,
+                "pull_request": 1
+            },
+            "completion_evidence": {
+                "policy": "required",
+                "required_artifact_types": [
+                    "pull_request",
+                    "commit"
+                ],
+                "status": "satisfied",
+                "validated_artifact_ids": [
+                    "artifact-pr-bridge-1",
+                    "artifact-commit-bridge-1"
+                ],
+                "validated_at": "2026-04-03T10:20:15Z",
+                "validation_method": "external_reconciliation",
+                "validator": {
+                    "captured_by": "harness-api",
+                    "source_id": "verification-kno-166-bridge-1",
+                    "source_system": "harness",
+                    "source_type": "verification"
+                }
+            },
+            "validated_artifact_count": 2,
+            "verification_status_counts": {
+                "verified": 2
+            }
+        },
+        "extensions": {
+            "openclaw": {
+                "agent_id": "openclaw-assistant",
+                "channel": "cli",
+                "conversation_id": "conv-kno-166-bridge-1",
+                "message_id": "msg-kno-166-bridge-1",
+                "metadata": {
+                    "linear_issue": "KNO-166",
+                    "request_kind": "kno-166-bridge-proof"
+                },
+                "user_id": "operator@example.com",
+                "workspace_id": "workspace-harness"
+            }
+        },
+        "lifecycle_history": [
+            {
+                "changed_at": "2026-04-03T19:05:46.847639Z",
+                "changed_by": "verification",
+                "from_status": "intake_ready",
+                "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                "to_status": "completed"
+            }
+        ],
+        "objective_summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+        "origin": {
+            "ingress_id": "conv-kno-166-bridge-1",
+            "ingress_name": "OpenClaw",
+            "requested_by": "operator@example.com",
+            "source_id": "msg-kno-166-bridge-1",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+        },
+        "reconciliation_summary": {
+            "blocking": false,
+            "mismatch_categories": [],
+            "outcome": "no_mismatch",
+            "reasons": [
+                "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                "No blocking reconciliation mismatch was detected"
+            ],
+            "status": "passed",
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "terminal": false
+        },
+        "relationships": {
+            "child_task_ids": [],
+            "dependencies": [],
+            "parent_task_id": null
+        },
+        "review_summary": {
+            "decision_count": 0,
+            "decisions": [],
+            "latest_decision": null,
+            "latest_request": null,
+            "request_count": 0,
+            "requests": [],
+            "status": "none"
+        },
+        "task_id": "kno-166-openclaw-bridge-2026-04-03",
+        "timeline": [
+            {
+                "details": {
+                    "artifact_id": "artifact-pr-bridge-1",
+                    "branch": {
+                        "base_branch": "main",
+                        "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "name": "codex/real-task-proof"
+                    },
+                    "commit_sha": null,
+                    "pull_request_number": 121,
+                    "repository": {
+                        "external_id": "repo-kno-166-proof",
+                        "host": "github.com",
+                        "name": "Harness",
+                        "owner": "sfayka"
+                    },
+                    "title": "Harness persisted real task proof",
+                    "type": "pull_request",
+                    "verification_status": "verified"
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:artifact:artifact-pr-bridge-1",
+                "event_type": "artifact_captured",
+                "occurred_at": "2026-04-03T10:20:00Z",
+                "source": "github",
+                "summary": "Artifact captured: pull_request"
+            },
+            {
+                "details": {
+                    "artifact_id": "artifact-commit-bridge-1",
+                    "branch": null,
+                    "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                    "pull_request_number": null,
+                    "repository": {
+                        "external_id": "repo-kno-166-proof",
+                        "host": "github.com",
+                        "name": "Harness",
+                        "owner": "sfayka"
+                    },
+                    "title": null,
+                    "type": "commit",
+                    "verification_status": "verified"
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:artifact:artifact-commit-bridge-1",
+                "event_type": "artifact_captured",
+                "occurred_at": "2026-04-03T10:20:05Z",
+                "source": "github",
+                "summary": "Artifact captured: commit"
+            },
+            {
+                "details": {
+                    "origin": {
+                        "ingress_id": "conv-kno-166-bridge-1",
+                        "ingress_name": "OpenClaw",
+                        "requested_by": "operator@example.com",
+                        "source_id": "msg-kno-166-bridge-1",
+                        "source_system": "openclaw",
+                        "source_type": "ingress_request"
+                    },
+                    "status": "completed",
+                    "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:created",
+                "event_type": "task_created",
+                "occurred_at": "2026-04-03T19:05:43.822495Z",
+                "source": "openclaw",
+                "summary": "Task created"
+            },
+            {
+                "details": {
+                    "accepted_completion": false,
+                    "action": "no_op",
+                    "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                    "reasons": [
+                        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                        "No completion claim is currently being evaluated"
+                    ],
+                    "reconciliation_result": {
+                        "blocking": false,
+                        "mismatch_categories": [],
+                        "outcome": "no_mismatch",
+                        "reasons": [
+                            "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                            "No blocking reconciliation mismatch was detected"
+                        ],
+                        "status": "passed",
+                        "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                        "terminal": false
+                    },
+                    "requires_review": false,
+                    "target_status": null,
+                    "verification_result": {
+                        "accepted_completion": false,
+                        "claimed_completion": false,
+                        "evidence_is_sufficient": false,
+                        "evidence_is_valid": true,
+                        "failure_classification": {
+                            "category": "none",
+                            "nature": "none",
+                            "reason": "No completion claim is currently being evaluated",
+                            "retryable": false
+                        },
+                        "is_terminal": false,
+                        "outcome": "verification_deferred",
+                        "reasons": [
+                            "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                            "No completion claim is currently being evaluated"
+                        ],
+                        "reconciliation_status": "passed",
+                        "requires_review": false,
+                        "target_status": null,
+                        "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                        "verification_passed": false
+                    }
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                "event_type": "evaluation_recorded",
+                "occurred_at": "2026-04-03T19:05:43.862477Z",
+                "source": "harness",
+                "summary": "Evaluation recorded: no_op"
+            },
+            {
+                "details": {
+                    "issue_id": "KNO-166",
+                    "issue_key": "KNO-166",
+                    "project": null,
+                    "provenance": {
+                        "linked_at": "2026-04-03T19:05:46.803444Z",
+                        "linked_by": "reevaluation",
+                        "source": "reevaluation_request.external_facts"
+                    },
+                    "reasons": [],
+                    "record_found": true,
+                    "state": "in_progress",
+                    "task_reference": null,
+                    "workflow": {
+                        "state_type": "in_progress",
+                        "workflow_id": "workflow-in_progress",
+                        "workflow_name": "In Progress"
+                    }
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:linear_linkage",
+                "event_type": "linear_linkage_recorded",
+                "occurred_at": "2026-04-03T19:05:46.803444Z",
+                "source": "reevaluation",
+                "summary": "Linear linkage recorded"
+            },
+            {
+                "details": {
+                    "changed_at": "2026-04-03T19:05:46.847639Z",
+                    "changed_by": "verification",
+                    "from_status": "intake_ready",
+                    "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                    "to_status": "completed"
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:status:0",
+                "event_type": "status_transition",
+                "occurred_at": "2026-04-03T19:05:46.847639Z",
+                "source": "verification",
+                "summary": "Status changed intake_ready -> completed"
+            },
+            {
+                "details": {
+                    "accepted_completion": true,
+                    "action": "transition_applied",
+                    "evaluation_id": "83eaac42-491c-4984-a28f-a058e4f89c79",
+                    "reasons": [
+                        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
+                    ],
+                    "reconciliation_result": {
+                        "blocking": false,
+                        "mismatch_categories": [],
+                        "outcome": "no_mismatch",
+                        "reasons": [
+                            "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                            "No blocking reconciliation mismatch was detected"
+                        ],
+                        "status": "passed",
+                        "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                        "terminal": false
+                    },
+                    "requires_review": false,
+                    "target_status": "completed",
+                    "verification_result": {
+                        "accepted_completion": true,
+                        "claimed_completion": true,
+                        "evidence_is_sufficient": true,
+                        "evidence_is_valid": true,
+                        "failure_classification": {
+                            "category": "none",
+                            "nature": "none",
+                            "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                            "retryable": false
+                        },
+                        "is_terminal": false,
+                        "outcome": "accepted_completion",
+                        "reasons": [
+                            "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                            "Executor-reported success was treated as advisory input only",
+                            "Acceptance criteria, evidence, and reconciliation all support completion"
+                        ],
+                        "reconciliation_status": "passed",
+                        "requires_review": false,
+                        "target_status": "completed",
+                        "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                        "verification_passed": true
+                    }
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:83eaac42-491c-4984-a28f-a058e4f89c79",
+                "event_type": "evaluation_recorded",
+                "occurred_at": "2026-04-03T19:05:46.857295Z",
+                "source": "harness",
+                "summary": "Evaluation recorded: transition_applied"
+            }
+        ],
+        "timestamps": {
+            "completed_at": "2026-04-03T19:05:46.847639Z",
+            "created_at": "2026-04-03T19:05:43.822495Z",
+            "updated_at": "2026-04-03T19:05:46.847639Z"
+        },
+        "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle",
+        "verification_summary": {
+            "accepted_completion": true,
+            "claimed_completion": true,
+            "evidence_is_sufficient": true,
+            "evidence_is_valid": true,
+            "failure_classification": {
+                "category": "none",
+                "nature": "none",
+                "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                "retryable": false
+            },
+            "is_terminal": false,
+            "outcome": "accepted_completion",
+            "reasons": [
+                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                "Executor-reported success was treated as advisory input only",
+                "Acceptance criteria, evidence, and reconciliation all support completion"
+            ],
+            "reconciliation_status": "passed",
+            "requires_review": false,
+            "target_status": "completed",
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "verification_passed": true
+        }
+    }
+}

--- a/docs/demo/kno-166-openclaw-bridge/read-model-initial.json
+++ b/docs/demo/kno-166-openclaw-bridge/read-model-initial.json
@@ -1,0 +1,193 @@
+{
+    "task": {
+        "assigned_executor": null,
+        "coordination_summary": {
+            "linear": null
+        },
+        "current_status": "intake_ready",
+        "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+        "evaluation_summary": {
+            "count": 1,
+            "history": [
+                {
+                    "action": "no_op",
+                    "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                    "recorded_at": "2026-04-03T19:05:43.862477Z",
+                    "target_status": null
+                }
+            ],
+            "latest_action": "no_op",
+            "latest_recorded_at": "2026-04-03T19:05:43.862477Z",
+            "latest_target_status": null
+        },
+        "evidence_summary": {
+            "artifact_count": 0,
+            "artifact_type_counts": {},
+            "completion_evidence": {
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+            },
+            "validated_artifact_count": 0,
+            "verification_status_counts": {}
+        },
+        "extensions": {
+            "openclaw": {
+                "agent_id": "openclaw-assistant",
+                "channel": "cli",
+                "conversation_id": "conv-kno-166-bridge-1",
+                "message_id": "msg-kno-166-bridge-1",
+                "metadata": {
+                    "linear_issue": "KNO-166",
+                    "request_kind": "kno-166-bridge-proof"
+                },
+                "user_id": "operator@example.com",
+                "workspace_id": "workspace-harness"
+            }
+        },
+        "lifecycle_history": [],
+        "objective_summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+        "origin": {
+            "ingress_id": "conv-kno-166-bridge-1",
+            "ingress_name": "OpenClaw",
+            "requested_by": "operator@example.com",
+            "source_id": "msg-kno-166-bridge-1",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+        },
+        "reconciliation_summary": {
+            "blocking": false,
+            "mismatch_categories": [],
+            "outcome": "no_mismatch",
+            "reasons": [
+                "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                "No blocking reconciliation mismatch was detected"
+            ],
+            "status": "passed",
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "terminal": false
+        },
+        "relationships": {
+            "child_task_ids": [],
+            "dependencies": [],
+            "parent_task_id": null
+        },
+        "review_summary": {
+            "decision_count": 0,
+            "decisions": [],
+            "latest_decision": null,
+            "latest_request": null,
+            "request_count": 0,
+            "requests": [],
+            "status": "none"
+        },
+        "task_id": "kno-166-openclaw-bridge-2026-04-03",
+        "timeline": [
+            {
+                "details": {
+                    "origin": {
+                        "ingress_id": "conv-kno-166-bridge-1",
+                        "ingress_name": "OpenClaw",
+                        "requested_by": "operator@example.com",
+                        "source_id": "msg-kno-166-bridge-1",
+                        "source_system": "openclaw",
+                        "source_type": "ingress_request"
+                    },
+                    "status": "intake_ready",
+                    "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:created",
+                "event_type": "task_created",
+                "occurred_at": "2026-04-03T19:05:43.822495Z",
+                "source": "openclaw",
+                "summary": "Task created"
+            },
+            {
+                "details": {
+                    "accepted_completion": false,
+                    "action": "no_op",
+                    "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                    "reasons": [
+                        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                        "No completion claim is currently being evaluated"
+                    ],
+                    "reconciliation_result": {
+                        "blocking": false,
+                        "mismatch_categories": [],
+                        "outcome": "no_mismatch",
+                        "reasons": [
+                            "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                            "No blocking reconciliation mismatch was detected"
+                        ],
+                        "status": "passed",
+                        "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                        "terminal": false
+                    },
+                    "requires_review": false,
+                    "target_status": null,
+                    "verification_result": {
+                        "accepted_completion": false,
+                        "claimed_completion": false,
+                        "evidence_is_sufficient": false,
+                        "evidence_is_valid": true,
+                        "failure_classification": {
+                            "category": "none",
+                            "nature": "none",
+                            "reason": "No completion claim is currently being evaluated",
+                            "retryable": false
+                        },
+                        "is_terminal": false,
+                        "outcome": "verification_deferred",
+                        "reasons": [
+                            "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                            "No completion claim is currently being evaluated"
+                        ],
+                        "reconciliation_status": "passed",
+                        "requires_review": false,
+                        "target_status": null,
+                        "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                        "verification_passed": false
+                    }
+                },
+                "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                "event_type": "evaluation_recorded",
+                "occurred_at": "2026-04-03T19:05:43.862477Z",
+                "source": "harness",
+                "summary": "Evaluation recorded: no_op"
+            }
+        ],
+        "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-04-03T19:05:43.822495Z",
+            "updated_at": "2026-04-03T19:05:43.822495Z"
+        },
+        "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle",
+        "verification_summary": {
+            "accepted_completion": false,
+            "claimed_completion": false,
+            "evidence_is_sufficient": false,
+            "evidence_is_valid": true,
+            "failure_classification": {
+                "category": "none",
+                "nature": "none",
+                "reason": "No completion claim is currently being evaluated",
+                "retryable": false
+            },
+            "is_terminal": false,
+            "outcome": "verification_deferred",
+            "reasons": [
+                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                "No completion claim is currently being evaluated"
+            ],
+            "reconciliation_status": "passed",
+            "requires_review": false,
+            "target_status": null,
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "verification_passed": false
+        }
+    }
+}

--- a/docs/demo/kno-166-openclaw-bridge/reevaluate-request.json
+++ b/docs/demo/kno-166-openclaw-bridge/reevaluate-request.json
@@ -1,0 +1,153 @@
+{
+  "request": {
+    "claimed_completion": true,
+    "acceptance_criteria_satisfied": true,
+    "runtime_facts": {
+      "executor_reported_success": true,
+      "executor_reported_failure": false,
+      "attempt_count": 1
+    },
+    "new_artifacts": [
+      {
+        "id": "artifact-pr-bridge-1",
+        "type": "pull_request",
+        "title": "Harness persisted real task proof",
+        "description": "Real PR artifact used to validate completion evidence during bridge proof.",
+        "location": "https://github.com/sfayka/Harness/pull/121",
+        "content_type": null,
+        "external_id": "PR-121",
+        "commit_sha": null,
+        "pull_request_number": 121,
+        "review_state": "approved",
+        "provenance": {
+          "source_system": "github",
+          "source_type": "api",
+          "source_id": "pull/121",
+          "captured_by": "github-sync"
+        },
+        "verification_status": "verified",
+        "repository": {
+          "host": "github.com",
+          "owner": "sfayka",
+          "name": "Harness",
+          "external_id": "repo-kno-166-proof"
+        },
+        "branch": {
+          "name": "codex/real-task-proof",
+          "base_branch": "main",
+          "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95"
+        },
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-04-03T10:20:00Z",
+        "metadata": {}
+      },
+      {
+        "id": "artifact-commit-bridge-1",
+        "type": "commit",
+        "title": null,
+        "description": null,
+        "location": "https://github.com/sfayka/Harness/commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+        "content_type": null,
+        "external_id": "commit-04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+        "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+        "pull_request_number": null,
+        "review_state": null,
+        "provenance": {
+          "source_system": "github",
+          "source_type": "api",
+          "source_id": "commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+          "captured_by": "github-sync"
+        },
+        "verification_status": "verified",
+        "repository": {
+          "host": "github.com",
+          "owner": "sfayka",
+          "name": "Harness",
+          "external_id": "repo-kno-166-proof"
+        },
+        "branch": null,
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": "2026-04-03T10:20:05Z",
+        "metadata": {}
+      }
+    ],
+    "completion_evidence": {
+      "policy": "required",
+      "status": "satisfied",
+      "required_artifact_types": [
+        "pull_request",
+        "commit"
+      ],
+      "validated_artifact_ids": [
+        "artifact-pr-bridge-1",
+        "artifact-commit-bridge-1"
+      ],
+      "validation_method": "external_reconciliation",
+      "validated_at": "2026-04-03T10:20:15Z",
+      "validator": {
+        "source_system": "harness",
+        "source_type": "verification",
+        "source_id": "verification-kno-166-bridge-1",
+        "captured_by": "harness-api"
+      }
+    },
+    "external_facts": {
+      "github_facts": {
+        "artifact_found": true,
+        "reasons": [],
+        "repository": {
+          "host": "github.com",
+          "owner": "sfayka",
+          "name": "Harness",
+          "external_id": "repo-kno-166-proof"
+        },
+        "branch": {
+          "name": "codex/real-task-proof",
+          "base_branch": "main",
+          "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95"
+        },
+        "commit": {
+          "sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95"
+        },
+        "pull_request": {
+          "number": 121,
+          "review_state": "approved"
+        },
+        "changed_files": {
+          "matches_expected_scope": true,
+          "files": [
+            {
+              "path": "modules/connectors/openclaw_ingress.py",
+              "change_type": "modified"
+            },
+            {
+              "path": "modules/api.py",
+              "change_type": "modified"
+            }
+          ]
+        }
+      },
+      "linear_facts": {
+        "record_found": true,
+        "reasons": [],
+        "issue_id": "KNO-166",
+        "issue_key": "KNO-166",
+        "state": "in_progress",
+        "workflow": {
+          "workflow_id": "workflow-in_progress",
+          "workflow_name": "In Progress",
+          "state_type": "in_progress"
+        }
+      },
+      "expected_code_context": {
+        "repository_host": "github.com",
+        "repository_owner": "sfayka",
+        "repository_name": "Harness",
+        "base_branch": "main",
+        "branch_name": "codex/real-task-proof"
+      }
+    }
+  }
+}

--- a/docs/demo/kno-166-openclaw-bridge/reevaluate-response.json
+++ b/docs/demo/kno-166-openclaw-bridge/reevaluate-response.json
@@ -1,0 +1,1802 @@
+{
+    "accepted_completion": true,
+    "action": "transition_applied",
+    "enforcement_result": {
+        "action": "transition_applied",
+        "error": null,
+        "evidence_result": {
+            "artifact_results": [
+                {
+                    "artifact_id": "artifact-pr-bridge-1",
+                    "artifact_type": "pull_request",
+                    "is_valid": true,
+                    "issues": []
+                },
+                {
+                    "artifact_id": "artifact-commit-bridge-1",
+                    "artifact_type": "commit",
+                    "is_valid": true,
+                    "issues": []
+                }
+            ],
+            "is_sufficient": true,
+            "is_valid": true,
+            "issues": [],
+            "missing_required_artifact_types": [],
+            "unknown_validated_artifact_ids": [],
+            "validated_artifact_ids": [
+                "artifact-pr-bridge-1",
+                "artifact-commit-bridge-1"
+            ]
+        },
+        "failure_classification": {
+            "category": "none",
+            "nature": "none",
+            "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+            "retryable": false
+        },
+        "reasons": [
+            "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
+        ],
+        "reconciliation_result": {
+            "blocking": false,
+            "mismatch_categories": [],
+            "outcome": "no_mismatch",
+            "reasons": [
+                "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                "No blocking reconciliation mismatch was detected"
+            ],
+            "status": "passed",
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "terminal": false
+        },
+        "review_decision": null,
+        "review_request": null,
+        "target_status": "completed",
+        "task_envelope": {
+            "acceptance_criteria": [
+                {
+                    "description": "Task persists in Harness with OpenClaw provenance.",
+                    "id": "ac-1",
+                    "required": true
+                },
+                {
+                    "description": "Execution and evaluation records are appended in canonical history.",
+                    "id": "ac-2",
+                    "required": true
+                },
+                {
+                    "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                    "id": "ac-3",
+                    "required": true
+                }
+            ],
+            "artifacts": {
+                "completion_evidence": {
+                    "notes": null,
+                    "policy": "required",
+                    "required_artifact_types": [
+                        "pull_request",
+                        "commit"
+                    ],
+                    "status": "satisfied",
+                    "validated_artifact_ids": [
+                        "artifact-pr-bridge-1",
+                        "artifact-commit-bridge-1"
+                    ],
+                    "validated_at": "2026-04-03T10:20:15Z",
+                    "validation_method": "external_reconciliation",
+                    "validator": {
+                        "captured_by": "harness-api",
+                        "source_id": "verification-kno-166-bridge-1",
+                        "source_system": "harness",
+                        "source_type": "verification"
+                    }
+                },
+                "items": [
+                    {
+                        "branch": {
+                            "base_branch": "main",
+                            "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "name": "codex/real-task-proof"
+                        },
+                        "captured_at": "2026-04-03T10:20:00Z",
+                        "changed_files": [],
+                        "commit_sha": null,
+                        "content_type": null,
+                        "description": "Real PR artifact used to validate completion evidence during bridge proof.",
+                        "external_id": "PR-121",
+                        "external_refs": [],
+                        "id": "artifact-pr-bridge-1",
+                        "location": "https://github.com/sfayka/Harness/pull/121",
+                        "metadata": {},
+                        "provenance": {
+                            "captured_by": "github-sync",
+                            "source_id": "pull/121",
+                            "source_system": "github",
+                            "source_type": "api"
+                        },
+                        "pull_request_number": 121,
+                        "repository": {
+                            "external_id": "repo-kno-166-proof",
+                            "host": "github.com",
+                            "name": "Harness",
+                            "owner": "sfayka"
+                        },
+                        "review_state": "approved",
+                        "title": "Harness persisted real task proof",
+                        "type": "pull_request",
+                        "verification_status": "verified"
+                    },
+                    {
+                        "branch": null,
+                        "captured_at": "2026-04-03T10:20:05Z",
+                        "changed_files": [],
+                        "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "content_type": null,
+                        "description": null,
+                        "external_id": "commit-04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "external_refs": [],
+                        "id": "artifact-commit-bridge-1",
+                        "location": "https://github.com/sfayka/Harness/commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "metadata": {},
+                        "provenance": {
+                            "captured_by": "github-sync",
+                            "source_id": "commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "source_system": "github",
+                            "source_type": "api"
+                        },
+                        "pull_request_number": null,
+                        "repository": {
+                            "external_id": "repo-kno-166-proof",
+                            "host": "github.com",
+                            "name": "Harness",
+                            "owner": "sfayka"
+                        },
+                        "review_state": null,
+                        "title": null,
+                        "type": "commit",
+                        "verification_status": "verified"
+                    }
+                ]
+            },
+            "assigned_executor": null,
+            "child_task_ids": [],
+            "constraints": [
+                {
+                    "description": "Use canonical Harness submission and reevaluation paths.",
+                    "required": true,
+                    "type": "ingress_constraint"
+                },
+                {
+                    "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                    "required": true,
+                    "type": "ingress_constraint"
+                }
+            ],
+            "coordination": {
+                "linear": {
+                    "issue_id": "KNO-166",
+                    "issue_key": "KNO-166",
+                    "project": null,
+                    "provenance": {
+                        "linked_at": "2026-04-03T19:05:46.803444Z",
+                        "linked_by": "reevaluation",
+                        "source": "reevaluation_request.external_facts"
+                    },
+                    "reasons": [],
+                    "record_found": true,
+                    "state": "in_progress",
+                    "task_reference": null,
+                    "workflow": {
+                        "state_type": "in_progress",
+                        "workflow_id": "workflow-in_progress",
+                        "workflow_name": "In Progress"
+                    }
+                }
+            },
+            "dependencies": [],
+            "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+            "extensions": {
+                "openclaw": {
+                    "agent_id": "openclaw-assistant",
+                    "channel": "cli",
+                    "conversation_id": "conv-kno-166-bridge-1",
+                    "message_id": "msg-kno-166-bridge-1",
+                    "metadata": {
+                        "linear_issue": "KNO-166",
+                        "request_kind": "kno-166-bridge-proof"
+                    },
+                    "user_id": "operator@example.com",
+                    "workspace_id": "workspace-harness"
+                }
+            },
+            "id": "kno-166-openclaw-bridge-2026-04-03",
+            "objective": {
+                "deliverable_type": "unspecified",
+                "success_signal": "Task satisfies declared acceptance criteria.",
+                "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+            },
+            "observability": {
+                "errors": [],
+                "execution_metadata": {
+                    "schema_required_deferred_fields": [
+                        "parent_task_id",
+                        "child_task_ids",
+                        "dependencies",
+                        "assigned_executor",
+                        "required_capabilities",
+                        "priority",
+                        "artifacts.items",
+                        "artifacts.completion_evidence",
+                        "observability"
+                    ]
+                },
+                "retries": {
+                    "attempt_count": 0,
+                    "last_retry_at": null,
+                    "max_attempts": 0
+                }
+            },
+            "origin": {
+                "ingress_id": "conv-kno-166-bridge-1",
+                "ingress_name": "OpenClaw",
+                "requested_by": "operator@example.com",
+                "source_id": "msg-kno-166-bridge-1",
+                "source_system": "openclaw",
+                "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "high",
+            "required_capabilities": [],
+            "status": "completed",
+            "status_history": [
+                {
+                    "changed_at": "2026-04-03T19:05:46.847639Z",
+                    "changed_by": "verification",
+                    "from_status": "intake_ready",
+                    "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                    "to_status": "completed"
+                }
+            ],
+            "timestamps": {
+                "completed_at": "2026-04-03T19:05:46.847639Z",
+                "created_at": "2026-04-03T19:05:43.822495Z",
+                "updated_at": "2026-04-03T19:05:46.847639Z"
+            },
+            "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+        },
+        "transition_result": {
+            "actor": "verification",
+            "changed_at": "2026-04-03T19:05:46.847639Z",
+            "from_status": "intake_ready",
+            "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+            "status_history_entry": {
+                "changed_at": "2026-04-03T19:05:46.847639Z",
+                "changed_by": "verification",
+                "from_status": "intake_ready",
+                "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                "to_status": "completed"
+            },
+            "task_envelope": {
+                "acceptance_criteria": [
+                    {
+                        "description": "Task persists in Harness with OpenClaw provenance.",
+                        "id": "ac-1",
+                        "required": true
+                    },
+                    {
+                        "description": "Execution and evaluation records are appended in canonical history.",
+                        "id": "ac-2",
+                        "required": true
+                    },
+                    {
+                        "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                        "id": "ac-3",
+                        "required": true
+                    }
+                ],
+                "artifacts": {
+                    "completion_evidence": {
+                        "notes": null,
+                        "policy": "required",
+                        "required_artifact_types": [
+                            "pull_request",
+                            "commit"
+                        ],
+                        "status": "satisfied",
+                        "validated_artifact_ids": [
+                            "artifact-pr-bridge-1",
+                            "artifact-commit-bridge-1"
+                        ],
+                        "validated_at": "2026-04-03T10:20:15Z",
+                        "validation_method": "external_reconciliation",
+                        "validator": {
+                            "captured_by": "harness-api",
+                            "source_id": "verification-kno-166-bridge-1",
+                            "source_system": "harness",
+                            "source_type": "verification"
+                        }
+                    },
+                    "items": [
+                        {
+                            "branch": {
+                                "base_branch": "main",
+                                "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "name": "codex/real-task-proof"
+                            },
+                            "captured_at": "2026-04-03T10:20:00Z",
+                            "changed_files": [],
+                            "commit_sha": null,
+                            "content_type": null,
+                            "description": "Real PR artifact used to validate completion evidence during bridge proof.",
+                            "external_id": "PR-121",
+                            "external_refs": [],
+                            "id": "artifact-pr-bridge-1",
+                            "location": "https://github.com/sfayka/Harness/pull/121",
+                            "metadata": {},
+                            "provenance": {
+                                "captured_by": "github-sync",
+                                "source_id": "pull/121",
+                                "source_system": "github",
+                                "source_type": "api"
+                            },
+                            "pull_request_number": 121,
+                            "repository": {
+                                "external_id": "repo-kno-166-proof",
+                                "host": "github.com",
+                                "name": "Harness",
+                                "owner": "sfayka"
+                            },
+                            "review_state": "approved",
+                            "title": "Harness persisted real task proof",
+                            "type": "pull_request",
+                            "verification_status": "verified"
+                        },
+                        {
+                            "branch": null,
+                            "captured_at": "2026-04-03T10:20:05Z",
+                            "changed_files": [],
+                            "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "content_type": null,
+                            "description": null,
+                            "external_id": "commit-04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "external_refs": [],
+                            "id": "artifact-commit-bridge-1",
+                            "location": "https://github.com/sfayka/Harness/commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "metadata": {},
+                            "provenance": {
+                                "captured_by": "github-sync",
+                                "source_id": "commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "source_system": "github",
+                                "source_type": "api"
+                            },
+                            "pull_request_number": null,
+                            "repository": {
+                                "external_id": "repo-kno-166-proof",
+                                "host": "github.com",
+                                "name": "Harness",
+                                "owner": "sfayka"
+                            },
+                            "review_state": null,
+                            "title": null,
+                            "type": "commit",
+                            "verification_status": "verified"
+                        }
+                    ]
+                },
+                "assigned_executor": null,
+                "child_task_ids": [],
+                "constraints": [
+                    {
+                        "description": "Use canonical Harness submission and reevaluation paths.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    },
+                    {
+                        "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    }
+                ],
+                "coordination": {
+                    "linear": {
+                        "issue_id": "KNO-166",
+                        "issue_key": "KNO-166",
+                        "project": null,
+                        "provenance": {
+                            "linked_at": "2026-04-03T19:05:46.803444Z",
+                            "linked_by": "reevaluation",
+                            "source": "reevaluation_request.external_facts"
+                        },
+                        "reasons": [],
+                        "record_found": true,
+                        "state": "in_progress",
+                        "task_reference": null,
+                        "workflow": {
+                            "state_type": "in_progress",
+                            "workflow_id": "workflow-in_progress",
+                            "workflow_name": "In Progress"
+                        }
+                    }
+                },
+                "dependencies": [],
+                "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+                "extensions": {
+                    "openclaw": {
+                        "agent_id": "openclaw-assistant",
+                        "channel": "cli",
+                        "conversation_id": "conv-kno-166-bridge-1",
+                        "message_id": "msg-kno-166-bridge-1",
+                        "metadata": {
+                            "linear_issue": "KNO-166",
+                            "request_kind": "kno-166-bridge-proof"
+                        },
+                        "user_id": "operator@example.com",
+                        "workspace_id": "workspace-harness"
+                    }
+                },
+                "id": "kno-166-openclaw-bridge-2026-04-03",
+                "objective": {
+                    "deliverable_type": "unspecified",
+                    "success_signal": "Task satisfies declared acceptance criteria.",
+                    "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+                },
+                "observability": {
+                    "errors": [],
+                    "execution_metadata": {
+                        "schema_required_deferred_fields": [
+                            "parent_task_id",
+                            "child_task_ids",
+                            "dependencies",
+                            "assigned_executor",
+                            "required_capabilities",
+                            "priority",
+                            "artifacts.items",
+                            "artifacts.completion_evidence",
+                            "observability"
+                        ]
+                    },
+                    "retries": {
+                        "attempt_count": 0,
+                        "last_retry_at": null,
+                        "max_attempts": 0
+                    }
+                },
+                "origin": {
+                    "ingress_id": "conv-kno-166-bridge-1",
+                    "ingress_name": "OpenClaw",
+                    "requested_by": "operator@example.com",
+                    "source_id": "msg-kno-166-bridge-1",
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request"
+                },
+                "parent_task_id": null,
+                "priority": "high",
+                "required_capabilities": [],
+                "status": "completed",
+                "status_history": [
+                    {
+                        "changed_at": "2026-04-03T19:05:46.847639Z",
+                        "changed_by": "verification",
+                        "from_status": "intake_ready",
+                        "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                        "to_status": "completed"
+                    }
+                ],
+                "timestamps": {
+                    "completed_at": "2026-04-03T19:05:46.847639Z",
+                    "created_at": "2026-04-03T19:05:43.822495Z",
+                    "updated_at": "2026-04-03T19:05:46.847639Z"
+                },
+                "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+            },
+            "to_status": "completed"
+        },
+        "verification_result": {
+            "accepted_completion": true,
+            "claimed_completion": true,
+            "evidence_is_sufficient": true,
+            "evidence_is_valid": true,
+            "failure_classification": {
+                "category": "none",
+                "nature": "none",
+                "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                "retryable": false
+            },
+            "is_terminal": false,
+            "outcome": "accepted_completion",
+            "reasons": [
+                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                "Executor-reported success was treated as advisory input only",
+                "Acceptance criteria, evidence, and reconciliation all support completion"
+            ],
+            "reconciliation_status": "passed",
+            "requires_review": false,
+            "target_status": "completed",
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "verification_passed": true
+        }
+    },
+    "error": null,
+    "evaluation_record": {
+        "evaluation_id": "83eaac42-491c-4984-a28f-a058e4f89c79",
+        "recorded_at": "2026-04-03T19:05:46.857295Z",
+        "request": {
+            "acceptance_criteria_satisfied": true,
+            "claimed_completion": true,
+            "external_facts": {
+                "expected_code_context": {
+                    "base_branch": "main",
+                    "branch_name": "codex/real-task-proof",
+                    "repository_host": "github.com",
+                    "repository_name": "Harness",
+                    "repository_owner": "sfayka"
+                },
+                "github_facts": {
+                    "artifact_found": true,
+                    "artifact_refs": [
+                        {
+                            "artifact_type": "pull_request",
+                            "external_id": "PR-121",
+                            "url": null
+                        },
+                        {
+                            "artifact_type": "commit",
+                            "external_id": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "url": null
+                        }
+                    ],
+                    "branch": {
+                        "base_branch": "main",
+                        "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "name": "codex/real-task-proof"
+                    },
+                    "changed_files": {
+                        "files": [
+                            {
+                                "additions": null,
+                                "change_type": "unknown",
+                                "deletions": null,
+                                "path": "modules/connectors/openclaw_ingress.py",
+                                "previous_path": null
+                            },
+                            {
+                                "additions": null,
+                                "change_type": "unknown",
+                                "deletions": null,
+                                "path": "modules/api.py",
+                                "previous_path": null
+                            }
+                        ],
+                        "matches_expected_scope": true
+                    },
+                    "commit": {
+                        "message_summary": null,
+                        "sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "url": null
+                    },
+                    "pull_request": {
+                        "merged": null,
+                        "number": 121,
+                        "review_state": "approved",
+                        "state": null,
+                        "url": null
+                    },
+                    "reasons": [],
+                    "repository": {
+                        "external_id": null,
+                        "host": "github.com",
+                        "name": "Harness",
+                        "owner": "sfayka"
+                    }
+                },
+                "linear_facts": {
+                    "issue_id": "KNO-166",
+                    "issue_key": "KNO-166",
+                    "project": null,
+                    "reasons": [],
+                    "record_found": true,
+                    "state": "in_progress",
+                    "task_reference": null,
+                    "workflow": {
+                        "state_type": "in_progress",
+                        "workflow_id": "workflow-in_progress",
+                        "workflow_name": "In Progress"
+                    }
+                }
+            },
+            "retry_context": null,
+            "review_decision": null,
+            "review_is_active": false,
+            "review_reasons": [],
+            "review_request": null,
+            "runtime_facts": {
+                "attempt_count": 1,
+                "executor_reported_failure": false,
+                "executor_reported_success": true,
+                "latest_attempt_outcome": null,
+                "terminal_failure": false
+            },
+            "task_envelope": {
+                "acceptance_criteria": [
+                    {
+                        "description": "Task persists in Harness with OpenClaw provenance.",
+                        "id": "ac-1",
+                        "required": true
+                    },
+                    {
+                        "description": "Execution and evaluation records are appended in canonical history.",
+                        "id": "ac-2",
+                        "required": true
+                    },
+                    {
+                        "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                        "id": "ac-3",
+                        "required": true
+                    }
+                ],
+                "artifacts": {
+                    "completion_evidence": {
+                        "notes": null,
+                        "policy": "required",
+                        "required_artifact_types": [
+                            "pull_request",
+                            "commit"
+                        ],
+                        "status": "satisfied",
+                        "validated_artifact_ids": [
+                            "artifact-pr-bridge-1",
+                            "artifact-commit-bridge-1"
+                        ],
+                        "validated_at": "2026-04-03T10:20:15Z",
+                        "validation_method": "external_reconciliation",
+                        "validator": {
+                            "captured_by": "harness-api",
+                            "source_id": "verification-kno-166-bridge-1",
+                            "source_system": "harness",
+                            "source_type": "verification"
+                        }
+                    },
+                    "items": [
+                        {
+                            "branch": {
+                                "base_branch": "main",
+                                "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "name": "codex/real-task-proof"
+                            },
+                            "captured_at": "2026-04-03T10:20:00Z",
+                            "changed_files": [],
+                            "commit_sha": null,
+                            "content_type": null,
+                            "description": "Real PR artifact used to validate completion evidence during bridge proof.",
+                            "external_id": "PR-121",
+                            "external_refs": [],
+                            "id": "artifact-pr-bridge-1",
+                            "location": "https://github.com/sfayka/Harness/pull/121",
+                            "metadata": {},
+                            "provenance": {
+                                "captured_by": "github-sync",
+                                "source_id": "pull/121",
+                                "source_system": "github",
+                                "source_type": "api"
+                            },
+                            "pull_request_number": 121,
+                            "repository": {
+                                "external_id": "repo-kno-166-proof",
+                                "host": "github.com",
+                                "name": "Harness",
+                                "owner": "sfayka"
+                            },
+                            "review_state": "approved",
+                            "title": "Harness persisted real task proof",
+                            "type": "pull_request",
+                            "verification_status": "verified"
+                        },
+                        {
+                            "branch": null,
+                            "captured_at": "2026-04-03T10:20:05Z",
+                            "changed_files": [],
+                            "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "content_type": null,
+                            "description": null,
+                            "external_id": "commit-04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "external_refs": [],
+                            "id": "artifact-commit-bridge-1",
+                            "location": "https://github.com/sfayka/Harness/commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "metadata": {},
+                            "provenance": {
+                                "captured_by": "github-sync",
+                                "source_id": "commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "source_system": "github",
+                                "source_type": "api"
+                            },
+                            "pull_request_number": null,
+                            "repository": {
+                                "external_id": "repo-kno-166-proof",
+                                "host": "github.com",
+                                "name": "Harness",
+                                "owner": "sfayka"
+                            },
+                            "review_state": null,
+                            "title": null,
+                            "type": "commit",
+                            "verification_status": "verified"
+                        }
+                    ]
+                },
+                "assigned_executor": null,
+                "child_task_ids": [],
+                "constraints": [
+                    {
+                        "description": "Use canonical Harness submission and reevaluation paths.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    },
+                    {
+                        "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    }
+                ],
+                "coordination": {
+                    "linear": {
+                        "issue_id": "KNO-166",
+                        "issue_key": "KNO-166",
+                        "project": null,
+                        "provenance": {
+                            "linked_at": "2026-04-03T19:05:46.803444Z",
+                            "linked_by": "reevaluation",
+                            "source": "reevaluation_request.external_facts"
+                        },
+                        "reasons": [],
+                        "record_found": true,
+                        "state": "in_progress",
+                        "task_reference": null,
+                        "workflow": {
+                            "state_type": "in_progress",
+                            "workflow_id": "workflow-in_progress",
+                            "workflow_name": "In Progress"
+                        }
+                    }
+                },
+                "dependencies": [],
+                "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+                "extensions": {
+                    "openclaw": {
+                        "agent_id": "openclaw-assistant",
+                        "channel": "cli",
+                        "conversation_id": "conv-kno-166-bridge-1",
+                        "message_id": "msg-kno-166-bridge-1",
+                        "metadata": {
+                            "linear_issue": "KNO-166",
+                            "request_kind": "kno-166-bridge-proof"
+                        },
+                        "user_id": "operator@example.com",
+                        "workspace_id": "workspace-harness"
+                    }
+                },
+                "id": "kno-166-openclaw-bridge-2026-04-03",
+                "objective": {
+                    "deliverable_type": "unspecified",
+                    "success_signal": "Task satisfies declared acceptance criteria.",
+                    "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+                },
+                "observability": {
+                    "errors": [],
+                    "execution_metadata": {
+                        "schema_required_deferred_fields": [
+                            "parent_task_id",
+                            "child_task_ids",
+                            "dependencies",
+                            "assigned_executor",
+                            "required_capabilities",
+                            "priority",
+                            "artifacts.items",
+                            "artifacts.completion_evidence",
+                            "observability"
+                        ]
+                    },
+                    "retries": {
+                        "attempt_count": 0,
+                        "last_retry_at": null,
+                        "max_attempts": 0
+                    }
+                },
+                "origin": {
+                    "ingress_id": "conv-kno-166-bridge-1",
+                    "ingress_name": "OpenClaw",
+                    "requested_by": "operator@example.com",
+                    "source_id": "msg-kno-166-bridge-1",
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request"
+                },
+                "parent_task_id": null,
+                "priority": "high",
+                "required_capabilities": [],
+                "status": "intake_ready",
+                "status_history": [],
+                "timestamps": {
+                    "completed_at": null,
+                    "created_at": "2026-04-03T19:05:43.822495Z",
+                    "updated_at": "2026-04-03T19:05:46.802779Z"
+                },
+                "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+            },
+            "unresolved_conditions": []
+        },
+        "result": {
+            "accepted_completion": true,
+            "action": "transition_applied",
+            "enforcement_result": {
+                "action": "transition_applied",
+                "error": null,
+                "evidence_result": {
+                    "artifact_results": [
+                        {
+                            "artifact_id": "artifact-pr-bridge-1",
+                            "artifact_type": "pull_request",
+                            "is_valid": true,
+                            "issues": []
+                        },
+                        {
+                            "artifact_id": "artifact-commit-bridge-1",
+                            "artifact_type": "commit",
+                            "is_valid": true,
+                            "issues": []
+                        }
+                    ],
+                    "is_sufficient": true,
+                    "is_valid": true,
+                    "issues": [],
+                    "missing_required_artifact_types": [],
+                    "unknown_validated_artifact_ids": [],
+                    "validated_artifact_ids": [
+                        "artifact-pr-bridge-1",
+                        "artifact-commit-bridge-1"
+                    ]
+                },
+                "failure_classification": {
+                    "category": "none",
+                    "nature": "none",
+                    "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                    "retryable": false
+                },
+                "reasons": [
+                    "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
+                ],
+                "reconciliation_result": {
+                    "blocking": false,
+                    "mismatch_categories": [],
+                    "outcome": "no_mismatch",
+                    "reasons": [
+                        "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                        "No blocking reconciliation mismatch was detected"
+                    ],
+                    "status": "passed",
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "terminal": false
+                },
+                "review_decision": null,
+                "review_request": null,
+                "target_status": "completed",
+                "task_envelope": {
+                    "acceptance_criteria": [
+                        {
+                            "description": "Task persists in Harness with OpenClaw provenance.",
+                            "id": "ac-1",
+                            "required": true
+                        },
+                        {
+                            "description": "Execution and evaluation records are appended in canonical history.",
+                            "id": "ac-2",
+                            "required": true
+                        },
+                        {
+                            "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                            "id": "ac-3",
+                            "required": true
+                        }
+                    ],
+                    "artifacts": {
+                        "completion_evidence": {
+                            "notes": null,
+                            "policy": "required",
+                            "required_artifact_types": [
+                                "pull_request",
+                                "commit"
+                            ],
+                            "status": "satisfied",
+                            "validated_artifact_ids": [
+                                "artifact-pr-bridge-1",
+                                "artifact-commit-bridge-1"
+                            ],
+                            "validated_at": "2026-04-03T10:20:15Z",
+                            "validation_method": "external_reconciliation",
+                            "validator": {
+                                "captured_by": "harness-api",
+                                "source_id": "verification-kno-166-bridge-1",
+                                "source_system": "harness",
+                                "source_type": "verification"
+                            }
+                        },
+                        "items": [
+                            {
+                                "branch": {
+                                    "base_branch": "main",
+                                    "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                    "name": "codex/real-task-proof"
+                                },
+                                "captured_at": "2026-04-03T10:20:00Z",
+                                "changed_files": [],
+                                "commit_sha": null,
+                                "content_type": null,
+                                "description": "Real PR artifact used to validate completion evidence during bridge proof.",
+                                "external_id": "PR-121",
+                                "external_refs": [],
+                                "id": "artifact-pr-bridge-1",
+                                "location": "https://github.com/sfayka/Harness/pull/121",
+                                "metadata": {},
+                                "provenance": {
+                                    "captured_by": "github-sync",
+                                    "source_id": "pull/121",
+                                    "source_system": "github",
+                                    "source_type": "api"
+                                },
+                                "pull_request_number": 121,
+                                "repository": {
+                                    "external_id": "repo-kno-166-proof",
+                                    "host": "github.com",
+                                    "name": "Harness",
+                                    "owner": "sfayka"
+                                },
+                                "review_state": "approved",
+                                "title": "Harness persisted real task proof",
+                                "type": "pull_request",
+                                "verification_status": "verified"
+                            },
+                            {
+                                "branch": null,
+                                "captured_at": "2026-04-03T10:20:05Z",
+                                "changed_files": [],
+                                "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "content_type": null,
+                                "description": null,
+                                "external_id": "commit-04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "external_refs": [],
+                                "id": "artifact-commit-bridge-1",
+                                "location": "https://github.com/sfayka/Harness/commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "metadata": {},
+                                "provenance": {
+                                    "captured_by": "github-sync",
+                                    "source_id": "commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                    "source_system": "github",
+                                    "source_type": "api"
+                                },
+                                "pull_request_number": null,
+                                "repository": {
+                                    "external_id": "repo-kno-166-proof",
+                                    "host": "github.com",
+                                    "name": "Harness",
+                                    "owner": "sfayka"
+                                },
+                                "review_state": null,
+                                "title": null,
+                                "type": "commit",
+                                "verification_status": "verified"
+                            }
+                        ]
+                    },
+                    "assigned_executor": null,
+                    "child_task_ids": [],
+                    "constraints": [
+                        {
+                            "description": "Use canonical Harness submission and reevaluation paths.",
+                            "required": true,
+                            "type": "ingress_constraint"
+                        },
+                        {
+                            "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                            "required": true,
+                            "type": "ingress_constraint"
+                        }
+                    ],
+                    "coordination": {
+                        "linear": {
+                            "issue_id": "KNO-166",
+                            "issue_key": "KNO-166",
+                            "project": null,
+                            "provenance": {
+                                "linked_at": "2026-04-03T19:05:46.803444Z",
+                                "linked_by": "reevaluation",
+                                "source": "reevaluation_request.external_facts"
+                            },
+                            "reasons": [],
+                            "record_found": true,
+                            "state": "in_progress",
+                            "task_reference": null,
+                            "workflow": {
+                                "state_type": "in_progress",
+                                "workflow_id": "workflow-in_progress",
+                                "workflow_name": "In Progress"
+                            }
+                        }
+                    },
+                    "dependencies": [],
+                    "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+                    "extensions": {
+                        "openclaw": {
+                            "agent_id": "openclaw-assistant",
+                            "channel": "cli",
+                            "conversation_id": "conv-kno-166-bridge-1",
+                            "message_id": "msg-kno-166-bridge-1",
+                            "metadata": {
+                                "linear_issue": "KNO-166",
+                                "request_kind": "kno-166-bridge-proof"
+                            },
+                            "user_id": "operator@example.com",
+                            "workspace_id": "workspace-harness"
+                        }
+                    },
+                    "id": "kno-166-openclaw-bridge-2026-04-03",
+                    "objective": {
+                        "deliverable_type": "unspecified",
+                        "success_signal": "Task satisfies declared acceptance criteria.",
+                        "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+                    },
+                    "observability": {
+                        "errors": [],
+                        "execution_metadata": {
+                            "schema_required_deferred_fields": [
+                                "parent_task_id",
+                                "child_task_ids",
+                                "dependencies",
+                                "assigned_executor",
+                                "required_capabilities",
+                                "priority",
+                                "artifacts.items",
+                                "artifacts.completion_evidence",
+                                "observability"
+                            ]
+                        },
+                        "retries": {
+                            "attempt_count": 0,
+                            "last_retry_at": null,
+                            "max_attempts": 0
+                        }
+                    },
+                    "origin": {
+                        "ingress_id": "conv-kno-166-bridge-1",
+                        "ingress_name": "OpenClaw",
+                        "requested_by": "operator@example.com",
+                        "source_id": "msg-kno-166-bridge-1",
+                        "source_system": "openclaw",
+                        "source_type": "ingress_request"
+                    },
+                    "parent_task_id": null,
+                    "priority": "high",
+                    "required_capabilities": [],
+                    "status": "completed",
+                    "status_history": [
+                        {
+                            "changed_at": "2026-04-03T19:05:46.847639Z",
+                            "changed_by": "verification",
+                            "from_status": "intake_ready",
+                            "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                            "to_status": "completed"
+                        }
+                    ],
+                    "timestamps": {
+                        "completed_at": "2026-04-03T19:05:46.847639Z",
+                        "created_at": "2026-04-03T19:05:43.822495Z",
+                        "updated_at": "2026-04-03T19:05:46.847639Z"
+                    },
+                    "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+                },
+                "transition_result": {
+                    "actor": "verification",
+                    "changed_at": "2026-04-03T19:05:46.847639Z",
+                    "from_status": "intake_ready",
+                    "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                    "status_history_entry": {
+                        "changed_at": "2026-04-03T19:05:46.847639Z",
+                        "changed_by": "verification",
+                        "from_status": "intake_ready",
+                        "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                        "to_status": "completed"
+                    },
+                    "task_envelope": {
+                        "acceptance_criteria": [
+                            {
+                                "description": "Task persists in Harness with OpenClaw provenance.",
+                                "id": "ac-1",
+                                "required": true
+                            },
+                            {
+                                "description": "Execution and evaluation records are appended in canonical history.",
+                                "id": "ac-2",
+                                "required": true
+                            },
+                            {
+                                "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                                "id": "ac-3",
+                                "required": true
+                            }
+                        ],
+                        "artifacts": {
+                            "completion_evidence": {
+                                "notes": null,
+                                "policy": "required",
+                                "required_artifact_types": [
+                                    "pull_request",
+                                    "commit"
+                                ],
+                                "status": "satisfied",
+                                "validated_artifact_ids": [
+                                    "artifact-pr-bridge-1",
+                                    "artifact-commit-bridge-1"
+                                ],
+                                "validated_at": "2026-04-03T10:20:15Z",
+                                "validation_method": "external_reconciliation",
+                                "validator": {
+                                    "captured_by": "harness-api",
+                                    "source_id": "verification-kno-166-bridge-1",
+                                    "source_system": "harness",
+                                    "source_type": "verification"
+                                }
+                            },
+                            "items": [
+                                {
+                                    "branch": {
+                                        "base_branch": "main",
+                                        "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                        "name": "codex/real-task-proof"
+                                    },
+                                    "captured_at": "2026-04-03T10:20:00Z",
+                                    "changed_files": [],
+                                    "commit_sha": null,
+                                    "content_type": null,
+                                    "description": "Real PR artifact used to validate completion evidence during bridge proof.",
+                                    "external_id": "PR-121",
+                                    "external_refs": [],
+                                    "id": "artifact-pr-bridge-1",
+                                    "location": "https://github.com/sfayka/Harness/pull/121",
+                                    "metadata": {},
+                                    "provenance": {
+                                        "captured_by": "github-sync",
+                                        "source_id": "pull/121",
+                                        "source_system": "github",
+                                        "source_type": "api"
+                                    },
+                                    "pull_request_number": 121,
+                                    "repository": {
+                                        "external_id": "repo-kno-166-proof",
+                                        "host": "github.com",
+                                        "name": "Harness",
+                                        "owner": "sfayka"
+                                    },
+                                    "review_state": "approved",
+                                    "title": "Harness persisted real task proof",
+                                    "type": "pull_request",
+                                    "verification_status": "verified"
+                                },
+                                {
+                                    "branch": null,
+                                    "captured_at": "2026-04-03T10:20:05Z",
+                                    "changed_files": [],
+                                    "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                    "content_type": null,
+                                    "description": null,
+                                    "external_id": "commit-04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                    "external_refs": [],
+                                    "id": "artifact-commit-bridge-1",
+                                    "location": "https://github.com/sfayka/Harness/commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                    "metadata": {},
+                                    "provenance": {
+                                        "captured_by": "github-sync",
+                                        "source_id": "commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                        "source_system": "github",
+                                        "source_type": "api"
+                                    },
+                                    "pull_request_number": null,
+                                    "repository": {
+                                        "external_id": "repo-kno-166-proof",
+                                        "host": "github.com",
+                                        "name": "Harness",
+                                        "owner": "sfayka"
+                                    },
+                                    "review_state": null,
+                                    "title": null,
+                                    "type": "commit",
+                                    "verification_status": "verified"
+                                }
+                            ]
+                        },
+                        "assigned_executor": null,
+                        "child_task_ids": [],
+                        "constraints": [
+                            {
+                                "description": "Use canonical Harness submission and reevaluation paths.",
+                                "required": true,
+                                "type": "ingress_constraint"
+                            },
+                            {
+                                "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                                "required": true,
+                                "type": "ingress_constraint"
+                            }
+                        ],
+                        "coordination": {
+                            "linear": {
+                                "issue_id": "KNO-166",
+                                "issue_key": "KNO-166",
+                                "project": null,
+                                "provenance": {
+                                    "linked_at": "2026-04-03T19:05:46.803444Z",
+                                    "linked_by": "reevaluation",
+                                    "source": "reevaluation_request.external_facts"
+                                },
+                                "reasons": [],
+                                "record_found": true,
+                                "state": "in_progress",
+                                "task_reference": null,
+                                "workflow": {
+                                    "state_type": "in_progress",
+                                    "workflow_id": "workflow-in_progress",
+                                    "workflow_name": "In Progress"
+                                }
+                            }
+                        },
+                        "dependencies": [],
+                        "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+                        "extensions": {
+                            "openclaw": {
+                                "agent_id": "openclaw-assistant",
+                                "channel": "cli",
+                                "conversation_id": "conv-kno-166-bridge-1",
+                                "message_id": "msg-kno-166-bridge-1",
+                                "metadata": {
+                                    "linear_issue": "KNO-166",
+                                    "request_kind": "kno-166-bridge-proof"
+                                },
+                                "user_id": "operator@example.com",
+                                "workspace_id": "workspace-harness"
+                            }
+                        },
+                        "id": "kno-166-openclaw-bridge-2026-04-03",
+                        "objective": {
+                            "deliverable_type": "unspecified",
+                            "success_signal": "Task satisfies declared acceptance criteria.",
+                            "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+                        },
+                        "observability": {
+                            "errors": [],
+                            "execution_metadata": {
+                                "schema_required_deferred_fields": [
+                                    "parent_task_id",
+                                    "child_task_ids",
+                                    "dependencies",
+                                    "assigned_executor",
+                                    "required_capabilities",
+                                    "priority",
+                                    "artifacts.items",
+                                    "artifacts.completion_evidence",
+                                    "observability"
+                                ]
+                            },
+                            "retries": {
+                                "attempt_count": 0,
+                                "last_retry_at": null,
+                                "max_attempts": 0
+                            }
+                        },
+                        "origin": {
+                            "ingress_id": "conv-kno-166-bridge-1",
+                            "ingress_name": "OpenClaw",
+                            "requested_by": "operator@example.com",
+                            "source_id": "msg-kno-166-bridge-1",
+                            "source_system": "openclaw",
+                            "source_type": "ingress_request"
+                        },
+                        "parent_task_id": null,
+                        "priority": "high",
+                        "required_capabilities": [],
+                        "status": "completed",
+                        "status_history": [
+                            {
+                                "changed_at": "2026-04-03T19:05:46.847639Z",
+                                "changed_by": "verification",
+                                "from_status": "intake_ready",
+                                "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                                "to_status": "completed"
+                            }
+                        ],
+                        "timestamps": {
+                            "completed_at": "2026-04-03T19:05:46.847639Z",
+                            "created_at": "2026-04-03T19:05:43.822495Z",
+                            "updated_at": "2026-04-03T19:05:46.847639Z"
+                        },
+                        "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+                    },
+                    "to_status": "completed"
+                },
+                "verification_result": {
+                    "accepted_completion": true,
+                    "claimed_completion": true,
+                    "evidence_is_sufficient": true,
+                    "evidence_is_valid": true,
+                    "failure_classification": {
+                        "category": "none",
+                        "nature": "none",
+                        "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                        "retryable": false
+                    },
+                    "is_terminal": false,
+                    "outcome": "accepted_completion",
+                    "reasons": [
+                        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                        "Executor-reported success was treated as advisory input only",
+                        "Acceptance criteria, evidence, and reconciliation all support completion"
+                    ],
+                    "reconciliation_status": "passed",
+                    "requires_review": false,
+                    "target_status": "completed",
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "verification_passed": true
+                }
+            },
+            "error": null,
+            "failure_classification": {
+                "category": "none",
+                "nature": "none",
+                "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                "retryable": false
+            },
+            "invalid_input": false,
+            "reasons": [
+                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
+            ],
+            "requires_review": false,
+            "target_status": "completed",
+            "task_envelope": {
+                "acceptance_criteria": [
+                    {
+                        "description": "Task persists in Harness with OpenClaw provenance.",
+                        "id": "ac-1",
+                        "required": true
+                    },
+                    {
+                        "description": "Execution and evaluation records are appended in canonical history.",
+                        "id": "ac-2",
+                        "required": true
+                    },
+                    {
+                        "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                        "id": "ac-3",
+                        "required": true
+                    }
+                ],
+                "artifacts": {
+                    "completion_evidence": {
+                        "notes": null,
+                        "policy": "required",
+                        "required_artifact_types": [
+                            "pull_request",
+                            "commit"
+                        ],
+                        "status": "satisfied",
+                        "validated_artifact_ids": [
+                            "artifact-pr-bridge-1",
+                            "artifact-commit-bridge-1"
+                        ],
+                        "validated_at": "2026-04-03T10:20:15Z",
+                        "validation_method": "external_reconciliation",
+                        "validator": {
+                            "captured_by": "harness-api",
+                            "source_id": "verification-kno-166-bridge-1",
+                            "source_system": "harness",
+                            "source_type": "verification"
+                        }
+                    },
+                    "items": [
+                        {
+                            "branch": {
+                                "base_branch": "main",
+                                "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "name": "codex/real-task-proof"
+                            },
+                            "captured_at": "2026-04-03T10:20:00Z",
+                            "changed_files": [],
+                            "commit_sha": null,
+                            "content_type": null,
+                            "description": "Real PR artifact used to validate completion evidence during bridge proof.",
+                            "external_id": "PR-121",
+                            "external_refs": [],
+                            "id": "artifact-pr-bridge-1",
+                            "location": "https://github.com/sfayka/Harness/pull/121",
+                            "metadata": {},
+                            "provenance": {
+                                "captured_by": "github-sync",
+                                "source_id": "pull/121",
+                                "source_system": "github",
+                                "source_type": "api"
+                            },
+                            "pull_request_number": 121,
+                            "repository": {
+                                "external_id": "repo-kno-166-proof",
+                                "host": "github.com",
+                                "name": "Harness",
+                                "owner": "sfayka"
+                            },
+                            "review_state": "approved",
+                            "title": "Harness persisted real task proof",
+                            "type": "pull_request",
+                            "verification_status": "verified"
+                        },
+                        {
+                            "branch": null,
+                            "captured_at": "2026-04-03T10:20:05Z",
+                            "changed_files": [],
+                            "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "content_type": null,
+                            "description": null,
+                            "external_id": "commit-04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "external_refs": [],
+                            "id": "artifact-commit-bridge-1",
+                            "location": "https://github.com/sfayka/Harness/commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "metadata": {},
+                            "provenance": {
+                                "captured_by": "github-sync",
+                                "source_id": "commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                                "source_system": "github",
+                                "source_type": "api"
+                            },
+                            "pull_request_number": null,
+                            "repository": {
+                                "external_id": "repo-kno-166-proof",
+                                "host": "github.com",
+                                "name": "Harness",
+                                "owner": "sfayka"
+                            },
+                            "review_state": null,
+                            "title": null,
+                            "type": "commit",
+                            "verification_status": "verified"
+                        }
+                    ]
+                },
+                "assigned_executor": null,
+                "child_task_ids": [],
+                "constraints": [
+                    {
+                        "description": "Use canonical Harness submission and reevaluation paths.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    },
+                    {
+                        "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                        "required": true,
+                        "type": "ingress_constraint"
+                    }
+                ],
+                "coordination": {
+                    "linear": {
+                        "issue_id": "KNO-166",
+                        "issue_key": "KNO-166",
+                        "project": null,
+                        "provenance": {
+                            "linked_at": "2026-04-03T19:05:46.803444Z",
+                            "linked_by": "reevaluation",
+                            "source": "reevaluation_request.external_facts"
+                        },
+                        "reasons": [],
+                        "record_found": true,
+                        "state": "in_progress",
+                        "task_reference": null,
+                        "workflow": {
+                            "state_type": "in_progress",
+                            "workflow_id": "workflow-in_progress",
+                            "workflow_name": "In Progress"
+                        }
+                    }
+                },
+                "dependencies": [],
+                "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+                "extensions": {
+                    "openclaw": {
+                        "agent_id": "openclaw-assistant",
+                        "channel": "cli",
+                        "conversation_id": "conv-kno-166-bridge-1",
+                        "message_id": "msg-kno-166-bridge-1",
+                        "metadata": {
+                            "linear_issue": "KNO-166",
+                            "request_kind": "kno-166-bridge-proof"
+                        },
+                        "user_id": "operator@example.com",
+                        "workspace_id": "workspace-harness"
+                    }
+                },
+                "id": "kno-166-openclaw-bridge-2026-04-03",
+                "objective": {
+                    "deliverable_type": "unspecified",
+                    "success_signal": "Task satisfies declared acceptance criteria.",
+                    "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+                },
+                "observability": {
+                    "errors": [],
+                    "execution_metadata": {
+                        "schema_required_deferred_fields": [
+                            "parent_task_id",
+                            "child_task_ids",
+                            "dependencies",
+                            "assigned_executor",
+                            "required_capabilities",
+                            "priority",
+                            "artifacts.items",
+                            "artifacts.completion_evidence",
+                            "observability"
+                        ]
+                    },
+                    "retries": {
+                        "attempt_count": 0,
+                        "last_retry_at": null,
+                        "max_attempts": 0
+                    }
+                },
+                "origin": {
+                    "ingress_id": "conv-kno-166-bridge-1",
+                    "ingress_name": "OpenClaw",
+                    "requested_by": "operator@example.com",
+                    "source_id": "msg-kno-166-bridge-1",
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request"
+                },
+                "parent_task_id": null,
+                "priority": "high",
+                "required_capabilities": [],
+                "status": "completed",
+                "status_history": [
+                    {
+                        "changed_at": "2026-04-03T19:05:46.847639Z",
+                        "changed_by": "verification",
+                        "from_status": "intake_ready",
+                        "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                        "to_status": "completed"
+                    }
+                ],
+                "timestamps": {
+                    "completed_at": "2026-04-03T19:05:46.847639Z",
+                    "created_at": "2026-04-03T19:05:43.822495Z",
+                    "updated_at": "2026-04-03T19:05:46.847639Z"
+                },
+                "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+            }
+        },
+        "task_id": "kno-166-openclaw-bridge-2026-04-03"
+    },
+    "failure_classification": {
+        "category": "none",
+        "nature": "none",
+        "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+        "retryable": false
+    },
+    "invalid_input": false,
+    "reasons": [
+        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
+    ],
+    "requires_review": false,
+    "target_status": "completed",
+    "task_envelope": {
+        "acceptance_criteria": [
+            {
+                "description": "Task persists in Harness with OpenClaw provenance.",
+                "id": "ac-1",
+                "required": true
+            },
+            {
+                "description": "Execution and evaluation records are appended in canonical history.",
+                "id": "ac-2",
+                "required": true
+            },
+            {
+                "description": "Task is visible in read-model, timeline, and task list surfaces used by the dashboard.",
+                "id": "ac-3",
+                "required": true
+            }
+        ],
+        "artifacts": {
+            "completion_evidence": {
+                "notes": null,
+                "policy": "required",
+                "required_artifact_types": [
+                    "pull_request",
+                    "commit"
+                ],
+                "status": "satisfied",
+                "validated_artifact_ids": [
+                    "artifact-pr-bridge-1",
+                    "artifact-commit-bridge-1"
+                ],
+                "validated_at": "2026-04-03T10:20:15Z",
+                "validation_method": "external_reconciliation",
+                "validator": {
+                    "captured_by": "harness-api",
+                    "source_id": "verification-kno-166-bridge-1",
+                    "source_system": "harness",
+                    "source_type": "verification"
+                }
+            },
+            "items": [
+                {
+                    "branch": {
+                        "base_branch": "main",
+                        "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "name": "codex/real-task-proof"
+                    },
+                    "captured_at": "2026-04-03T10:20:00Z",
+                    "changed_files": [],
+                    "commit_sha": null,
+                    "content_type": null,
+                    "description": "Real PR artifact used to validate completion evidence during bridge proof.",
+                    "external_id": "PR-121",
+                    "external_refs": [],
+                    "id": "artifact-pr-bridge-1",
+                    "location": "https://github.com/sfayka/Harness/pull/121",
+                    "metadata": {},
+                    "provenance": {
+                        "captured_by": "github-sync",
+                        "source_id": "pull/121",
+                        "source_system": "github",
+                        "source_type": "api"
+                    },
+                    "pull_request_number": 121,
+                    "repository": {
+                        "external_id": "repo-kno-166-proof",
+                        "host": "github.com",
+                        "name": "Harness",
+                        "owner": "sfayka"
+                    },
+                    "review_state": "approved",
+                    "title": "Harness persisted real task proof",
+                    "type": "pull_request",
+                    "verification_status": "verified"
+                },
+                {
+                    "branch": null,
+                    "captured_at": "2026-04-03T10:20:05Z",
+                    "changed_files": [],
+                    "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                    "content_type": null,
+                    "description": null,
+                    "external_id": "commit-04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                    "external_refs": [],
+                    "id": "artifact-commit-bridge-1",
+                    "location": "https://github.com/sfayka/Harness/commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                    "metadata": {},
+                    "provenance": {
+                        "captured_by": "github-sync",
+                        "source_id": "commit/04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "source_system": "github",
+                        "source_type": "api"
+                    },
+                    "pull_request_number": null,
+                    "repository": {
+                        "external_id": "repo-kno-166-proof",
+                        "host": "github.com",
+                        "name": "Harness",
+                        "owner": "sfayka"
+                    },
+                    "review_state": null,
+                    "title": null,
+                    "type": "commit",
+                    "verification_status": "verified"
+                }
+            ]
+        },
+        "assigned_executor": null,
+        "child_task_ids": [],
+        "constraints": [
+            {
+                "description": "Use canonical Harness submission and reevaluation paths.",
+                "required": true,
+                "type": "ingress_constraint"
+            },
+            {
+                "description": "Keep OpenClaw metadata in ingress extensions without making it canonical truth.",
+                "required": true,
+                "type": "ingress_constraint"
+            }
+        ],
+        "coordination": {
+            "linear": {
+                "issue_id": "KNO-166",
+                "issue_key": "KNO-166",
+                "project": null,
+                "provenance": {
+                    "linked_at": "2026-04-03T19:05:46.803444Z",
+                    "linked_by": "reevaluation",
+                    "source": "reevaluation_request.external_facts"
+                },
+                "reasons": [],
+                "record_found": true,
+                "state": "in_progress",
+                "task_reference": null,
+                "workflow": {
+                    "state_type": "in_progress",
+                    "workflow_id": "workflow-in_progress",
+                    "workflow_name": "In Progress"
+                }
+            }
+        },
+        "dependencies": [],
+        "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+        "extensions": {
+            "openclaw": {
+                "agent_id": "openclaw-assistant",
+                "channel": "cli",
+                "conversation_id": "conv-kno-166-bridge-1",
+                "message_id": "msg-kno-166-bridge-1",
+                "metadata": {
+                    "linear_issue": "KNO-166",
+                    "request_kind": "kno-166-bridge-proof"
+                },
+                "user_id": "operator@example.com",
+                "workspace_id": "workspace-harness"
+            }
+        },
+        "id": "kno-166-openclaw-bridge-2026-04-03",
+        "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces."
+        },
+        "observability": {
+            "errors": [],
+            "execution_metadata": {
+                "schema_required_deferred_fields": [
+                    "parent_task_id",
+                    "child_task_ids",
+                    "dependencies",
+                    "assigned_executor",
+                    "required_capabilities",
+                    "priority",
+                    "artifacts.items",
+                    "artifacts.completion_evidence",
+                    "observability"
+                ]
+            },
+            "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+            }
+        },
+        "origin": {
+            "ingress_id": "conv-kno-166-bridge-1",
+            "ingress_name": "OpenClaw",
+            "requested_by": "operator@example.com",
+            "source_id": "msg-kno-166-bridge-1",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "high",
+        "required_capabilities": [],
+        "status": "completed",
+        "status_history": [
+            {
+                "changed_at": "2026-04-03T19:05:46.847639Z",
+                "changed_by": "verification",
+                "from_status": "intake_ready",
+                "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                "to_status": "completed"
+            }
+        ],
+        "timestamps": {
+            "completed_at": "2026-04-03T19:05:46.847639Z",
+            "created_at": "2026-04-03T19:05:43.822495Z",
+            "updated_at": "2026-04-03T19:05:46.847639Z"
+        },
+        "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+    }
+}

--- a/docs/demo/kno-166-openclaw-bridge/tasks-after-create.json
+++ b/docs/demo/kno-166-openclaw-bridge/tasks-after-create.json
@@ -1,0 +1,195 @@
+{
+    "tasks": [
+        {
+            "assigned_executor": null,
+            "coordination_summary": {
+                "linear": null
+            },
+            "current_status": "intake_ready",
+            "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+            "evaluation_summary": {
+                "count": 1,
+                "history": [
+                    {
+                        "action": "no_op",
+                        "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                        "recorded_at": "2026-04-03T19:05:43.862477Z",
+                        "target_status": null
+                    }
+                ],
+                "latest_action": "no_op",
+                "latest_recorded_at": "2026-04-03T19:05:43.862477Z",
+                "latest_target_status": null
+            },
+            "evidence_summary": {
+                "artifact_count": 0,
+                "artifact_type_counts": {},
+                "completion_evidence": {
+                    "policy": "deferred",
+                    "required_artifact_types": [],
+                    "status": "deferred",
+                    "validated_artifact_ids": [],
+                    "validated_at": null,
+                    "validation_method": "deferred",
+                    "validator": null
+                },
+                "validated_artifact_count": 0,
+                "verification_status_counts": {}
+            },
+            "extensions": {
+                "openclaw": {
+                    "agent_id": "openclaw-assistant",
+                    "channel": "cli",
+                    "conversation_id": "conv-kno-166-bridge-1",
+                    "message_id": "msg-kno-166-bridge-1",
+                    "metadata": {
+                        "linear_issue": "KNO-166",
+                        "request_kind": "kno-166-bridge-proof"
+                    },
+                    "user_id": "operator@example.com",
+                    "workspace_id": "workspace-harness"
+                }
+            },
+            "lifecycle_history": [],
+            "objective_summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+            "origin": {
+                "ingress_id": "conv-kno-166-bridge-1",
+                "ingress_name": "OpenClaw",
+                "requested_by": "operator@example.com",
+                "source_id": "msg-kno-166-bridge-1",
+                "source_system": "openclaw",
+                "source_type": "ingress_request"
+            },
+            "reconciliation_summary": {
+                "blocking": false,
+                "mismatch_categories": [],
+                "outcome": "no_mismatch",
+                "reasons": [
+                    "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                    "No blocking reconciliation mismatch was detected"
+                ],
+                "status": "passed",
+                "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                "terminal": false
+            },
+            "relationships": {
+                "child_task_ids": [],
+                "dependencies": [],
+                "parent_task_id": null
+            },
+            "review_summary": {
+                "decision_count": 0,
+                "decisions": [],
+                "latest_decision": null,
+                "latest_request": null,
+                "request_count": 0,
+                "requests": [],
+                "status": "none"
+            },
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "timeline": [
+                {
+                    "details": {
+                        "origin": {
+                            "ingress_id": "conv-kno-166-bridge-1",
+                            "ingress_name": "OpenClaw",
+                            "requested_by": "operator@example.com",
+                            "source_id": "msg-kno-166-bridge-1",
+                            "source_system": "openclaw",
+                            "source_type": "ingress_request"
+                        },
+                        "status": "intake_ready",
+                        "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:created",
+                    "event_type": "task_created",
+                    "occurred_at": "2026-04-03T19:05:43.822495Z",
+                    "source": "openclaw",
+                    "summary": "Task created"
+                },
+                {
+                    "details": {
+                        "accepted_completion": false,
+                        "action": "no_op",
+                        "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                        "reasons": [
+                            "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                            "No completion claim is currently being evaluated"
+                        ],
+                        "reconciliation_result": {
+                            "blocking": false,
+                            "mismatch_categories": [],
+                            "outcome": "no_mismatch",
+                            "reasons": [
+                                "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                                "No blocking reconciliation mismatch was detected"
+                            ],
+                            "status": "passed",
+                            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                            "terminal": false
+                        },
+                        "requires_review": false,
+                        "target_status": null,
+                        "verification_result": {
+                            "accepted_completion": false,
+                            "claimed_completion": false,
+                            "evidence_is_sufficient": false,
+                            "evidence_is_valid": true,
+                            "failure_classification": {
+                                "category": "none",
+                                "nature": "none",
+                                "reason": "No completion claim is currently being evaluated",
+                                "retryable": false
+                            },
+                            "is_terminal": false,
+                            "outcome": "verification_deferred",
+                            "reasons": [
+                                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                                "No completion claim is currently being evaluated"
+                            ],
+                            "reconciliation_status": "passed",
+                            "requires_review": false,
+                            "target_status": null,
+                            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                            "verification_passed": false
+                        }
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                    "event_type": "evaluation_recorded",
+                    "occurred_at": "2026-04-03T19:05:43.862477Z",
+                    "source": "harness",
+                    "summary": "Evaluation recorded: no_op"
+                }
+            ],
+            "timestamps": {
+                "completed_at": null,
+                "created_at": "2026-04-03T19:05:43.822495Z",
+                "updated_at": "2026-04-03T19:05:43.822495Z"
+            },
+            "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle",
+            "verification_summary": {
+                "accepted_completion": false,
+                "claimed_completion": false,
+                "evidence_is_sufficient": false,
+                "evidence_is_valid": true,
+                "failure_classification": {
+                    "category": "none",
+                    "nature": "none",
+                    "reason": "No completion claim is currently being evaluated",
+                    "retryable": false
+                },
+                "is_terminal": false,
+                "outcome": "verification_deferred",
+                "reasons": [
+                    "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                    "No completion claim is currently being evaluated"
+                ],
+                "reconciliation_status": "passed",
+                "requires_review": false,
+                "target_status": null,
+                "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                "verification_passed": false
+            }
+        }
+    ]
+}

--- a/docs/demo/kno-166-openclaw-bridge/tasks-after-reevaluate.json
+++ b/docs/demo/kno-166-openclaw-bridge/tasks-after-reevaluate.json
@@ -1,0 +1,385 @@
+{
+    "tasks": [
+        {
+            "assigned_executor": null,
+            "coordination_summary": {
+                "linear": {
+                    "issue_id": "KNO-166",
+                    "issue_key": "KNO-166",
+                    "project": null,
+                    "provenance": {
+                        "linked_at": "2026-04-03T19:05:46.803444Z",
+                        "linked_by": "reevaluation",
+                        "source": "reevaluation_request.external_facts"
+                    },
+                    "reasons": [],
+                    "record_found": true,
+                    "state": "in_progress",
+                    "task_reference": null,
+                    "workflow": {
+                        "state_type": "in_progress",
+                        "workflow_id": "workflow-in_progress",
+                        "workflow_name": "In Progress"
+                    }
+                }
+            },
+            "current_status": "completed",
+            "description": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+            "evaluation_summary": {
+                "count": 2,
+                "history": [
+                    {
+                        "action": "no_op",
+                        "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                        "recorded_at": "2026-04-03T19:05:43.862477Z",
+                        "target_status": null
+                    },
+                    {
+                        "action": "transition_applied",
+                        "evaluation_id": "83eaac42-491c-4984-a28f-a058e4f89c79",
+                        "recorded_at": "2026-04-03T19:05:46.857295Z",
+                        "target_status": "completed"
+                    }
+                ],
+                "latest_action": "transition_applied",
+                "latest_recorded_at": "2026-04-03T19:05:46.857295Z",
+                "latest_target_status": "completed"
+            },
+            "evidence_summary": {
+                "artifact_count": 2,
+                "artifact_type_counts": {
+                    "commit": 1,
+                    "pull_request": 1
+                },
+                "completion_evidence": {
+                    "policy": "required",
+                    "required_artifact_types": [
+                        "pull_request",
+                        "commit"
+                    ],
+                    "status": "satisfied",
+                    "validated_artifact_ids": [
+                        "artifact-pr-bridge-1",
+                        "artifact-commit-bridge-1"
+                    ],
+                    "validated_at": "2026-04-03T10:20:15Z",
+                    "validation_method": "external_reconciliation",
+                    "validator": {
+                        "captured_by": "harness-api",
+                        "source_id": "verification-kno-166-bridge-1",
+                        "source_system": "harness",
+                        "source_type": "verification"
+                    }
+                },
+                "validated_artifact_count": 2,
+                "verification_status_counts": {
+                    "verified": 2
+                }
+            },
+            "extensions": {
+                "openclaw": {
+                    "agent_id": "openclaw-assistant",
+                    "channel": "cli",
+                    "conversation_id": "conv-kno-166-bridge-1",
+                    "message_id": "msg-kno-166-bridge-1",
+                    "metadata": {
+                        "linear_issue": "KNO-166",
+                        "request_kind": "kno-166-bridge-proof"
+                    },
+                    "user_id": "operator@example.com",
+                    "workspace_id": "workspace-harness"
+                }
+            },
+            "lifecycle_history": [
+                {
+                    "changed_at": "2026-04-03T19:05:46.847639Z",
+                    "changed_by": "verification",
+                    "from_status": "intake_ready",
+                    "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                    "to_status": "completed"
+                }
+            ],
+            "objective_summary": "Run one persisted bridge from OpenClaw ingress through canonical evaluation and inspection surfaces.",
+            "origin": {
+                "ingress_id": "conv-kno-166-bridge-1",
+                "ingress_name": "OpenClaw",
+                "requested_by": "operator@example.com",
+                "source_id": "msg-kno-166-bridge-1",
+                "source_system": "openclaw",
+                "source_type": "ingress_request"
+            },
+            "reconciliation_summary": {
+                "blocking": false,
+                "mismatch_categories": [],
+                "outcome": "no_mismatch",
+                "reasons": [
+                    "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                    "No blocking reconciliation mismatch was detected"
+                ],
+                "status": "passed",
+                "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                "terminal": false
+            },
+            "relationships": {
+                "child_task_ids": [],
+                "dependencies": [],
+                "parent_task_id": null
+            },
+            "review_summary": {
+                "decision_count": 0,
+                "decisions": [],
+                "latest_decision": null,
+                "latest_request": null,
+                "request_count": 0,
+                "requests": [],
+                "status": "none"
+            },
+            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+            "timeline": [
+                {
+                    "details": {
+                        "artifact_id": "artifact-pr-bridge-1",
+                        "branch": {
+                            "base_branch": "main",
+                            "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                            "name": "codex/real-task-proof"
+                        },
+                        "commit_sha": null,
+                        "pull_request_number": 121,
+                        "repository": {
+                            "external_id": "repo-kno-166-proof",
+                            "host": "github.com",
+                            "name": "Harness",
+                            "owner": "sfayka"
+                        },
+                        "title": "Harness persisted real task proof",
+                        "type": "pull_request",
+                        "verification_status": "verified"
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:artifact:artifact-pr-bridge-1",
+                    "event_type": "artifact_captured",
+                    "occurred_at": "2026-04-03T10:20:00Z",
+                    "source": "github",
+                    "summary": "Artifact captured: pull_request"
+                },
+                {
+                    "details": {
+                        "artifact_id": "artifact-commit-bridge-1",
+                        "branch": null,
+                        "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                        "pull_request_number": null,
+                        "repository": {
+                            "external_id": "repo-kno-166-proof",
+                            "host": "github.com",
+                            "name": "Harness",
+                            "owner": "sfayka"
+                        },
+                        "title": null,
+                        "type": "commit",
+                        "verification_status": "verified"
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:artifact:artifact-commit-bridge-1",
+                    "event_type": "artifact_captured",
+                    "occurred_at": "2026-04-03T10:20:05Z",
+                    "source": "github",
+                    "summary": "Artifact captured: commit"
+                },
+                {
+                    "details": {
+                        "origin": {
+                            "ingress_id": "conv-kno-166-bridge-1",
+                            "ingress_name": "OpenClaw",
+                            "requested_by": "operator@example.com",
+                            "source_id": "msg-kno-166-bridge-1",
+                            "source_system": "openclaw",
+                            "source_type": "ingress_request"
+                        },
+                        "status": "completed",
+                        "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:created",
+                    "event_type": "task_created",
+                    "occurred_at": "2026-04-03T19:05:43.822495Z",
+                    "source": "openclaw",
+                    "summary": "Task created"
+                },
+                {
+                    "details": {
+                        "accepted_completion": false,
+                        "action": "no_op",
+                        "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                        "reasons": [
+                            "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                            "No completion claim is currently being evaluated"
+                        ],
+                        "reconciliation_result": {
+                            "blocking": false,
+                            "mismatch_categories": [],
+                            "outcome": "no_mismatch",
+                            "reasons": [
+                                "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                                "No blocking reconciliation mismatch was detected"
+                            ],
+                            "status": "passed",
+                            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                            "terminal": false
+                        },
+                        "requires_review": false,
+                        "target_status": null,
+                        "verification_result": {
+                            "accepted_completion": false,
+                            "claimed_completion": false,
+                            "evidence_is_sufficient": false,
+                            "evidence_is_valid": true,
+                            "failure_classification": {
+                                "category": "none",
+                                "nature": "none",
+                                "reason": "No completion claim is currently being evaluated",
+                                "retryable": false
+                            },
+                            "is_terminal": false,
+                            "outcome": "verification_deferred",
+                            "reasons": [
+                                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                                "No completion claim is currently being evaluated"
+                            ],
+                            "reconciliation_status": "passed",
+                            "requires_review": false,
+                            "target_status": null,
+                            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                            "verification_passed": false
+                        }
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                    "event_type": "evaluation_recorded",
+                    "occurred_at": "2026-04-03T19:05:43.862477Z",
+                    "source": "harness",
+                    "summary": "Evaluation recorded: no_op"
+                },
+                {
+                    "details": {
+                        "issue_id": "KNO-166",
+                        "issue_key": "KNO-166",
+                        "project": null,
+                        "provenance": {
+                            "linked_at": "2026-04-03T19:05:46.803444Z",
+                            "linked_by": "reevaluation",
+                            "source": "reevaluation_request.external_facts"
+                        },
+                        "reasons": [],
+                        "record_found": true,
+                        "state": "in_progress",
+                        "task_reference": null,
+                        "workflow": {
+                            "state_type": "in_progress",
+                            "workflow_id": "workflow-in_progress",
+                            "workflow_name": "In Progress"
+                        }
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:linear_linkage",
+                    "event_type": "linear_linkage_recorded",
+                    "occurred_at": "2026-04-03T19:05:46.803444Z",
+                    "source": "reevaluation",
+                    "summary": "Linear linkage recorded"
+                },
+                {
+                    "details": {
+                        "changed_at": "2026-04-03T19:05:46.847639Z",
+                        "changed_by": "verification",
+                        "from_status": "intake_ready",
+                        "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                        "to_status": "completed"
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:status:0",
+                    "event_type": "status_transition",
+                    "occurred_at": "2026-04-03T19:05:46.847639Z",
+                    "source": "verification",
+                    "summary": "Status changed intake_ready -> completed"
+                },
+                {
+                    "details": {
+                        "accepted_completion": true,
+                        "action": "transition_applied",
+                        "evaluation_id": "83eaac42-491c-4984-a28f-a058e4f89c79",
+                        "reasons": [
+                            "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
+                        ],
+                        "reconciliation_result": {
+                            "blocking": false,
+                            "mismatch_categories": [],
+                            "outcome": "no_mismatch",
+                            "reasons": [
+                                "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                                "No blocking reconciliation mismatch was detected"
+                            ],
+                            "status": "passed",
+                            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                            "terminal": false
+                        },
+                        "requires_review": false,
+                        "target_status": "completed",
+                        "verification_result": {
+                            "accepted_completion": true,
+                            "claimed_completion": true,
+                            "evidence_is_sufficient": true,
+                            "evidence_is_valid": true,
+                            "failure_classification": {
+                                "category": "none",
+                                "nature": "none",
+                                "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                                "retryable": false
+                            },
+                            "is_terminal": false,
+                            "outcome": "accepted_completion",
+                            "reasons": [
+                                "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                                "Executor-reported success was treated as advisory input only",
+                                "Acceptance criteria, evidence, and reconciliation all support completion"
+                            ],
+                            "reconciliation_status": "passed",
+                            "requires_review": false,
+                            "target_status": "completed",
+                            "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                            "verification_passed": true
+                        }
+                    },
+                    "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:83eaac42-491c-4984-a28f-a058e4f89c79",
+                    "event_type": "evaluation_recorded",
+                    "occurred_at": "2026-04-03T19:05:46.857295Z",
+                    "source": "harness",
+                    "summary": "Evaluation recorded: transition_applied"
+                }
+            ],
+            "timestamps": {
+                "completed_at": "2026-04-03T19:05:46.847639Z",
+                "created_at": "2026-04-03T19:05:43.822495Z",
+                "updated_at": "2026-04-03T19:05:46.847639Z"
+            },
+            "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle",
+            "verification_summary": {
+                "accepted_completion": true,
+                "claimed_completion": true,
+                "evidence_is_sufficient": true,
+                "evidence_is_valid": true,
+                "failure_classification": {
+                    "category": "none",
+                    "nature": "none",
+                    "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                    "retryable": false
+                },
+                "is_terminal": false,
+                "outcome": "accepted_completion",
+                "reasons": [
+                    "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                    "Executor-reported success was treated as advisory input only",
+                    "Acceptance criteria, evidence, and reconciliation all support completion"
+                ],
+                "reconciliation_status": "passed",
+                "requires_review": false,
+                "target_status": "completed",
+                "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                "verification_passed": true
+            }
+        }
+    ]
+}

--- a/docs/demo/kno-166-openclaw-bridge/timeline-final.json
+++ b/docs/demo/kno-166-openclaw-bridge/timeline-final.json
@@ -1,0 +1,220 @@
+{
+    "current_status": "completed",
+    "event_count": 7,
+    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+    "timeline": [
+        {
+            "details": {
+                "artifact_id": "artifact-pr-bridge-1",
+                "branch": {
+                    "base_branch": "main",
+                    "head_commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                    "name": "codex/real-task-proof"
+                },
+                "commit_sha": null,
+                "pull_request_number": 121,
+                "repository": {
+                    "external_id": "repo-kno-166-proof",
+                    "host": "github.com",
+                    "name": "Harness",
+                    "owner": "sfayka"
+                },
+                "title": "Harness persisted real task proof",
+                "type": "pull_request",
+                "verification_status": "verified"
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:artifact:artifact-pr-bridge-1",
+            "event_type": "artifact_captured",
+            "occurred_at": "2026-04-03T10:20:00Z",
+            "source": "github",
+            "summary": "Artifact captured: pull_request"
+        },
+        {
+            "details": {
+                "artifact_id": "artifact-commit-bridge-1",
+                "branch": null,
+                "commit_sha": "04d9da2b7d8add29e33f8c98bf558e2d145b0f95",
+                "pull_request_number": null,
+                "repository": {
+                    "external_id": "repo-kno-166-proof",
+                    "host": "github.com",
+                    "name": "Harness",
+                    "owner": "sfayka"
+                },
+                "title": null,
+                "type": "commit",
+                "verification_status": "verified"
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:artifact:artifact-commit-bridge-1",
+            "event_type": "artifact_captured",
+            "occurred_at": "2026-04-03T10:20:05Z",
+            "source": "github",
+            "summary": "Artifact captured: commit"
+        },
+        {
+            "details": {
+                "origin": {
+                    "ingress_id": "conv-kno-166-bridge-1",
+                    "ingress_name": "OpenClaw",
+                    "requested_by": "operator@example.com",
+                    "source_id": "msg-kno-166-bridge-1",
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request"
+                },
+                "status": "completed",
+                "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:created",
+            "event_type": "task_created",
+            "occurred_at": "2026-04-03T19:05:43.822495Z",
+            "source": "openclaw",
+            "summary": "Task created"
+        },
+        {
+            "details": {
+                "accepted_completion": false,
+                "action": "no_op",
+                "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                "reasons": [
+                    "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                    "No completion claim is currently being evaluated"
+                ],
+                "reconciliation_result": {
+                    "blocking": false,
+                    "mismatch_categories": [],
+                    "outcome": "no_mismatch",
+                    "reasons": [
+                        "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                        "No blocking reconciliation mismatch was detected"
+                    ],
+                    "status": "passed",
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "terminal": false
+                },
+                "requires_review": false,
+                "target_status": null,
+                "verification_result": {
+                    "accepted_completion": false,
+                    "claimed_completion": false,
+                    "evidence_is_sufficient": false,
+                    "evidence_is_valid": true,
+                    "failure_classification": {
+                        "category": "none",
+                        "nature": "none",
+                        "reason": "No completion claim is currently being evaluated",
+                        "retryable": false
+                    },
+                    "is_terminal": false,
+                    "outcome": "verification_deferred",
+                    "reasons": [
+                        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                        "No completion claim is currently being evaluated"
+                    ],
+                    "reconciliation_status": "passed",
+                    "requires_review": false,
+                    "target_status": null,
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "verification_passed": false
+                }
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+            "event_type": "evaluation_recorded",
+            "occurred_at": "2026-04-03T19:05:43.862477Z",
+            "source": "harness",
+            "summary": "Evaluation recorded: no_op"
+        },
+        {
+            "details": {
+                "issue_id": "KNO-166",
+                "issue_key": "KNO-166",
+                "project": null,
+                "provenance": {
+                    "linked_at": "2026-04-03T19:05:46.803444Z",
+                    "linked_by": "reevaluation",
+                    "source": "reevaluation_request.external_facts"
+                },
+                "reasons": [],
+                "record_found": true,
+                "state": "in_progress",
+                "task_reference": null,
+                "workflow": {
+                    "state_type": "in_progress",
+                    "workflow_id": "workflow-in_progress",
+                    "workflow_name": "In Progress"
+                }
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:linear_linkage",
+            "event_type": "linear_linkage_recorded",
+            "occurred_at": "2026-04-03T19:05:46.803444Z",
+            "source": "reevaluation",
+            "summary": "Linear linkage recorded"
+        },
+        {
+            "details": {
+                "changed_at": "2026-04-03T19:05:46.847639Z",
+                "changed_by": "verification",
+                "from_status": "intake_ready",
+                "reason": "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
+                "to_status": "completed"
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:status:0",
+            "event_type": "status_transition",
+            "occurred_at": "2026-04-03T19:05:46.847639Z",
+            "source": "verification",
+            "summary": "Status changed intake_ready -> completed"
+        },
+        {
+            "details": {
+                "accepted_completion": true,
+                "action": "transition_applied",
+                "evaluation_id": "83eaac42-491c-4984-a28f-a058e4f89c79",
+                "reasons": [
+                    "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
+                ],
+                "reconciliation_result": {
+                    "blocking": false,
+                    "mismatch_categories": [],
+                    "outcome": "no_mismatch",
+                    "reasons": [
+                        "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                        "No blocking reconciliation mismatch was detected"
+                    ],
+                    "status": "passed",
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "terminal": false
+                },
+                "requires_review": false,
+                "target_status": "completed",
+                "verification_result": {
+                    "accepted_completion": true,
+                    "claimed_completion": true,
+                    "evidence_is_sufficient": true,
+                    "evidence_is_valid": true,
+                    "failure_classification": {
+                        "category": "none",
+                        "nature": "none",
+                        "reason": "Acceptance criteria, evidence, and reconciliation all support completion",
+                        "retryable": false
+                    },
+                    "is_terminal": false,
+                    "outcome": "accepted_completion",
+                    "reasons": [
+                        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                        "Executor-reported success was treated as advisory input only",
+                        "Acceptance criteria, evidence, and reconciliation all support completion"
+                    ],
+                    "reconciliation_status": "passed",
+                    "requires_review": false,
+                    "target_status": "completed",
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "verification_passed": true
+                }
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:83eaac42-491c-4984-a28f-a058e4f89c79",
+            "event_type": "evaluation_recorded",
+            "occurred_at": "2026-04-03T19:05:46.857295Z",
+            "source": "harness",
+            "summary": "Evaluation recorded: transition_applied"
+        }
+    ]
+}

--- a/docs/demo/kno-166-openclaw-bridge/timeline-initial.json
+++ b/docs/demo/kno-166-openclaw-bridge/timeline-initial.json
@@ -1,0 +1,79 @@
+{
+    "current_status": "intake_ready",
+    "event_count": 2,
+    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+    "timeline": [
+        {
+            "details": {
+                "origin": {
+                    "ingress_id": "conv-kno-166-bridge-1",
+                    "ingress_name": "OpenClaw",
+                    "requested_by": "operator@example.com",
+                    "source_id": "msg-kno-166-bridge-1",
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request"
+                },
+                "status": "intake_ready",
+                "title": "Prove OpenClaw ingress bridge into Harness canonical task lifecycle"
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:created",
+            "event_type": "task_created",
+            "occurred_at": "2026-04-03T19:05:43.822495Z",
+            "source": "openclaw",
+            "summary": "Task created"
+        },
+        {
+            "details": {
+                "accepted_completion": false,
+                "action": "no_op",
+                "evaluation_id": "0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+                "reasons": [
+                    "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                    "No completion claim is currently being evaluated"
+                ],
+                "reconciliation_result": {
+                    "blocking": false,
+                    "mismatch_categories": [],
+                    "outcome": "no_mismatch",
+                    "reasons": [
+                        "Reconciliation evaluated task 'kno-166-openclaw-bridge-2026-04-03' against normalized external facts",
+                        "No blocking reconciliation mismatch was detected"
+                    ],
+                    "status": "passed",
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "terminal": false
+                },
+                "requires_review": false,
+                "target_status": null,
+                "verification_result": {
+                    "accepted_completion": false,
+                    "claimed_completion": false,
+                    "evidence_is_sufficient": false,
+                    "evidence_is_valid": true,
+                    "failure_classification": {
+                        "category": "none",
+                        "nature": "none",
+                        "reason": "No completion claim is currently being evaluated",
+                        "retryable": false
+                    },
+                    "is_terminal": false,
+                    "outcome": "verification_deferred",
+                    "reasons": [
+                        "Verification evaluated task 'kno-166-openclaw-bridge-2026-04-03' against canonical completion policy",
+                        "No completion claim is currently being evaluated"
+                    ],
+                    "reconciliation_status": "passed",
+                    "requires_review": false,
+                    "target_status": null,
+                    "task_id": "kno-166-openclaw-bridge-2026-04-03",
+                    "verification_passed": false
+                }
+            },
+            "event_id": "kno-166-openclaw-bridge-2026-04-03:evaluation:0de1c18c-bc52-475b-af4b-51b6a46bb53b",
+            "event_type": "evaluation_recorded",
+            "occurred_at": "2026-04-03T19:05:43.862477Z",
+            "source": "harness",
+            "summary": "Evaluation recorded: no_op"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add a new documented KNO-166 real-run bundle under `docs/demo/kno-166-openclaw-bridge/`
- capture a full persisted flow using canonical APIs:
  - `POST /ingress/openclaw`
  - `GET /tasks`, `GET /tasks/<id>/read-model`, `GET /tasks/<id>/timeline`
  - `POST /tasks/<id>/reevaluate`
- include request/response and inspection payload snapshots for both pre- and post-reevaluation states
- document external artifact provenance and honest remaining manual gap in the run README

## Validation
- `python -m json.tool` on all new request/response JSON artifacts
- local README reference check to confirm all documented artifact paths exist

## Why
This provides concrete, persisted proof for KNO-166 that OpenClaw ingress can bridge into Harness canonical task persistence, governed evaluation, and dashboard-facing visibility surfaces without bypassing control-plane contracts.
