### PR TITLE
Clear stale assignment on terminal review outcomes

### DIFF
--- a/modules/contracts/task_envelope_lifecycle.py
+++ b/modules/contracts/task_envelope_lifecycle.py
@@ -56,6 +56,7 @@ _STATUSES = {
     "failed",
     "canceled",
 }
+_TERMINAL_STATUSES = {"completed", "failed", "canceled"}
 
 _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "intake_ready": {"planned", "reconciling", "blocked", "in_review", "completed", "failed"},
@@ -327,6 +328,9 @@ def apply_task_transition(
     updated = deepcopy(task_envelope)
     updated["status"] = to_status
     updated["timestamps"]["updated_at"] = changed_at
+
+    if to_status in _TERMINAL_STATUSES:
+        updated["assigned_executor"] = None
 
     if to_status == "completed":
         updated["timestamps"]["completed_at"] = changed_at

--- a/tests/contracts/test_task_envelope_lifecycle.py
+++ b/tests/contracts/test_task_envelope_lifecycle.py
@@ -225,6 +225,26 @@ class TaskEnvelopeLifecycleTests(unittest.TestCase):
                 self.assertEqual(result.task_envelope["status_history"][-1]["from_status"], status)
                 self.assertEqual(result.task_envelope["status_history"][-1]["to_status"], "completed")
 
+    def test_terminal_transition_clears_active_assignment(self) -> None:
+        task = _base_task()
+        task["status"] = "assigned"
+        task["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-terminal-clear-1",
+            "assignment_reason": "Active assignment should not survive terminal transitions.",
+        }
+
+        result = apply_task_transition(
+            task,
+            to_status="canceled",
+            actor="manual_review",
+            reason="Manual review canceled the task.",
+            now="2026-03-25T12:19:00Z",
+        )
+
+        self.assertEqual(result.task_envelope["status"], "canceled")
+        self.assertIsNone(result.task_envelope.get("assigned_executor"))
+
     def test_executing_can_transition_to_reconciling(self) -> None:
         task = _base_task()
         task["status"] = "executing"

--- a/tests/e2e/test_control_plane_review_flows.py
+++ b/tests/e2e/test_control_plane_review_flows.py
@@ -273,6 +273,42 @@ class ControlPlaneReviewFlowTests(RuntimeApiTestCase):
         self.assertTrue(resolved.read_model["task"]["verification_summary"]["failure_classification"]["terminal"])
         self.assertTrue(resolved.read_model["task"]["verification_summary"]["is_terminal"])
 
+    def test_manual_review_cancel_task_clears_active_assignment_across_surfaces(self) -> None:
+        task_envelope = build_create_task_payload(
+            "e2e-control-review-cancel-clears-assignment",
+            title="Manual review cancel should clear stale active assignment",
+        )["request"]["task_envelope"]
+        task_envelope["status"] = "assigned"
+        task_envelope["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-e2e-review-cancel-clear-1",
+            "assignment_reason": "Seed active assignment for cancel review coverage.",
+        }
+        payload = build_review_required_payload(task_envelope)
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "cancel_task",
+        ]
+        scenario = self.create_evaluate_scenario(payload)
+
+        resolved = scenario.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        scenario.created.response["enforcement_result"]["review_request"],
+                        outcome="cancel_task",
+                    )
+                }
+            }
+        )
+
+        self.assertEqual(resolved.response["action"], "transition_applied")
+        self.assertEqual(resolved.task["status"], "canceled")
+        self.assertIsNone(resolved.task.get("assigned_executor"))
+        self.assertEqual(resolved.read_model["task"]["current_status"], "canceled")
+        self.assertIsNone(resolved.read_model["task"].get("assigned_executor"))
+        self.assertTrue(any(event["event_type"] == "review_decided" for event in resolved.timeline["timeline"]))
+
     def test_manual_review_authorize_retry_without_assignment_keeps_review_gate_active(self) -> None:
         payload = build_review_required_payload(
             build_create_task_payload(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2759,6 +2759,44 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(read_status, 200)
         self.assertEqual(read_payload["task"]["current_status"], "canceled")
 
+    def test_service_reevaluate_cancel_task_clears_active_assignment(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["task_envelope"]["status"] = "assigned"
+        initial_payload["request"]["task_envelope"]["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-review-cancel-clear-1",
+            "assignment_reason": "Seed active assignment for review cancel coverage.",
+        }
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "cancel_task",
+        ]
+
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        resolution_status, resolution_response = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        initial_response["enforcement_result"]["review_request"],
+                        outcome="cancel_task",
+                    )
+                }
+            },
+        )
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(resolution_status, 200)
+        self.assertEqual(resolution_response["action"], "transition_applied")
+        self.assertEqual(resolution_response["task_envelope"]["status"], "canceled")
+        self.assertIsNone(resolution_response["task_envelope"].get("assigned_executor"))
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["current_status"], "canceled")
+        self.assertIsNone(read_payload["task"].get("assigned_executor"))
+
     def test_service_completion_claim_ignores_support_artifact_context_for_execution_validation(self) -> None:
         payload = _manual_happy_path_overlay_payload()
         submit_payload = {


### PR DESCRIPTION
## Summary
- clear `assigned_executor` back to null whenever canonical lifecycle transitions land in a terminal state
- add contract, service, and live HTTP regressions for manual-review `cancel_task` from an assigned task
- keep non-terminal follow-up paths like `authorize_retry` unchanged while removing stale active-assignment truth from canceled tasks

## Validation
- python3 -m unittest tests.contracts.test_task_envelope_lifecycle tests.test_api.HarnessApiServiceTests.test_service_reevaluate_cancel_task_clears_active_assignment tests.e2e.test_control_plane_review_flows -v
- python3 -m py_compile modules/contracts/task_envelope_lifecycle.py tests/contracts/test_task_envelope_lifecycle.py tests/test_api.py tests/e2e/test_control_plane_review_flows.py
- python3 -m unittest discover -s tests
- git diff --check
