### PR TITLE
Add review follow-up coverage

### DIFF
--- a/tests/e2e/test_control_plane_review_flows.py
+++ b/tests/e2e/test_control_plane_review_flows.py
@@ -141,6 +141,46 @@ class ControlPlaneReviewFlowTests(RuntimeApiTestCase):
             ]
         )
 
+    def test_manual_review_reject_completion_clears_prior_completion_proof(self) -> None:
+        payload = build_review_required_payload(
+            build_create_task_payload(
+                "e2e-control-review-reject-proof-reset",
+                title="Manual review reject should clear stale completion proof",
+            )["request"]["task_envelope"]
+        )
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "reject_completion",
+        ]
+        scenario = self.create_evaluate_scenario(payload)
+
+        resolved = scenario.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        scenario.created.response["enforcement_result"]["review_request"],
+                        outcome="reject_completion",
+                    )
+                }
+            }
+        )
+
+        self.assertEqual(resolved.response["action"], "transition_applied")
+        self.assertEqual(resolved.task["status"], "blocked")
+        self.assertEqual(resolved.task["artifacts"]["completion_evidence"]["status"], "deferred")
+        self.assertEqual(resolved.task["artifacts"]["completion_evidence"]["validated_artifact_ids"], [])
+        self.assertEqual(resolved.read_model["task"]["review_summary"]["status"], "resolved")
+        self.assertEqual(
+            resolved.read_model["task"]["review_summary"]["latest_decision"]["outcome"],
+            "reject_completion",
+        )
+        self.assertFalse(resolved.read_model["task"]["verification_summary"]["accepted_completion"])
+        self.assertFalse(
+            resolved.read_model["task"]["verification_summary"]["acceptance_criteria_assessment"][
+                "automatic_completion_safe"
+            ]
+        )
+
     def test_manual_review_authorize_replan_clears_prior_completion_proof(self) -> None:
         payload = build_review_required_payload(
             build_create_task_payload(
@@ -283,6 +323,50 @@ class ControlPlaneReviewFlowTests(RuntimeApiTestCase):
             "executor-e2e-review-clarification-resume-1",
         )
         self.assertTrue(any(event["event_type"] == "clarification_resolved" for event in resolved.timeline["timeline"]))
+
+    def test_manual_review_clarification_from_dispatch_ready_creates_real_follow_up_dispatch_attempt(self) -> None:
+        task_envelope = build_create_task_payload(
+            "e2e-control-review-clarification-dispatch-resume",
+            title="Manual review clarification should resume dispatch-ready work with a real attempt",
+        )["request"]["task_envelope"]
+        task_envelope["status"] = "dispatch_ready"
+        payload = build_review_required_payload(task_envelope)
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "require_clarification",
+        ]
+        scenario = self.create_evaluate_scenario(payload)
+
+        blocked = scenario.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        scenario.created.response["enforcement_result"]["review_request"],
+                        outcome="require_clarification",
+                    )
+                }
+            }
+        )
+        resolved = scenario.reevaluate(
+            {"request": {"claimed_completion": False, "acceptance_criteria_satisfied": False}}
+        )
+        dispatch_events = [
+            event
+            for event in resolved.timeline["timeline"]
+            if event["event_type"] == "task_dispatched"
+        ]
+
+        self.assertEqual(blocked.task["status"], "blocked")
+        self.assertEqual(blocked.task["clarification"]["resume_target_status"], "dispatch_ready")
+        self.assertEqual(resolved.task["clarification"]["status"], "resolved")
+        self.assertTrue(resolved.response["automatic_dispatch"]["attempted"])
+        self.assertEqual(resolved.response["automatic_dispatch"]["dispatch"]["attempt_id"], "attempt-1")
+        self.assertEqual(resolved.read_model["task"]["clarification_summary"]["status"], "resolved")
+        self.assertEqual(resolved.read_model["task"]["execution_summary"]["attempt_count"], 1)
+        self.assertTrue(any(event["event_type"] == "clarification_resolved" for event in resolved.timeline["timeline"]))
+        self.assertTrue(
+            any(event["details"]["dispatch_trigger"] == "automatic_policy_post_reevaluation" for event in dispatch_events)
+        )
 
     def test_manual_review_mark_failed_projects_terminal_verification_failure(self) -> None:
         payload = build_review_required_payload(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4173,6 +4173,56 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertFalse(follow_up_response["accepted_completion"])
         self.assertNotEqual(follow_up_response["task_envelope"]["status"], "completed")
 
+    def test_service_reevaluate_reject_completion_clears_prior_completion_evidence(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "reject_completion",
+        ]
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        resolution_status, resolution_response = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": _review_decision_payload(
+                        task_id,
+                        outcome=ReviewOutcome.REJECT_COMPLETION,
+                        allowed_outcomes=(
+                            ReviewOutcome.ACCEPT_COMPLETION,
+                            ReviewOutcome.REJECT_COMPLETION,
+                        ),
+                    )
+                }
+            },
+        )
+        evidence = resolution_response["task_envelope"]["artifacts"]["completion_evidence"]
+        follow_up_status, follow_up_response = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "external_facts": deepcopy(_request_payload("accepted_completion")["request"]["external_facts"]),
+                    "runtime_facts": deepcopy(_request_payload("accepted_completion")["request"]["runtime_facts"]),
+                    "claimed_completion": True,
+                    "acceptance_criteria_satisfied": True,
+                }
+            },
+        )
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(resolution_status, 200)
+        self.assertEqual(resolution_response["action"], "transition_applied")
+        self.assertEqual(resolution_response["task_envelope"]["status"], "blocked")
+        self.assertEqual(evidence["validated_artifact_ids"], [])
+        self.assertEqual(evidence["status"], "deferred")
+        self.assertIsNone(evidence["validated_at"])
+        self.assertIsNone(evidence["validator"])
+        self.assertEqual(evidence["validation_method"], "deferred")
+        self.assertEqual(follow_up_status, 200)
+        self.assertFalse(follow_up_response["accepted_completion"])
+        self.assertNotEqual(follow_up_response["task_envelope"]["status"], "completed")
+
     def test_service_reevaluate_require_clarification_creates_canonical_clarification_block(self) -> None:
         initial_payload = _request_payload("review_required")
         initial_payload["request"]["review_request"]["allowed_outcomes"] = [
@@ -4271,6 +4321,55 @@ class HarnessApiServiceTests(unittest.TestCase):
             read_payload["task"]["assigned_executor"]["executor_id"],
             "executor-review-clarification-resume-1",
         )
