### PR TITLE
Order current-run attempt binding by recorded_at

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Within `execution_summary`, `attempt_count` is the number of recorded canonical 
 
 That same chronology rule applies to the projected latest-attempt fields. `execution_summary.latest_attempt`, `latest_status`, and related latest-attempt details follow the newest recorded execution attempt by `recorded_at`; they do not trust raw list append order when stored attempt arrays arrive out of sequence.
 
+That chronology rule also applies to current-run binding outside the read model. When reconciliation or replay logic needs the active execution attempt and there is no explicit completion-claim `attempt_id` binding, Harness selects the newest recorded execution attempt by `recorded_at` rather than whichever attempt happened to be appended last.
+
 ## Storage And Environment
 
 Required frontend environment variable:

--- a/docs/architecture/reconciliation-rules.md
+++ b/docs/architecture/reconciliation-rules.md
@@ -308,7 +308,7 @@ For `missing_pr_after_execution`, Harness runs a pluggable reconciliation handle
 1. Check that the target branch exists through Git or the GitHub API.
 2. If the commit SHA is missing but repository and branch are known, resolve the current branch head SHA through Git or the GitHub API.
 3. Validate that the resulting commit SHA is present, non-empty, and resolvable.
-4. Bind the current completion claim to the specific execution attempt it references, using the explicit claim `attempt_id` when present rather than whichever attempt happens to be latest.
+4. Bind the current completion claim to the specific execution attempt it references, using the explicit claim `attempt_id` when present rather than whichever attempt happens to be latest. When no explicit attempt binding is available, treat the current attempt as the newest recorded execution attempt by `recorded_at`, not raw append order.
 5. Compare repository, branch, and commit context across `external_facts`, attached artifacts, and execution-attempt metadata. If those sources disagree, stop and record the conflict rather than choosing one implicitly.
 6. If repository and branch identity come from execution metadata or normalized external facts, do not let attached artifacts silently backfill a missing commit SHA. Leave commit identity unresolved and continue through the bounded recovery path instead of treating historical artifact state as current-run proof.
 7. When reading execution-attempt metadata, ignore non-code artifact references. Support references such as review notes may provide audit context, but they must not seed repository, branch, or commit identity for reconciliation.

