### PR TITLE
Keep execution-summary attempt totals truthful

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Backend inspection routes:
 
 For triage surfaces, `review_required` stays distinct from terminal failure. If a task is in `in_review`, the projected `failure_summary.state` and `execution_summary.failure_state` remain `review_required` rather than collapsing into `failed`.
 
+Within `execution_summary`, `attempt_count` is the number of recorded canonical execution attempts. `total_attempts` may be higher when retry/evaluation history exists without a new execution-attempt record, but it must never undercount the recorded execution attempts already attached to the task.
+
 ## Storage And Environment
 
 Required frontend environment variable:

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -128,6 +128,12 @@ Current canonical example:
 
 - `linear_record_not_found` is treated as `review_required`, not as an automatic mismatch, because the system cannot safely infer whether the task is missing, mislinked, or temporarily unresolved
 
+## Inspection Surface Attempt Semantics
+
+On `GET /tasks` and `GET /tasks/<task_id>/read-model`, `execution_summary.attempt_count` is the number of canonical execution attempts currently recorded on the task.
+
+`execution_summary.total_attempts` is broader: it can include retry/evaluation-chain activity even when no new execution-attempt record exists. It must never be lower than `attempt_count`, because inspection surfaces cannot truthfully report fewer total attempts than the canonical execution-attempt history already attached to the task.
+
 ## Linear Facts Workflow Rule
 
 The `external_facts.linear_facts.workflow` field is conditional on `record_found`.

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -436,6 +436,7 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
         (attempt for attempt in reversed(execution_attempts) if isinstance(attempt, dict)),
         None,
     )
+    attempt_count = len([attempt for attempt in execution_attempts if isinstance(attempt, dict)])
     for attempt in execution_attempts:
         if not isinstance(attempt, dict):
             continue
@@ -454,7 +455,7 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
         recoverable=bool((latest_failure_summary or {}).get("recoverable")),
     )
     return {
-        "attempt_count": len([attempt for attempt in execution_attempts if isinstance(attempt, dict)]),
+        "attempt_count": attempt_count,
         "latest_attempt": dict(latest_attempt) if latest_attempt is not None else None,
         "latest_status": latest_attempt.get("status") if isinstance(latest_attempt, dict) else None,
         "latest_dispatch_origin": (
@@ -468,7 +469,7 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
             else None
         ),
         "latest_artifact_references": list((latest_attempt or {}).get("artifact_references") or []),
-        "total_attempts": len(records),
+        "total_attempts": max(len(records), attempt_count),
         "retry_count": retry_count,
         "invalid_attempt_count": invalid_attempt_count,
         "last_failure_type": (latest_failure_summary or {}).get("failure_type"),

--- a/tests/e2e/test_control_plane_task_list_execution_flows.py
+++ b/tests/e2e/test_control_plane_task_list_execution_flows.py
@@ -128,3 +128,47 @@ class ControlPlaneTaskListExecutionFlowTests(RuntimeApiTestCase):
         )
         self.assertEqual(entry["review_summary"]["status"], "resolved")
         self.assertEqual(entry["review_summary"]["decision_count"], 1)
+
+    def test_task_list_total_attempts_does_not_undercount_recorded_execution_attempts(self) -> None:
+        scenario = self.create_task_scenario(
+            build_create_task_payload(
+                "e2e-list-execution-total-attempts",
+                title="Task list execution total attempts scenario",
+            )
+        )
+
+        scenario.mutate_task(
+            lambda task: task["observability"]["execution_metadata"].__setitem__(
+                "execution_attempts",
+                [
+                    {
+                        "attempt_id": "attempt-1",
+                        "recorded_at": "2026-04-10T12:00:00Z",
+                        "status": "completed",
+                        "reported_by": "codex",
+                        "completion_claim_id": None,
+                        "artifact_references": [],
+                        "metadata": {"dispatch_trigger": "manual_api", "dispatch_mode": "manual"},
+                        "reevaluation": {},
+                    },
+                    {
+                        "attempt_id": "attempt-2",
+                        "recorded_at": "2026-04-10T12:05:00Z",
+                        "status": "failed",
+                        "reported_by": "codex",
+                        "completion_claim_id": None,
+                        "artifact_references": [],
+                        "metadata": {"dispatch_trigger": "manual_api", "dispatch_mode": "manual"},
+                        "reevaluation": {},
+                    },
+                ],
+            )
+        )
+
+        list_status, list_payload = self.list_tasks()
+        entry = self._tasks_by_id(list_payload)["e2e-list-execution-total-attempts"]
+
+        self.assertEqual(list_status, 200)
+        self.assertEqual(entry["execution_summary"]["attempt_count"], 2)
+        self.assertEqual(entry["execution_summary"]["total_attempts"], 2)
+        self.assertEqual(entry["execution_summary"]["latest_attempt"]["attempt_id"], "attempt-2")

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -717,6 +717,67 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertEqual(read_payload["task"]["execution_summary"]["attempt_count"], 1)
         self.assertIsNotNone(read_payload["task"]["execution_summary"]["latest_attempt"])
 