+
+    def test_service_reevaluate_manual_review_clarification_from_dispatch_ready_auto_dispatches(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["task_envelope"]["status"] = "dispatch_ready"
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "require_clarification",
+        ]
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        blocked_status, blocked_response = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        initial_response["enforcement_result"]["review_request"],
+                        outcome="require_clarification",
+                    )
+                }
+            },
+        )
+        resolved_status, resolved_response = self.service.reevaluate(
+            task_id,
+            {"request": {"claimed_completion": False, "acceptance_criteria_satisfied": False}},
+        )
+        timeline_status, timeline_payload = self.service.get_task_timeline(task_id)
+        execution_attempts = (
+            ((resolved_response["task_envelope"].get("observability") or {}).get("execution_metadata") or {}).get(
+                "execution_attempts"
+            )
+            or []
+        )
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(blocked_status, 200)
+        self.assertEqual(blocked_response["task_envelope"]["status"], "blocked")
+        self.assertEqual(blocked_response["task_envelope"]["clarification"]["resume_target_status"], "dispatch_ready")
+        self.assertEqual(resolved_status, 200)
+        self.assertEqual(resolved_response["task_envelope"]["clarification"]["status"], "resolved")
+        self.assertTrue(resolved_response["automatic_dispatch"]["attempted"])
+        self.assertEqual(resolved_response["automatic_dispatch"]["dispatch"]["attempt_id"], "attempt-1")
+        self.assertEqual(len(execution_attempts), 1)
+        self.assertEqual(timeline_status, 200)
+        dispatch_events = [event for event in timeline_payload["timeline"] if event["event_type"] == "task_dispatched"]
+        self.assertTrue(
+            any(event["event_type"] == "clarification_resolved" for event in timeline_payload["timeline"])
+        )
+        self.assertEqual(dispatch_events[-1]["details"]["dispatch_trigger"], "automatic_policy_post_reevaluation")
 
     def test_service_reevaluate_authorize_retry_with_assignment_clears_prior_completion_evidence(self) -> None:
         initial_payload = _request_payload("review_required")
@@ -4393,6 +4492,43 @@ class HarnessApiServiceTests(unittest.TestCase):
                     "review_decision": build_review_decision_from_request(
                         initial_response["enforcement_result"]["review_request"],
                         outcome="keep_blocked",
+                    )
+                }
+            },
+        )
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(initial_status, 200)
+        self.assertEqual(resolution_status, 200)
+        self.assertEqual(resolution_response["action"], "transition_applied")
+        self.assertEqual(resolution_response["task_envelope"]["status"], "blocked")
+        self.assertIsNone(resolution_response["task_envelope"].get("assigned_executor"))
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["current_status"], "blocked")
+        self.assertIsNone(read_payload["task"].get("assigned_executor"))
+
+    def test_service_reevaluate_reject_completion_clears_active_assignment(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["task_envelope"]["status"] = "assigned"
+        initial_payload["request"]["task_envelope"]["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-review-reject-clear-1",
+            "assignment_reason": "Seed active assignment for review reject coverage.",
+        }
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "reject_completion",
+        ]
+        initial_status, initial_response = self.service.evaluate(initial_payload)
+        task_id = initial_response["task_envelope"]["id"]
+
+        resolution_status, resolution_response = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        initial_response["enforcement_result"]["review_request"],
+                        outcome="reject_completion",
                     )
                 }
             },


### PR DESCRIPTION
## Summary
- add service regressions for reject_completion proof reset and assignment clearing
- add service coverage for manual-review clarification from dispatch_ready auto-dispatching on resume
- add matching end-to-end review-flow coverage for reject_completion and dispatch-ready clarification resume

## Validation
- python3 -m unittest tests.test_api.HarnessApiServiceTests.test_service_reevaluate_reject_completion_clears_prior_completion_evidence tests.test_api.HarnessApiServiceTests.test_service_reevaluate_manual_review_clarification_from_dispatch_ready_auto_dispatches tests.test_api.HarnessApiServiceTests.test_service_reevaluate_reject_completion_clears_active_assignment -v
- python3 -m unittest tests.e2e.test_control_plane_review_flows.ControlPlaneReviewFlowTests.test_manual_review_reject_completion_clears_prior_completion_proof tests.e2e.test_control_plane_review_flows.ControlPlaneReviewFlowTests.test_manual_review_clarification_from_dispatch_ready_creates_real_follow_up_dispatch_attempt -v
- python3 -m unittest tests.e2e.test_control_plane_review_flows -v
- python3 -m py_compile tests/test_api.py tests/e2e/test_control_plane_review_flows.py
- python3 -m unittest discover -s tests
- git diff --check