### PR TITLE
Implement manual task dispatch bridge for canonical Harness tasks

### DIFF
--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -18,6 +18,19 @@ For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritativ
 - A completion claim is treated as `claimed_completion=true` advisory input; it does not directly authorize a lifecycle transition.
 - The canonical lifecycle outcome still comes from verification/reconciliation/review enforcement.
 
+### Manual Dispatch Bridge
+
+- `POST /tasks/<task_id>/dispatch` manually dispatches an existing canonical task to an executor adapter.
+- The request supports:
+  - `request.executor` (optional: `codex`, `openclaw`, or `stub-executor`; default `codex`)
+  - `request.execution_parameters` (optional object for advisory execution metadata)
+  - `request.artifact_references` (optional list of advisory artifact references such as PR URL, commit SHA, and branch metadata)
+- Dispatch:
+  - records a new execution attempt under `observability.execution_metadata.execution_attempts`
+  - records advisory completion claim metadata
+  - automatically triggers canonical reevaluation through the existing completion-claim path
+- Dispatch remains advisory-only and must not bypass verification, reconciliation, lifecycle enforcement, or review gates.
+
 - Existing-task reevaluation uses the stored task snapshot as the source of truth.
 - `POST /evaluate` may still be used as an evaluation surface for an existing task id, but Harness evaluates against the stored task snapshot and only reapplies the supported top-level overlays listed below.
 - Automatic callers must not rely on `POST /evaluate` to overwrite an existing task lifecycle state by supplying a different nested `request.task_envelope`.

--- a/modules/api.py
+++ b/modules/api.py
@@ -14,6 +14,11 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import unquote, urlparse
 
+from modules.adapters.executor_adapter import (
+    ExecutorAdapterInputError,
+    ExecutorDispatchInput,
+    StubExecutorAdapter,
+)
 from modules.connectors import (
     GitHubConnectorInputError,
     LinearConnectorInputError,
@@ -69,6 +74,8 @@ _RETRYABLE_FAILURE_CATEGORIES = frozenset(
         FailureCategory.EXTERNAL_AVAILABILITY_FAILURE,
     }
 )
+_TERMINAL_TASK_STATUSES = frozenset({"completed", "failed", "canceled"})
+_DISPATCH_BLOCKED_STATUSES = frozenset({"in_review"})
 
 
 def _iso_now() -> str:
