### PR TITLE
Persist clarification after manual review follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The same fail-closed rule now applies to other rejected late follow-up. If reeva
 
 If manual review resolves the gate without accepting completion, Harness also clears any previously satisfied completion evidence back to deferred. A replan, retry, blocked, failed, canceled, or clarification outcome must not leave stale validated proof behind that can auto-complete the task later without a new governed execution or explicit acceptance.
 
+If that manual-review outcome is `require_clarification`, Harness now records a real canonical `task.clarification` contract at the same time. The task does not just become generically `blocked`; operators can see the explicit clarification blocker, its `resume_target_status`, and the required input through the task, read-model, list, and timeline surfaces.
+
 When manual review explicitly authorizes redispatch, Harness now performs that redispatch automatically instead of leaving the task parked in `dispatch_ready` with a resolved review record and no follow-up execution.
 
 Reevaluation also cannot pre-satisfy completion evidence as a side channel. If a reevaluation is not itself a claimed completion, it may not set `completion_evidence.status=satisfied`, inject validated artifact IDs, or otherwise preload final evidence state before a canonical completion decision.

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -113,6 +113,7 @@ It must not be used to inject runtime or terminal states such as `executing`, `r
 - If a manual-review follow-up is attempted but lifecycle policy rejects the requested transition, the review gate stays active. Inspection surfaces should keep `review_summary.status="requested"` and expose the attempt as a rejected review decision instead of projecting the gate as resolved.
 - That rejected attempt does not consume the active request. A later valid `review_decision` must still be able to resolve the same persisted gate.
 - If manual review resolves the gate without accepting completion, Harness clears the task's satisfied completion evidence back to deferred. Follow-up outcomes such as `authorize_replan`, `authorize_retry`, `keep_blocked`, `mark_failed`, `require_clarification`, and `cancel_task` must not leave stale validated artifact proof behind.
+- `require_clarification` is not just a blocked lifecycle move. When manual review chooses that outcome, Harness also writes a canonical `task_envelope.clarification` block so the missing-information requirement is visible and resumable through the inspection surfaces.
 - More generally, `transition_rejected` on an existing task is an auditable rejected action, not a new lifecycle truth. Rejected reevaluation or completion-claim follow-up may append evaluation history and timeline entries, and may still persist new synchronized facts, but it must not replace the current lifecycle/verification/reconciliation/failure projection for an already-settled task.
 
 ## Reconciliation Classification Rule

--- a/modules/api.py
+++ b/modules/api.py
@@ -604,39 +604,17 @@ def _clarification_resume_target(
     return "intake_ready"
 
 
-def _with_submission_clarification(
+def _upsert_clarification_block(
     task_envelope: dict[str, Any],
     *,
     unresolved_conditions: tuple[str, ...],
-    preferred_resume_target_status: str | None,
     requested_by: str,
+    requested_at: str,
+    resume_target_status: str | None,
 ) -> dict[str, Any]:
-    if not unresolved_conditions:
-        return task_envelope
-
     updated_task = deepcopy(task_envelope)
     blocking_reason = _infer_clarification_blocking_reason(unresolved_conditions)
-    requested_at = _iso_now()
-    resume_target_status = _clarification_resume_target(
-        updated_task,
-        preferred_status=preferred_resume_target_status,
-    )
-    current_status = str(updated_task.get("status") or "")
-    if current_status != "blocked":
-        transition = apply_task_transition(
-            updated_task,
-            to_status="blocked",
-            actor=_clarification_transition_actor(current_status),
-            reason=f"Clarification is required before work can continue: {unresolved_conditions[0]}",
-            facts={"reason_provided": True},
-        )
-        updated_task = transition.task_envelope
-        requested_at = transition.changed_at
-    else:
-        updated_task["timestamps"]["updated_at"] = requested_at
-
-    existing_clarification = updated_task.get("clarification")
-    clarification = dict(existing_clarification) if isinstance(existing_clarification, dict) else {}
+    clarification = dict(updated_task.get("clarification") or {}) if isinstance(updated_task.get("clarification"), dict) else {}
     existing_required_inputs = [
         deepcopy(item)
         for item in clarification.get("required_inputs", [])
@@ -687,6 +665,44 @@ def _with_submission_clarification(
     return updated_task
 
 
+def _with_submission_clarification(
+    task_envelope: dict[str, Any],
+    *,
+    unresolved_conditions: tuple[str, ...],
+    preferred_resume_target_status: str | None,
+    requested_by: str,
+) -> dict[str, Any]:
+    if not unresolved_conditions:
+        return task_envelope
+
+    updated_task = deepcopy(task_envelope)
+    requested_at = _iso_now()
+    resume_target_status = _clarification_resume_target(
+        updated_task,
+        preferred_status=preferred_resume_target_status,
+    )
+    current_status = str(updated_task.get("status") or "")
+    if current_status != "blocked":
+        transition = apply_task_transition(
+            updated_task,
+            to_status="blocked",
+            actor=_clarification_transition_actor(current_status),
+            reason=f"Clarification is required before work can continue: {unresolved_conditions[0]}",
+            facts={"reason_provided": True},
+        )
+        updated_task = transition.task_envelope
+        requested_at = transition.changed_at
+    else:
+        updated_task["timestamps"]["updated_at"] = requested_at
+    return _upsert_clarification_block(
+        updated_task,
+        unresolved_conditions=unresolved_conditions,
+        requested_by=requested_by,
+        requested_at=requested_at,
+        resume_target_status=resume_target_status,
+    )
+
+
 def _resolve_submission_clarification_if_cleared(
     task_envelope: dict[str, Any],
     *,
@@ -735,6 +751,24 @@ def _resolve_submission_clarification_if_cleared(
         resolved_task["clarification"] = updated_clarification
 
     return resolved_task
+
+
+def _manual_review_clarification_resume_target(task_envelope: dict[str, Any]) -> str | None:
+    history = task_envelope.get("status_history")
+    if isinstance(history, list):
+        for entry in reversed(history):
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("to_status") or "") != "in_review":
+                continue
+            from_status = str(entry.get("from_status") or "")
+            if from_status in _CLARIFICATION_RESUME_TARGET_STATUSES:
+                return from_status
+
+    if isinstance(task_envelope.get("assigned_executor"), dict):
+        return "assigned"
+
+    return _clarification_resume_target(task_envelope, preferred_status=None)
 
 _EXISTING_TASK_EVALUATE_OVERLAY_FIELDS: tuple[tuple[str, str], ...] = (
     ("task_status", "request.task_status"),
@@ -1148,6 +1182,41 @@ def _with_manual_review_completion_evidence_reset(
     if updated_task is result.task_envelope:
         return result
 
+    enforcement_result = result.enforcement_result
+    if enforcement_result is not None:
+        enforcement_result = replace(enforcement_result, task_envelope=updated_task)
+
+    return replace(
+        result,
+        task_envelope=updated_task,
+        enforcement_result=enforcement_result,
+    )
+
+
+def _with_manual_review_clarification_follow_up(
+    request: HarnessEvaluationRequest,
+    result: HarnessEvaluationResult,
+) -> HarnessEvaluationResult:
+    review_decision = request.review_decision
+    if review_decision is None or review_decision.follow_up_action != ReviewFollowUpAction.CLARIFICATION:
+        return result
+    if result.action not in {EnforcementAction.FOLLOW_UP_AUTHORIZED, EnforcementAction.TRANSITION_APPLIED}:
+        return result
+    if result.requires_review:
+        return result
+
+    clarification_reason = str(review_decision.record.reasoning or "").strip()
+    if not clarification_reason:
+        clarification_reason = "Manual review requested clarification before work can continue."
+
+    requested_at = str(((result.task_envelope.get("timestamps") or {}).get("updated_at")) or _iso_now())
+    updated_task = _upsert_clarification_block(
+        result.task_envelope,
+        unresolved_conditions=(clarification_reason,),
+        requested_by="manual_review",
+        requested_at=requested_at,
+        resume_target_status=_manual_review_clarification_resume_target(request.task_envelope),
+    )
     enforcement_result = result.enforcement_result
     if enforcement_result is not None:
         enforcement_result = replace(enforcement_result, task_envelope=updated_task)
@@ -2801,6 +2870,7 @@ def _evaluate_request(request: HarnessEvaluationRequest) -> tuple[int, dict[str,
         }, None
 
     result = _with_manual_review_completion_evidence_reset(request, result)
+    result = _with_manual_review_clarification_follow_up(request, result)
     status = HTTPStatus.BAD_REQUEST if result.invalid_input else HTTPStatus.OK
     return status, _to_jsonable(result), result
 

--- a/tests/e2e/test_control_plane_review_flows.py
+++ b/tests/e2e/test_control_plane_review_flows.py
@@ -196,6 +196,43 @@ class ControlPlaneReviewFlowTests(RuntimeApiTestCase):
         self.assertFalse(follow_up.read_model["task"]["verification_summary"]["failure_classification"]["terminal"])
         self.assertFalse(follow_up.read_model["task"]["verification_summary"]["is_terminal"])
 
+    def test_manual_review_require_clarification_creates_visible_clarification_block(self) -> None:
+        payload = build_review_required_payload(
+            build_create_task_payload(
+                "e2e-control-review-require-clarification",
+                title="Manual review clarification should create an explicit clarification block",
+            )["request"]["task_envelope"]
+        )
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "require_clarification",
+        ]
+        scenario = self.create_evaluate_scenario(payload)
+
+        resolved = scenario.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        scenario.created.response["enforcement_result"]["review_request"],
+                        outcome="require_clarification",
+                    )
+                }
+            }
+        )
+
+        self.assertEqual(resolved.response["action"], "follow_up_authorized")
+        self.assertEqual(resolved.task["status"], "blocked")
+        self.assertEqual(resolved.task["clarification"]["status"], "required")
+        self.assertEqual(resolved.task["clarification"]["resume_target_status"], "intake_ready")
+        self.assertEqual(resolved.task["clarification"]["requested_by"], "manual_review")
+        self.assertEqual(
+            resolved.task["clarification"]["required_inputs"][0]["description"],
+            "Manual review authorized the next control-plane action.",
+        )
+        self.assertEqual(resolved.read_model["task"]["clarification_summary"]["status"], "required")
+        self.assertEqual(resolved.read_model["task"]["clarification_summary"]["resume_target_status"], "intake_ready")
+        self.assertTrue(any(event["event_type"] == "clarification_required" for event in resolved.timeline["timeline"]))
+
     def test_manual_review_mark_failed_projects_terminal_verification_failure(self) -> None:
         payload = build_review_required_payload(
             build_create_task_payload(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4135,6 +4135,55 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertFalse(follow_up_response["accepted_completion"])
         self.assertNotEqual(follow_up_response["task_envelope"]["status"], "completed")
 
+    def test_service_reevaluate_require_clarification_creates_canonical_clarification_block(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "require_clarification",
+        ]
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        resolution_status, resolution_response = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        initial_response["enforcement_result"]["review_request"],
+                        outcome="require_clarification",
+                    )
+                }
+            },
+        )
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+        timeline_status, timeline_payload = self.service.get_task_timeline(task_id)
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(initial_response["task_envelope"]["status"], "in_review")
+        self.assertEqual(resolution_status, 200)
+        self.assertEqual(resolution_response["action"], "follow_up_authorized")
+        self.assertEqual(resolution_response["task_envelope"]["status"], "blocked")
+        self.assertEqual(resolution_response["task_envelope"]["clarification"]["status"], "required")
+        self.assertEqual(
+            resolution_response["task_envelope"]["clarification"]["resume_target_status"],
+            "intake_ready",
+        )
+        self.assertEqual(
+            resolution_response["task_envelope"]["clarification"]["requested_by"],
+            "manual_review",
+        )
+        self.assertEqual(
+            resolution_response["task_envelope"]["clarification"]["required_inputs"][0]["description"],
+            "Manual review authorized the next control-plane action.",
+        )
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["clarification_summary"]["status"], "required")
+        self.assertEqual(read_payload["task"]["clarification_summary"]["resume_target_status"], "intake_ready")
+        self.assertEqual(timeline_status, 200)
+        self.assertTrue(
+            any(event["event_type"] == "clarification_required" for event in timeline_payload["timeline"])
+        )
+
     def test_service_reevaluate_authorize_retry_with_assignment_clears_prior_completion_evidence(self) -> None:
         initial_payload = _request_payload("review_required")
         initial_payload["request"]["review_request"]["allowed_outcomes"] = [


### PR DESCRIPTION
## Summary
- persist a canonical task clarification block when manual review resolves with require_clarification
- make that blocker visible through the task, read-model, and timeline surfaces instead of leaving a naked blocked state
- document the review follow-up clarification contract

## Testing
- python3 -m unittest tests.test_api.HarnessApiServiceTests.test_service_reevaluate_require_clarification_creates_canonical_clarification_block -v
- python3 -m unittest tests.e2e.test_control_plane_review_flows.ControlPlaneReviewFlowTests.test_manual_review_require_clarification_creates_visible_clarification_block -v
- python3 -m unittest tests.e2e.test_control_plane_review_flows tests.e2e.test_control_plane_clarification_surface_flows tests.test_api.HarnessApiServiceTests.test_service_reevaluate_require_clarification_creates_canonical_clarification_block -v
- python3 -m unittest discover -s tests
- python3 -m py_compile modules/api.py tests/test_api.py tests/e2e/test_control_plane_review_flows.py
- git diff --check