--- a/modules/api.py
+++ b/modules/api.py
@@ -1818,10 +1818,21 @@ def _advisory_completion_claim_by_id(task_envelope: dict[str, Any], claim_id: st
 
 
 def _latest_execution_attempt(task_envelope: dict[str, Any]) -> dict[str, Any] | None:
-    attempts = ((task_envelope.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []
+    attempts = (
+        ((task_envelope.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []
+    )
     if not isinstance(attempts, list):
         return None
-    return next((attempt for attempt in reversed(attempts) if isinstance(attempt, dict)), None)
+    dict_attempts = [attempt for attempt in attempts if isinstance(attempt, dict)]
+    if not dict_attempts:
+        return None
+    return max(
+        dict_attempts,
+        key=lambda attempt: (
+            _parse_iso_timestamp(str(attempt.get("recorded_at") or "")),
+            str(attempt.get("attempt_id") or ""),
+        ),
+    )
 
 
 def _execution_attempts(task_envelope: dict[str, Any]) -> list[dict[str, Any]]:

--- a/modules/reconciliation_runtime.py
+++ b/modules/reconciliation_runtime.py
@@ -487,7 +487,7 @@ def _context_from_execution_attempt(task_envelope: TaskEnvelope) -> Reconciliati
     if not isinstance(attempts, list):
         return None
 
-    latest_attempt = next((attempt for attempt in reversed(attempts) if isinstance(attempt, dict)), None)
+    latest_attempt = _latest_recorded_execution_attempt(attempts)
     if latest_attempt is None:
         return None
 
@@ -733,6 +733,27 @@ def _current_completion_claim(task_envelope: TaskEnvelope) -> dict[str, Any] | N
     return next((claim for claim in reversed(claims) if isinstance(claim, dict)), None)
 
 
+def _parse_iso_timestamp(value: str | None):
+    from datetime import datetime, timezone
+
+    if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _latest_recorded_execution_attempt(attempts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    valid_attempts = [attempt for attempt in attempts if isinstance(attempt, dict)]
+    if not valid_attempts:
+        return None
+    return max(
+        valid_attempts,
+        key=lambda attempt: (
+            _parse_iso_timestamp(str(attempt.get("recorded_at") or "")),
+            str(attempt.get("attempt_id") or ""),
+        ),
+    )
+
+
 def _current_execution_attempt(task_envelope: TaskEnvelope) -> dict[str, Any] | None:
     execution_metadata = ((task_envelope.get("observability") or {}).get("execution_metadata") or {})
     attempts = execution_metadata.get("execution_attempts") or []
@@ -741,26 +762,36 @@ def _current_execution_attempt(task_envelope: TaskEnvelope) -> dict[str, Any] | 
 
     claim = _current_completion_claim(task_envelope)
     if claim is None:
-        return next((attempt for attempt in reversed(attempts) if isinstance(attempt, dict)), None)
+        return _latest_recorded_execution_attempt(attempts)
 
     claim_metadata = claim.get("metadata") if isinstance(claim.get("metadata"), dict) else {}
     attempt_id = _normalize_sha(claim_metadata.get("attempt_id"))
     if attempt_id is not None:
-        for attempt in reversed(attempts):
-            if not isinstance(attempt, dict):
-                continue
-            if _normalize_sha(attempt.get("attempt_id")) == attempt_id:
-                return attempt
+        matching_attempt = _latest_recorded_execution_attempt(
+            [
+                attempt
+                for attempt in attempts
+                if isinstance(attempt, dict)
+                and _normalize_sha(attempt.get("attempt_id")) == attempt_id
+            ]
+        )
+        if matching_attempt is not None:
+            return matching_attempt
 
     claim_id = _normalize_sha(claim.get("claim_id"))
     if claim_id is not None:
-        for attempt in reversed(attempts):
-            if not isinstance(attempt, dict):
-                continue
-            if _normalize_sha(attempt.get("completion_claim_id")) == claim_id:
-                return attempt
+        matching_attempt = _latest_recorded_execution_attempt(
+            [
+                attempt
+                for attempt in attempts
+                if isinstance(attempt, dict)
+                and _normalize_sha(attempt.get("completion_claim_id")) == claim_id
+            ]
+        )
+        if matching_attempt is not None:
+            return matching_attempt
 
-    return next((attempt for attempt in reversed(attempts) if isinstance(attempt, dict)), None)
+    return _latest_recorded_execution_attempt(attempts)
 
 
 def _execution_attempt_count(task_envelope: TaskEnvelope) -> int:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from modules.adapters.executor_adapter import StubExecutorAdapter
-from modules.api import HarnessApiService, build_parser, evaluate_http_payload, run_server
+from modules.api import HarnessApiService, _latest_execution_attempt, build_parser, evaluate_http_payload, run_server
 from modules.reconciliation_runtime import (
     GitHubPullRequestRecord,
     ReconciliationFailureType,
@@ -55,6 +55,33 @@ class _FakeCursor:
         row = self._rows[self._index]
         self._index += 1
         return row
+
+
+class LatestExecutionAttemptTests(unittest.TestCase):
+    def test_latest_execution_attempt_uses_newest_recorded_attempt_when_out_of_order(self) -> None:
+        task = {
+            "observability": {
+                "execution_metadata": {
+                    "execution_attempts": [
+                        {
+                            "attempt_id": "attempt-newer",
+                            "recorded_at": "2026-04-11T09:10:05Z",
+                            "status": "completed",
+                        },
+                        {
+                            "attempt_id": "attempt-older",
+                            "recorded_at": "2026-04-11T09:05:05Z",
+                            "status": "failed",
+                        },
+                    ]
+                }
+            }
+        }
+
+        attempt = _latest_execution_attempt(task)
+
+        self.assertIsNotNone(attempt)
+        self.assertEqual(attempt["attempt_id"], "attempt-newer")
 
 
 class _FakeConnection:

--- a/tests/test_reconciliation_runtime.py
+++ b/tests/test_reconciliation_runtime.py
@@ -11,6 +11,7 @@ from modules.reconciliation_runtime import (
     ReconciliationRuntimeError,
     RetryableReconciliationRuntimeError,
     _context_from_artifacts,
+    _current_execution_attempt,
     _context_from_execution_attempt,
     _resolved_code_context,
 )
@@ -448,6 +449,140 @@ class ResolveCodeContextTests(unittest.TestCase):
         self.assertEqual(selected, "merged")
         self.assertEqual(context.branch_name, "codex/e2e-test")
         self.assertEqual(context.commit_sha, "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705")
+
+    def test_current_execution_attempt_uses_newest_recorded_attempt_when_attempts_are_out_of_order(self) -> None:
+        task = create_task_envelope(
+            {
+                "id": "task-current-execution-attempt-ordering-1",
+                "title": "Current execution attempt follows recorded_at",
+                "description": "Current attempt binding should not trust raw append order.",
+                "origin": {
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request",
+                    "source_id": "req-current-execution-attempt-ordering-1",
+                },
+                "acceptance_criteria": [
+                    {
+                        "id": "ac-1",
+                        "description": "Current attempt falls back to the newest recorded attempt.",
+                        "required": True,
+                    }
+                ],
+            },
+            now="2026-04-11T09:00:00Z",
+        )
+        execution_metadata = task["observability"]["execution_metadata"]
+        execution_metadata["advisory_completion_claims"] = [
+            {
+                "claim_id": "claim-newer",
+                "reported_at": "2026-04-11T09:10:00Z",
+                "reported_by": "codex",
+                "reason": "newer historical claim",
+                "metadata": {"attempt_id": "attempt-newer"},
+            },
+            {
+                "claim_id": "claim-current",
+                "reported_at": "2026-04-11T09:15:00Z",
+                "reported_by": "codex",
+                "reason": "current completion claim without explicit attempt binding",
+                "metadata": {},
+            },
+        ]
+        execution_metadata["execution_attempts"] = [
+            {
+                "attempt_id": "attempt-newer",
+                "recorded_at": "2026-04-11T09:10:05Z",
+                "status": "completed",
+                "reported_by": "codex",
+                "completion_claim_id": "claim-newer",
+                "artifact_references": [],
+                "metadata": {"executor_run_id": "run-attempt-newer"},
+                "reevaluation": {},
+            },
+            {
+                "attempt_id": "attempt-older",
+                "recorded_at": "2026-04-11T09:05:05Z",
+                "status": "failed",
+                "reported_by": "codex",
+                "completion_claim_id": "claim-older",
+                "artifact_references": [],
+                "metadata": {"executor_run_id": "run-attempt-older"},
+                "reevaluation": {},
+            },
+        ]
+
+        attempt = _current_execution_attempt(task)
+
+        self.assertIsNotNone(attempt)
+        self.assertEqual(attempt["attempt_id"], "attempt-newer")
+
+    def test_execution_attempt_context_uses_newest_recorded_attempt_when_attempts_are_out_of_order(self) -> None:
+        task = create_task_envelope(
+            {
+                "id": "task-context-execution-attempt-ordering-1",
+                "title": "Execution attempt context follows recorded_at",
+                "description": "Reconciliation context should bind to the newest recorded execution attempt.",
+                "origin": {
+                    "source_system": "openclaw",
+                    "source_type": "ingress_request",
+                    "source_id": "req-context-execution-attempt-ordering-1",
+                },
+                "acceptance_criteria": [
+                    {
+                        "id": "ac-1",
+                        "description": "Execution-attempt context comes from the newest recorded attempt.",
+                        "required": True,
+                    }
+                ],
+            },
+            now="2026-04-11T09:00:00Z",
+        )
+        task["observability"]["execution_metadata"]["execution_attempts"] = [
+            {
+                "attempt_id": "attempt-newer",
+                "recorded_at": "2026-04-11T09:10:05Z",
+                "artifact_references": [
+                    {
+                        "reference_id": "attempt-newer-ref-1",
+                        "artifact_type": "branch",
+                        "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/tree/codex/e2e-test-newer",
+                        "metadata": {
+                            "repository_host": "github.com",
+                            "repository_owner": "KnoxAnalytics",
+                            "repository_name": "HARNESS-DRYRUN",
+                            "branch_name": "codex/e2e-test-newer",
+                            "base_branch": "main",
+                            "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        },
+                    }
+                ],
+            },
+            {
+                "attempt_id": "attempt-older",
+                "recorded_at": "2026-04-11T09:05:05Z",
+                "artifact_references": [
+                    {
+                        "reference_id": "attempt-older-ref-1",
+                        "artifact_type": "branch",
+                        "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/tree/codex/e2e-test-older",
+                        "metadata": {
+                            "repository_host": "github.com",
+                            "repository_owner": "KnoxAnalytics",
+                            "repository_name": "HARNESS-DRYRUN",
+                            "branch_name": "codex/e2e-test-older",
+                            "base_branch": "main",
+                            "commit_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        },
+                    }
+                ],
+            },
+        ]
+
+        context = _context_from_execution_attempt(task)
+
+        self.assertIsNotNone(context)
+        self.assertEqual(context.branch_name, "codex/e2e-test-newer")
+        self.assertEqual(context.commit_sha, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
     def test_ignores_support_artifact_references_in_execution_attempt_context(self) -> None:
         task = create_task_envelope(


### PR DESCRIPTION
## Summary
- order current-run execution-attempt binding by `recorded_at` in reconciliation/runtime and API replay helpers instead of raw append order
- add regressions covering current attempt selection, execution-attempt reconciliation context, and API latest-attempt fallback when attempts arrive out of sequence
- document that unbound current-run selection follows the newest recorded attempt chronologically

## Verification
- python3 -m unittest tests.test_reconciliation_runtime.ResolveCodeContextTests.test_current_execution_attempt_uses_newest_recorded_attempt_when_attempts_are_out_of_order -v
- python3 -m unittest tests.test_reconciliation_runtime.ResolveCodeContextTests.test_execution_attempt_context_uses_newest_recorded_attempt_when_attempts_are_out_of_order -v
- python3 -m unittest tests.test_api.LatestExecutionAttemptTests.test_latest_execution_attempt_uses_newest_recorded_attempt_when_out_of_order -v
- python3 -m unittest tests.test_reconciliation_runtime tests.test_api.LatestExecutionAttemptTests tests.test_completion_claim_reconciliation.CompletionClaimReconciliationTests.test_submit_completion_claim_reconciles_against_explicitly_claimed_attempt_not_latest_attempt -v
- python3 -m py_compile /Users/ssbob/Documents/Developer/Knox_Analytics/Harness/modules/api.py /Users/ssbob/Documents/Developer/Knox_Analytics/Harness/modules/reconciliation_runtime.py /Users/ssbob/Documents/Developer/Knox_Analytics/Harness/tests/test_api.py /Users/ssbob/Documents/Developer/Knox_Analytics/Harness/tests/test_reconciliation_runtime.py /Users/ssbob/Documents/Developer/Knox_Analytics/Harness/tests/test_completion_claim_reconciliation.py
- git diff --check
- python3 -m unittest discover -s tests