@@ -594,6 +601,37 @@ def parse_reevaluation_request(task_envelope: dict[str, Any], payload: dict[str,
     )
 
 
+def _dispatch_attempt_number(task_envelope: dict[str, Any]) -> int:
+    attempts = ((task_envelope.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []
+    if not isinstance(attempts, list):
+        raise ApiRequestError("observability.execution_metadata.execution_attempts must be an array")
+    return len(attempts) + 1
+
+
+def _dispatch_attempt_status(execution_events: tuple[dict[str, Any], ...]) -> str:
+    event_types = {str(event.get("event_type")) for event in execution_events}
+    if "execution_failed" in event_types:
+        return "failed"
+    if "execution_succeeded" in event_types:
+        return "completed"
+    if "execution_stalled" in event_types or "execution_timed_out" in event_types:
+        return "blocked"
+    if "progress_reported" in event_types:
+        return "in_progress"
+    return "started"
+
+
+def _executor_hint(hint: str | None) -> str:
+    if hint is None:
+        return "codex"
+    normalized = hint.strip().lower()
+    if not normalized:
+        return "codex"
+    if normalized in {"codex", "openclaw", "stub-executor", "stub"}:
+        return normalized
+    raise ApiRequestError("request.executor must be one of: codex, openclaw, stub-executor")
+
+
 def _collect_review_activity(records: tuple[EvaluationRecord, ...]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     requests: list[dict[str, Any]] = []
     decisions: list[dict[str, Any]] = []
@@ -1040,6 +1078,134 @@ class HarnessApiService:
             response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
+    def dispatch_task(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            stored_task = self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+
+        task_status = str(stored_task.get("status") or "")
+        if task_status in _TERMINAL_TASK_STATUSES:
+            return HTTPStatus.CONFLICT, {"error": f"Task {task_id!r} is terminal and cannot be dispatched"}
+        if task_status in _DISPATCH_BLOCKED_STATUSES:
+            return HTTPStatus.CONFLICT, {"error": f"Task {task_id!r} is currently blocked for dispatch"}
+
+        request_payload = _optional_mapping(payload.get("request"), field_name="request") or {}
+        executor = _executor_hint(_optional_non_empty_string(request_payload.get("executor"), field_name="request.executor"))
+        execution_parameters = _optional_mapping(
+            request_payload.get("execution_parameters"),
+            field_name="request.execution_parameters",
+        ) or {}
+        extra_artifact_refs = _optional_object_list(
+            request_payload.get("artifact_references"),
+            field_name="request.artifact_references",
+        )
+
+        try:
+            attempt_number = _dispatch_attempt_number(stored_task)
+            attempt_id = f"attempt-{attempt_number}"
+            dispatch_input = ExecutorDispatchInput.from_task_envelope(
+                stored_task,
+                attempt_id=attempt_id,
+                assigned_executor=executor,
+            )
+            adapter_output = StubExecutorAdapter().dispatch(dispatch_input)
+        except (ApiRequestError, ExecutorAdapterInputError, ValueError) as error:
+            return HTTPStatus.BAD_REQUEST, {"error": str(error), "invalid_input": True}
+
+        event_payloads = tuple(
+            {
+                "event_id": str(event.event_id),
+                "event_type": str(event.event_type.value),
+                "occurred_at": str(event.occurred_at),
+                "source_system": str(event.provenance.source_system),
+                "metadata": dict(event.metadata),
+            }
+            for event in adapter_output.events
+        )
+        artifact_references = [
+            {
+                "reference_id": str(item.reference_id),
+                "artifact_type": str(item.artifact_type),
+                "location": item.location,
+                "external_id": item.external_id,
+                "commit_sha": item.commit_sha,
+                "metadata": dict(item.metadata),
+            }
+            for item in adapter_output.artifact_references
+        ]
+        artifact_references.extend(deepcopy(item) for item in extra_artifact_refs)
+        attempt_status = _dispatch_attempt_status(event_payloads)
+        claim_event = next(
+            (
+                event
+                for event in reversed(adapter_output.events)
+                if event.advisory_completion is not None
+            ),
+            None,
+        )
+        completion_claim_payload = claim_event.advisory_completion if claim_event is not None else None
+        completion_claim = {
+            "claim_id": (
+                completion_claim_payload.claim_id
+                if completion_claim_payload is not None
+                else f"{attempt_id}:claim"
+            ),
+            "reported_at": _iso_now(),
+            "reported_by": executor,
+            "reason": "manual dispatch execution attempt recorded",
+            "metadata": {
+                "attempt_id": attempt_id,
+                "dispatch_mode": "manual",
+                "execution_parameters": dict(execution_parameters),
+                "advisory_only": True,
+            },
+        }
+        execution_attempt = {
+            "attempt_id": attempt_id,
+            "recorded_at": _iso_now(),
+            "status": attempt_status,
+            "reported_by": executor,
+            "completion_claim_id": completion_claim["claim_id"],
+            "artifact_references": artifact_references,
+            "metadata": {
+                "dispatch_id": f"dispatch:{task_id}:{attempt_number}",
+                "dispatch_trigger": "manual_api",
+                "executor": executor,
+                "execution_parameters": dict(execution_parameters),
+                "dispatch_at": _iso_now(),
+                "execution_events": list(event_payloads),
+            },
+            "reevaluation": {},
+        }
+
+        dispatch_response_payload = {
+            "request": {
+                "completion_claim": completion_claim,
+                "execution_attempt": execution_attempt,
+                "acceptance_criteria_satisfied": bool(request_payload.get("acceptance_criteria_satisfied", False)),
+                "runtime_facts": {
+                    "executor_reported_success": attempt_status == "completed",
+                    "attempt_count": attempt_number,
+                    "latest_attempt_outcome": attempt_status,
+                },
+            }
+        }
+        external_facts_payload = _optional_mapping(request_payload.get("external_facts"), field_name="request.external_facts")
+        if external_facts_payload is not None:
+            dispatch_response_payload["request"]["external_facts"] = deepcopy(external_facts_payload)
+
+        status, response_payload = self.submit_completion_claim(task_id, dispatch_response_payload)
+        if status == HTTPStatus.OK:
+            response_payload["dispatch"] = {
+                "dispatch_id": execution_attempt["metadata"]["dispatch_id"],
+                "task_id": task_id,
+                "attempt_id": attempt_id,
+                "executor": executor,
+                "attempt_status": attempt_status,
+            }
+        return status, response_payload
+
     def get_task(self, task_id: str) -> tuple[int, dict[str, Any]]:
         try:
             task = self.store.get_task(task_id)
@@ -1149,7 +1315,7 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         if request_path not in {"/evaluate", "/tasks", "/ingress/linear", "/ingress/manual", "/ingress/openclaw"} and not (
             len(path_components) == 3
             and path_components[0] == "tasks"
-            and path_components[2] in {"reevaluate", "completion-claims"}
+            and path_components[2] in {"reevaluate", "completion-claims", "dispatch"}
         ):
             self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
             return
@@ -1175,6 +1341,8 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             status, response_payload = service.evaluate(payload)
         elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "completion-claims":
             status, response_payload = service.submit_completion_claim(path_components[1], payload)
+        elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "dispatch":
+            status, response_payload = service.dispatch_task(path_components[1], payload)
         else:
             status, response_payload = service.reevaluate(path_components[1], payload)
         self._write_json(status, response_payload)

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -105,6 +105,26 @@ def _build_review_summary(records: tuple[EvaluationRecord, ...]) -> dict[str, An
     }
 
 
+def _build_execution_summary(task_envelope: TaskEnvelope) -> dict[str, Any]:
+    execution_attempts = ((task_envelope.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []
+    if not isinstance(execution_attempts, list):
+        return {
+            "attempt_count": 0,
+            "latest_attempt": None,
+            "latest_artifact_references": [],
+        }
+    latest_attempt = next(
+        (attempt for attempt in reversed(execution_attempts) if isinstance(attempt, dict)),
+        None,
+    )
+    return {
+        "attempt_count": len([attempt for attempt in execution_attempts if isinstance(attempt, dict)]),
+        "latest_attempt": dict(latest_attempt) if latest_attempt is not None else None,
+        "latest_status": latest_attempt.get("status") if isinstance(latest_attempt, dict) else None,
+        "latest_artifact_references": list((latest_attempt or {}).get("artifact_references") or []),
+    }
+
+
 def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord, ...]) -> list[dict[str, Any]]:
     events: list[dict[str, Any]] = []
 
@@ -169,6 +189,27 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
         if not isinstance(attempt, dict):
             continue
         reevaluation = attempt.get("reevaluation") if isinstance(attempt.get("reevaluation"), dict) else {}
+        metadata = attempt.get("metadata") if isinstance(attempt.get("metadata"), dict) else {}
+        execution_events = metadata.get("execution_events") if isinstance(metadata.get("execution_events"), list) else []
+        dispatch_id = metadata.get("dispatch_id")
+        dispatch_at = metadata.get("dispatch_at")
+        if dispatch_id:
+            events.append(
+                {
+                    "event_id": f"{task_envelope['id']}:dispatch:{dispatch_id}",
+                    "event_type": "task_dispatched",
+                    "occurred_at": dispatch_at or attempt.get("recorded_at") or timestamps.get("updated_at"),
+                    "summary": f"Task dispatched: {attempt.get('attempt_id')}",
+                    "source": metadata.get("executor") or "dispatcher",
+                    "details": {
+                        "dispatch_id": dispatch_id,
+                        "attempt_id": attempt.get("attempt_id"),
+                        "executor": metadata.get("executor"),
+                        "dispatch_trigger": metadata.get("dispatch_trigger"),
+                        "execution_parameters": dict(metadata.get("execution_parameters") or {}),
+                    },
+                }
+            )
         events.append(
             {
                 "event_id": f"{task_envelope['id']}:execution_attempt:{attempt.get('attempt_id') or index}",
@@ -185,6 +226,32 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
                 },
             }
         )
+        for event_index, execution_event in enumerate(execution_events):
+            if not isinstance(execution_event, dict):
+                continue
+            events.append(
+                {
+                    "event_id": f"{task_envelope['id']}:execution_event:{attempt.get('attempt_id') or index}:{event_index}",
+                    "event_type": "execution_event_recorded",
+                    "occurred_at": execution_event.get("occurred_at") or attempt.get("recorded_at") or timestamps.get("updated_at"),
+                    "summary": f"Execution event: {execution_event.get('event_type')}",
+                    "source": ((execution_event.get("provenance") or {}).get("source_system")) or attempt.get("reported_by") or "executor",
+                    "details": dict(execution_event),
+                }
+            )
+        for artifact_reference in attempt.get("artifact_references") or []:
+            if not isinstance(artifact_reference, dict):
+                continue
+            events.append(
+                {
+                    "event_id": f"{task_envelope['id']}:execution_artifact:{attempt.get('attempt_id') or index}:{artifact_reference.get('reference_id')}",
+                    "event_type": "execution_artifact_attached",
+                    "occurred_at": attempt.get("recorded_at") or timestamps.get("updated_at"),
+                    "summary": f"Execution artifact attached: {artifact_reference.get('artifact_type')}",
+                    "source": ((artifact_reference.get("provenance") or {}).get("source_system")) or attempt.get("reported_by") or "executor",
+                    "details": dict(artifact_reference),
+                }
+            )
 
     linear_coordination = ((task_envelope.get("coordination") or {}).get("linear")) or None
     if isinstance(linear_coordination, dict):
@@ -295,6 +362,7 @@ class TaskReadModel:
     verification_summary: dict[str, Any] | None
     reconciliation_summary: dict[str, Any] | None
     review_summary: dict[str, Any]
+    execution_summary: dict[str, Any]
     evaluation_summary: dict[str, Any]
     lifecycle_history: list[dict[str, Any]]
     timestamps: dict[str, Any]
@@ -333,6 +401,7 @@ class HarnessReadModelService:
         verification_summary = _latest_mapping(records, ("enforcement_result", "verification_result"))
         reconciliation_summary = _latest_mapping(records, ("enforcement_result", "reconciliation_result"))
         review_summary = _build_review_summary(records)
+        execution_summary = _build_execution_summary(task)
         timeline = _build_timeline(task, records)
 
         return TaskReadModel(
@@ -357,6 +426,7 @@ class HarnessReadModelService:
             verification_summary=verification_summary,
             reconciliation_summary=reconciliation_summary,
             review_summary=review_summary,
+            execution_summary=execution_summary,
             evaluation_summary={
                 "count": len(records),
                 "latest_recorded_at": records[-1].recorded_at if records else None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -895,6 +895,60 @@ class HarnessApiServiceTests(unittest.TestCase):
         ]
         self.assertTrue(execution_events)
 
+    def test_service_dispatch_task_records_attempt_and_runs_reevaluation(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+        submit_payload = {"request": {"task_envelope": deepcopy(payload["request"]["task_envelope"])}}
+        submit_status, submit_response = self.service.submit(submit_payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        dispatch_status, dispatch_response = self.service.dispatch_task(
+            task_id,
+            {
+                "request": {
+                    "executor": "codex",
+                    "execution_parameters": {"mode": "manual"},
+                    "artifact_references": [
+                        {
+                            "reference_id": "attempt-1:pr",
+                            "artifact_type": "pull_request",
+                            "location": "https://github.com/sfayka/Harness/pull/999",
+                            "metadata": {
+                                "branch_name": "codex/manual-task-dispatch",
+                                "commit_sha": "abc123",
+                            },
+                        }
+                    ],
+                }
+            },
+        )
+        timeline_status, timeline_payload = self.service.get_task_timeline(task_id)
+        read_model_status, read_model_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(dispatch_status, 200)
+        self.assertEqual(dispatch_response["dispatch"]["attempt_id"], "attempt-1")
+        self.assertEqual(dispatch_response["dispatch"]["executor"], "codex")
+        self.assertIn(
+            dispatch_response["dispatch"]["attempt_status"],
+            {"started", "in_progress", "completed", "failed", "blocked"},
+        )
+        self.assertEqual(timeline_status, 200)
+        self.assertTrue(any(event["event_type"] == "task_dispatched" for event in timeline_payload["timeline"]))
+        self.assertTrue(any(event["event_type"] == "execution_event_recorded" for event in timeline_payload["timeline"]))
+        self.assertTrue(any(event["event_type"] == "execution_artifact_attached" for event in timeline_payload["timeline"]))
+        self.assertEqual(read_model_status, 200)
+        self.assertEqual(read_model_payload["task"]["execution_summary"]["attempt_count"], 1)
+
+    def test_service_dispatch_rejects_terminal_tasks(self) -> None:
+        submit_status, submit_payload = self.service.submit(_request_payload("accepted_completion"))
+        task_id = submit_payload["task_envelope"]["id"]
+
+        dispatch_status, dispatch_response = self.service.dispatch_task(task_id, {"request": {"executor": "codex"}})
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(dispatch_status, 409)
+        self.assertIn("terminal", dispatch_response["error"])
+
     def test_service_evaluate_existing_review_required_task_cannot_be_overwritten_to_completed(self) -> None:
         initial_status, initial_response = self.service.evaluate(_request_payload("review_required"))
         task_id = initial_response["task_envelope"]["id"]
@@ -1543,6 +1597,21 @@ class HarnessHttpApiTests(unittest.TestCase):
             "advisory_completion_claims"
         ]
         self.assertEqual(claims[-1]["claim_id"], "claim-api-1")
+
+    def test_api_dispatch_endpoint_records_execution_attempt(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+        submit_payload = {"request": {"task_envelope": deepcopy(payload["request"]["task_envelope"])}}
+        submit_status, submit_response = self._post_json("/tasks", submit_payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        dispatch_status, dispatch_response = self._post_json(
+            f"/tasks/{task_id}/dispatch",
+            {"request": {"executor": "codex"}},
+        )
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(dispatch_status, 200)
+        self.assertEqual(dispatch_response["dispatch"]["task_id"], task_id)
 
     def test_api_can_reevaluate_completed_task_back_to_blocked_for_contradictory_facts(self) -> None:
         initial_payload = _request_payload("accepted_completion")

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -225,6 +225,19 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertIn("linear", payload["task"]["extensions"])
         self.assertGreaterEqual(payload["task"]["evaluation_summary"]["count"], 1)
 
+    def test_read_model_includes_execution_summary_after_dispatch(self) -> None:
+        submit_status, submit_payload = self.service.submit(_request_payload("blocked_insufficient_evidence"))
+        task_id = submit_payload["task_envelope"]["id"]
+        dispatch_status, _ = self.service.dispatch_task(task_id, {"request": {"executor": "codex"}})
+
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(dispatch_status, 200)
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["execution_summary"]["attempt_count"], 1)
+        self.assertIsNotNone(read_payload["task"]["execution_summary"]["latest_attempt"])
+
 
 class HarnessReadModelHttpApiTests(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
- add `POST /tasks/<task_id>/dispatch` as a manual dispatch trigger
- validate dispatchable task state and reject terminal/in-review tasks for dispatch
- create and persist canonical execution attempts with advisory claim linkage
- run automatic reevaluation by routing dispatch output through completion-claim evaluation flow
- enrich read-model timeline with dispatch, execution-event, and execution-artifact events
- expose read-model `execution_summary` with latest attempt state and artifacts
- document the dispatch API in `docs/api/agent-api-usage.md`
- add service/http/read-model tests for dispatch behavior

## Validation
- `python -m unittest discover -s tests`
