### PR TITLE
Implement canonical failure classification across execution and evaluation

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -31,7 +31,7 @@ from modules.connectors import (
     translate_linear_submission_payload,
     translate_manual_submission_payload,
 )
-from modules.contracts.failure_classification import FailureCategory
+from modules.contracts.failure_classification import FailureType
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
 from modules.contracts.task_envelope_external_facts import ExternalFactValidationError, GitHubArtifactFacts, LinearFacts
 from modules.contracts.task_envelope_reconciliation import ExpectedCodeContext
@@ -69,9 +69,9 @@ _DEFAULT_CLASSIFIED_RETRY_BUDGET = 2
 _CLASSIFIED_RETRY_BUDGET_ENV = "HARNESS_CLASSIFIED_RETRY_BUDGET"
 _RETRYABLE_FAILURE_CATEGORIES = frozenset(
     {
-        FailureCategory.ENVIRONMENT_BOOTSTRAP_FAILURE,
-        FailureCategory.EXECUTOR_RUNTIME_FAILURE,
-        FailureCategory.EXTERNAL_AVAILABILITY_FAILURE,
+        FailureType.BOOTSTRAP_FAILURE,
+        FailureType.DISPATCH_FAILURE,
+        FailureType.EXECUTOR_FAILURE,
     }
 )
 _TERMINAL_TASK_STATUSES = frozenset({"completed", "failed", "canceled"})
@@ -845,7 +845,7 @@ class HarnessApiService:
         attempt_number: int,
         max_retries: int,
         retry_reason: str,
-        category: FailureCategory,
+        category: FailureType,
     ) -> HarnessEvaluationRequest:
         runtime_facts = request.runtime_facts
         next_attempt_count = max(runtime_facts.attempt_count, 1) + 1

--- a/modules/contracts/failure_classification.py
+++ b/modules/contracts/failure_classification.py
@@ -2,40 +2,46 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 
-class FailureCategory(StrEnum):
-    """Stable failure categories used by retry and diagnosis workflows."""
+class FailureType(StrEnum):
+    """Canonical machine-readable failure types."""
 
     NONE = "none"
-    ENVIRONMENT_BOOTSTRAP_FAILURE = "environment_bootstrap_failure"
-    EXECUTOR_RUNTIME_FAILURE = "executor_runtime_failure"
-    EXTERNAL_AVAILABILITY_FAILURE = "external_availability_failure"
+    BOOTSTRAP_FAILURE = "bootstrap_failure"
+    DISPATCH_FAILURE = "dispatch_failure"
+    EXECUTOR_FAILURE = "executor_failure"
     CONTRACT_VIOLATION = "contract_violation"
-    ARTIFACT_VALIDATION_FAILURE = "artifact_validation_failure"
-    EVIDENCE_INSUFFICIENCY = "evidence_insufficiency"
+    EVIDENCE_INSUFFICIENT = "evidence_insufficient"
     RECONCILIATION_MISMATCH = "reconciliation_mismatch"
-    MANUAL_REVIEW_REQUIRED = "manual_review_required"
+    REVIEW_REQUIRED = "review_required"
 
 
-class FailureNature(StrEnum):
-    """High-level class for retry and policy handling."""
+class FailureSource(StrEnum):
+    """System layer where failure truth was determined."""
 
     NONE = "none"
-    TRANSIENT = "transient"
-    SEMANTIC = "semantic"
-    CONTRACT = "contract"
+    DISPATCH = "dispatch"
+    EXECUTOR = "executor"
+    EVALUATION = "evaluation"
 
 
 @dataclass(frozen=True)
 class FailureClassification:
     """Explicit, auditable failure classification output."""
 
-    category: FailureCategory
-    nature: FailureNature
-    retryable: bool
+    failure_type: FailureType
+    source: FailureSource
     reason: str