+    def test_read_model_total_attempts_does_not_undercount_recorded_execution_attempts(self) -> None:
+        submit_status, submit_payload = self.service.submit(
+            {
+                "request": {
+                    "task_envelope": create_task_envelope(
+                        {
+                            "id": "task-read-model-total-attempts-1",
+                            "title": "Execution attempt totals stay truthful",
+                            "description": "Read-model execution totals should not undercount recorded attempts.",
+                            "origin": {
+                                "source_system": "manual",
+                                "source_type": "manual",
+                                "source_id": "task-read-model-total-attempts-1",
+                            },
+                            "acceptance_criteria": [
+                                {
+                                    "id": "ac-1",
+                                    "description": "Execution totals reflect recorded attempts truthfully.",
+                                    "required": True,
+                                }
+                            ],
+                        },
+                        now="2026-04-10T00:00:00Z",
+                    )
+                }
+            }
+        )
+        task_id = submit_payload["task_envelope"]["id"]
+        task = deepcopy(self.store.get_task(task_id))
+        task["observability"]["execution_metadata"]["execution_attempts"] = [
+            {
+                "attempt_id": "attempt-1",
+                "recorded_at": "2026-04-10T00:05:00Z",
+                "status": "completed",
+                "reported_by": "codex",
+                "completion_claim_id": None,
+                "artifact_references": [],
+                "metadata": {"dispatch_trigger": "manual_api", "dispatch_mode": "manual"},
+                "reevaluation": {},
+            },
+            {
+                "attempt_id": "attempt-2",
+                "recorded_at": "2026-04-10T00:10:00Z",
+                "status": "failed",
+                "reported_by": "codex",
+                "completion_claim_id": None,
+                "artifact_references": [],
+                "metadata": {"dispatch_trigger": "manual_api", "dispatch_mode": "manual"},
+                "reevaluation": {},
+            },
+        ]
+        self.store.update_task(task)
+
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["execution_summary"]["attempt_count"], 2)
+        self.assertEqual(read_payload["task"]["execution_summary"]["total_attempts"], 2)
+        self.assertEqual(read_payload["task"]["execution_summary"]["latest_attempt"]["attempt_id"], "attempt-2")
+
     def test_read_model_exposes_clarification_summary_and_timeline_event(self) -> None:
         task_envelope = create_task_envelope(
             {


### PR DESCRIPTION
## Summary
- keep read-model and task-list execution totals from undercounting canonical execution attempts
- add detail and live-HTTP regressions for tasks that already carry recorded execution attempts
- document that execution_summary.total_attempts may exceed evaluation history but must never be lower than attempt_count

## Testing
- python3 -m unittest tests.test_read_model.HarnessReadModelServiceTests.test_read_model_total_attempts_does_not_undercount_recorded_execution_attempts tests.e2e.test_control_plane_task_list_execution_flows.ControlPlaneTaskListExecutionFlowTests.test_task_list_total_attempts_does_not_undercount_recorded_execution_attempts tests.test_read_model.HarnessReadModelServiceTests.test_read_model_exposes_retry_fields_for_retryable_failures tests.e2e.test_control_plane_retry_visibility_flows.ControlPlaneRetryVisibilityFlowTests.test_retryable_failure_surfaces_bounded_retry_state_across_inspection_surfaces -v
- python3 -m py_compile modules/read_model.py tests/test_read_model.py tests/e2e/test_control_plane_task_list_execution_flows.py
- python3 -m unittest discover -s tests
- git diff --check