### PR TITLE
Add review outcome operator surface coverage

### DIFF
--- a/tests/e2e/test_control_plane_task_list_triage_flows.py
+++ b/tests/e2e/test_control_plane_task_list_triage_flows.py
@@ -110,3 +110,77 @@ class ControlPlaneTaskListTriageFlowTests(RuntimeApiTestCase):
         self.assertFalse(entry["verification_summary"]["claimed_completion"])
         self.assertFalse(entry["verification_summary"]["evidence_is_sufficient"])
         self.assertFalse(entry["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"])
+
+    def test_task_list_disables_automatic_completion_safe_after_manual_reject_completion(self) -> None:
+        payload = {"request": to_jsonable(build_demo_request("review_required"))}
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "reject_completion",
+        ]
+        review = self.create_evaluate_scenario(payload)
+
+        review.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        review.created.response["enforcement_result"]["review_request"],
+                        outcome="reject_completion",
+                    )
+                }
+            }
+        )
+
+        list_status, list_payload = self.list_tasks()
+        entry = self._tasks_by_id(list_payload)[review.task_id]
+
+        self.assertEqual(list_status, 200)
+        self.assertEqual(entry["current_status"], "blocked")
+        self.assertEqual(entry["review_summary"]["status"], "resolved")
+        self.assertEqual(entry["review_summary"]["latest_decision"]["outcome"], "reject_completion")
+        self.assertEqual(entry["verification_summary"]["outcome"], "review_resolved")
+        self.assertFalse(entry["verification_summary"]["accepted_completion"])
+        self.assertFalse(entry["verification_summary"]["claimed_completion"])
+        self.assertFalse(entry["verification_summary"]["evidence_is_sufficient"])
+        self.assertFalse(entry["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"])
+
+    def test_task_list_projects_manual_cancel_task_as_canceled_without_safe_completion(self) -> None:
+        payload = {"request": to_jsonable(build_demo_request("review_required"))}
+        payload["request"]["task_envelope"]["status"] = "assigned"
+        payload["request"]["task_envelope"]["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-e2e-task-list-cancel-1",
+            "assignment_reason": "Seed active assignment for cancel task-list coverage.",
+        }
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "cancel_task",
+        ]
+        review = self.create_evaluate_scenario(payload)
+
+        review.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        review.created.response["enforcement_result"]["review_request"],
+                        outcome="cancel_task",
+                    )
+                }
+            }
+        )
+
+        list_status, list_payload = self.list_tasks()
+        entry = self._tasks_by_id(list_payload)[review.task_id]
+
+        self.assertEqual(list_status, 200)
+        self.assertEqual(entry["current_status"], "canceled")
+        self.assertIsNone(entry["assigned_executor"])
+        self.assertEqual(entry["review_summary"]["status"], "resolved")
+        self.assertEqual(entry["review_summary"]["latest_decision"]["outcome"], "cancel_task")
+        self.assertEqual(entry["verification_summary"]["outcome"], "review_resolved")
+        self.assertEqual(entry["verification_summary"]["target_status"], "canceled")
+        self.assertFalse(entry["verification_summary"]["accepted_completion"])
+        self.assertFalse(entry["verification_summary"]["claimed_completion"])
+        self.assertFalse(entry["verification_summary"]["evidence_is_sufficient"])
+        self.assertFalse(entry["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"])
+        self.assertEqual(entry["failure_summary"]["state"], "clear")
+        self.assertEqual(entry["execution_summary"]["failure_state"], "clear")

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -220,6 +220,42 @@ class HarnessReadModelServiceTests(unittest.TestCase):
             payload["task"]["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"]
         )
 