+    terminal: bool
+    recoverable: bool
+    category: FailureType = field(init=False)
+    retryable: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "category", self.failure_type)
+        object.__setattr__(self, "retryable", self.recoverable)
 
 
 def classify_verification_outcome(
@@ -48,71 +54,79 @@ def classify_verification_outcome(
 
     if outcome == "accepted_completion":
         return FailureClassification(
-            category=FailureCategory.NONE,
-            nature=FailureNature.NONE,
-            retryable=False,
+            failure_type=FailureType.NONE,
+            source=FailureSource.NONE,
             reason=reason,
+            terminal=False,
+            recoverable=False,
         )
 
     if outcome == "verification_deferred":
         return FailureClassification(
-            category=FailureCategory.NONE,
-            nature=FailureNature.NONE,
-            retryable=False,
+            failure_type=FailureType.NONE,
+            source=FailureSource.NONE,
             reason=reason,
+            terminal=False,
+            recoverable=False,
         )
 
     if outcome == "review_required":
         return FailureClassification(
-            category=FailureCategory.MANUAL_REVIEW_REQUIRED,
-            nature=FailureNature.SEMANTIC,
-            retryable=False,
+            failure_type=FailureType.REVIEW_REQUIRED,
+            source=FailureSource.EVALUATION,
             reason=reason,
+            terminal=False,
+            recoverable=False,
         )
 
     if outcome == "insufficient_evidence":
         return FailureClassification(
-            category=FailureCategory.EVIDENCE_INSUFFICIENCY,
-            nature=FailureNature.SEMANTIC,
-            retryable=False,
+            failure_type=FailureType.EVIDENCE_INSUFFICIENT,
+            source=FailureSource.EVALUATION,
             reason=reason,
+            terminal=False,
+            recoverable=False,
         )
 
     if outcome == "external_mismatch":
         return FailureClassification(
-            category=FailureCategory.RECONCILIATION_MISMATCH,
-            nature=FailureNature.SEMANTIC,
-            retryable=False,
+            failure_type=FailureType.RECONCILIATION_MISMATCH,
+            source=FailureSource.EVALUATION,
             reason=reason,
+            terminal=True,
+            recoverable=False,
         )
 
     if outcome == "terminal_invalid" and runtime_failure_observed:
         return FailureClassification(
-            category=FailureCategory.EXECUTOR_RUNTIME_FAILURE,
-            nature=FailureNature.TRANSIENT,
-            retryable=True,
+            failure_type=FailureType.EXECUTOR_FAILURE,
+            source=FailureSource.EXECUTOR,
             reason=reason,
+            terminal=True,
+            recoverable=True,
         )
 
     if outcome in {"terminal_invalid", "blocked_unresolved_conditions"}:
         return FailureClassification(
-            category=FailureCategory.CONTRACT_VIOLATION,
-            nature=FailureNature.CONTRACT,
-            retryable=False,
+            failure_type=FailureType.CONTRACT_VIOLATION,
+            source=FailureSource.EVALUATION,
             reason=reason,
+            terminal=outcome == "terminal_invalid",
+            recoverable=False,
         )
 
     return FailureClassification(
-        category=FailureCategory.CONTRACT_VIOLATION,
-        nature=FailureNature.CONTRACT,
-        retryable=False,
+        failure_type=FailureType.CONTRACT_VIOLATION,
+        source=FailureSource.EVALUATION,
         reason=reason,
+        terminal=False,
+        recoverable=False,
     )
 
 
 __all__ = [
-    "FailureCategory",
+    "FailureType",
     "FailureClassification",
-    "FailureNature",
+    "FailureSource",
     "classify_verification_outcome",
 ]

--- a/modules/contracts/task_envelope_enforcement.py
+++ b/modules/contracts/task_envelope_enforcement.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from modules.contracts.failure_classification import FailureCategory, FailureClassification, FailureNature
+from modules.contracts.failure_classification import FailureClassification, FailureSource, FailureType
 from modules.contracts.task_envelope_evidence import (
     CompletionEvidenceValidationResult,
     validate_task_evidence,
@@ -122,21 +122,21 @@ def _result_with_error(
 ) -> EnforcementResult:
     message = str(error).lower()
     if "bootstrap" in message or "environment" in message:
-        failure_category = FailureCategory.ENVIRONMENT_BOOTSTRAP_FAILURE
-        failure_nature = FailureNature.TRANSIENT
-        retryable = True
+        failure_type = FailureType.BOOTSTRAP_FAILURE
+        failure_source = FailureSource.DISPATCH
+        recoverable = True
     elif "timeout" in message or "temporarily unavailable" in message or "connection" in message:
-        failure_category = FailureCategory.EXTERNAL_AVAILABILITY_FAILURE
-        failure_nature = FailureNature.TRANSIENT
-        retryable = True
+        failure_type = FailureType.DISPATCH_FAILURE
+        failure_source = FailureSource.DISPATCH
+        recoverable = True
     elif "evidence" in message or "artifact" in message:
-        failure_category = FailureCategory.ARTIFACT_VALIDATION_FAILURE
-        failure_nature = FailureNature.CONTRACT
-        retryable = False
+        failure_type = FailureType.CONTRACT_VIOLATION
+        failure_source = FailureSource.EVALUATION
+        recoverable = False
     else:
-        failure_category = FailureCategory.CONTRACT_VIOLATION
-        failure_nature = FailureNature.CONTRACT
-        retryable = False
+        failure_type = FailureType.CONTRACT_VIOLATION
+        failure_source = FailureSource.EVALUATION
+        recoverable = False
     return EnforcementResult(
         action=action,
         task_envelope=task_envelope,
@@ -149,10 +149,11 @@ def _result_with_error(
         target_status=None,
         reasons=(str(error),),
         failure_classification=FailureClassification(
-            category=failure_category,
-            nature=failure_nature,
-            retryable=retryable,
+            failure_type=failure_type,
+            source=failure_source,
             reason=str(error),
+            terminal=True,
+            recoverable=recoverable,
         ),
         error=str(error),
     )
@@ -209,10 +210,11 @@ def _apply_transition(
             verification_result.failure_classification
             if verification_result is not None
             else FailureClassification(
-                category=FailureCategory.NONE,
-                nature=FailureNature.NONE,
-                retryable=False,
+                failure_type=FailureType.NONE,
+                source=FailureSource.NONE,
                 reason=reason,
+                terminal=False,
+                recoverable=False,
             )
         ),
     )
@@ -266,10 +268,11 @@ def enforce_task_envelope(
                 target_status=review_decision.recommended_target_status,
                 reasons=(reason,),
                 failure_classification=FailureClassification(
-                    category=FailureCategory.NONE,
-                    nature=FailureNature.NONE,
-                    retryable=False,
+                    failure_type=FailureType.NONE,
+                    source=FailureSource.NONE,
                     reason=reason,
+                    terminal=False,
+                    recoverable=False,
                 ),
             )
         review_transition_facts = {"terminal_failure": review_decision.record.outcome.value == "mark_failed"}

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -38,6 +38,28 @@ def _latest_mapping(records: tuple[EvaluationRecord, ...], path: tuple[str, ...]
     return None
 
 
+def _latest_failure_summary(records: tuple[EvaluationRecord, ...]) -> dict[str, Any] | None:
+    for record in reversed(records):
+        payload = record.result if isinstance(record.result, dict) else {}
+        failure = payload.get("failure_classification")
+        if not isinstance(failure, dict):
+            continue
+        failure_type = failure.get("failure_type") or failure.get("category")
+        if failure_type in (None, "none"):
+            continue
+        return {
+            "state": "failed",
+            "failure_type": failure_type,
+            "failure_source": failure.get("source") or "evaluation",
+            "failure_reason": failure.get("reason"),
+            "terminal": bool(failure.get("terminal")),
+            "recoverable": bool(failure.get("recoverable") or failure.get("retryable")),
+            "recorded_at": record.recorded_at,
+            "evaluation_id": record.evaluation_id,
+        }
+    return {"state": "clear", "failure_type": "none", "failure_source": "none", "terminal": False, "recoverable": False}
+
+
 def _review_status(
     *,
     requests: list[dict[str, Any]],
@@ -150,7 +172,6 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
                 },
             }
         )
-
     for index, entry in enumerate(task_envelope.get("status_history") or []):
         if not isinstance(entry, dict):
             continue
@@ -164,7 +185,6 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
                 "details": dict(entry),
             }
         )
