### PR TITLE
Cover remaining review follow-up surfaces

### DIFF
--- a/tests/e2e/test_control_plane_task_list_triage_flows.py
+++ b/tests/e2e/test_control_plane_task_list_triage_flows.py
@@ -184,3 +184,93 @@ class ControlPlaneTaskListTriageFlowTests(RuntimeApiTestCase):
         self.assertFalse(entry["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"])
         self.assertEqual(entry["failure_summary"]["state"], "clear")
         self.assertEqual(entry["execution_summary"]["failure_state"], "clear")
+
+    def test_task_list_surfaces_manual_authorize_retry_as_resolved_review_with_active_assignment(self) -> None:
+        payload = {"request": to_jsonable(build_demo_request("review_required"))}
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "authorize_retry",
+        ]
+        review = self.create_evaluate_scenario(payload)
+        review.mutate_task(
+            lambda task: task.__setitem__(
+                "assigned_executor",
+                {
+                    "executor_type": "codex",
+                    "executor_id": "executor-e2e-task-list-retry-1",
+                    "assignment_reason": "Seed active assignment for task-list retry coverage.",
+                },
+            )
+        )
+
+        review.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        review.created.response["enforcement_result"]["review_request"],
+                        outcome="authorize_retry",
+                    )
+                }
+            }
+        )
+
+        list_status, list_payload = self.list_tasks()
+        entry = self._tasks_by_id(list_payload)[review.task_id]
+
+        self.assertEqual(list_status, 200)
+        self.assertEqual(entry["current_status"], "assigned")
+        self.assertEqual(entry["assigned_executor"]["executor_id"], "executor-e2e-task-list-retry-1")
+        self.assertEqual(entry["review_summary"]["status"], "resolved")
+        self.assertEqual(entry["review_summary"]["latest_decision"]["outcome"], "authorize_retry")
+        self.assertEqual(entry["verification_summary"]["outcome"], "review_resolved")
+        self.assertEqual(entry["verification_summary"]["target_status"], "assigned")
+        self.assertFalse(entry["verification_summary"]["accepted_completion"])
+        self.assertFalse(entry["verification_summary"]["claimed_completion"])
+        self.assertFalse(entry["verification_summary"]["evidence_is_sufficient"])
+        self.assertFalse(entry["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"])
+        self.assertEqual(entry["failure_summary"]["state"], "clear")
+        self.assertEqual(entry["execution_summary"]["failure_state"], "clear")
+
+    def test_task_list_surfaces_manual_clarification_as_resolved_review_plus_active_blocker(self) -> None:
+        payload = {"request": to_jsonable(build_demo_request("review_required"))}
+        payload["request"]["task_envelope"]["status"] = "assigned"
+        payload["request"]["task_envelope"]["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-e2e-task-list-review-clarification-1",
+            "assignment_reason": "Resume assigned work after manual review clarification.",
+        }
+        payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "require_clarification",
+        ]
+        review = self.create_evaluate_scenario(payload)
+
+        review.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        review.created.response["enforcement_result"]["review_request"],
+                        outcome="require_clarification",
+                    )
+                }
+            }
+        )
+
+        list_status, list_payload = self.list_tasks()
+        entry = self._tasks_by_id(list_payload)[review.task_id]
+
+        self.assertEqual(list_status, 200)
+        self.assertEqual(entry["current_status"], "blocked")
+        self.assertEqual(entry["assigned_executor"]["executor_id"], "executor-e2e-task-list-review-clarification-1")
+        self.assertEqual(entry["review_summary"]["status"], "resolved")
+        self.assertEqual(entry["review_summary"]["latest_decision"]["outcome"], "require_clarification")
+        self.assertEqual(entry["verification_summary"]["outcome"], "review_resolved")
+        self.assertEqual(entry["verification_summary"]["target_status"], "blocked")
+        self.assertFalse(entry["verification_summary"]["accepted_completion"])
+        self.assertFalse(entry["verification_summary"]["claimed_completion"])
+        self.assertFalse(entry["verification_summary"]["evidence_is_sufficient"])
+        self.assertEqual(entry["clarification_summary"]["status"], "required")
+        self.assertEqual(entry["clarification_summary"]["resume_target_status"], "assigned")
+        self.assertEqual(entry["clarification_summary"]["requested_by"], "manual_review")
+        self.assertEqual(entry["failure_summary"]["state"], "clear")
+        self.assertEqual(entry["execution_summary"]["failure_state"], "clear")

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -330,6 +330,100 @@ class HarnessReadModelServiceTests(unittest.TestCase):
             payload["task"]["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"]
         )
 