+    def test_read_model_disables_automatic_completion_safe_after_manual_reject_completion(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "reject_completion",
+        ]
+        submit_status, submit_payload = self.service.evaluate(initial_payload)
+        task_id = submit_payload["task_envelope"]["id"]
+
+        reevaluate_status, _ = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        submit_payload["enforcement_result"]["review_request"],
+                        outcome="reject_completion",
+                    )
+                }
+            },
+        )
+        status, payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(reevaluate_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task"]["current_status"], "blocked")
+        self.assertEqual(payload["task"]["review_summary"]["status"], "resolved")
+        self.assertEqual(payload["task"]["review_summary"]["latest_decision"]["outcome"], "reject_completion")
+        self.assertEqual(payload["task"]["verification_summary"]["outcome"], "review_resolved")
+        self.assertFalse(payload["task"]["verification_summary"]["accepted_completion"])
+        self.assertFalse(payload["task"]["verification_summary"]["claimed_completion"])
+        self.assertFalse(payload["task"]["verification_summary"]["evidence_is_sufficient"])
+        self.assertFalse(
+            payload["task"]["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"]
+        )
+
     def test_read_model_disables_automatic_completion_safe_after_manual_mark_failed(self) -> None:
         initial_payload = _request_payload("review_required")
         initial_payload["request"]["review_request"]["allowed_outcomes"] = [
@@ -256,6 +292,43 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         )
         self.assertTrue(payload["task"]["verification_summary"]["failure_classification"]["terminal"])
         self.assertTrue(payload["task"]["verification_summary"]["is_terminal"])
+
+    def test_read_model_disables_automatic_completion_safe_after_manual_cancel_task(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "cancel_task",
+        ]
+        submit_status, submit_payload = self.service.evaluate(initial_payload)
+        task_id = submit_payload["task_envelope"]["id"]
+
+        reevaluate_status, _ = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        submit_payload["enforcement_result"]["review_request"],
+                        outcome="cancel_task",
+                    )
+                }
+            },
+        )
+        status, payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(reevaluate_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task"]["current_status"], "canceled")
+        self.assertEqual(payload["task"]["review_summary"]["status"], "resolved")
+        self.assertEqual(payload["task"]["review_summary"]["latest_decision"]["outcome"], "cancel_task")
+        self.assertEqual(payload["task"]["verification_summary"]["outcome"], "review_resolved")
+        self.assertEqual(payload["task"]["verification_summary"]["target_status"], "canceled")
+        self.assertFalse(payload["task"]["verification_summary"]["accepted_completion"])
+        self.assertFalse(payload["task"]["verification_summary"]["claimed_completion"])
+        self.assertFalse(payload["task"]["verification_summary"]["evidence_is_sufficient"])
+        self.assertFalse(
+            payload["task"]["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"]
+        )
 
     def test_read_model_clears_pending_verification_projection_after_reconciliation_redispatch_failure(self) -> None:
         service = HarnessApiService(


### PR DESCRIPTION
## Summary
- add read-model regressions for manual review reject_completion and cancel_task outcomes
- add task-list regressions proving those outcomes do not project safe or latent completion
- keep operator-facing review resolution semantics explicit across detail and list surfaces

## Validation
- python3 -m unittest tests.test_read_model.HarnessReadModelServiceTests.test_read_model_disables_automatic_completion_safe_after_manual_reject_completion tests.test_read_model.HarnessReadModelServiceTests.test_read_model_disables_automatic_completion_safe_after_manual_cancel_task tests.e2e.test_control_plane_task_list_triage_flows.ControlPlaneTaskListTriageFlowTests.test_task_list_disables_automatic_completion_safe_after_manual_reject_completion tests.e2e.test_control_plane_task_list_triage_flows.ControlPlaneTaskListTriageFlowTests.test_task_list_projects_manual_cancel_task_as_canceled_without_safe_completion -v
- python3 -m unittest tests.test_read_model tests.e2e.test_control_plane_task_list_triage_flows -v
- python3 -m py_compile tests/test_read_model.py tests/e2e/test_control_plane_task_list_triage_flows.py
- python3 -m unittest discover -s tests
- git diff --check