### PR TITLE
Implement manual task dispatch bridge for canonical Harness tasks

### DIFF
--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -5,11 +5,22 @@ This document is the source-of-truth API usage guide for execution agents and do
 ## Canonical Submission Paths
 
 - `POST /tasks`: submit a new canonical task payload
+- `POST /tasks/<task_id>/dispatch`: manually dispatch an existing canonical task to an executor and trigger reevaluation
 - `POST /tasks/<task_id>/reevaluate`: submit new facts, artifacts, or review decisions for an existing task
 - `POST /ingress/manual`: submit a manually initiated task and let Harness intake assign a canonical `task_id` when one is not provided
 - `POST /ingress/openclaw`: submit an OpenClaw-shaped ingress payload that is normalized into canonical `TaskEnvelope` submission
 
 For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritative mutation path.
+
+### Manual Dispatch Bridge
+
+- `POST /tasks/<task_id>/dispatch` is a manual trigger that bridges persisted canonical tasks into a real execution attempt.
+- Dispatch records:
+  - executor assignment metadata
+  - a canonical execution attempt under `task_envelope.observability.execution_metadata.execution_attempts`
+  - advisory execution events and artifact references
+- Dispatch can include optional `request.new_artifacts` and `request.external_facts`.
+- Harness immediately runs canonical reevaluation after dispatch; executor output remains advisory and does not bypass verification or lifecycle policy.
 
 ### Completion Claim Interception Helper
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -26,6 +26,7 @@ from modules.connectors import (
     translate_linear_submission_payload,
     translate_manual_submission_payload,
 )
+from modules.adapters.executor_adapter import ExecutorDispatchInput, StubExecutorAdapter
 from modules.contracts.failure_classification import FailureCategory
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
 from modules.contracts.task_envelope_external_facts import ExternalFactValidationError, GitHubArtifactFacts, LinearFacts
