### PR TITLE
Make blocked external mismatch non-terminal

### DIFF
--- a/modules/contracts/failure_classification.py
+++ b/modules/contracts/failure_classification.py
@@ -94,7 +94,7 @@ def classify_verification_outcome(
             failure_type=FailureType.RECONCILIATION_MISMATCH,
             source=FailureSource.EVALUATION,
             reason=reason,
-            terminal=True,
+            terminal=False,
             recoverable=False,
         )
 

--- a/tests/contracts/test_task_envelope_verification.py
+++ b/tests/contracts/test_task_envelope_verification.py
@@ -274,6 +274,8 @@ class VerificationDecisionPrimitiveTests(unittest.TestCase):
         self.assertEqual(result.target_status, "blocked")
         self.assertFalse(result.is_terminal)
         self.assertEqual(result.failure_classification.category, FailureType.RECONCILIATION_MISMATCH)
+        self.assertFalse(result.failure_classification.terminal)
+        self.assertFalse(result.failure_classification.recoverable)
 
     def test_returns_review_required_when_manual_review_is_needed(self) -> None:
         result = _evaluate(

--- a/tests/e2e/test_control_plane_retry_visibility_flows.py
+++ b/tests/e2e/test_control_plane_retry_visibility_flows.py
@@ -58,7 +58,8 @@ class ControlPlaneRetryVisibilityFlowTests(RuntimeApiTestCase):
             "reconciliation_mismatch",
         )
         self.assertFalse(scenario.created.read_model["task"]["execution_summary"]["retry_eligible"])
-        self.assertEqual(scenario.created.read_model["task"]["execution_summary"]["failure_state"], "terminal")
+        self.assertEqual(scenario.created.read_model["task"]["execution_summary"]["failure_state"], "failed")
+        self.assertFalse(scenario.created.read_model["task"]["failure_summary"]["terminal"])
         self.assertEqual(len(scenario.created.history["evaluations"]), 1)
         self.assertNotIn("retry_scheduled", event_types)
         self.assertNotIn("retry_attempt_started", event_types)

--- a/tests/e2e/test_control_plane_review_flows.py
+++ b/tests/e2e/test_control_plane_review_flows.py
@@ -183,7 +183,18 @@ class ControlPlaneReviewFlowTests(RuntimeApiTestCase):
         self.assertEqual(resolved.read_model["task"]["evidence_summary"]["completion_evidence"]["status"], "deferred")
         self.assertEqual(follow_up.status, 200)
         self.assertFalse(follow_up.response["accepted_completion"])
-        self.assertNotEqual(follow_up.task["status"], "completed")
+        self.assertEqual(follow_up.task["status"], "blocked")
+        self.assertEqual(follow_up.response["failure_classification"]["failure_type"], "reconciliation_mismatch")
+        self.assertFalse(follow_up.response["failure_classification"]["terminal"])
+        self.assertFalse(follow_up.response["failure_classification"]["recoverable"])
+        self.assertEqual(follow_up.read_model["task"]["failure_summary"]["state"], "failed")
+        self.assertFalse(follow_up.read_model["task"]["failure_summary"]["terminal"])
+        self.assertEqual(
+            follow_up.read_model["task"]["verification_summary"]["failure_classification"]["failure_type"],
+            "reconciliation_mismatch",
+        )
+        self.assertFalse(follow_up.read_model["task"]["verification_summary"]["failure_classification"]["terminal"])
+        self.assertFalse(follow_up.read_model["task"]["verification_summary"]["is_terminal"])
 
     def test_manual_review_mark_failed_projects_terminal_verification_failure(self) -> None:
         payload = build_review_required_payload(

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -237,6 +237,8 @@ class HarnessEvaluationEntryPointTests(unittest.TestCase):
         self.assertEqual(result.action, EnforcementAction.TRANSITION_APPLIED)
         self.assertEqual(result.target_status, "blocked")
         self.assertEqual(result.enforcement_result.verification_result.outcome, VerificationOutcome.EXTERNAL_MISMATCH)
+        self.assertFalse(result.failure_classification.terminal)
+        self.assertFalse(result.failure_classification.recoverable)
 
     def test_returns_review_required_result(self) -> None:
         task = _base_task(status="intake_ready")


### PR DESCRIPTION
## Summary
- classify blocked \ verification outcomes as non-terminal reconciliation mismatches
- add contract and evaluator regressions for the blocked mismatch classification
- tighten E2E review and retry visibility coverage so blocked reconciliation mismatches stop projecting as terminal

## Testing
- python3 -m unittest tests.contracts.test_task_envelope_verification tests.test_evaluation tests.e2e.test_control_plane_review_flows tests.e2e.test_control_plane_failure_flows tests.e2e.test_control_plane_task_list_reconciliation_flows -v
- python3 -m unittest tests.e2e.test_control_plane_retry_visibility_flows -v
- python3 -m unittest discover -s tests
- python3 -m py_compile modules/contracts/failure_classification.py tests/contracts/test_task_envelope_verification.py tests/test_evaluation.py tests/e2e/test_control_plane_review_flows.py tests/e2e/test_control_plane_retry_visibility_flows.py
- git diff --check