-
     artifacts = list(((task_envelope.get("artifacts") or {}).get("items") or []))
     for artifact in artifacts:
         if not isinstance(artifact, dict):
@@ -299,6 +319,27 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
                 },
             }
         )
+        failure = result_payload.get("failure_classification")
+        if isinstance(failure, dict):
+            failure_type = failure.get("failure_type") or failure.get("category")
+            if failure_type not in (None, "none"):
+                events.append(
+                    {
+                        "event_id": f"{task_envelope['id']}:failure:{record.evaluation_id}",
+                        "event_type": "failure_recorded",
+                        "occurred_at": record.recorded_at,
+                        "summary": f"Failure recorded: {failure_type}",
+                        "source": failure.get("source") or "evaluation",
+                        "details": {
+                            "failure_recorded": True,
+                            "failure_type": failure_type,
+                            "failure_source": failure.get("source") or "evaluation",
+                            "failure_reason": failure.get("reason"),
+                            "terminal": bool(failure.get("terminal")),
+                            "recoverable": bool(failure.get("recoverable") or failure.get("retryable")),
+                        },
+                    }
+                )
 
         review_request = enforcement_result.get("review_request") or (
             record.request.get("review_request") if isinstance(record.request, dict) else None
@@ -340,7 +381,8 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
         "review_requested": 2,
         "review_decided": 3,
         "evaluation_recorded": 4,
-        "status_transition": 5,
+        "failure_recorded": 5,
+        "status_transition": 6,
     }
     return sorted(
         events,
@@ -370,6 +412,7 @@ class TaskReadModel:
     reconciliation_summary: dict[str, Any] | None
     review_summary: dict[str, Any]
     execution_summary: dict[str, Any]
+    failure_summary: dict[str, Any] | None
     evaluation_summary: dict[str, Any]
     lifecycle_history: list[dict[str, Any]]
     timestamps: dict[str, Any]
@@ -409,6 +452,7 @@ class HarnessReadModelService:
         reconciliation_summary = _latest_mapping(records, ("enforcement_result", "reconciliation_result"))
         review_summary = _build_review_summary(records)
         execution_summary = _build_execution_summary(task)
+        failure_summary = _latest_failure_summary(records)
         timeline = _build_timeline(task, records)
 
         return TaskReadModel(
@@ -434,6 +478,7 @@ class HarnessReadModelService:
             reconciliation_summary=reconciliation_summary,
             review_summary=review_summary,
             execution_summary=execution_summary,
+            failure_summary=failure_summary,
             evaluation_summary={
                 "count": len(records),
                 "latest_recorded_at": records[-1].recorded_at if records else None,

--- a/tests/contracts/test_task_envelope_enforcement.py
+++ b/tests/contracts/test_task_envelope_enforcement.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from modules.contracts.failure_classification import FailureCategory
+from modules.contracts.failure_classification import FailureType
 from modules.contracts.task_envelope_enforcement import (
     EnforcementAction,
     EnforcementInput,
@@ -228,7 +228,7 @@ class IntegratedEnforcementTests(unittest.TestCase):
         self.assertEqual(result.verification_result.outcome, VerificationOutcome.VERIFICATION_DEFERRED)
         self.assertIsNone(result.transition_result)
         self.assertIsNone(result.error)
-        self.assertEqual(result.failure_classification.category, FailureCategory.NONE)
+        self.assertEqual(result.failure_classification.category, FailureType.NONE)
 
     def test_claimed_completion_with_valid_evidence_transitions_to_completed(self) -> None:
         task = _base_task(status="executing")
@@ -266,7 +266,7 @@ class IntegratedEnforcementTests(unittest.TestCase):
         self.assertEqual(result.target_status, "blocked")
         self.assertEqual(result.task_envelope["status"], "blocked")
         self.assertEqual(result.verification_result.outcome, VerificationOutcome.INSUFFICIENT_EVIDENCE)
-        self.assertEqual(result.failure_classification.category, FailureCategory.EVIDENCE_INSUFFICIENCY)
+        self.assertEqual(result.failure_classification.category, FailureType.EVIDENCE_INSUFFICIENT)
 
     def test_reconciliation_mismatch_moves_completed_task_back_to_blocked(self) -> None:
         task = _base_task(status="completed")
@@ -285,7 +285,7 @@ class IntegratedEnforcementTests(unittest.TestCase):
         self.assertEqual(result.action, EnforcementAction.TRANSITION_APPLIED)
         self.assertEqual(result.target_status, "blocked")
         self.assertEqual(result.verification_result.outcome, VerificationOutcome.EXTERNAL_MISMATCH)
-        self.assertEqual(result.failure_classification.category, FailureCategory.RECONCILIATION_MISMATCH)
+        self.assertEqual(result.failure_classification.category, FailureType.RECONCILIATION_MISMATCH)
 
     def test_task_requiring_manual_review_returns_review_required(self) -> None:
         task = _base_task(status="intake_ready")
@@ -515,7 +515,7 @@ class IntegratedEnforcementTests(unittest.TestCase):
 
         self.assertEqual(result.action, EnforcementAction.INVALID_INPUT)
         self.assertIsNotNone(result.error)
-        self.assertEqual(result.failure_classification.category, FailureCategory.ARTIFACT_VALIDATION_FAILURE)
+        self.assertEqual(result.failure_classification.category, FailureType.CONTRACT_VIOLATION)
 
 
 if __name__ == "__main__":

--- a/tests/contracts/test_task_envelope_verification.py
+++ b/tests/contracts/test_task_envelope_verification.py
@@ -4,7 +4,7 @@ import copy
 import unittest
 
 from modules.contracts.task_envelope_evidence import validate_task_evidence
-from modules.contracts.failure_classification import FailureCategory, FailureNature
+from modules.contracts.failure_classification import FailureType, FailureSource
 from modules.contracts.task_envelope_verification import (
     ReconciliationFacts,
     ReconciliationStatus,
@@ -199,8 +199,8 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.target_status, "completed")
         self.assertTrue(result.accepted_completion)
         self.assertTrue(result.verification_passed)
-        self.assertEqual(result.failure_classification.category, FailureCategory.NONE)
-        self.assertEqual(result.failure_classification.nature, FailureNature.NONE)
+        self.assertEqual(result.failure_classification.category, FailureType.NONE)
+        self.assertEqual(result.failure_classification.source, FailureSource.NONE)
 
     def test_returns_insufficient_evidence_when_validated_evidence_is_not_sufficient(self) -> None:
         task_envelope = _base_task_envelope()
@@ -211,7 +211,7 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.outcome, VerificationOutcome.INSUFFICIENT_EVIDENCE)
         self.assertEqual(result.target_status, "blocked")
         self.assertFalse(result.accepted_completion)
-        self.assertEqual(result.failure_classification.category, FailureCategory.EVIDENCE_INSUFFICIENCY)
+        self.assertEqual(result.failure_classification.category, FailureType.EVIDENCE_INSUFFICIENT)
 
     def test_reports_concrete_reason_when_evidence_policy_is_deferred(self) -> None:
         task_envelope = _base_task_envelope()
@@ -248,7 +248,7 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.outcome, VerificationOutcome.EXTERNAL_MISMATCH)
         self.assertEqual(result.target_status, "blocked")
         self.assertFalse(result.is_terminal)
-        self.assertEqual(result.failure_classification.category, FailureCategory.RECONCILIATION_MISMATCH)
+        self.assertEqual(result.failure_classification.category, FailureType.RECONCILIATION_MISMATCH)
 
     def test_returns_review_required_when_manual_review_is_needed(self) -> None:
         result = _evaluate(
@@ -259,7 +259,7 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.outcome, VerificationOutcome.REVIEW_REQUIRED)
         self.assertTrue(result.requires_review)
         self.assertEqual(result.target_status, "in_review")
-        self.assertEqual(result.failure_classification.category, FailureCategory.MANUAL_REVIEW_REQUIRED)
+        self.assertEqual(result.failure_classification.category, FailureType.REVIEW_REQUIRED)
 
     def test_returns_blocked_when_verification_conditions_are_unresolved(self) -> None:
         result = _evaluate(
@@ -288,8 +288,8 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.outcome, VerificationOutcome.TERMINAL_INVALID)
         self.assertEqual(result.target_status, "failed")
         self.assertTrue(result.is_terminal)
-        self.assertEqual(result.failure_classification.category, FailureCategory.EXECUTOR_RUNTIME_FAILURE)
-        self.assertEqual(result.failure_classification.nature, FailureNature.TRANSIENT)
+        self.assertEqual(result.failure_classification.category, FailureType.EXECUTOR_FAILURE)
+        self.assertEqual(result.failure_classification.source, FailureSource.EXECUTOR)
 
     def test_rejects_invalid_evidence_inputs_before_policy_evaluation(self) -> None:
         task_envelope = _base_task_envelope()
@@ -315,7 +315,7 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertIsNone(result.target_status)
         self.assertFalse(result.verification_passed)
         self.assertIn("No completion claim is currently being evaluated", result.reasons)
-        self.assertEqual(result.failure_classification.category, FailureCategory.NONE)
+        self.assertEqual(result.failure_classification.category, FailureType.NONE)
 
     def test_distinguishes_deferred_verification_from_blocked_control_plane_outcome(self) -> None:
         deferred = _evaluate(_base_task_envelope(), claimed_completion=False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1093,13 +1093,13 @@ class HarnessApiServiceTests(unittest.TestCase):
         history_status, history = self.service.get_evaluation_history(response["task_envelope"]["id"])
 
         self.assertEqual(status, 200)
-        self.assertEqual(response["failure_classification"]["category"], "executor_runtime_failure")
+        self.assertEqual(response["failure_classification"]["category"], "executor_failure")
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history["evaluations"]), 3)
         retry_requests = [item["request"].get("retry_context") for item in history["evaluations"]]
         self.assertIsNone(retry_requests[0])
-        self.assertEqual(retry_requests[1]["triggered_by_category"], "executor_runtime_failure")
-        self.assertEqual(retry_requests[2]["triggered_by_category"], "executor_runtime_failure")
+        self.assertEqual(retry_requests[1]["triggered_by_category"], "executor_failure")
+        self.assertEqual(retry_requests[2]["triggered_by_category"], "executor_failure")
 
     def test_service_does_not_retry_non_retryable_contract_violation(self) -> None:
         payload = _request_payload("accepted_completion")
@@ -1114,7 +1114,7 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history["evaluations"]), 1)
 