@@ -402,6 +403,44 @@ def _parse_execution_attempt(payload: dict[str, Any], *, completion_claim: dict[
     }
 
 
+def _build_dispatch_attempt_record(
+    *,
+    attempt_id: str,
+    executor: str,
+    dispatch_parameters: dict[str, Any],
+    adapter_output: dict[str, Any],
+    linked_artifacts: tuple[dict[str, Any], ...],
+    recorded_at: str,
+) -> dict[str, Any]:
+    artifact_references = list(adapter_output.get("artifact_references") or [])
+    for artifact in linked_artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        artifact_references.append(
+            {
+                "reference_id": artifact.get("id"),
+                "artifact_type": artifact.get("type"),
+                "location": artifact.get("location"),
+            }
+        )
+
+    execution_status = "succeeded" if adapter_output.get("reported_complete") else "failed"
+    return {
+        "attempt_id": attempt_id,
+        "recorded_at": recorded_at,
+        "status": execution_status,
+        "reported_by": executor,
+        "completion_claim_id": f"{attempt_id}:completion-claim",
+        "artifact_references": artifact_references,
+        "metadata": {
+            "dispatch_parameters": dict(dispatch_parameters),
+            "adapter_name": adapter_output.get("adapter_name"),
+            "events": list(adapter_output.get("events") or []),
+        },
+        "reevaluation": {},
+    }
+
+
 def _with_advisory_completion_claim(task_envelope: dict[str, Any], *, claim: dict[str, Any]) -> dict[str, Any]:
     merged_task = deepcopy(task_envelope)
     execution_metadata = dict(merged_task["observability"]["execution_metadata"] or {})
@@ -592,6 +631,29 @@ def parse_reevaluation_request(task_envelope: dict[str, Any], payload: dict[str,
         review_request=review_request,
         review_decision=review_decision,
     )
+
+
+def _parse_dispatch_request(payload: dict[str, Any]) -> dict[str, Any]:
+    request_payload = _require_mapping(payload.get("request"), field_name="request")
+    executor = _optional_non_empty_string(request_payload.get("executor"), field_name="request.executor") or "codex"
+    execution_parameters = (
+        _optional_mapping(request_payload.get("execution_parameters"), field_name="request.execution_parameters") or {}
+    )
+    new_artifacts = _optional_object_list(request_payload.get("new_artifacts"), field_name="request.new_artifacts")
+    external_facts = _parse_external_facts(
+        _optional_mapping(request_payload.get("external_facts"), field_name="request.external_facts")
+    )
+    runtime_facts = _parse_runtime_facts(_optional_mapping(request_payload.get("runtime_facts"), field_name="request.runtime_facts"))
+    acceptance_criteria_satisfied = bool(request_payload.get("acceptance_criteria_satisfied", False))
+
+    return {
+        "executor": executor,
+        "execution_parameters": execution_parameters,
+        "new_artifacts": new_artifacts,
+        "external_facts": external_facts,
+        "runtime_facts": runtime_facts,
+        "acceptance_criteria_satisfied": acceptance_criteria_satisfied,
+    }
 
 
 def _collect_review_activity(records: tuple[EvaluationRecord, ...]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -989,6 +1051,96 @@ class HarnessApiService:
             response_payload["evaluation_record"] = _serialize_evaluation_record(record)
         return status, response_payload
 
+    def dispatch_task(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            stored_task = self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+
+        if str(stored_task.get("status")) in {"completed", "failed", "canceled"}:
+            return HTTPStatus.CONFLICT, {
+                "error": f"Task {task_id!r} is in non-dispatchable terminal status {stored_task.get('status')!r}"
+            }
+
+        try:
+            dispatch_request = _parse_dispatch_request(payload)
+            attempt_id = f"{task_id}:attempt:{len(((stored_task.get('observability') or {}).get('execution_metadata') or {}).get('execution_attempts') or []) + 1}"
+            dispatch_input = ExecutorDispatchInput.from_task_envelope(
+                stored_task,
+                attempt_id=attempt_id,
+                assigned_executor=dispatch_request["executor"],
+            )
+            adapter_output = StubExecutorAdapter().dispatch(dispatch_input)
+            adapter_payload = {
+                "adapter_name": StubExecutorAdapter.adapter_name,
+                "events": [event.event_type.value for event in adapter_output.events],
+                "artifact_references": [
+                    {
+                        "reference_id": ref.reference_id,
+                        "artifact_type": ref.artifact_type,
+                        "location": ref.location,
+                    }
+                    for ref in adapter_output.artifact_references
+                ],
+                "reported_complete": any(event.advisory_completion for event in adapter_output.events),
+            }
+            merged_task = deepcopy(stored_task)
+            merged_task["assigned_executor"] = {
+                "executor_type": dispatch_request["executor"],
+                "executor_id": dispatch_request["executor"],
+                "assignment_reason": "manual_dispatch",
+            }
+            merged_task = _merge_artifacts(merged_task, new_artifacts=dispatch_request["new_artifacts"])
+            merged_task = _with_execution_attempt_record(
+                merged_task,
+                attempt=_build_dispatch_attempt_record(
+                    attempt_id=attempt_id,
+                    executor=dispatch_request["executor"],
+                    dispatch_parameters=dispatch_request["execution_parameters"],
+                    adapter_output=adapter_payload,
+                    linked_artifacts=dispatch_request["new_artifacts"],
+                    recorded_at=_iso_now(),
+                ),
+            )
+        except Exception as error:
+            return HTTPStatus.BAD_REQUEST, {"error": str(error), "invalid_input": True}
+
+        reevaluation_request = HarnessEvaluationRequest(
+            task_envelope=merged_task,
+            external_facts=dispatch_request["external_facts"],
+            claimed_completion=bool(adapter_payload["reported_complete"]),
+            acceptance_criteria_satisfied=dispatch_request["acceptance_criteria_satisfied"],
+            runtime_facts=dispatch_request["runtime_facts"],
+            review_is_active=_review_gate_is_active(stored_task, self.store.list_evaluation_records(task_id)),
+        )
+        status, response_payload, result, attempts = self._evaluate_with_classified_retries(reevaluation_request)
+        if result is None:
+            return status, response_payload
+        if result.invalid_input:
+            return status, response_payload
+
+        stored_task = self.store.update_task(result.task_envelope)
+        record = None
+        for attempt_request, attempt_result in attempts:
+            record = self.store.put_evaluation_record(request=attempt_request, result=attempt_result)
+        stored_task = self.store.update_task(
+            _with_reevaluation_linked_execution_attempt(
+                stored_task,
+                completion_claim_id=f"{attempt_id}:completion-claim",
+                evaluation_record=record,
+            )
+        )
+
+        response_payload["task_envelope"] = _to_jsonable(stored_task)
+        response_payload["dispatch"] = {
+            "attempt_id": attempt_id,
+            "executor": dispatch_request["executor"],
+            "events": adapter_payload["events"],
+        }
+        if record is not None:
+            response_payload["evaluation_record"] = _serialize_evaluation_record(record)
+        return status, response_payload
+
     def submit_completion_claim(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:
             stored_task = self.store.get_task(task_id)
@@ -1149,7 +1301,7 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         if request_path not in {"/evaluate", "/tasks", "/ingress/linear", "/ingress/manual", "/ingress/openclaw"} and not (
             len(path_components) == 3
             and path_components[0] == "tasks"
-            and path_components[2] in {"reevaluate", "completion-claims"}
+            and path_components[2] in {"reevaluate", "completion-claims", "dispatch"}
         ):
             self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
             return
@@ -1175,6 +1327,8 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             status, response_payload = service.evaluate(payload)
         elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "completion-claims":
             status, response_payload = service.submit_completion_claim(path_components[1], payload)
+        elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "dispatch":
+            status, response_payload = service.dispatch_task(path_components[1], payload)
         else:
             status, response_payload = service.reevaluate(path_components[1], payload)
         self._write_json(status, response_payload)

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -171,6 +171,20 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
         reevaluation = attempt.get("reevaluation") if isinstance(attempt.get("reevaluation"), dict) else {}
         events.append(
             {
+                "event_id": f"{task_envelope['id']}:dispatch:{attempt.get('attempt_id') or index}",
+                "event_type": "task_dispatched",
+                "occurred_at": attempt.get("recorded_at") or timestamps.get("updated_at"),
+                "summary": f"Task dispatched to executor: {attempt.get('reported_by') or 'unknown'}",
+                "source": "dispatcher",
+                "details": {
+                    "attempt_id": attempt.get("attempt_id"),
+                    "executor": attempt.get("reported_by"),
+                    "dispatch_parameters": dict((attempt.get("metadata") or {}).get("dispatch_parameters") or {}),
+                },
+            }
+        )
+        events.append(
+            {
                 "event_id": f"{task_envelope['id']}:execution_attempt:{attempt.get('attempt_id') or index}",
                 "event_type": "execution_attempt_recorded",
                 "occurred_at": attempt.get("recorded_at") or timestamps.get("updated_at"),
@@ -185,6 +199,21 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
                 },
             }
         )
+        attempt_events = list((attempt.get("metadata") or {}).get("events") or [])
+        for event_index, event_name in enumerate(attempt_events):
+            events.append(
+                {
+                    "event_id": f"{task_envelope['id']}:execution_event:{attempt.get('attempt_id') or index}:{event_index}",
+                    "event_type": "execution_event",
+                    "occurred_at": attempt.get("recorded_at") or timestamps.get("updated_at"),
+                    "summary": f"Execution event: {event_name}",
+                    "source": attempt.get("reported_by") or "executor",
+                    "details": {
+                        "attempt_id": attempt.get("attempt_id"),
+                        "event": event_name,
+                    },
+                }
+            )
 
     linear_coordination = ((task_envelope.get("coordination") or {}).get("linear")) or None
     if isinstance(linear_coordination, dict):
@@ -290,6 +319,7 @@ class TaskReadModel:
     origin: dict[str, Any]
     relationships: dict[str, Any]
     assigned_executor: dict[str, Any] | None
+    execution_summary: dict[str, Any]
     evidence_summary: dict[str, Any]
     coordination_summary: dict[str, Any]
     verification_summary: dict[str, Any] | None
@@ -348,6 +378,12 @@ class HarnessReadModelService:
                 "dependencies": list(task.get("dependencies") or []),
             },
             assigned_executor=dict(task.get("assigned_executor") or {}) if task.get("assigned_executor") is not None else None,
+            execution_summary={
+                "attempt_count": len(((task.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []),
+                "latest_attempt": (((task.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or [None])[-1],
+                "latest_status": (((task.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or [{}])[-1].get("status"),
+                "latest_artifacts": (((task.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or [{}])[-1].get("artifact_references") or [],
+            },
             evidence_summary=_build_evidence_summary(task),
             coordination_summary={
                 "linear": dict(((task.get("coordination") or {}).get("linear") or {}))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -895,6 +895,33 @@ class HarnessApiServiceTests(unittest.TestCase):
         ]
         self.assertTrue(execution_events)
 
+    def test_service_dispatch_creates_execution_attempt_and_triggers_reevaluation(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+        submit_payload = {"request": {"task_envelope": deepcopy(payload["request"]["task_envelope"])}}
+        submit_status, submit_response = self.service.submit(submit_payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        dispatch_status, dispatch_response = self.service.dispatch_task(
+            task_id,
+            {
+                "request": {
+                    "executor": "codex",
+                    "new_artifacts": deepcopy(payload["request"]["linked_artifacts"]),
+                    "completion_evidence": deepcopy(payload["request"]["completion_evidence"]),
+                    "external_facts": deepcopy(payload["request"]["external_facts"]),
+                    "acceptance_criteria_satisfied": True,
+                    "runtime_facts": deepcopy(payload["request"]["runtime_facts"]),
+                }
+            },
+        )
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(dispatch_status, 200)
+        self.assertEqual(dispatch_response["dispatch"]["executor"], "codex")
+        attempts = dispatch_response["task_envelope"]["observability"]["execution_metadata"]["execution_attempts"]
+        self.assertTrue(attempts)
+        self.assertIn("evaluation_id", attempts[-1]["reevaluation"])
+
     def test_service_evaluate_existing_review_required_task_cannot_be_overwritten_to_completed(self) -> None:
         initial_status, initial_response = self.service.evaluate(_request_payload("review_required"))
         task_id = initial_response["task_envelope"]["id"]
@@ -1543,6 +1570,34 @@ class HarnessHttpApiTests(unittest.TestCase):
             "advisory_completion_claims"
         ]
         self.assertEqual(claims[-1]["claim_id"], "claim-api-1")
+
+    def test_api_dispatch_endpoint_records_attempt_and_events(self) -> None:
+        payload = _manual_happy_path_overlay_payload()
+        submit_payload = {"request": {"task_envelope": deepcopy(payload["request"]["task_envelope"])}}
+        submit_status, submit_response = self._post_json("/tasks", submit_payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        dispatch_status, dispatch_response = self._post_json(
+            f"/tasks/{task_id}/dispatch",
+            {
+                "request": {
+                    "executor": "codex",
+                    "new_artifacts": deepcopy(payload["request"]["linked_artifacts"]),
+                    "external_facts": deepcopy(payload["request"]["external_facts"]),
+                    "acceptance_criteria_satisfied": True,
+                    "runtime_facts": deepcopy(payload["request"]["runtime_facts"]),
+                }
+            },
+        )
+        timeline_status, timeline_payload = self._get_json(f"/tasks/{task_id}/timeline")
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(dispatch_status, 200)
+        self.assertEqual(dispatch_response["dispatch"]["executor"], "codex")
+        self.assertEqual(timeline_status, 200)
+        event_types = [item["event_type"] for item in timeline_payload["timeline"]]
+        self.assertIn("task_dispatched", event_types)
+        self.assertIn("execution_event", event_types)
 
     def test_api_can_reevaluate_completed_task_back_to_blocked_for_contradictory_facts(self) -> None:
         initial_payload = _request_payload("accepted_completion")

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -118,8 +118,25 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertEqual(payload["task"]["verification_summary"]["outcome"], "accepted_completion")
         self.assertEqual(payload["task"]["reconciliation_summary"]["outcome"], "no_mismatch")
         self.assertEqual(payload["task"]["evidence_summary"]["artifact_count"], 2)
+        self.assertEqual(payload["task"]["execution_summary"]["attempt_count"], 0)
         self.assertTrue(payload["task"]["coordination_summary"]["linear"]["record_found"])
         self.assertEqual(payload["task"]["evaluation_summary"]["count"], 1)
+
+    def test_dispatch_updates_execution_summary_and_timeline(self) -> None:
+        payload = {"request": {"task_envelope": deepcopy(_request_payload("accepted_completion")["request"]["task_envelope"])}}
+        submit_status, submit_response = self.service.submit(payload)
+        task_id = submit_response["task_envelope"]["id"]
+
+        dispatch_status, _ = self.service.dispatch_task(task_id, {"request": {"executor": "codex"}})
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+        timeline_status, timeline_payload = self.service.get_task_timeline(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(dispatch_status, 200)
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["execution_summary"]["latest_status"], "succeeded")
+        self.assertEqual(timeline_status, 200)
+        self.assertTrue(any(item["event_type"] == "task_dispatched" for item in timeline_payload["timeline"]))
 
     def test_builds_read_model_for_blocked_insufficient_evidence(self) -> None:
         submit_status, submit_payload = self.service.submit(_request_payload("blocked_insufficient_evidence"))


### PR DESCRIPTION
## Summary
- add a manual dispatch API endpoint at `POST /tasks/<task_id>/dispatch`
- record canonical execution attempts (including status, advisory events, and artifact references) under task observability metadata
- trigger automatic canonical reevaluation after each dispatch attempt
- expose dispatch + execution activity in task timeline/read-model projections
- document dispatch usage in `docs/api/agent-api-usage.md`

## Validation
- `python -m unittest discover -s tests`
- targeted dispatch coverage in `tests/test_api.py` and `tests/test_read_model.py`