+    def test_read_model_surfaces_manual_authorize_retry_as_resolved_review_with_active_assignment(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "authorize_retry",
+        ]
+        submit_status, submit_payload = self.service.evaluate(initial_payload)
+        task_id = submit_payload["task_envelope"]["id"]
+
+        stored_task = deepcopy(self.service.store.get_task(task_id))
+        stored_task["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-read-model-review-retry-1",
+            "assignment_reason": "Seed active assignment for manual review retry projection coverage.",
+        }
+        self.service.store.update_task(stored_task)
+
+        reevaluate_status, _ = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        submit_payload["enforcement_result"]["review_request"],
+                        outcome="authorize_retry",
+                    )
+                }
+            },
+        )
+        status, payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(reevaluate_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task"]["current_status"], "assigned")
+        self.assertEqual(payload["task"]["assigned_executor"]["executor_id"], "executor-read-model-review-retry-1")
+        self.assertEqual(payload["task"]["review_summary"]["status"], "resolved")
+        self.assertEqual(payload["task"]["review_summary"]["latest_decision"]["outcome"], "authorize_retry")
+        self.assertEqual(payload["task"]["verification_summary"]["outcome"], "review_resolved")
+        self.assertEqual(payload["task"]["verification_summary"]["target_status"], "assigned")
+        self.assertFalse(payload["task"]["verification_summary"]["accepted_completion"])
+        self.assertFalse(payload["task"]["verification_summary"]["claimed_completion"])
+        self.assertFalse(payload["task"]["verification_summary"]["evidence_is_sufficient"])
+        self.assertFalse(
+            payload["task"]["verification_summary"]["acceptance_criteria_assessment"]["automatic_completion_safe"]
+        )
+        self.assertEqual(payload["task"]["failure_summary"]["state"], "clear")
+        self.assertEqual(payload["task"]["execution_summary"]["failure_state"], "clear")
+
+    def test_read_model_surfaces_manual_clarification_as_resolved_review_plus_active_blocker(self) -> None:
+        initial_payload = _request_payload("review_required")
+        initial_payload["request"]["task_envelope"]["status"] = "assigned"
+        initial_payload["request"]["task_envelope"]["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-read-model-review-clarification-1",
+            "assignment_reason": "Resume assigned work after manual review clarification.",
+        }
+        initial_payload["request"]["review_request"]["allowed_outcomes"] = [
+            "accept_completion",
+            "require_clarification",
+        ]
+        submit_status, submit_payload = self.service.evaluate(initial_payload)
+        task_id = submit_payload["task_envelope"]["id"]
+
+        reevaluate_status, _ = self.service.reevaluate(
+            task_id,
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        submit_payload["enforcement_result"]["review_request"],
+                        outcome="require_clarification",
+                    )
+                }
+            },
+        )
+        status, payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(reevaluate_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["task"]["current_status"], "blocked")
+        self.assertEqual(payload["task"]["assigned_executor"]["executor_id"], "executor-read-model-review-clarification-1")
+        self.assertEqual(payload["task"]["review_summary"]["status"], "resolved")
+        self.assertEqual(payload["task"]["review_summary"]["latest_decision"]["outcome"], "require_clarification")
+        self.assertEqual(payload["task"]["verification_summary"]["outcome"], "review_resolved")
+        self.assertEqual(payload["task"]["verification_summary"]["target_status"], "blocked")
+        self.assertFalse(payload["task"]["verification_summary"]["accepted_completion"])
+        self.assertFalse(payload["task"]["verification_summary"]["claimed_completion"])
+        self.assertFalse(payload["task"]["verification_summary"]["evidence_is_sufficient"])
+        self.assertEqual(payload["task"]["clarification_summary"]["status"], "required")
+        self.assertEqual(payload["task"]["clarification_summary"]["resume_target_status"], "assigned")
+        self.assertEqual(payload["task"]["clarification_summary"]["requested_by"], "manual_review")
+        self.assertEqual(payload["task"]["failure_summary"]["state"], "clear")
+        self.assertEqual(payload["task"]["execution_summary"]["failure_state"], "clear")
+
     def test_read_model_clears_pending_verification_projection_after_reconciliation_redispatch_failure(self) -> None:
         service = HarnessApiService(
             store=FileBackedHarnessStore(self.temp_dir.name),


### PR DESCRIPTION
## Summary
- add read-model regressions for manual-review authorize-retry and require-clarification follow-up states
- add live task-list coverage for those same operator-facing surfaces
- lock down the remaining follow-up paths from the audit without changing product semantics

## Testing
- python3 -m unittest tests.test_read_model.HarnessReadModelServiceTests.test_read_model_surfaces_manual_authorize_retry_as_resolved_review_with_active_assignment tests.test_read_model.HarnessReadModelServiceTests.test_read_model_surfaces_manual_clarification_as_resolved_review_plus_active_blocker tests.e2e.test_control_plane_task_list_triage_flows.ControlPlaneTaskListTriageFlowTests.test_task_list_surfaces_manual_authorize_retry_as_resolved_review_with_active_assignment tests.e2e.test_control_plane_task_list_triage_flows.ControlPlaneTaskListTriageFlowTests.test_task_list_surfaces_manual_clarification_as_resolved_review_plus_active_blocker -v
- python3 -m py_compile tests/test_read_model.py tests/e2e/test_control_plane_task_list_triage_flows.py
- python3 -m unittest discover -s tests
- git diff --check