-    def test_service_does_not_retry_non_retryable_evidence_insufficiency(self) -> None:
+    def test_service_does_not_retry_non_retryable_evidence_insufficient(self) -> None:
         payload = _request_payload("blocked_insufficient_evidence")
 
         with patch.dict(os.environ, {"HARNESS_CLASSIFIED_RETRY_BUDGET": "2"}):
@@ -1122,7 +1122,7 @@ class HarnessApiServiceTests(unittest.TestCase):
         history_status, history = self.service.get_evaluation_history(response["task_envelope"]["id"])
 
         self.assertEqual(status, 200)
-        self.assertEqual(response["failure_classification"]["category"], "evidence_insufficiency")
+        self.assertEqual(response["failure_classification"]["category"], "evidence_insufficient")
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history["evaluations"]), 1)
 

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -130,6 +130,8 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(payload["task"]["current_status"], "blocked")
         self.assertEqual(payload["task"]["verification_summary"]["outcome"], "insufficient_evidence")
+        self.assertEqual(payload["task"]["failure_summary"]["failure_type"], "evidence_insufficient")
+        self.assertEqual(payload["task"]["failure_summary"]["failure_source"], "evaluation")
 
     def test_timeline_shows_completed_to_blocked_rollback(self) -> None:
         initial_status, initial_payload = self.service.submit(_request_payload("accepted_completion"))
@@ -157,6 +159,7 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(transition_targets[-2:], ["completed", "blocked"])
         self.assertTrue(any(event["event_type"] == "linear_linkage_recorded" for event in payload["timeline"]))
+        self.assertTrue(any(event["event_type"] == "failure_recorded" for event in payload["timeline"]))
 
     def test_review_summary_shows_request_then_resolution(self) -> None:
         accepted_payload = _request_payload("accepted_completion")


### PR DESCRIPTION
## Summary
- replace legacy failure categories with canonical failure types aligned to issue #142
- add explicit failure source attribution and terminal/recoverable semantics
- propagate structured failure classification into enforcement, retry, read-model, and timeline outputs
- add failure read-model summary and `failure_recorded` timeline events
- update contract/API/read-model tests for canonical failure outputs

## Testing
- python -m unittest discover -s tests
- python -m unittest tests.test_read_model tests.test_api tests.contracts.test_task_envelope_verification tests.contracts.test_task_envelope_enforcement
