### PR TITLE
Preserve assignment for review clarification resumes

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -1200,6 +1200,8 @@ def _with_manual_review_assignment_reset(
     review_decision = request.review_decision
     if review_decision is None:
         return result
+    if review_decision.follow_up_action == ReviewFollowUpAction.CLARIFICATION:
+        return result
     if result.action not in {EnforcementAction.FOLLOW_UP_AUTHORIZED, EnforcementAction.TRANSITION_APPLIED}:
         return result
     if result.requires_review:

--- a/tests/e2e/test_control_plane_review_flows.py
+++ b/tests/e2e/test_control_plane_review_flows.py
@@ -237,6 +237,53 @@ class ControlPlaneReviewFlowTests(RuntimeApiTestCase):
         self.assertEqual(resolved.read_model["task"]["clarification_summary"]["resume_target_status"], "intake_ready")
         self.assertTrue(any(event["event_type"] == "clarification_required" for event in resolved.timeline["timeline"]))
 
+    def test_manual_review_clarification_from_assigned_resumes_original_assignment(self) -> None:
+        task_envelope = build_create_task_payload(
+            "e2e-control-review-clarification-assigned-resume",
+            title="Manual review clarification should resume assigned work truthfully",
+        )["request"]["task_envelope"]
+        task_envelope["status"] = "assigned"
+        task_envelope["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-e2e-review-clarification-resume-1",
+            "assignment_reason": "Resume assigned work after manual review clarification.",
+        }
+        payload = build_review_required_payload(task_envelope)
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "require_clarification",
+        ]
+        scenario = self.create_evaluate_scenario(payload)
+
+        blocked = scenario.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        scenario.created.response["enforcement_result"]["review_request"],
+                        outcome="require_clarification",
+                    )
+                }
+            }
+        )
+        resolved = scenario.reevaluate(
+            {"request": {"claimed_completion": False, "acceptance_criteria_satisfied": False}}
+        )
+
+        self.assertEqual(blocked.task["status"], "blocked")
+        self.assertEqual(blocked.task["clarification"]["resume_target_status"], "assigned")
+        self.assertEqual(resolved.task["status"], "assigned")
+        self.assertEqual(
+            resolved.task["assigned_executor"]["executor_id"],
+            "executor-e2e-review-clarification-resume-1",
+        )
+        self.assertEqual(resolved.task["clarification"]["status"], "resolved")
+        self.assertEqual(resolved.read_model["task"]["current_status"], "assigned")
+        self.assertEqual(
+            resolved.read_model["task"]["assigned_executor"]["executor_id"],
+            "executor-e2e-review-clarification-resume-1",
+        )
+        self.assertTrue(any(event["event_type"] == "clarification_resolved" for event in resolved.timeline["timeline"]))
+
     def test_manual_review_mark_failed_projects_terminal_verification_failure(self) -> None:
         payload = build_review_required_payload(
             build_create_task_payload(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4222,6 +4222,56 @@ class HarnessApiServiceTests(unittest.TestCase):
             any(event["event_type"] == "clarification_required" for event in timeline_payload["timeline"])
         )
 
+    def test_service_reevaluate_manual_review_clarification_from_assigned_resumes_original_assignment(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["task_envelope"]["status"] = "assigned"
+        initial_payload["request"]["task_envelope"]["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-review-clarification-resume-1",
+            "assignment_reason": "Resume assigned work after manual review clarification.",
+        }
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "require_clarification",
+        ]
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        blocked_status, blocked_response = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        initial_response["enforcement_result"]["review_request"],
+                        outcome="require_clarification",
+                    )
+                }
+            },
+        )
+        resolved_status, resolved_response = self.service.reevaluate(
+            task_id,
+            {"request": {"claimed_completion": False, "acceptance_criteria_satisfied": False}},
+        )
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(blocked_status, 200)
+        self.assertEqual(blocked_response["task_envelope"]["status"], "blocked")
+        self.assertEqual(blocked_response["task_envelope"]["clarification"]["resume_target_status"], "assigned")
+        self.assertEqual(resolved_status, 200)
+        self.assertEqual(resolved_response["task_envelope"]["status"], "assigned")
+        self.assertEqual(
+            resolved_response["task_envelope"]["assigned_executor"]["executor_id"],
+            "executor-review-clarification-resume-1",
+        )
+        self.assertEqual(resolved_response["task_envelope"]["clarification"]["status"], "resolved")
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["current_status"], "assigned")
+        self.assertEqual(
+            read_payload["task"]["assigned_executor"]["executor_id"],
+            "executor-review-clarification-resume-1",
+        )
+
     def test_service_reevaluate_authorize_retry_with_assignment_clears_prior_completion_evidence(self) -> None:
         initial_payload = _request_payload("review_required")
         initial_payload["request"]["review_request"]["allowed_outcomes"] = [


### PR DESCRIPTION
## Summary
- preserve the active assignment when manual review resolves to `require_clarification` so a blocked task with `resume_target_status="assigned"` can actually resume
- add service and live HTTP regressions for manual-review clarification from assigned work
- keep the earlier stale-assignment cleanup for non-clarification review outcomes like `authorize_replan` and `keep_blocked`

## Validation
- python3 -m unittest tests.test_api.HarnessApiServiceTests.test_service_reevaluate_manual_review_clarification_from_assigned_resumes_original_assignment tests.test_api.HarnessApiServiceTests.test_service_reevaluate_authorize_replan_clears_active_assignment tests.test_api.HarnessApiServiceTests.test_service_reevaluate_keep_blocked_clears_active_assignment -v
- python3 -m unittest tests.e2e.test_control_plane_review_flows.ControlPlaneReviewFlowTests.test_manual_review_clarification_from_assigned_resumes_original_assignment tests.e2e.test_control_plane_review_flows.ControlPlaneReviewFlowTests.test_manual_review_keep_blocked_resolves_gate_without_projecting_automatic_acceptance tests.e2e.test_control_plane_review_flows.ControlPlaneReviewFlowTests.test_manual_review_authorize_replan_clears_prior_completion_proof tests.e2e.test_control_plane_reconciliation_flows.ControlPlaneReconciliationFlowTests.test_missing_pr_reconciliation_authorize_redispatch_response_reflects_post_dispatch_failure -v
- python3 -m py_compile modules/api.py tests/test_api.py tests/e2e/test_control_plane_review_flows.py
- python3 -m unittest discover -s tests
- git diff --check
