### PR TITLE
Order latest execution summaries by recorded_at

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ For triage surfaces, `review_required` stays distinct from terminal failure. If 
 
 Within `execution_summary`, `attempt_count` is the number of recorded canonical execution attempts. `total_attempts` may be higher when retry/evaluation history exists without a new execution-attempt record, but it must never undercount the recorded execution attempts already attached to the task.
 
+That same chronology rule applies to the projected latest-attempt fields. `execution_summary.latest_attempt`, `latest_status`, and related latest-attempt details follow the newest recorded execution attempt by `recorded_at`; they do not trust raw list append order when stored attempt arrays arrive out of sequence.
+
 ## Storage And Environment
 
 Required frontend environment variable:

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -137,6 +137,8 @@ On `GET /tasks` and `GET /tasks/<task_id>/read-model`, `execution_summary.attemp
 
 `execution_summary.total_attempts` is broader: it can include retry/evaluation-chain activity even when no new execution-attempt record exists. It must never be lower than `attempt_count`, because inspection surfaces cannot truthfully report fewer total attempts than the canonical execution-attempt history already attached to the task.
 
+`execution_summary.latest_attempt`, `latest_status`, `latest_dispatch_origin`, and `latest_attempt_validation` must follow the newest recorded execution attempt by `recorded_at`. Clients must not treat storage append order as authoritative when execution-attempt arrays are out of sequence.
+
 ## Linear Facts Workflow Rule
 
 The `external_facts.linear_facts.workflow` field is conditional on `record_found`.

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -474,6 +474,19 @@ def _build_review_summary(records: tuple[EvaluationRecord, ...]) -> dict[str, An
     }
 
 
+def _latest_execution_attempt(execution_attempts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    valid_attempts = [attempt for attempt in execution_attempts if isinstance(attempt, dict)]
+    if not valid_attempts:
+        return None
+    return max(
+        valid_attempts,
+        key=lambda attempt: (
+            _parse_iso_timestamp(str(attempt.get("recorded_at") or "")),
+            str(attempt.get("attempt_id") or ""),
+        ),
+    )
+
+
 def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord, ...]) -> dict[str, Any]:
     execution_attempts = ((task_envelope.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []
     review_summary = _build_review_summary(records)
@@ -506,10 +519,7 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
             "retry_eligible": bool((latest_failure_summary or {}).get("recoverable")),
             "failure_state": failure_state,
         }
-    latest_attempt = next(
-        (attempt for attempt in reversed(execution_attempts) if isinstance(attempt, dict)),
-        None,
-    )
+    latest_attempt = _latest_execution_attempt(execution_attempts)
     attempt_count = len([attempt for attempt in execution_attempts if isinstance(attempt, dict)])
     for attempt in execution_attempts:
         if not isinstance(attempt, dict):

--- a/tests/e2e/test_control_plane_task_list_execution_flows.py
+++ b/tests/e2e/test_control_plane_task_list_execution_flows.py
@@ -172,3 +172,47 @@ class ControlPlaneTaskListExecutionFlowTests(RuntimeApiTestCase):
         self.assertEqual(entry["execution_summary"]["attempt_count"], 2)
         self.assertEqual(entry["execution_summary"]["total_attempts"], 2)
         self.assertEqual(entry["execution_summary"]["latest_attempt"]["attempt_id"], "attempt-2")
+
+    def test_task_list_uses_newest_recorded_execution_attempt_for_latest_summary(self) -> None:
+        scenario = self.create_task_scenario(
+            build_create_task_payload(
+                "e2e-list-execution-latest-attempt-by-recorded-at",
+                title="Task list latest attempt follows recorded_at",
+            )
+        )
+
+        scenario.mutate_task(
+            lambda task: task["observability"]["execution_metadata"].__setitem__(
+                "execution_attempts",
+                [
+                    {
+                        "attempt_id": "attempt-newer",
+                        "recorded_at": "2026-04-10T12:10:00Z",
+                        "status": "completed",
+                        "reported_by": "codex",
+                        "completion_claim_id": None,
+                        "artifact_references": [],
+                        "metadata": {"dispatch_trigger": "manual_api", "dispatch_mode": "manual"},
+                        "reevaluation": {},
+                    },
+                    {
+                        "attempt_id": "attempt-older",
+                        "recorded_at": "2026-04-10T12:05:00Z",
+                        "status": "failed",
+                        "reported_by": "codex",
+                        "completion_claim_id": None,
+                        "artifact_references": [],
+                        "metadata": {"dispatch_trigger": "manual_api", "dispatch_mode": "manual"},
+                        "reevaluation": {},
+                    },
+                ],
+            )
+        )
+
+        list_status, list_payload = self.list_tasks()
+        entry = self._tasks_by_id(list_payload)["e2e-list-execution-latest-attempt-by-recorded-at"]
+
+        self.assertEqual(list_status, 200)
+        self.assertEqual(entry["execution_summary"]["attempt_count"], 2)
+        self.assertEqual(entry["execution_summary"]["latest_attempt"]["attempt_id"], "attempt-newer")
+        self.assertEqual(entry["execution_summary"]["latest_status"], "completed")

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -1118,6 +1118,67 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertEqual(read_payload["task"]["execution_summary"]["total_attempts"], 2)
         self.assertEqual(read_payload["task"]["execution_summary"]["latest_attempt"]["attempt_id"], "attempt-2")
 
+    def test_read_model_uses_newest_recorded_execution_attempt_for_latest_summary(self) -> None:
+        submit_status, submit_payload = self.service.submit(
+            {
+                "request": {
+                    "task_envelope": create_task_envelope(
+                        {
+                            "id": "task-read-model-latest-attempt-by-recorded-at-1",
+                            "title": "Latest execution attempt follows recorded_at",
+                            "description": "Read-model execution summaries should follow canonical attempt chronology.",
+                            "origin": {
+                                "source_system": "manual",
+                                "source_type": "manual",
+                                "source_id": "task-read-model-latest-attempt-by-recorded-at-1",
+                            },
+                            "acceptance_criteria": [
+                                {
+                                    "id": "ac-1",
+                                    "description": "Execution summary picks the newest recorded attempt.",
+                                    "required": True,
+                                }
+                            ],
+                        },
+                        now="2026-04-10T00:00:00Z",
+                    )
+                }
+            }
+        )
+        task_id = submit_payload["task_envelope"]["id"]
+        task = deepcopy(self.store.get_task(task_id))
+        task["observability"]["execution_metadata"]["execution_attempts"] = [
+            {
+                "attempt_id": "attempt-newer",
+                "recorded_at": "2026-04-10T00:10:00Z",
+                "status": "completed",
+                "reported_by": "codex",
+                "completion_claim_id": None,
+                "artifact_references": [],
+                "metadata": {"dispatch_trigger": "manual_api", "dispatch_mode": "manual"},
+                "reevaluation": {},
+            },
+            {
+                "attempt_id": "attempt-older",
+                "recorded_at": "2026-04-10T00:05:00Z",
+                "status": "failed",
+                "reported_by": "codex",
+                "completion_claim_id": None,
+                "artifact_references": [],
+                "metadata": {"dispatch_trigger": "manual_api", "dispatch_mode": "manual"},
+                "reevaluation": {},
+            },
+        ]
+        self.store.update_task(task)
+
+        read_status, read_payload = self.service.get_task_read_model(task_id)
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(read_status, 200)
+        self.assertEqual(read_payload["task"]["execution_summary"]["attempt_count"], 2)
+        self.assertEqual(read_payload["task"]["execution_summary"]["latest_attempt"]["attempt_id"], "attempt-newer")
+        self.assertEqual(read_payload["task"]["execution_summary"]["latest_status"], "completed")
+
     def test_read_model_exposes_clarification_summary_and_timeline_event(self) -> None:
         task_envelope = create_task_envelope(
             {


### PR DESCRIPTION
## Summary
- order read-model latest execution attempt projection by `recorded_at` instead of raw list position
- add regression coverage for both read-model and task-list surfaces when execution attempts arrive out of sequence
- document that inspection surfaces treat `recorded_at` as the canonical latest-attempt ordering signal

## Verification
- python3 -m unittest tests.test_read_model.HarnessReadModelServiceTests.test_read_model_uses_newest_recorded_execution_attempt_for_latest_summary -v
- python3 -m unittest tests.e2e.test_control_plane_task_list_execution_flows.ControlPlaneTaskListExecutionFlowTests.test_task_list_uses_newest_recorded_execution_attempt_for_latest_summary -v
- python3 -m unittest tests.test_read_model.HarnessReadModelServiceTests.test_read_model_total_attempts_does_not_undercount_recorded_execution_attempts tests.e2e.test_control_plane_task_list_execution_flows.ControlPlaneTaskListExecutionFlowTests.test_task_list_total_attempts_does_not_undercount_recorded_execution_attempts -v
- python3 -m unittest tests.test_read_model tests.e2e.test_control_plane_task_list_execution_flows -v
- python3 -m py_compile /Users/ssbob/Documents/Developer/Knox_Analytics/Harness/modules/read_model.py /Users/ssbob/Documents/Developer/Knox_Analytics/Harness/tests/test_read_model.py /Users/ssbob/Documents/Developer/Knox_Analytics/Harness/tests/e2e/test_control_plane_task_list_execution_flows.py
- git diff --check
- python3 -m unittest discover -s tests