### PR TITLE
Harden rejected terminal follow-up truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If a manual-review follow-up is attempted but lifecycle policy rejects it, Harne
 
 That rejected attempt also must not strand the task. Later manual review decisions still resolve the original persisted review request; a failed follow-up attempt does not consume the gate.
 
+The same fail-closed rule now applies to other rejected late follow-up. If reevaluation or completion-claim input hits a forbidden transition against already-settled task truth, Harness records the rejected attempt in evaluation history and timeline without letting that rejected action replace the current lifecycle, verification, reconciliation, or failure projection for the task. New external facts may still be persisted when they represent real synchronized state; the rejected transition itself is what does not become canonical task truth.
+
 If manual review resolves the gate without accepting completion, Harness also clears any previously satisfied completion evidence back to deferred. A replan, retry, blocked, failed, canceled, or clarification outcome must not leave stale validated proof behind that can auto-complete the task later without a new governed execution or explicit acceptance.
 
 When manual review explicitly authorizes redispatch, Harness now performs that redispatch automatically instead of leaving the task parked in `dispatch_ready` with a resolved review record and no follow-up execution.

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -112,6 +112,7 @@ It must not be used to inject runtime or terminal states such as `executing`, `r
 - If a manual-review follow-up is attempted but lifecycle policy rejects the requested transition, the review gate stays active. Inspection surfaces should keep `review_summary.status="requested"` and expose the attempt as a rejected review decision instead of projecting the gate as resolved.
 - That rejected attempt does not consume the active request. A later valid `review_decision` must still be able to resolve the same persisted gate.
 - If manual review resolves the gate without accepting completion, Harness clears the task's satisfied completion evidence back to deferred. Follow-up outcomes such as `authorize_replan`, `authorize_retry`, `keep_blocked`, `mark_failed`, `require_clarification`, and `cancel_task` must not leave stale validated artifact proof behind.
+- More generally, `transition_rejected` on an existing task is an auditable rejected action, not a new lifecycle truth. Rejected reevaluation or completion-claim follow-up may append evaluation history and timeline entries, and may still persist new synchronized facts, but it must not replace the current lifecycle/verification/reconciliation/failure projection for an already-settled task.
 
 ## Reconciliation Classification Rule
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -32,7 +32,7 @@ from modules.connectors import (
     translate_manual_submission_payload,
 )
 from modules.contracts.failure_classification import FailureClassification, FailureSource, FailureType
-from modules.contracts.task_envelope_lifecycle import apply_task_transition
+from modules.contracts.task_envelope_lifecycle import ForbiddenTransitionError, apply_task_transition
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
 from modules.contracts.task_envelope_external_facts import ExternalFactValidationError, GitHubArtifactFacts, LinearFacts
 from modules.contracts.task_envelope_enforcement import EnforcementAction, EnforcementResult
@@ -3227,13 +3227,13 @@ class HarnessApiService:
         request: HarnessEvaluationRequest,
         validation: dict[str, Any],
     ) -> tuple[int, dict[str, Any]]:
+        stored_task = deepcopy(self.store.get_task(task_id))
         completion_claim = _latest_advisory_completion_claim(request.task_envelope)
         validated_task = _with_execution_attempt_validation(
             request.task_envelope,
             completion_claim=completion_claim,
             validation=validation,
         )
-        self.store.update_task(validated_task)
 
         reasons = tuple(str(item) for item in validation.get("reasons") or () if isinstance(item, str) and item.strip())
         reason = reasons[0] if reasons else "Execution attempt is invalid for completion handling."
@@ -3275,6 +3275,7 @@ class HarnessApiService:
         evaluation_record = self.store.put_evaluation_record(request=evaluation_request, result=evaluation_result)
 
         if can_retry:
+            self.store.update_task(validated_task)
             dispatch_status, dispatch_payload = self.dispatch_task(
                 task_id,
                 {
@@ -3303,13 +3304,72 @@ class HarnessApiService:
             failed_reason = (
                 f"{reason} Automatic retry could not be scheduled because no compatible executor was assigned."
             )
-        failed_task = self._task_with_transition(
-            validated_task,
-            to_status="failed",
-            reason=failed_reason,
-            actor="verification",
-            facts={"terminal_failure": True, "reason_provided": True},
-        )
+        try:
+            failed_task = self._task_with_transition(
+                validated_task,
+                to_status="failed",
+                reason=failed_reason,
+                actor="verification",
+                facts={"terminal_failure": True, "reason_provided": True},
+            )
+        except ForbiddenTransitionError as error:
+            rejected_reason = str(error)
+            rejected_failure = FailureClassification(
+                failure_type=FailureType.CONTRACT_VIOLATION,
+                source=FailureSource.EVALUATION,
+                reason=rejected_reason,
+                terminal=True,
+                recoverable=False,
+            )
+            rejected_result = HarnessEvaluationResult(
+                action=EnforcementAction.TRANSITION_REJECTED,
+                target_status=None,
+                task_envelope=stored_task,
+                enforcement_result=EnforcementResult(
+                    action=EnforcementAction.TRANSITION_REJECTED,
+                    task_envelope=stored_task,
+                    evidence_result=None,
+                    reconciliation_result=None,
+                    verification_result=None,
+                    review_request=None,
+                    review_decision=None,
+                    transition_result=None,
+                    target_status=None,
+                    reasons=(rejected_reason,),
+                    failure_classification=rejected_failure,
+                    error=rejected_reason,
+                ),
+                accepted_completion=False,
+                requires_review=False,
+                invalid_input=False,
+                failure_classification=rejected_failure,
+                reasons=(rejected_reason,),
+                error=rejected_reason,
+            )
+            failure_record = self.store.put_evaluation_record(
+                request=evaluation_request,
+                result=rejected_result,
+            )
+            return HTTPStatus.OK, {
+                "action": "transition_rejected",
+                "accepted_completion": False,
+                "requires_review": False,
+                "invalid_input": False,
+                "target_status": None,
+                "error": rejected_reason,
+                "reasons": [rejected_reason],
+                "invalid_execution_attempt": {
+                    "status": "rejected",
+                    "validation": deepcopy(validation),
+                    "retry_budget": retry_budget,
+                    "invalid_attempt_count": invalid_attempt_count,
+                    "initial_evaluation_record": _serialize_evaluation_record(evaluation_record),
+                    "failure_evaluation_record": _serialize_evaluation_record(failure_record),
+                },
+                "task_envelope": _to_jsonable(stored_task),
+                "evaluation_record": _serialize_evaluation_record(failure_record),
+            }
+
         self.store.update_task(failed_task)
         failure_record = self.store.put_evaluation_record(
             request=replace(request, task_envelope=failed_task),

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -25,8 +25,21 @@ def _count_by(items: list[dict[str, Any]], field_name: str) -> dict[str, int]:
     return counts
 
 
-def _latest_mapping(records: tuple[EvaluationRecord, ...], path: tuple[str, ...]) -> dict[str, Any] | None:
+def _record_action(record: EvaluationRecord) -> str:
+    result = record.result if isinstance(record.result, dict) else {}
+    enforcement_result = result.get("enforcement_result") if isinstance(result.get("enforcement_result"), dict) else {}
+    return str(enforcement_result.get("action") or result.get("action") or "")
+
+
+def _latest_mapping(
+    records: tuple[EvaluationRecord, ...],
+    path: tuple[str, ...],
+    *,
+    include_transition_rejected: bool = True,
+) -> dict[str, Any] | None:
     for record in reversed(records):
+        if not include_transition_rejected and _record_action(record) == "transition_rejected":
+            continue
         current: Any = record.result
         for key in path:
             if not isinstance(current, dict):
@@ -39,12 +52,18 @@ def _latest_mapping(records: tuple[EvaluationRecord, ...], path: tuple[str, ...]
 
 
 def _latest_verification_base(records: tuple[EvaluationRecord, ...]) -> dict[str, Any] | None:
-    latest_verification = _latest_mapping(records, ("enforcement_result", "verification_result"))
+    latest_verification = _latest_mapping(
+        records,
+        ("enforcement_result", "verification_result"),
+        include_transition_rejected=False,
+    )
     if isinstance(latest_verification, dict):
         outcome = latest_verification.get("outcome")
         if outcome not in (None, "verification_deferred") or latest_verification.get("claimed_completion"):
             return latest_verification
     for record in reversed(records):
+        if _record_action(record) == "transition_rejected":
+            continue
         result = record.result if isinstance(record.result, dict) else {}
         enforcement_result = result.get("enforcement_result") if isinstance(result.get("enforcement_result"), dict) else {}
         verification_result = enforcement_result.get("verification_result")
@@ -127,7 +146,11 @@ def _latest_reconciliation_summary(
     *,
     review_summary: dict[str, Any],
 ) -> dict[str, Any] | None:
-    reconciliation_summary = _latest_mapping(records, ("enforcement_result", "reconciliation_result"))
+    reconciliation_summary = _latest_mapping(
+        records,
+        ("enforcement_result", "reconciliation_result"),
+        include_transition_rejected=False,
+    )
     if not isinstance(reconciliation_summary, dict):
         return None
     latest_request = review_summary.get("latest_request") if isinstance(review_summary, dict) else None
@@ -203,6 +226,8 @@ def _latest_failure_summary(
             ),
         }
     for record in reversed(records):
+        if _record_action(record) == "transition_rejected":
+            continue
         payload = record.result if isinstance(record.result, dict) else {}
         failure = payload.get("failure_classification")
         if not isinstance(failure, dict):

--- a/tests/e2e/test_control_plane_store_integrity_flows.py
+++ b/tests/e2e/test_control_plane_store_integrity_flows.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 from modules.demo_cases import build_demo_request
 from tests.e2e.runtime_harness import RuntimeApiTestCase, RuntimeTaskSnapshot
-from tests.e2e.scenario_builders import build_review_note_artifact, to_jsonable
+from tests.e2e.scenario_builders import (
+    build_review_decision_from_request,
+    build_review_note_artifact,
+    to_jsonable,
+)
 
 
 class ControlPlaneStoreIntegrityFlowTests(RuntimeApiTestCase):
@@ -69,3 +75,61 @@ class ControlPlaneStoreIntegrityFlowTests(RuntimeApiTestCase):
         self.assertEqual(after_list_status, 200)
         self._assert_snapshot_unchanged(scenario.created.snapshot, rejected.snapshot)
         self._assert_task_list_unchanged(before_list, after_list, task_id=scenario.task_id)
+
+    def test_rejected_reevaluation_keeps_canceled_task_projection_stable_while_recording_new_facts(self) -> None:
+        payload = {"request": to_jsonable(build_demo_request("review_required"))}
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "cancel_task",
+        ]
+        scenario = self.create_evaluate_scenario(payload)
+        scenario.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        scenario.created.response["enforcement_result"]["review_request"],
+                        outcome="cancel_task",
+                    )
+                }
+            }
+        )
+        before = scenario.refresh()
+        before_list_status, before_list = self.list_tasks()
+
+        rejected = scenario.reevaluate(
+            {
+                "request": {
+                    "external_facts": to_jsonable(build_demo_request("accepted_completion").external_facts),
+                    "runtime_facts": to_jsonable(build_demo_request("accepted_completion").runtime_facts),
+                    "claimed_completion": True,
+                    "acceptance_criteria_satisfied": True,
+                }
+            }
+        )
+        after_list_status, after_list = self.list_tasks()
+
+        self.assertEqual(before_list_status, 200)
+        self.assertEqual(rejected.status, 200)
+        self.assertEqual(rejected.response["action"], "transition_rejected")
+        self.assertIn("canceled -> blocked", rejected.response["error"])
+        self.assertEqual(after_list_status, 200)
+        self.assertEqual(rejected.task["status"], "canceled")
+        self.assertTrue(rejected.task["coordination"]["linear"]["record_found"])
+        self.assertEqual(
+            rejected.task["coordination"]["linear"]["provenance"]["source"],
+            "reevaluation_request.external_facts",
+        )
+        self.assertEqual(rejected.read_model["task"]["current_status"], "canceled")
+        self.assertEqual(
+            rejected.read_model["task"]["failure_summary"],
+            before.read_model_response["task"]["failure_summary"],
+        )
+        self.assertEqual(
+            rejected.read_model["task"]["verification_summary"],
+            before.read_model_response["task"]["verification_summary"],
+        )
+        before_entry = {item["task_id"]: item for item in before_list["tasks"]}[scenario.task_id]
+        after_entry = {item["task_id"]: item for item in after_list["tasks"]}[scenario.task_id]
+        self.assertEqual(after_entry["current_status"], before_entry["current_status"])
+        self.assertEqual(after_entry["failure_summary"], before_entry["failure_summary"])
+        self.assertEqual(after_entry["verification_summary"], before_entry["verification_summary"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,7 @@ from modules.contracts.task_envelope_review import (
 from modules.demo_cases import build_demo_request
 from modules.intake import create_task_envelope
 from modules.store import FileBackedHarnessStore, PostgresHarnessStore
+from tests.e2e.scenario_builders import build_review_decision_from_request
 
 
 POSTGRES_TEST_DATABASE_URL = os.environ.get("HARNESS_TEST_DATABASE_URL")
@@ -2700,6 +2701,63 @@ class HarnessApiServiceTests(unittest.TestCase):
             "contract_violation",
         )
         self.assertEqual(read_payload["task"]["failure_summary"]["failure_type"], "contract_violation")
+
+    def test_service_completion_claim_invalid_execution_attempt_does_not_corrupt_canceled_task_truth(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "cancel_task",
+        ]
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        canceled_status, canceled_response = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        initial_response["enforcement_result"]["review_request"],
+                        outcome="cancel_task",
+                    )
+                }
+            },
+        )
+        before_task = deepcopy(self.service.store.get_task(task_id))
+
+        invalid_attempt_payload = _execution_attempt_payload(attempt_id="attempt-canceled-invalid-1")
+        invalid_attempt_payload["execution_attempt"]["artifact_references"] = [
+            {
+                "reference_id": "attempt-canceled-invalid-1:commit",
+                "artifact_type": "commit",
+                "location": "stub://attempts/attempt-canceled-invalid-1/commit",
+                "metadata": {
+                    "branch_name": "codex/e2e-test",
+                },
+            }
+        ]
+        claim_status, claim_response = self.service.submit_completion_claim(
+            task_id,
+            {
+                "request": {
+                    **_completion_claim_payload(claim_id="claim-canceled-invalid-1"),
+                    **invalid_attempt_payload,
+                    "runtime_facts": {"executor_reported_success": True, "attempt_count": 1},
+                }
+            },
+        )
+        after_task = self.service.store.get_task(task_id)
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(canceled_status, 200)
+        self.assertEqual(canceled_response["task_envelope"]["status"], "canceled")
+        self.assertEqual(claim_status, 200)
+        self.assertEqual(claim_response["action"], "transition_rejected")
+        self.assertIn("canceled -> failed", claim_response["error"])
+        self.assertEqual(claim_response["task_envelope"]["status"], "canceled")
+        self.assertEqual(before_task, after_task)
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["current_status"], "canceled")
 
     def test_service_completion_claim_ignores_support_artifact_context_for_execution_validation(self) -> None:
         payload = _manual_happy_path_overlay_payload()

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -24,6 +24,7 @@ from modules.contracts.task_envelope_review import (
     ReviewerIdentity,
     resolve_review_request,
 )
+from tests.e2e.scenario_builders import build_review_decision_from_request
 
 
 def _to_jsonable(value):
@@ -249,6 +250,54 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         )
         self.assertTrue(payload["task"]["verification_summary"]["failure_classification"]["terminal"])
         self.assertTrue(payload["task"]["verification_summary"]["is_terminal"])
+
+    def test_read_model_ignores_rejected_follow_up_when_projecting_canceled_task_truth(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "cancel_task",
+        ]
+        submit_status, submit_payload = self.service.evaluate(initial_payload)
+        task_id = submit_payload["task_envelope"]["id"]
+
+        canceled_status, _ = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        submit_payload["enforcement_result"]["review_request"],
+                        outcome="cancel_task",
+                    )
+                }
+            },
+        )
+        before_status, before_payload = self.service.get_task_read_model(task_id)
+
+        rejected_status, _ = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "external_facts": _to_jsonable(build_demo_request("accepted_completion").external_facts),
+                    "runtime_facts": _to_jsonable(build_demo_request("accepted_completion").runtime_facts),
+                    "claimed_completion": True,
+                    "acceptance_criteria_satisfied": True,
+                }
+            },
+        )
+        after_status, after_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(canceled_status, 200)
+        self.assertEqual(before_status, 200)
+        self.assertEqual(rejected_status, 200)
+        self.assertEqual(after_status, 200)
+        self.assertEqual(after_payload["task"]["current_status"], "canceled")
+        self.assertEqual(after_payload["task"]["failure_summary"], before_payload["task"]["failure_summary"])
+        self.assertEqual(
+            after_payload["task"]["verification_summary"],
+            before_payload["task"]["verification_summary"],
+        )
+        self.assertEqual(after_payload["task"]["evaluation_summary"]["latest_action"], "transition_rejected")
 
     def test_read_model_and_timeline_expose_clarification_state(self) -> None:
         task_envelope = create_task_envelope(


### PR DESCRIPTION
## Summary\n- prevent invalid completion claims against settled terminal tasks from crashing the control plane\n- keep rejected late follow-up auditable without letting transition_rejected overwrite verification, reconciliation, or failure projections\n- add service, read-model, and E2E coverage for canceled-task follow-up and projection stability\n\n## Testing\n- python3 -m unittest tests.test_read_model tests.e2e.test_control_plane_store_integrity_flows tests.e2e.test_control_plane_review_flows tests.e2e.test_control_plane_task_list_triage_flows -v\n- python3 -m unittest tests.test_api.HarnessApiServiceTests.test_service_completion_claim_invalid_execution_attempt_does_not_corrupt_canceled_task_truth tests.test_api.HarnessApiServiceTests.test_service_reevaluate_authorize_retry_without_assignment_keeps_review_gate_active tests.test_api.HarnessApiServiceTests.test_service_reevaluate_can_accept_completion_after_rejected_retry_attempt tests.test_api.HarnessApiServiceTests.test_service_reevaluate_authorize_replan_clears_prior_completion_evidence -v\n- python3 -m unittest tests.e2e.test_control_plane_linear_provenance_flows -v\n- python3 -m unittest discover -s tests\n- python3 -m py_compile modules/api.py modules/read_model.py tests/test_api.py tests/test_read_model.py tests/e2e/test_control_plane_store_integrity_flows.py tests/e2e/test_control_plane_linear_provenance_flows.py\n- git diff --check