### PR TITLE
[codex] Refresh demo proof bundles against current semantics

### DIFF
--- a/docs/demo/kno-181-invalid-execution-attempt-gate/generate_proof_bundle.py
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/generate_proof_bundle.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from modules.api import HarnessApiService
+from modules.intake import create_task_envelope
+from modules.store import FileBackedHarnessStore
+from tests.test_api import (
+    _completion_claim_payload,
+    _execution_attempt_payload,
+    _registry_with_no_create_pull_request_gateway,
+)
+
+BUNDLE_DIR = Path("docs/demo/kno-181-invalid-execution-attempt-gate")
+TASK_CREATED_AT = "2026-03-31T14:30:00Z"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _base_task(*, task_id: str, description: str, executor_id: str) -> dict:
+    task = create_task_envelope(
+        {
+            "id": task_id,
+            "title": f"KNO-181 {task_id}",
+            "description": description,
+            "origin": {
+                "source_system": "openclaw",
+                "source_type": "ingress_request",
+                "source_id": "req-happy-overlay-1",
+            },
+            "acceptance_criteria": [
+                {
+                    "id": "ac-1",
+                    "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                    "required": True,
+                }
+            ],
+        },
+        now=TASK_CREATED_AT,
+    )
+    task["status"] = "assigned"
+    task["assigned_executor"] = {
+        "executor_type": "codex",
+        "executor_id": executor_id,
+        "assignment_reason": description,
+    }
+    return task
+
+
+def _seed_artifacts(task: dict) -> tuple[dict, dict]:
+    seeded_task = deepcopy(task)
+    seed_request = {
+        "request": {
+            "task_envelope": {
+                **deepcopy(task),
+                "status": "intake_ready",
+                "assigned_executor": None,
+            },
+            "assigned_executor": deepcopy(task["assigned_executor"]),
+        }
+    }
+    seed_response = {
+        "status": 200,
+        "response": {
+            "action": "seeded_controlled_task",
+            "target_status": "assigned",
+            "task_envelope": seeded_task,
+        },
+    }
+    return seed_request, seed_response
+
+
+def _scenario_a() -> dict:
+    task = _base_task(
+        task_id="task-kno-181-scenario-a",
+        description="Scenario A: invalid execution attempt without current-run code identity proof.",
+        executor_id="executor-kno-181-a",
+    )
+    seed_request, seed_response = _seed_artifacts(task)
+
+    invalid_attempt_payload = _execution_attempt_payload(attempt_id="attempt-kno-181-a-1")
+    invalid_attempt_payload["execution_attempt"]["recorded_at"] = "2026-04-01T08:00:05Z"
+    invalid_attempt_payload["execution_attempt"]["reported_by"] = "stub-executor"
+    invalid_attempt_payload["execution_attempt"]["metadata"] = {"executor_run_id": "stub-run-attempt-kno-181-a-1"}
+    invalid_attempt_payload["execution_attempt"]["artifact_references"] = [
+        {
+            "reference_id": "attempt-kno-181-a-1:commit",
+            "artifact_type": "commit",
+            "location": "stub://attempts/attempt-kno-181-a-1/commit",
+            "metadata": {
+                "branch_name": "codex/e2e-test",
+            },
+        }
+    ]
+    request_payload = {
+        "request": {
+            **_completion_claim_payload(claim_id="claim-kno-181-a-1"),
+            **invalid_attempt_payload,
+            "runtime_facts": {"executor_reported_success": True, "attempt_count": 1},
+        }
+    }
+    request_payload["request"]["completion_claim"]["reported_at"] = "2026-04-01T08:00:00Z"
+    request_payload["request"]["completion_claim"]["reported_by"] = "stub-executor"
+
+    with TemporaryDirectory(prefix="kno181-scenario-a-") as temp_dir:
+        service = HarnessApiService(store=FileBackedHarnessStore(temp_dir))
+        service.store.create_task(task)
+
+        read_initial_status, read_initial = service.get_task_read_model(task["id"])
+        timeline_initial_status, timeline_initial = service.get_task_timeline(task["id"])
+
+        with patch.dict("os.environ", {"HARNESS_INVALID_EXECUTION_RETRY_BUDGET": "1"}):
+            claim_status, claim_response = service.submit_completion_claim(task["id"], request_payload)
+
+        read_final_status, read_final = service.get_task_read_model(task["id"])
+        timeline_final_status, timeline_final = service.get_task_timeline(task["id"])
+        history_status, history = service.get_evaluation_history(task["id"])
+
+    prefix = BUNDLE_DIR / "scenario-a"
+    _write_json(prefix.with_name("scenario-a-submit-request.json"), seed_request)
+    _write_json(prefix.with_name("scenario-a-submit-response.json"), seed_response)
+    _write_json(prefix.with_name("scenario-a-completion-claim-request.json"), request_payload)
+    _write_json(prefix.with_name("scenario-a-completion-claim-response.json"), {"status": claim_status, "response": claim_response})
+    _write_json(prefix.with_name("scenario-a-read-model-initial.json"), read_initial)
+    _write_json(prefix.with_name("scenario-a-read-model-final.json"), read_final)
+    _write_json(prefix.with_name("scenario-a-timeline-initial.json"), timeline_initial)
+    _write_json(prefix.with_name("scenario-a-timeline-final.json"), timeline_final)
+    _write_json(prefix.with_name("scenario-a-evaluation-history-final.json"), history)
+
+    checks = {
+        "claim_http_200": claim_status == 200,
+        "read_model_http_200": read_initial_status == 200 and read_final_status == 200,
+        "timeline_http_200": timeline_initial_status == 200 and timeline_final_status == 200,
+        "history_http_200": history_status == 200,
+        "action_contract_violation_failed": claim_response.get("action") == "contract_violation_failed",
+        "task_failed": claim_response.get("task_envelope", {}).get("status") == "failed",
+        "invalid_execution_attempt_present": bool(claim_response.get("invalid_execution_attempt")),
+    }
+    return {
+        "scenario": "a",
+        "checks": checks,
+        "all_checks_passed": all(checks.values()),
+    }
+
+
+def _scenario_b() -> dict:
+    task = _base_task(
+        task_id="task-kno-181-scenario-b",
+        description="Scenario B: valid attributable execution attempt with missing PR proof.",
+        executor_id="executor-kno-181-b",
+    )
+    seed_request, seed_response = _seed_artifacts(task)
+
+    valid_attempt_payload = _execution_attempt_payload(attempt_id="attempt-kno-181-b-1")
+    valid_attempt_payload["execution_attempt"]["recorded_at"] = "2026-04-01T08:00:05Z"
+    valid_attempt_payload["execution_attempt"]["reported_by"] = "stub-executor"
+    valid_attempt_payload["execution_attempt"]["metadata"] = {"executor_run_id": "stub-run-attempt-kno-181-b-1"}
+    valid_attempt_payload["execution_attempt"]["artifact_references"] = [
+        {
+            "reference_id": "attempt-kno-181-b-1:commit",
+            "artifact_type": "commit",
+            "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "metadata": {
+                "repository_host": "github.com",
+                "repository_owner": "KnoxAnalytics",
+                "repository_name": "HARNESS-DRYRUN",
+                "branch_name": "codex/e2e-test",
+                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            },
+        }
+    ]
+    request_payload = {
+        "request": {
+            **_completion_claim_payload(claim_id="claim-kno-181-b-1"),
+            **valid_attempt_payload,
+            "runtime_facts": {"executor_reported_success": True, "attempt_count": 1},
+        }
+    }
+    request_payload["request"]["completion_claim"]["reported_at"] = "2026-04-01T08:00:00Z"
+    request_payload["request"]["completion_claim"]["reported_by"] = "stub-executor"
+
+    with TemporaryDirectory(prefix="kno181-scenario-b-") as temp_dir:
+        service = HarnessApiService(
+            store=FileBackedHarnessStore(temp_dir),
+            reconciliation_registry=_registry_with_no_create_pull_request_gateway(),
+        )
+        service.store.create_task(task)
+
+        read_initial_status, read_initial = service.get_task_read_model(task["id"])
+        timeline_initial_status, timeline_initial = service.get_task_timeline(task["id"])
+        claim_status, claim_response = service.submit_completion_claim(task["id"], request_payload)
+        read_final_status, read_final = service.get_task_read_model(task["id"])
+        timeline_final_status, timeline_final = service.get_task_timeline(task["id"])
+        history_status, history = service.get_evaluation_history(task["id"])
+
+    prefix = BUNDLE_DIR / "scenario-b"
+    _write_json(prefix.with_name("scenario-b-submit-request.json"), seed_request)
+    _write_json(prefix.with_name("scenario-b-submit-response.json"), seed_response)
+    _write_json(prefix.with_name("scenario-b-completion-claim-request.json"), request_payload)
+    _write_json(prefix.with_name("scenario-b-completion-claim-response.json"), {"status": claim_status, "response": claim_response})
+    _write_json(prefix.with_name("scenario-b-read-model-initial.json"), read_initial)
+    _write_json(prefix.with_name("scenario-b-read-model-final.json"), read_final)
+    _write_json(prefix.with_name("scenario-b-timeline-initial.json"), timeline_initial)
+    _write_json(prefix.with_name("scenario-b-timeline-final.json"), timeline_final)
+    _write_json(prefix.with_name("scenario-b-evaluation-history-final.json"), history)
+
+    checks = {
+        "claim_http_200": claim_status == 200,
+        "read_model_http_200": read_initial_status == 200 and read_final_status == 200,
+        "timeline_http_200": timeline_initial_status == 200 and timeline_final_status == 200,
+        "history_http_200": history_status == 200,
+        "action_reconciliation_failed": claim_response.get("action") == "reconciliation_failed",
+        "task_in_review": claim_response.get("task_envelope", {}).get("status") == "in_review",
+        "review_request_present": bool(claim_response.get("review_request")),
+        "read_model_review_requested": ((read_final.get("task", {}).get("review_summary") or {}).get("status")) == "requested",
+        "read_model_assignment_hidden": read_final.get("task", {}).get("assigned_executor") is None,
+    }
+    return {
+        "scenario": "b",
+        "checks": checks,
+        "all_checks_passed": all(checks.values()),
+    }
+
+
+def main() -> None:
+    BUNDLE_DIR.mkdir(parents=True, exist_ok=True)
+    scenarios = [_scenario_a(), _scenario_b()]
+    summary = {
+        "proof_name": "kno-181-invalid-execution-attempt-gate",
+        "execution_mode": "local-controlled",
+        "hosted_validation": "not_performed",
+        "scenarios": scenarios,
+        "overall": {
+            "all_scenarios_passed": all(item["all_checks_passed"] for item in scenarios),
+            "conclusion": "validated" if all(item["all_checks_passed"] for item in scenarios) else "partially validated",
+        },
+    }
+    _write_json(BUNDLE_DIR / "summary.json", summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/proof.md
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/proof.md
@@ -5,17 +5,18 @@
 - Repository: `sfayka/Harness`
 - Validation mode: **local controlled run** using `HarnessApiService` with a deterministic in-memory/file-backed harness store.
 - Hosted execution: **not used** in this run. No hosted proof is claimed.
+- Generator: `PYTHONPATH=. python docs/demo/kno-181-invalid-execution-attempt-gate/generate_proof_bundle.py`
 - Goal: prove the boundary between:
   1. `invalid_execution_attempt` (no attributable current-run repository/branch/commit proof), and
   2. `missing_pr_after_execution` (real attributable run exists, PR proof still missing).
 
-A deterministic GitHub reconciliation gateway stub was used for reproducibility. It confirms branch/commit existence but intentionally fails PR creation so Scenario B remains in the missing-PR boundary and does not mutate into a created PR artifact.
+A deterministic GitHub reconciliation gateway stub was used for reproducibility. It confirms branch/commit existence but intentionally fails PR creation so Scenario B remains in the missing-PR boundary and requires explicit manual review instead of mutating into a created PR artifact.
 
 ## Scenario A — Invalid execution attempt
 
 ### Construction
 
-- Created a task with assigned code executor.
+- Seeded a controlled local task with an assigned code executor.
 - Submitted a completion claim with a successful execution attempt that only provided an execution log artifact.
 - **No repository / branch / commit current-run proof** was included.
 - Set `HARNESS_INVALID_EXECUTION_RETRY_BUDGET=1` to force a bounded retry and terminal outcome for validation.
@@ -59,7 +60,7 @@ Artifacts:
 
 ### Construction
 
-- Created a task with assigned code executor.
+- Seeded a controlled local task with an assigned code executor.
 - Submitted a completion claim with a successful execution attempt that includes explicit current-run code identity:
   - repository host/owner/name,
   - branch name,
@@ -95,6 +96,8 @@ Artifacts:
 - Reconciliation failure type: `missing_pr_after_execution`.
 - Latest execution attempt validation: `status=valid`.
 - Task moved to `in_review` (manual review required after reconciliation failure).
+- Final read-model now shows `review_summary.status=requested`.
+- Final read-model hides the stale `assigned_executor` while the review gate remains active.
 - No `invalid_execution_attempt` response block appears.
 - Timeline captures reconciliation attempt/failure events for missing PR.
 

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-completion-claim-request.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-completion-claim-request.json
@@ -2,32 +2,35 @@
   "request": {
     "completion_claim": {
       "claim_id": "claim-kno-181-a-1",
-      "reported_at": "2026-04-01T08:00:00Z",
-      "reported_by": "stub-executor",
-      "reason": "executor reported completion",
       "metadata": {
         "attempt_id": "attempt-1"
-      }
+      },
+      "reason": "executor reported completion",
+      "reported_at": "2026-04-01T08:00:00Z",
+      "reported_by": "stub-executor"
     },
     "execution_attempt": {
-      "attempt_id": "attempt-kno-181-a-1",
-      "recorded_at": "2026-04-01T08:00:05Z",
-      "status": "succeeded",
-      "reported_by": "stub-executor",
       "artifact_references": [
         {
-          "reference_id": "attempt-kno-181-a-1:log",
-          "artifact_type": "execution_log",
-          "location": "stub://attempts/log"
+          "artifact_type": "commit",
+          "location": "stub://attempts/attempt-kno-181-a-1/commit",
+          "metadata": {
+            "branch_name": "codex/e2e-test"
+          },
+          "reference_id": "attempt-kno-181-a-1:commit"
         }
       ],
+      "attempt_id": "attempt-kno-181-a-1",
       "metadata": {
         "executor_run_id": "stub-run-attempt-kno-181-a-1"
-      }
+      },
+      "recorded_at": "2026-04-01T08:00:05Z",
+      "reported_by": "stub-executor",
+      "status": "succeeded"
     },
     "runtime_facts": {
-      "executor_reported_success": true,
-      "attempt_count": 1
+      "attempt_count": 1,
+      "executor_reported_success": true
     }
   }
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-completion-claim-response.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-completion-claim-response.json
@@ -1,224 +1,27 @@
 {
-  "status": 200,
   "response": {
-    "action": "invalid_execution_attempt_failed",
     "accepted_completion": false,
-    "requires_review": false,
-    "invalid_input": false,
-    "target_status": "failed",
-    "error": "Successful execution attempt is missing repository identity for the current run.",
-    "reasons": [
-      "Successful execution attempt is missing repository identity for the current run.",
-      "Successful execution attempt is missing branch identity for the current run.",
-      "Successful execution attempt is missing commit SHA for the current run."
-    ],
-    "invalid_execution_attempt": {
-      "status": "retry_scheduled",
-      "validation": {
-        "validated_at": "2026-04-05T17:30:31.541310Z",
-        "validated_by": "execution_validation",
-        "policy": {
-          "require_repository": true,
-          "require_exact_branch": true,
-          "require_commit": true,
-          "allow_missing_pull_request": true,
-          "task_artifact_fallback_requires_single_attempt": true
-        },
-        "context_observations": {
-          "used_task_artifact_fallback": false
-        },
-        "status": "invalid",
-        "failure_type": "invalid_execution_attempt",
-        "retryable": true,
-        "reasons": [
-          "Successful execution attempt is missing repository identity for the current run.",
-          "Successful execution attempt is missing branch identity for the current run.",
-          "Successful execution attempt is missing commit SHA for the current run."
-        ]
-      },
-      "retry_context": {
-        "attempt_number": 1,
-        "max_retries": 1,
-        "triggered_by_category": "invalid_execution_attempt",
-        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run.",
-        "is_final_attempt": true,
-        "scheduled_at": "2026-04-05T17:30:31.543299Z"
-      },
-      "evaluation_record": {
-        "evaluation_id": "11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-        "task_id": "task-kno-181-scenario-a",
-        "recorded_at": "2026-04-05T17:30:31.543550Z",
+    "action": "contract_violation_failed",
+    "contract_violation": {
+      "failure_evaluation_record": {
+        "evaluation_id": "bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+        "recorded_at": "2026-04-11T16:04:28.882026Z",
         "request": {
-          "task_envelope": {
-            "acceptance_criteria": [
-              {
-                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-                "id": "ac-1",
-                "required": true
-              }
-            ],
-            "artifacts": {
-              "completion_evidence": {
-                "notes": null,
-                "policy": "deferred",
-                "required_artifact_types": [],
-                "status": "deferred",
-                "validated_artifact_ids": [],
-                "validated_at": null,
-                "validation_method": "deferred",
-                "validator": null
-              },
-              "items": []
-            },
-            "assigned_executor": {
-              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-              "executor_id": "executor-kno-181-a",
-              "executor_type": "codex"
-            },
-            "child_task_ids": [],
-            "constraints": [],
-            "coordination": {
-              "linear": null
-            },
-            "dependencies": [],
-            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "id": "task-kno-181-scenario-a",
-            "objective": {
-              "deliverable_type": "unspecified",
-              "success_signal": "Task satisfies declared acceptance criteria.",
-              "summary": "Exercise /evaluate with top-level evidence overlays."
-            },
-            "observability": {
-              "errors": [],
-              "execution_metadata": {
-                "schema_required_deferred_fields": [
-                  "parent_task_id",
-                  "child_task_ids",
-                  "dependencies",
-                  "assigned_executor",
-                  "required_capabilities",
-                  "priority",
-                  "artifacts.items",
-                  "artifacts.completion_evidence",
-                  "observability"
-                ],
-                "advisory_completion_claims": [
-                  {
-                    "claim_id": "claim-kno-181-a-1",
-                    "reported_at": "2026-04-01T08:00:00Z",
-                    "reported_by": "stub-executor",
-                    "reason": "executor reported completion",
-                    "metadata": {
-                      "attempt_id": "attempt-1"
-                    }
-                  }
-                ],
-                "execution_attempts": [
-                  {
-                    "attempt_id": "attempt-kno-181-a-1",
-                    "recorded_at": "2026-04-01T08:00:05Z",
-                    "status": "succeeded",
-                    "reported_by": "stub-executor",
-                    "completion_claim_id": "claim-kno-181-a-1",
-                    "artifact_references": [
-                      {
-                        "reference_id": "attempt-kno-181-a-1:log",
-                        "artifact_type": "execution_log",
-                        "location": "stub://attempts/log"
-                      }
-                    ],
-                    "metadata": {
-                      "executor_run_id": "stub-run-attempt-kno-181-a-1",
-                      "attempt_validation": {
-                        "validated_at": "2026-04-05T17:30:31.541310Z",
-                        "validated_by": "execution_validation",
-                        "policy": {
-                          "require_repository": true,
-                          "require_exact_branch": true,
-                          "require_commit": true,
-                          "allow_missing_pull_request": true,
-                          "task_artifact_fallback_requires_single_attempt": true
-                        },
-                        "context_observations": {
-                          "used_task_artifact_fallback": false
-                        },
-                        "status": "invalid",
-                        "failure_type": "invalid_execution_attempt",
-                        "retryable": true,
-                        "reasons": [
-                          "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
-                          "Successful execution attempt is missing commit SHA for the current run."
-                        ]
-                      }
-                    },
-                    "reevaluation": {}
-                  }
-                ]
-              },
-              "retries": {
-                "attempt_count": 0,
-                "last_retry_at": null,
-                "max_attempts": 0
-              }
-            },
-            "origin": {
-              "ingress_id": null,
-              "ingress_name": null,
-              "requested_by": null,
-              "source_id": "req-happy-overlay-1",
-              "source_system": "openclaw",
-              "source_type": "ingress_request"
-            },
-            "parent_task_id": null,
-            "priority": "normal",
-            "reconciliation": {
-              "active_failure_type": null,
-              "attempts": [],
-              "failed_at": null,
-              "last_attempt_id": null,
-              "last_error": null,
-              "last_pr_url": null,
-              "resolved_at": null,
-              "status": "not_required"
-            },
-            "required_capabilities": [],
-            "status": "intake_ready",
-            "status_history": [],
-            "timestamps": {
-              "completed_at": null,
-              "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-04-05T17:30:31.541658Z"
-            },
-            "title": "KNO-181 task-kno-181-scenario-a"
-          },
-          "external_facts": null,
-          "claimed_completion": true,
           "acceptance_criteria_satisfied": false,
-          "runtime_facts": {
-            "executor_reported_success": true,
-            "executor_reported_failure": false,
-            "terminal_failure": false,
-            "attempt_count": 1,
-            "latest_attempt_outcome": null
-          },
-          "unresolved_conditions": [],
-          "review_reasons": [],
-          "review_request": null,
+          "claimed_completion": true,
+          "external_facts": null,
+          "retry_context": null,
           "review_decision": null,
           "review_is_active": false,
-          "retry_context": {
-            "attempt_number": 1,
-            "max_retries": 1,
-            "triggered_by_category": "invalid_execution_attempt",
-            "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run.",
-            "is_final_attempt": true,
-            "scheduled_at": "2026-04-05T17:30:31.543299Z"
-          }
-        },
-        "result": {
-          "action": "no_op",
-          "target_status": null,
+          "review_reasons": [],
+          "review_request": null,
+          "runtime_facts": {
+            "attempt_count": 2,
+            "executor_reported_failure": false,
+            "executor_reported_success": true,
+            "latest_attempt_outcome": "completed",
+            "terminal_failure": false
+          },
           "task_envelope": {
             "acceptance_criteria": [
               {
@@ -240,11 +43,7 @@
               },
               "items": []
             },
-            "assigned_executor": {
-              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-              "executor_id": "executor-kno-181-a",
-              "executor_type": "codex"
-            },
+            "assigned_executor": null,
             "child_task_ids": [],
             "constraints": [],
             "coordination": {
@@ -256,1082 +55,7 @@
             "objective": {
               "deliverable_type": "unspecified",
               "success_signal": "Task satisfies declared acceptance criteria.",
-              "summary": "Exercise /evaluate with top-level evidence overlays."
-            },
-            "observability": {
-              "errors": [],
-              "execution_metadata": {
-                "schema_required_deferred_fields": [
-                  "parent_task_id",
-                  "child_task_ids",
-                  "dependencies",
-                  "assigned_executor",
-                  "required_capabilities",
-                  "priority",
-                  "artifacts.items",
-                  "artifacts.completion_evidence",
-                  "observability"
-                ],
-                "advisory_completion_claims": [
-                  {
-                    "claim_id": "claim-kno-181-a-1",
-                    "reported_at": "2026-04-01T08:00:00Z",
-                    "reported_by": "stub-executor",
-                    "reason": "executor reported completion",
-                    "metadata": {
-                      "attempt_id": "attempt-1"
-                    }
-                  }
-                ],
-                "execution_attempts": [
-                  {
-                    "attempt_id": "attempt-kno-181-a-1",
-                    "recorded_at": "2026-04-01T08:00:05Z",
-                    "status": "succeeded",
-                    "reported_by": "stub-executor",
-                    "completion_claim_id": "claim-kno-181-a-1",
-                    "artifact_references": [
-                      {
-                        "reference_id": "attempt-kno-181-a-1:log",
-                        "artifact_type": "execution_log",
-                        "location": "stub://attempts/log"
-                      }
-                    ],
-                    "metadata": {
-                      "executor_run_id": "stub-run-attempt-kno-181-a-1",
-                      "attempt_validation": {
-                        "validated_at": "2026-04-05T17:30:31.541310Z",
-                        "validated_by": "execution_validation",
-                        "policy": {
-                          "require_repository": true,
-                          "require_exact_branch": true,
-                          "require_commit": true,
-                          "allow_missing_pull_request": true,
-                          "task_artifact_fallback_requires_single_attempt": true
-                        },
-                        "context_observations": {
-                          "used_task_artifact_fallback": false
-                        },
-                        "status": "invalid",
-                        "failure_type": "invalid_execution_attempt",
-                        "retryable": true,
-                        "reasons": [
-                          "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
-                          "Successful execution attempt is missing commit SHA for the current run."
-                        ]
-                      }
-                    },
-                    "reevaluation": {}
-                  }
-                ]
-              },
-              "retries": {
-                "attempt_count": 0,
-                "last_retry_at": null,
-                "max_attempts": 0
-              }
-            },
-            "origin": {
-              "ingress_id": null,
-              "ingress_name": null,
-              "requested_by": null,
-              "source_id": "req-happy-overlay-1",
-              "source_system": "openclaw",
-              "source_type": "ingress_request"
-            },
-            "parent_task_id": null,
-            "priority": "normal",
-            "reconciliation": {
-              "active_failure_type": null,
-              "attempts": [],
-              "failed_at": null,
-              "last_attempt_id": null,
-              "last_error": null,
-              "last_pr_url": null,
-              "resolved_at": null,
-              "status": "not_required"
-            },
-            "required_capabilities": [],
-            "status": "intake_ready",
-            "status_history": [],
-            "timestamps": {
-              "completed_at": null,
-              "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-04-05T17:30:31.541658Z"
-            },
-            "title": "KNO-181 task-kno-181-scenario-a"
-          },
-          "enforcement_result": {
-            "action": "no_op",
-            "task_envelope": {
-              "acceptance_criteria": [
-                {
-                  "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-                  "id": "ac-1",
-                  "required": true
-                }
-              ],
-              "artifacts": {
-                "completion_evidence": {
-                  "notes": null,
-                  "policy": "deferred",
-                  "required_artifact_types": [],
-                  "status": "deferred",
-                  "validated_artifact_ids": [],
-                  "validated_at": null,
-                  "validation_method": "deferred",
-                  "validator": null
-                },
-                "items": []
-              },
-              "assigned_executor": {
-                "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-                "executor_id": "executor-kno-181-a",
-                "executor_type": "codex"
-              },
-              "child_task_ids": [],
-              "constraints": [],
-              "coordination": {
-                "linear": null
-              },
-              "dependencies": [],
-              "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-              "id": "task-kno-181-scenario-a",
-              "objective": {
-                "deliverable_type": "unspecified",
-                "success_signal": "Task satisfies declared acceptance criteria.",
-                "summary": "Exercise /evaluate with top-level evidence overlays."
-              },
-              "observability": {
-                "errors": [],
-                "execution_metadata": {
-                  "schema_required_deferred_fields": [
-                    "parent_task_id",
-                    "child_task_ids",
-                    "dependencies",
-                    "assigned_executor",
-                    "required_capabilities",
-                    "priority",
-                    "artifacts.items",
-                    "artifacts.completion_evidence",
-                    "observability"
-                  ],
-                  "advisory_completion_claims": [
-                    {
-                      "claim_id": "claim-kno-181-a-1",
-                      "reported_at": "2026-04-01T08:00:00Z",
-                      "reported_by": "stub-executor",
-                      "reason": "executor reported completion",
-                      "metadata": {
-                        "attempt_id": "attempt-1"
-                      }
-                    }
-                  ],
-                  "execution_attempts": [
-                    {
-                      "attempt_id": "attempt-kno-181-a-1",
-                      "recorded_at": "2026-04-01T08:00:05Z",
-                      "status": "succeeded",
-                      "reported_by": "stub-executor",
-                      "completion_claim_id": "claim-kno-181-a-1",
-                      "artifact_references": [
-                        {
-                          "reference_id": "attempt-kno-181-a-1:log",
-                          "artifact_type": "execution_log",
-                          "location": "stub://attempts/log"
-                        }
-                      ],
-                      "metadata": {
-                        "executor_run_id": "stub-run-attempt-kno-181-a-1",
-                        "attempt_validation": {
-                          "validated_at": "2026-04-05T17:30:31.541310Z",
-                          "validated_by": "execution_validation",
-                          "policy": {
-                            "require_repository": true,
-                            "require_exact_branch": true,
-                            "require_commit": true,
-                            "allow_missing_pull_request": true,
-                            "task_artifact_fallback_requires_single_attempt": true
-                          },
-                          "context_observations": {
-                            "used_task_artifact_fallback": false
-                          },
-                          "status": "invalid",
-                          "failure_type": "invalid_execution_attempt",
-                          "retryable": true,
-                          "reasons": [
-                            "Successful execution attempt is missing repository identity for the current run.",
-                            "Successful execution attempt is missing branch identity for the current run.",
-                            "Successful execution attempt is missing commit SHA for the current run."
-                          ]
-                        }
-                      },
-                      "reevaluation": {}
-                    }
-                  ]
-                },
-                "retries": {
-                  "attempt_count": 0,
-                  "last_retry_at": null,
-                  "max_attempts": 0
-                }
-              },
-              "origin": {
-                "ingress_id": null,
-                "ingress_name": null,
-                "requested_by": null,
-                "source_id": "req-happy-overlay-1",
-                "source_system": "openclaw",
-                "source_type": "ingress_request"
-              },
-              "parent_task_id": null,
-              "priority": "normal",
-              "reconciliation": {
-                "active_failure_type": null,
-                "attempts": [],
-                "failed_at": null,
-                "last_attempt_id": null,
-                "last_error": null,
-                "last_pr_url": null,
-                "resolved_at": null,
-                "status": "not_required"
-              },
-              "required_capabilities": [],
-              "status": "intake_ready",
-              "status_history": [],
-              "timestamps": {
-                "completed_at": null,
-                "created_at": "2026-03-31T14:30:00Z",
-                "updated_at": "2026-04-05T17:30:31.541658Z"
-              },
-              "title": "KNO-181 task-kno-181-scenario-a"
-            },
-            "evidence_result": null,
-            "reconciliation_result": null,
-            "verification_result": null,
-            "review_request": null,
-            "review_decision": null,
-            "transition_result": null,
-            "target_status": null,
-            "reasons": [
-              "Successful execution attempt is missing repository identity for the current run."
-            ],
-            "failure_classification": {
-              "failure_type": "invalid_execution_attempt",
-              "source": "executor",
-              "reason": "Successful execution attempt is missing repository identity for the current run.",
-              "terminal": false,
-              "recoverable": true,
-              "category": "invalid_execution_attempt",
-              "retryable": true
-            },
-            "error": "Successful execution attempt is missing repository identity for the current run."
-          },
-          "accepted_completion": false,
-          "requires_review": false,
-          "invalid_input": false,
-          "failure_classification": {
-            "failure_type": "invalid_execution_attempt",
-            "source": "executor",
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
-            "terminal": false,
-            "recoverable": true,
-            "category": "invalid_execution_attempt",
-            "retryable": true
-          },
-          "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
-          ],
-          "error": "Successful execution attempt is missing repository identity for the current run."
-        }
-      }
-    },
-    "task_envelope": {
-      "acceptance_criteria": [
-        {
-          "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-          "id": "ac-1",
-          "required": true
-        }
-      ],
-      "artifacts": {
-        "completion_evidence": {
-          "notes": null,
-          "policy": "deferred",
-          "required_artifact_types": [],
-          "status": "deferred",
-          "validated_artifact_ids": [],
-          "validated_at": null,
-          "validation_method": "deferred",
-          "validator": null
-        },
-        "items": []
-      },
-      "assigned_executor": {
-        "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-        "executor_id": "executor-kno-181-a",
-        "executor_type": "codex"
-      },
-      "child_task_ids": [],
-      "constraints": [],
-      "coordination": {
-        "linear": null
-      },
-      "dependencies": [],
-      "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-      "id": "task-kno-181-scenario-a",
-      "objective": {
-        "deliverable_type": "unspecified",
-        "success_signal": "Task satisfies declared acceptance criteria.",
-        "summary": "Exercise /evaluate with top-level evidence overlays."
-      },
-      "observability": {
-        "errors": [],
-        "execution_metadata": {
-          "advisory_completion_claims": [
-            {
-              "claim_id": "claim-kno-181-a-1",
-              "metadata": {
-                "attempt_id": "attempt-1"
-              },
-              "reason": "executor reported completion",
-              "reported_at": "2026-04-01T08:00:00Z",
-              "reported_by": "stub-executor"
-            },
-            {
-              "claim_id": "attempt-2:claim",
-              "reported_at": "2026-04-05T17:30:31.551102Z",
-              "reported_by": "codex",
-              "reason": "Successful execution attempt is missing repository identity for the current run.",
-              "metadata": {
-                "attempt_id": "attempt-2",
-                "dispatch_mode": "automatic",
-                "execution_parameters": {
-                  "prior_invalid_attempt_id": "attempt-1"
-                },
-                "advisory_only": true
-              }
-            }
-          ],
-          "execution_attempts": [
-            {
-              "artifact_references": [
-                {
-                  "artifact_type": "execution_log",
-                  "location": "stub://attempts/log",
-                  "reference_id": "attempt-kno-181-a-1:log"
-                }
-              ],
-              "attempt_id": "attempt-kno-181-a-1",
-              "completion_claim_id": "claim-kno-181-a-1",
-              "metadata": {
-                "attempt_validation": {
-                  "context_observations": {
-                    "used_task_artifact_fallback": false
-                  },
-                  "failure_type": "invalid_execution_attempt",
-                  "policy": {
-                    "allow_missing_pull_request": true,
-                    "require_commit": true,
-                    "require_exact_branch": true,
-                    "require_repository": true,
-                    "task_artifact_fallback_requires_single_attempt": true
-                  },
-                  "reasons": [
-                    "Successful execution attempt is missing repository identity for the current run.",
-                    "Successful execution attempt is missing branch identity for the current run.",
-                    "Successful execution attempt is missing commit SHA for the current run."
-                  ],
-                  "retryable": true,
-                  "status": "invalid",
-                  "validated_at": "2026-04-05T17:30:31.541310Z",
-                  "validated_by": "execution_validation"
-                },
-                "executor_run_id": "stub-run-attempt-kno-181-a-1"
-              },
-              "recorded_at": "2026-04-01T08:00:05Z",
-              "reevaluation": {},
-              "reported_by": "stub-executor",
-              "status": "succeeded"
-            },
-            {
-              "attempt_id": "attempt-2",
-              "recorded_at": "2026-04-05T17:30:31.551118Z",
-              "status": "completed",
-              "reported_by": "codex",
-              "completion_claim_id": "attempt-2:claim",
-              "artifact_references": [
-                {
-                  "reference_id": "attempt-2:log",
-                  "artifact_type": "execution_log",
-                  "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
-                  "external_id": null,
-                  "commit_sha": null,
-                  "metadata": {
-                    "advisory": true
-                  }
-                }
-              ],
-              "metadata": {
-                "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
-                "dispatch_trigger": "invalid_execution_attempt_retry",
-                "dispatch_mode": "automatic",
-                "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-                "executor": "codex",
-                "execution_parameters": {
-                  "prior_invalid_attempt_id": "attempt-1"
-                },
-                "dispatch_at": "2026-04-05T17:30:31.551127Z",
-                "execution_events": [
-                  {
-                    "event_id": "attempt-2:started",
-                    "event_type": "execution_started",
-                    "occurred_at": "2026-04-05T17:30:31.550824Z",
-                    "source_system": "stub-executor",
-                    "metadata": {
-                      "adapter": "stub-executor",
-                      "mode": "stub"
-                    }
-                  },
-                  {
-                    "event_id": "attempt-2:completed",
-                    "event_type": "execution_succeeded",
-                    "occurred_at": "2026-04-05T17:30:31.550848Z",
-                    "source_system": "stub-executor",
-                    "metadata": {
-                      "adapter": "stub-executor",
-                      "executor_run_id": "stub-run-attempt-2"
-                    }
-                  }
-                ],
-                "attempt_validation": {
-                  "validated_at": "2026-04-05T17:30:31.553815Z",
-                  "validated_by": "execution_validation",
-                  "policy": {
-                    "require_repository": true,
-                    "require_exact_branch": true,
-                    "require_commit": true,
-                    "allow_missing_pull_request": true,
-                    "task_artifact_fallback_requires_single_attempt": true
-                  },
-                  "context_observations": {
-                    "used_task_artifact_fallback": false
-                  },
-                  "status": "invalid",
-                  "failure_type": "invalid_execution_attempt",
-                  "retryable": true,
-                  "reasons": [
-                    "Successful execution attempt is missing repository identity for the current run.",
-                    "Successful execution attempt is missing branch identity for the current run.",
-                    "Successful execution attempt is missing commit SHA for the current run."
-                  ]
-                }
-              },
-              "reevaluation": {}
-            }
-          ],
-          "schema_required_deferred_fields": [
-            "parent_task_id",
-            "child_task_ids",
-            "dependencies",
-            "assigned_executor",
-            "required_capabilities",
-            "priority",
-            "artifacts.items",
-            "artifacts.completion_evidence",
-            "observability"
-          ]
-        },
-        "retries": {
-          "attempt_count": 0,
-          "last_retry_at": null,
-          "max_attempts": 0
-        }
-      },
-      "origin": {
-        "ingress_id": null,
-        "ingress_name": null,
-        "requested_by": null,
-        "source_id": "req-happy-overlay-1",
-        "source_system": "openclaw",
-        "source_type": "ingress_request"
-      },
-      "parent_task_id": null,
-      "priority": "normal",
-      "reconciliation": {
-        "active_failure_type": null,
-        "attempts": [],
-        "failed_at": null,
-        "last_attempt_id": null,
-        "last_error": null,
-        "last_pr_url": null,
-        "resolved_at": null,
-        "status": "not_required"
-      },
-      "required_capabilities": [],
-      "status": "failed",
-      "status_history": [
-        {
-          "from_status": "intake_ready",
-          "to_status": "failed",
-          "changed_at": "2026-04-05T17:30:31.617375Z",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
-          "changed_by": "verification"
-        }
-      ],
-      "timestamps": {
-        "completed_at": null,
-        "created_at": "2026-03-31T14:30:00Z",
-        "updated_at": "2026-04-05T17:30:31.617375Z"
-      },
-      "title": "KNO-181 task-kno-181-scenario-a"
-    },
-    "evaluation_record": {
-      "evaluation_id": "1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-      "task_id": "task-kno-181-scenario-a",
-      "recorded_at": "2026-04-05T17:30:31.666755Z",
-      "request": {
-        "task_envelope": {
-          "acceptance_criteria": [
-            {
-              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-              "id": "ac-1",
-              "required": true
-            }
-          ],
-          "artifacts": {
-            "completion_evidence": {
-              "notes": null,
-              "policy": "deferred",
-              "required_artifact_types": [],
-              "status": "deferred",
-              "validated_artifact_ids": [],
-              "validated_at": null,
-              "validation_method": "deferred",
-              "validator": null
-            },
-            "items": []
-          },
-          "assigned_executor": {
-            "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "executor_id": "executor-kno-181-a",
-            "executor_type": "codex"
-          },
-          "child_task_ids": [],
-          "constraints": [],
-          "coordination": {
-            "linear": null
-          },
-          "dependencies": [],
-          "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-          "id": "task-kno-181-scenario-a",
-          "objective": {
-            "deliverable_type": "unspecified",
-            "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
-          },
-          "observability": {
-            "errors": [],
-            "execution_metadata": {
-              "advisory_completion_claims": [
-                {
-                  "claim_id": "claim-kno-181-a-1",
-                  "metadata": {
-                    "attempt_id": "attempt-1"
-                  },
-                  "reason": "executor reported completion",
-                  "reported_at": "2026-04-01T08:00:00Z",
-                  "reported_by": "stub-executor"
-                },
-                {
-                  "claim_id": "attempt-2:claim",
-                  "reported_at": "2026-04-05T17:30:31.551102Z",
-                  "reported_by": "codex",
-                  "reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "metadata": {
-                    "attempt_id": "attempt-2",
-                    "dispatch_mode": "automatic",
-                    "execution_parameters": {
-                      "prior_invalid_attempt_id": "attempt-1"
-                    },
-                    "advisory_only": true
-                  }
-                }
-              ],
-              "execution_attempts": [
-                {
-                  "artifact_references": [
-                    {
-                      "artifact_type": "execution_log",
-                      "location": "stub://attempts/log",
-                      "reference_id": "attempt-kno-181-a-1:log"
-                    }
-                  ],
-                  "attempt_id": "attempt-kno-181-a-1",
-                  "completion_claim_id": "claim-kno-181-a-1",
-                  "metadata": {
-                    "attempt_validation": {
-                      "context_observations": {
-                        "used_task_artifact_fallback": false
-                      },
-                      "failure_type": "invalid_execution_attempt",
-                      "policy": {
-                        "allow_missing_pull_request": true,
-                        "require_commit": true,
-                        "require_exact_branch": true,
-                        "require_repository": true,
-                        "task_artifact_fallback_requires_single_attempt": true
-                      },
-                      "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
-                      ],
-                      "retryable": true,
-                      "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.541310Z",
-                      "validated_by": "execution_validation"
-                    },
-                    "executor_run_id": "stub-run-attempt-kno-181-a-1"
-                  },
-                  "recorded_at": "2026-04-01T08:00:05Z",
-                  "reevaluation": {},
-                  "reported_by": "stub-executor",
-                  "status": "succeeded"
-                },
-                {
-                  "attempt_id": "attempt-2",
-                  "recorded_at": "2026-04-05T17:30:31.551118Z",
-                  "status": "completed",
-                  "reported_by": "codex",
-                  "completion_claim_id": "attempt-2:claim",
-                  "artifact_references": [
-                    {
-                      "reference_id": "attempt-2:log",
-                      "artifact_type": "execution_log",
-                      "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
-                      "external_id": null,
-                      "commit_sha": null,
-                      "metadata": {
-                        "advisory": true
-                      }
-                    }
-                  ],
-                  "metadata": {
-                    "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
-                    "dispatch_trigger": "invalid_execution_attempt_retry",
-                    "dispatch_mode": "automatic",
-                    "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-                    "executor": "codex",
-                    "execution_parameters": {
-                      "prior_invalid_attempt_id": "attempt-1"
-                    },
-                    "dispatch_at": "2026-04-05T17:30:31.551127Z",
-                    "execution_events": [
-                      {
-                        "event_id": "attempt-2:started",
-                        "event_type": "execution_started",
-                        "occurred_at": "2026-04-05T17:30:31.550824Z",
-                        "source_system": "stub-executor",
-                        "metadata": {
-                          "adapter": "stub-executor",
-                          "mode": "stub"
-                        }
-                      },
-                      {
-                        "event_id": "attempt-2:completed",
-                        "event_type": "execution_succeeded",
-                        "occurred_at": "2026-04-05T17:30:31.550848Z",
-                        "source_system": "stub-executor",
-                        "metadata": {
-                          "adapter": "stub-executor",
-                          "executor_run_id": "stub-run-attempt-2"
-                        }
-                      }
-                    ],
-                    "attempt_validation": {
-                      "validated_at": "2026-04-05T17:30:31.553815Z",
-                      "validated_by": "execution_validation",
-                      "policy": {
-                        "require_repository": true,
-                        "require_exact_branch": true,
-                        "require_commit": true,
-                        "allow_missing_pull_request": true,
-                        "task_artifact_fallback_requires_single_attempt": true
-                      },
-                      "context_observations": {
-                        "used_task_artifact_fallback": false
-                      },
-                      "status": "invalid",
-                      "failure_type": "invalid_execution_attempt",
-                      "retryable": true,
-                      "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
-                      ]
-                    }
-                  },
-                  "reevaluation": {}
-                }
-              ],
-              "schema_required_deferred_fields": [
-                "parent_task_id",
-                "child_task_ids",
-                "dependencies",
-                "assigned_executor",
-                "required_capabilities",
-                "priority",
-                "artifacts.items",
-                "artifacts.completion_evidence",
-                "observability"
-              ]
-            },
-            "retries": {
-              "attempt_count": 0,
-              "last_retry_at": null,
-              "max_attempts": 0
-            }
-          },
-          "origin": {
-            "ingress_id": null,
-            "ingress_name": null,
-            "requested_by": null,
-            "source_id": "req-happy-overlay-1",
-            "source_system": "openclaw",
-            "source_type": "ingress_request"
-          },
-          "parent_task_id": null,
-          "priority": "normal",
-          "reconciliation": {
-            "active_failure_type": null,
-            "attempts": [],
-            "failed_at": null,
-            "last_attempt_id": null,
-            "last_error": null,
-            "last_pr_url": null,
-            "resolved_at": null,
-            "status": "not_required"
-          },
-          "required_capabilities": [],
-          "status": "failed",
-          "status_history": [
-            {
-              "from_status": "intake_ready",
-              "to_status": "failed",
-              "changed_at": "2026-04-05T17:30:31.617375Z",
-              "reason": "Successful execution attempt is missing repository identity for the current run.",
-              "changed_by": "verification"
-            }
-          ],
-          "timestamps": {
-            "completed_at": null,
-            "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-04-05T17:30:31.617375Z"
-          },
-          "title": "KNO-181 task-kno-181-scenario-a"
-        },
-        "external_facts": null,
-        "claimed_completion": true,
-        "acceptance_criteria_satisfied": false,
-        "runtime_facts": {
-          "executor_reported_success": true,
-          "executor_reported_failure": false,
-          "terminal_failure": false,
-          "attempt_count": 2,
-          "latest_attempt_outcome": "completed"
-        },
-        "unresolved_conditions": [],
-        "review_reasons": [],
-        "review_request": null,
-        "review_decision": null,
-        "review_is_active": false,
-        "retry_context": null
-      },
-      "result": {
-        "action": "transition_applied",
-        "target_status": "failed",
-        "task_envelope": {
-          "acceptance_criteria": [
-            {
-              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-              "id": "ac-1",
-              "required": true
-            }
-          ],
-          "artifacts": {
-            "completion_evidence": {
-              "notes": null,
-              "policy": "deferred",
-              "required_artifact_types": [],
-              "status": "deferred",
-              "validated_artifact_ids": [],
-              "validated_at": null,
-              "validation_method": "deferred",
-              "validator": null
-            },
-            "items": []
-          },
-          "assigned_executor": {
-            "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "executor_id": "executor-kno-181-a",
-            "executor_type": "codex"
-          },
-          "child_task_ids": [],
-          "constraints": [],
-          "coordination": {
-            "linear": null
-          },
-          "dependencies": [],
-          "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-          "id": "task-kno-181-scenario-a",
-          "objective": {
-            "deliverable_type": "unspecified",
-            "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
-          },
-          "observability": {
-            "errors": [],
-            "execution_metadata": {
-              "advisory_completion_claims": [
-                {
-                  "claim_id": "claim-kno-181-a-1",
-                  "metadata": {
-                    "attempt_id": "attempt-1"
-                  },
-                  "reason": "executor reported completion",
-                  "reported_at": "2026-04-01T08:00:00Z",
-                  "reported_by": "stub-executor"
-                },
-                {
-                  "claim_id": "attempt-2:claim",
-                  "reported_at": "2026-04-05T17:30:31.551102Z",
-                  "reported_by": "codex",
-                  "reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "metadata": {
-                    "attempt_id": "attempt-2",
-                    "dispatch_mode": "automatic",
-                    "execution_parameters": {
-                      "prior_invalid_attempt_id": "attempt-1"
-                    },
-                    "advisory_only": true
-                  }
-                }
-              ],
-              "execution_attempts": [
-                {
-                  "artifact_references": [
-                    {
-                      "artifact_type": "execution_log",
-                      "location": "stub://attempts/log",
-                      "reference_id": "attempt-kno-181-a-1:log"
-                    }
-                  ],
-                  "attempt_id": "attempt-kno-181-a-1",
-                  "completion_claim_id": "claim-kno-181-a-1",
-                  "metadata": {
-                    "attempt_validation": {
-                      "context_observations": {
-                        "used_task_artifact_fallback": false
-                      },
-                      "failure_type": "invalid_execution_attempt",
-                      "policy": {
-                        "allow_missing_pull_request": true,
-                        "require_commit": true,
-                        "require_exact_branch": true,
-                        "require_repository": true,
-                        "task_artifact_fallback_requires_single_attempt": true
-                      },
-                      "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
-                      ],
-                      "retryable": true,
-                      "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.541310Z",
-                      "validated_by": "execution_validation"
-                    },
-                    "executor_run_id": "stub-run-attempt-kno-181-a-1"
-                  },
-                  "recorded_at": "2026-04-01T08:00:05Z",
-                  "reevaluation": {},
-                  "reported_by": "stub-executor",
-                  "status": "succeeded"
-                },
-                {
-                  "attempt_id": "attempt-2",
-                  "recorded_at": "2026-04-05T17:30:31.551118Z",
-                  "status": "completed",
-                  "reported_by": "codex",
-                  "completion_claim_id": "attempt-2:claim",
-                  "artifact_references": [
-                    {
-                      "reference_id": "attempt-2:log",
-                      "artifact_type": "execution_log",
-                      "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
-                      "external_id": null,
-                      "commit_sha": null,
-                      "metadata": {
-                        "advisory": true
-                      }
-                    }
-                  ],
-                  "metadata": {
-                    "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
-                    "dispatch_trigger": "invalid_execution_attempt_retry",
-                    "dispatch_mode": "automatic",
-                    "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-                    "executor": "codex",
-                    "execution_parameters": {
-                      "prior_invalid_attempt_id": "attempt-1"
-                    },
-                    "dispatch_at": "2026-04-05T17:30:31.551127Z",
-                    "execution_events": [
-                      {
-                        "event_id": "attempt-2:started",
-                        "event_type": "execution_started",
-                        "occurred_at": "2026-04-05T17:30:31.550824Z",
-                        "source_system": "stub-executor",
-                        "metadata": {
-                          "adapter": "stub-executor",
-                          "mode": "stub"
-                        }
-                      },
-                      {
-                        "event_id": "attempt-2:completed",
-                        "event_type": "execution_succeeded",
-                        "occurred_at": "2026-04-05T17:30:31.550848Z",
-                        "source_system": "stub-executor",
-                        "metadata": {
-                          "adapter": "stub-executor",
-                          "executor_run_id": "stub-run-attempt-2"
-                        }
-                      }
-                    ],
-                    "attempt_validation": {
-                      "validated_at": "2026-04-05T17:30:31.553815Z",
-                      "validated_by": "execution_validation",
-                      "policy": {
-                        "require_repository": true,
-                        "require_exact_branch": true,
-                        "require_commit": true,
-                        "allow_missing_pull_request": true,
-                        "task_artifact_fallback_requires_single_attempt": true
-                      },
-                      "context_observations": {
-                        "used_task_artifact_fallback": false
-                      },
-                      "status": "invalid",
-                      "failure_type": "invalid_execution_attempt",
-                      "retryable": true,
-                      "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
-                      ]
-                    }
-                  },
-                  "reevaluation": {}
-                }
-              ],
-              "schema_required_deferred_fields": [
-                "parent_task_id",
-                "child_task_ids",
-                "dependencies",
-                "assigned_executor",
-                "required_capabilities",
-                "priority",
-                "artifacts.items",
-                "artifacts.completion_evidence",
-                "observability"
-              ]
-            },
-            "retries": {
-              "attempt_count": 0,
-              "last_retry_at": null,
-              "max_attempts": 0
-            }
-          },
-          "origin": {
-            "ingress_id": null,
-            "ingress_name": null,
-            "requested_by": null,
-            "source_id": "req-happy-overlay-1",
-            "source_system": "openclaw",
-            "source_type": "ingress_request"
-          },
-          "parent_task_id": null,
-          "priority": "normal",
-          "reconciliation": {
-            "active_failure_type": null,
-            "attempts": [],
-            "failed_at": null,
-            "last_attempt_id": null,
-            "last_error": null,
-            "last_pr_url": null,
-            "resolved_at": null,
-            "status": "not_required"
-          },
-          "required_capabilities": [],
-          "status": "failed",
-          "status_history": [
-            {
-              "from_status": "intake_ready",
-              "to_status": "failed",
-              "changed_at": "2026-04-05T17:30:31.617375Z",
-              "reason": "Successful execution attempt is missing repository identity for the current run.",
-              "changed_by": "verification"
-            }
-          ],
-          "timestamps": {
-            "completed_at": null,
-            "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-04-05T17:30:31.617375Z"
-          },
-          "title": "KNO-181 task-kno-181-scenario-a"
-        },
-        "enforcement_result": {
-          "action": "transition_applied",
-          "task_envelope": {
-            "acceptance_criteria": [
-              {
-                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-                "id": "ac-1",
-                "required": true
-              }
-            ],
-            "artifacts": {
-              "completion_evidence": {
-                "notes": null,
-                "policy": "deferred",
-                "required_artifact_types": [],
-                "status": "deferred",
-                "validated_artifact_ids": [],
-                "validated_at": null,
-                "validation_method": "deferred",
-                "validator": null
-              },
-              "items": []
-            },
-            "assigned_executor": {
-              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-              "executor_id": "executor-kno-181-a",
-              "executor_type": "codex"
-            },
-            "child_task_ids": [],
-            "constraints": [],
-            "coordination": {
-              "linear": null
-            },
-            "dependencies": [],
-            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "id": "task-kno-181-scenario-a",
-            "objective": {
-              "deliverable_type": "unspecified",
-              "success_signal": "Task satisfies declared acceptance criteria.",
-              "summary": "Exercise /evaluate with top-level evidence overlays."
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
             },
             "observability": {
               "errors": [],
@@ -1348,26 +72,29 @@
                   },
                   {
                     "claim_id": "attempt-2:claim",
-                    "reported_at": "2026-04-05T17:30:31.551102Z",
-                    "reported_by": "codex",
-                    "reason": "Successful execution attempt is missing repository identity for the current run.",
                     "metadata": {
+                      "advisory_only": true,
                       "attempt_id": "attempt-2",
                       "dispatch_mode": "automatic",
                       "execution_parameters": {
                         "prior_invalid_attempt_id": "attempt-1"
-                      },
-                      "advisory_only": true
-                    }
+                      }
+                    },
+                    "reason": "Successful execution attempt is missing repository identity for the current run.",
+                    "reported_at": "2026-04-11T16:04:28.870785Z",
+                    "reported_by": "codex"
                   }
                 ],
                 "execution_attempts": [
                   {
                     "artifact_references": [
                       {
-                        "artifact_type": "execution_log",
-                        "location": "stub://attempts/log",
-                        "reference_id": "attempt-kno-181-a-1:log"
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
                       }
                     ],
                     "attempt_id": "attempt-kno-181-a-1",
@@ -1375,24 +102,40 @@
                     "metadata": {
                       "attempt_validation": {
                         "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "used_task_artifact_fallback": false
                         },
                         "failure_type": "invalid_execution_attempt",
                         "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [
                           "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
                           "Successful execution attempt is missing commit SHA for the current run."
                         ],
                         "retryable": true,
+                        "rule_failures": [],
                         "status": "invalid",
-                        "validated_at": "2026-04-05T17:30:31.541310Z",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
                         "validated_by": "execution_validation"
                       },
                       "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -1403,79 +146,91 @@
                     "status": "succeeded"
                   },
                   {
-                    "attempt_id": "attempt-2",
-                    "recorded_at": "2026-04-05T17:30:31.551118Z",
-                    "status": "completed",
-                    "reported_by": "codex",
-                    "completion_claim_id": "attempt-2:claim",
                     "artifact_references": [
                       {
-                        "reference_id": "attempt-2:log",
                         "artifact_type": "execution_log",
-                        "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
-                        "external_id": null,
                         "commit_sha": null,
+                        "external_id": null,
+                        "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
                         "metadata": {
                           "advisory": true
-                        }
+                        },
+                        "reference_id": "attempt-2:log"
                       }
                     ],
+                    "attempt_id": "attempt-2",
+                    "completion_claim_id": "attempt-2:claim",
                     "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "contract_violation",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing branch identity for the current run."
+                        ],
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.871964Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "dispatch_at": "2026-04-11T16:04:28.870771Z",
                       "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
-                      "dispatch_trigger": "invalid_execution_attempt_retry",
                       "dispatch_mode": "automatic",
                       "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-                      "executor": "codex",
-                      "execution_parameters": {
-                        "prior_invalid_attempt_id": "attempt-1"
-                      },
-                      "dispatch_at": "2026-04-05T17:30:31.551127Z",
+                      "dispatch_trigger": "invalid_execution_attempt_retry",
                       "execution_events": [
                         {
                           "event_id": "attempt-2:started",
                           "event_type": "execution_started",
-                          "occurred_at": "2026-04-05T17:30:31.550824Z",
-                          "source_system": "stub-executor",
                           "metadata": {
                             "adapter": "stub-executor",
                             "mode": "stub"
-                          }
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870771Z",
+                          "source_system": "stub-executor"
                         },
                         {
                           "event_id": "attempt-2:completed",
                           "event_type": "execution_succeeded",
-                          "occurred_at": "2026-04-05T17:30:31.550848Z",
-                          "source_system": "stub-executor",
                           "metadata": {
                             "adapter": "stub-executor",
                             "executor_run_id": "stub-run-attempt-2"
-                          }
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870785Z",
+                          "source_system": "stub-executor"
                         }
                       ],
-                      "attempt_validation": {
-                        "validated_at": "2026-04-05T17:30:31.553815Z",
-                        "validated_by": "execution_validation",
-                        "policy": {
-                          "require_repository": true,
-                          "require_exact_branch": true,
-                          "require_commit": true,
-                          "allow_missing_pull_request": true,
-                          "task_artifact_fallback_requires_single_attempt": true
-                        },
-                        "context_observations": {
-                          "used_task_artifact_fallback": false
-                        },
-                        "status": "invalid",
-                        "failure_type": "invalid_execution_attempt",
-                        "retryable": true,
-                        "reasons": [
-                          "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
-                          "Successful execution attempt is missing commit SHA for the current run."
-                        ]
-                      }
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      },
+                      "executor": "codex"
                     },
-                    "reevaluation": {}
+                    "recorded_at": "2026-04-11T16:04:28.870785Z",
+                    "reevaluation": {},
+                    "reported_by": "codex",
+                    "status": "completed"
                   }
                 ],
                 "schema_required_deferred_fields": [
@@ -1520,65 +275,3250 @@
             "status": "failed",
             "status_history": [
               {
-                "from_status": "intake_ready",
-                "to_status": "failed",
-                "changed_at": "2026-04-05T17:30:31.617375Z",
-                "reason": "Successful execution attempt is missing repository identity for the current run.",
-                "changed_by": "verification"
+                "changed_at": "2026-04-11T16:04:28.878677Z",
+                "changed_by": "verification",
+                "from_status": "assigned",
+                "reason": "Successful execution attempt is missing branch identity for the current run.",
+                "to_status": "failed"
               }
             ],
             "timestamps": {
               "completed_at": null,
               "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-04-05T17:30:31.617375Z"
+              "updated_at": "2026-04-11T16:04:28.878677Z"
             },
             "title": "KNO-181 task-kno-181-scenario-a"
           },
-          "evidence_result": null,
-          "reconciliation_result": null,
-          "verification_result": null,
-          "review_request": null,
-          "review_decision": null,
-          "transition_result": null,
-          "target_status": "failed",
-          "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
-          ],
-          "failure_classification": {
-            "failure_type": "invalid_execution_attempt",
-            "source": "executor",
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
-            "terminal": true,
-            "recoverable": false,
-            "category": "invalid_execution_attempt",
-            "retryable": false
+          "unresolved_conditions": []
+        },
+        "result": {
+          "accepted_completion": false,
+          "action": "transition_applied",
+          "enforcement_result": {
+            "action": "transition_applied",
+            "error": "Successful execution attempt is missing branch identity for the current run.",
+            "evidence_result": null,
+            "failure_classification": {
+              "category": "contract_violation",
+              "failure_type": "contract_violation",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
+              "recoverable": false,
+              "retryable": false,
+              "source": "executor",
+              "terminal": true
+            },
+            "reasons": [
+              "Successful execution attempt is missing branch identity for the current run."
+            ],
+            "reconciliation_result": null,
+            "review_decision": null,
+            "review_request": null,
+            "target_status": "failed",
+            "task_envelope": {
+              "acceptance_criteria": [
+                {
+                  "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                  "id": "ac-1",
+                  "required": true
+                }
+              ],
+              "artifacts": {
+                "completion_evidence": {
+                  "notes": null,
+                  "policy": "deferred",
+                  "required_artifact_types": [],
+                  "status": "deferred",
+                  "validated_artifact_ids": [],
+                  "validated_at": null,
+                  "validation_method": "deferred",
+                  "validator": null
+                },
+                "items": []
+              },
+              "assigned_executor": null,
+              "child_task_ids": [],
+              "constraints": [],
+              "coordination": {
+                "linear": null
+              },
+              "dependencies": [],
+              "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+              "id": "task-kno-181-scenario-a",
+              "objective": {
+                "deliverable_type": "unspecified",
+                "success_signal": "Task satisfies declared acceptance criteria.",
+                "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+              },
+              "observability": {
+                "errors": [],
+                "execution_metadata": {
+                  "advisory_completion_claims": [
+                    {
+                      "claim_id": "claim-kno-181-a-1",
+                      "metadata": {
+                        "attempt_id": "attempt-1"
+                      },
+                      "reason": "executor reported completion",
+                      "reported_at": "2026-04-01T08:00:00Z",
+                      "reported_by": "stub-executor"
+                    },
+                    {
+                      "claim_id": "attempt-2:claim",
+                      "metadata": {
+                        "advisory_only": true,
+                        "attempt_id": "attempt-2",
+                        "dispatch_mode": "automatic",
+                        "execution_parameters": {
+                          "prior_invalid_attempt_id": "attempt-1"
+                        }
+                      },
+                      "reason": "Successful execution attempt is missing repository identity for the current run.",
+                      "reported_at": "2026-04-11T16:04:28.870785Z",
+                      "reported_by": "codex"
+                    }
+                  ],
+                  "execution_attempts": [
+                    {
+                      "artifact_references": [
+                        {
+                          "artifact_type": "commit",
+                          "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                          "metadata": {
+                            "branch_name": "codex/e2e-test"
+                          },
+                          "reference_id": "attempt-kno-181-a-1:commit"
+                        }
+                      ],
+                      "attempt_id": "attempt-kno-181-a-1",
+                      "completion_claim_id": "claim-kno-181-a-1",
+                      "metadata": {
+                        "attempt_validation": {
+                          "context_observations": {
+                            "branch": [
+                              {
+                                "sources": [
+                                  "execution_attempt.artifact_references[0]"
+                                ],
+                                "value": "codex/e2e-test"
+                              }
+                            ],
+                            "commit_resolution_pending": false,
+                            "has_valid_current_run_pull_request_artifact": false,
+                            "used_task_artifact_fallback": false
+                          },
+                          "failure_type": "invalid_execution_attempt",
+                          "policy": {
+                            "allow_commit_resolution_via_reconciliation": true,
+                            "allow_missing_commit_artifact_with_verified_pull_request": true,
+                            "allow_missing_pull_request": true,
+                            "reject_closed_or_historical_pull_request": true,
+                            "reject_non_numeric_pull_request_url": true,
+                            "reject_reserved_shared_branch": true,
+                            "require_commit": true,
+                            "require_exact_branch": true,
+                            "require_repository": true,
+                            "task_artifact_fallback_requires_single_attempt": true
+                          },
+                          "pull_request_observations": [],
+                          "reasons": [
+                            "Successful execution attempt is missing repository identity for the current run.",
+                            "Successful execution attempt is missing commit SHA for the current run."
+                          ],
+                          "retryable": true,
+                          "rule_failures": [],
+                          "status": "invalid",
+                          "validated_at": "2026-04-11T16:04:28.868130Z",
+                          "validated_by": "execution_validation"
+                        },
+                        "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                      },
+                      "recorded_at": "2026-04-01T08:00:05Z",
+                      "reevaluation": {},
+                      "reported_by": "stub-executor",
+                      "status": "succeeded"
+                    },
+                    {
+                      "artifact_references": [
+                        {
+                          "artifact_type": "execution_log",
+                          "commit_sha": null,
+                          "external_id": null,
+                          "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                          "metadata": {
+                            "advisory": true
+                          },
+                          "reference_id": "attempt-2:log"
+                        }
+                      ],
+                      "attempt_id": "attempt-2",
+                      "completion_claim_id": "attempt-2:claim",
+                      "metadata": {
+                        "attempt_validation": {
+                          "context_observations": {
+                            "commit_resolution_pending": false,
+                            "has_valid_current_run_pull_request_artifact": false,
+                            "used_task_artifact_fallback": false
+                          },
+                          "failure_type": "contract_violation",
+                          "policy": {
+                            "allow_commit_resolution_via_reconciliation": true,
+                            "allow_missing_commit_artifact_with_verified_pull_request": true,
+                            "allow_missing_pull_request": true,
+                            "reject_closed_or_historical_pull_request": true,
+                            "reject_non_numeric_pull_request_url": true,
+                            "reject_reserved_shared_branch": true,
+                            "require_commit": true,
+                            "require_exact_branch": true,
+                            "require_repository": true,
+                            "task_artifact_fallback_requires_single_attempt": true
+                          },
+                          "pull_request_observations": [],
+                          "reasons": [
+                            "Successful execution attempt is missing branch identity for the current run."
+                          ],
+                          "retryable": false,
+                          "rule_failures": [
+                            {
+                              "message": "Successful execution attempt is missing branch identity for the current run.",
+                              "rule": "missing_branch_identity"
+                            }
+                          ],
+                          "status": "invalid",
+                          "validated_at": "2026-04-11T16:04:28.871964Z",
+                          "validated_by": "execution_validation"
+                        },
+                        "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                        "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                        "dispatch_mode": "automatic",
+                        "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                        "dispatch_trigger": "invalid_execution_attempt_retry",
+                        "execution_events": [
+                          {
+                            "event_id": "attempt-2:started",
+                            "event_type": "execution_started",
+                            "metadata": {
+                              "adapter": "stub-executor",
+                              "mode": "stub"
+                            },
+                            "occurred_at": "2026-04-11T16:04:28.870771Z",
+                            "source_system": "stub-executor"
+                          },
+                          {
+                            "event_id": "attempt-2:completed",
+                            "event_type": "execution_succeeded",
+                            "metadata": {
+                              "adapter": "stub-executor",
+                              "executor_run_id": "stub-run-attempt-2"
+                            },
+                            "occurred_at": "2026-04-11T16:04:28.870785Z",
+                            "source_system": "stub-executor"
+                          }
+                        ],
+                        "execution_parameters": {
+                          "prior_invalid_attempt_id": "attempt-1"
+                        },
+                        "executor": "codex"
+                      },
+                      "recorded_at": "2026-04-11T16:04:28.870785Z",
+                      "reevaluation": {},
+                      "reported_by": "codex",
+                      "status": "completed"
+                    }
+                  ],
+                  "schema_required_deferred_fields": [
+                    "parent_task_id",
+                    "child_task_ids",
+                    "dependencies",
+                    "assigned_executor",
+                    "required_capabilities",
+                    "priority",
+                    "artifacts.items",
+                    "artifacts.completion_evidence",
+                    "observability"
+                  ]
+                },
+                "retries": {
+                  "attempt_count": 0,
+                  "last_retry_at": null,
+                  "max_attempts": 0
+                }
+              },
+              "origin": {
+                "ingress_id": null,
+                "ingress_name": null,
+                "requested_by": null,
+                "source_id": "req-happy-overlay-1",
+                "source_system": "openclaw",
+                "source_type": "ingress_request"
+              },
+              "parent_task_id": null,
+              "priority": "normal",
+              "reconciliation": {
+                "active_failure_type": null,
+                "attempts": [],
+                "failed_at": null,
+                "last_attempt_id": null,
+                "last_error": null,
+                "last_pr_url": null,
+                "resolved_at": null,
+                "status": "not_required"
+              },
+              "required_capabilities": [],
+              "status": "failed",
+              "status_history": [
+                {
+                  "changed_at": "2026-04-11T16:04:28.878677Z",
+                  "changed_by": "verification",
+                  "from_status": "assigned",
+                  "reason": "Successful execution attempt is missing branch identity for the current run.",
+                  "to_status": "failed"
+                }
+              ],
+              "timestamps": {
+                "completed_at": null,
+                "created_at": "2026-03-31T14:30:00Z",
+                "updated_at": "2026-04-11T16:04:28.878677Z"
+              },
+              "title": "KNO-181 task-kno-181-scenario-a"
+            },
+            "transition_result": null,
+            "verification_result": null
           },
-          "error": "Successful execution attempt is missing repository identity for the current run."
+          "error": "Successful execution attempt is missing branch identity for the current run.",
+          "failure_classification": {
+            "category": "contract_violation",
+            "failure_type": "contract_violation",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
+            "recoverable": false,
+            "retryable": false,
+            "source": "executor",
+            "terminal": true
+          },
+          "invalid_input": false,
+          "reasons": [
+            "Successful execution attempt is missing branch identity for the current run."
+          ],
+          "requires_review": false,
+          "target_status": "failed",
+          "task_envelope": {
+            "acceptance_criteria": [
+              {
+                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                "id": "ac-1",
+                "required": true
+              }
+            ],
+            "artifacts": {
+              "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+              },
+              "items": []
+            },
+            "assigned_executor": null,
+            "child_task_ids": [],
+            "constraints": [],
+            "coordination": {
+              "linear": null
+            },
+            "dependencies": [],
+            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+            "id": "task-kno-181-scenario-a",
+            "objective": {
+              "deliverable_type": "unspecified",
+              "success_signal": "Task satisfies declared acceptance criteria.",
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+            },
+            "observability": {
+              "errors": [],
+              "execution_metadata": {
+                "advisory_completion_claims": [
+                  {
+                    "claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_id": "attempt-1"
+                    },
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-01T08:00:00Z",
+                    "reported_by": "stub-executor"
+                  },
+                  {
+                    "claim_id": "attempt-2:claim",
+                    "metadata": {
+                      "advisory_only": true,
+                      "attempt_id": "attempt-2",
+                      "dispatch_mode": "automatic",
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      }
+                    },
+                    "reason": "Successful execution attempt is missing repository identity for the current run.",
+                    "reported_at": "2026-04-11T16:04:28.870785Z",
+                    "reported_by": "codex"
+                  }
+                ],
+                "execution_attempts": [
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
+                      }
+                    ],
+                    "attempt_id": "attempt-kno-181-a-1",
+                    "completion_claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "invalid_execution_attempt",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing repository identity for the current run.",
+                          "Successful execution attempt is missing commit SHA for the current run."
+                        ],
+                        "retryable": true,
+                        "rule_failures": [],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                    },
+                    "recorded_at": "2026-04-01T08:00:05Z",
+                    "reevaluation": {},
+                    "reported_by": "stub-executor",
+                    "status": "succeeded"
+                  },
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "execution_log",
+                        "commit_sha": null,
+                        "external_id": null,
+                        "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                        "metadata": {
+                          "advisory": true
+                        },
+                        "reference_id": "attempt-2:log"
+                      }
+                    ],
+                    "attempt_id": "attempt-2",
+                    "completion_claim_id": "attempt-2:claim",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "contract_violation",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing branch identity for the current run."
+                        ],
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.871964Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                      "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                      "dispatch_mode": "automatic",
+                      "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                      "dispatch_trigger": "invalid_execution_attempt_retry",
+                      "execution_events": [
+                        {
+                          "event_id": "attempt-2:started",
+                          "event_type": "execution_started",
+                          "metadata": {
+                            "adapter": "stub-executor",
+                            "mode": "stub"
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870771Z",
+                          "source_system": "stub-executor"
+                        },
+                        {
+                          "event_id": "attempt-2:completed",
+                          "event_type": "execution_succeeded",
+                          "metadata": {
+                            "adapter": "stub-executor",
+                            "executor_run_id": "stub-run-attempt-2"
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870785Z",
+                          "source_system": "stub-executor"
+                        }
+                      ],
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      },
+                      "executor": "codex"
+                    },
+                    "recorded_at": "2026-04-11T16:04:28.870785Z",
+                    "reevaluation": {},
+                    "reported_by": "codex",
+                    "status": "completed"
+                  }
+                ],
+                "schema_required_deferred_fields": [
+                  "parent_task_id",
+                  "child_task_ids",
+                  "dependencies",
+                  "assigned_executor",
+                  "required_capabilities",
+                  "priority",
+                  "artifacts.items",
+                  "artifacts.completion_evidence",
+                  "observability"
+                ]
+              },
+              "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+              }
+            },
+            "origin": {
+              "ingress_id": null,
+              "ingress_name": null,
+              "requested_by": null,
+              "source_id": "req-happy-overlay-1",
+              "source_system": "openclaw",
+              "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "normal",
+            "reconciliation": {
+              "active_failure_type": null,
+              "attempts": [],
+              "failed_at": null,
+              "last_attempt_id": null,
+              "last_error": null,
+              "last_pr_url": null,
+              "resolved_at": null,
+              "status": "not_required"
+            },
+            "required_capabilities": [],
+            "status": "failed",
+            "status_history": [
+              {
+                "changed_at": "2026-04-11T16:04:28.878677Z",
+                "changed_by": "verification",
+                "from_status": "assigned",
+                "reason": "Successful execution attempt is missing branch identity for the current run.",
+                "to_status": "failed"
+              }
+            ],
+            "timestamps": {
+              "completed_at": null,
+              "created_at": "2026-03-31T14:30:00Z",
+              "updated_at": "2026-04-11T16:04:28.878677Z"
+            },
+            "title": "KNO-181 task-kno-181-scenario-a"
+          }
         },
-        "accepted_completion": false,
-        "requires_review": false,
-        "invalid_input": false,
-        "failure_classification": {
-          "failure_type": "invalid_execution_attempt",
-          "source": "executor",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
-          "terminal": true,
-          "recoverable": false,
-          "category": "invalid_execution_attempt",
-          "retryable": false
+        "task_id": "task-kno-181-scenario-a"
+      },
+      "initial_evaluation_record": {
+        "evaluation_id": "952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
+        "recorded_at": "2026-04-11T16:04:28.872467Z",
+        "request": {
+          "acceptance_criteria_satisfied": false,
+          "claimed_completion": true,
+          "external_facts": null,
+          "retry_context": null,
+          "review_decision": null,
+          "review_is_active": false,
+          "review_reasons": [],
+          "review_request": null,
+          "runtime_facts": {
+            "attempt_count": 2,
+            "executor_reported_failure": false,
+            "executor_reported_success": true,
+            "latest_attempt_outcome": "completed",
+            "terminal_failure": false
+          },
+          "task_envelope": {
+            "acceptance_criteria": [
+              {
+                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                "id": "ac-1",
+                "required": true
+              }
+            ],
+            "artifacts": {
+              "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+              },
+              "items": []
+            },
+            "assigned_executor": {
+              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+              "executor_id": "executor-kno-181-a",
+              "executor_type": "codex"
+            },
+            "child_task_ids": [],
+            "constraints": [],
+            "coordination": {
+              "linear": null
+            },
+            "dependencies": [],
+            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+            "id": "task-kno-181-scenario-a",
+            "objective": {
+              "deliverable_type": "unspecified",
+              "success_signal": "Task satisfies declared acceptance criteria.",
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+            },
+            "observability": {
+              "errors": [],
+              "execution_metadata": {
+                "advisory_completion_claims": [
+                  {
+                    "claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_id": "attempt-1"
+                    },
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-01T08:00:00Z",
+                    "reported_by": "stub-executor"
+                  },
+                  {
+                    "claim_id": "attempt-2:claim",
+                    "metadata": {
+                      "advisory_only": true,
+                      "attempt_id": "attempt-2",
+                      "dispatch_mode": "automatic",
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      }
+                    },
+                    "reason": "Successful execution attempt is missing repository identity for the current run.",
+                    "reported_at": "2026-04-11T16:04:28.870785Z",
+                    "reported_by": "codex"
+                  }
+                ],
+                "execution_attempts": [
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
+                      }
+                    ],
+                    "attempt_id": "attempt-kno-181-a-1",
+                    "completion_claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "invalid_execution_attempt",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing repository identity for the current run.",
+                          "Successful execution attempt is missing commit SHA for the current run."
+                        ],
+                        "retryable": true,
+                        "rule_failures": [],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                    },
+                    "recorded_at": "2026-04-01T08:00:05Z",
+                    "reevaluation": {},
+                    "reported_by": "stub-executor",
+                    "status": "succeeded"
+                  },
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "execution_log",
+                        "commit_sha": null,
+                        "external_id": null,
+                        "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                        "metadata": {
+                          "advisory": true
+                        },
+                        "reference_id": "attempt-2:log"
+                      }
+                    ],
+                    "attempt_id": "attempt-2",
+                    "completion_claim_id": "attempt-2:claim",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "contract_violation",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing branch identity for the current run."
+                        ],
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.871964Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                      "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                      "dispatch_mode": "automatic",
+                      "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                      "dispatch_trigger": "invalid_execution_attempt_retry",
+                      "execution_events": [
+                        {
+                          "event_id": "attempt-2:started",
+                          "event_type": "execution_started",
+                          "metadata": {
+                            "adapter": "stub-executor",
+                            "mode": "stub"
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870771Z",
+                          "source_system": "stub-executor"
+                        },
+                        {
+                          "event_id": "attempt-2:completed",
+                          "event_type": "execution_succeeded",
+                          "metadata": {
+                            "adapter": "stub-executor",
+                            "executor_run_id": "stub-run-attempt-2"
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870785Z",
+                          "source_system": "stub-executor"
+                        }
+                      ],
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      },
+                      "executor": "codex"
+                    },
+                    "recorded_at": "2026-04-11T16:04:28.870785Z",
+                    "reevaluation": {},
+                    "reported_by": "codex",
+                    "status": "completed"
+                  }
+                ],
+                "schema_required_deferred_fields": [
+                  "parent_task_id",
+                  "child_task_ids",
+                  "dependencies",
+                  "assigned_executor",
+                  "required_capabilities",
+                  "priority",
+                  "artifacts.items",
+                  "artifacts.completion_evidence",
+                  "observability"
+                ]
+              },
+              "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+              }
+            },
+            "origin": {
+              "ingress_id": null,
+              "ingress_name": null,
+              "requested_by": null,
+              "source_id": "req-happy-overlay-1",
+              "source_system": "openclaw",
+              "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "normal",
+            "reconciliation": {
+              "active_failure_type": null,
+              "attempts": [],
+              "failed_at": null,
+              "last_attempt_id": null,
+              "last_error": null,
+              "last_pr_url": null,
+              "resolved_at": null,
+              "status": "not_required"
+            },
+            "required_capabilities": [],
+            "status": "assigned",
+            "status_history": [],
+            "timestamps": {
+              "completed_at": null,
+              "created_at": "2026-03-31T14:30:00Z",
+              "updated_at": "2026-04-11T16:04:28.872406Z"
+            },
+            "title": "KNO-181 task-kno-181-scenario-a"
+          },
+          "unresolved_conditions": []
         },
+        "result": {
+          "accepted_completion": false,
+          "action": "no_op",
+          "enforcement_result": {
+            "action": "no_op",
+            "error": "Successful execution attempt is missing branch identity for the current run.",
+            "evidence_result": null,
+            "failure_classification": {
+              "category": "contract_violation",
+              "failure_type": "contract_violation",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
+              "recoverable": false,
+              "retryable": false,
+              "source": "executor",
+              "terminal": true
+            },
+            "reasons": [
+              "Successful execution attempt is missing branch identity for the current run."
+            ],
+            "reconciliation_result": null,
+            "review_decision": null,
+            "review_request": null,
+            "target_status": null,
+            "task_envelope": {
+              "acceptance_criteria": [
+                {
+                  "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                  "id": "ac-1",
+                  "required": true
+                }
+              ],
+              "artifacts": {
+                "completion_evidence": {
+                  "notes": null,
+                  "policy": "deferred",
+                  "required_artifact_types": [],
+                  "status": "deferred",
+                  "validated_artifact_ids": [],
+                  "validated_at": null,
+                  "validation_method": "deferred",
+                  "validator": null
+                },
+                "items": []
+              },
+              "assigned_executor": {
+                "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+                "executor_id": "executor-kno-181-a",
+                "executor_type": "codex"
+              },
+              "child_task_ids": [],
+              "constraints": [],
+              "coordination": {
+                "linear": null
+              },
+              "dependencies": [],
+              "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+              "id": "task-kno-181-scenario-a",
+              "objective": {
+                "deliverable_type": "unspecified",
+                "success_signal": "Task satisfies declared acceptance criteria.",
+                "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+              },
+              "observability": {
+                "errors": [],
+                "execution_metadata": {
+                  "advisory_completion_claims": [
+                    {
+                      "claim_id": "claim-kno-181-a-1",
+                      "metadata": {
+                        "attempt_id": "attempt-1"
+                      },
+                      "reason": "executor reported completion",
+                      "reported_at": "2026-04-01T08:00:00Z",
+                      "reported_by": "stub-executor"
+                    },
+                    {
+                      "claim_id": "attempt-2:claim",
+                      "metadata": {
+                        "advisory_only": true,
+                        "attempt_id": "attempt-2",
+                        "dispatch_mode": "automatic",
+                        "execution_parameters": {
+                          "prior_invalid_attempt_id": "attempt-1"
+                        }
+                      },
+                      "reason": "Successful execution attempt is missing repository identity for the current run.",
+                      "reported_at": "2026-04-11T16:04:28.870785Z",
+                      "reported_by": "codex"
+                    }
+                  ],
+                  "execution_attempts": [
+                    {
+                      "artifact_references": [
+                        {
+                          "artifact_type": "commit",
+                          "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                          "metadata": {
+                            "branch_name": "codex/e2e-test"
+                          },
+                          "reference_id": "attempt-kno-181-a-1:commit"
+                        }
+                      ],
+                      "attempt_id": "attempt-kno-181-a-1",
+                      "completion_claim_id": "claim-kno-181-a-1",
+                      "metadata": {
+                        "attempt_validation": {
+                          "context_observations": {
+                            "branch": [
+                              {
+                                "sources": [
+                                  "execution_attempt.artifact_references[0]"
+                                ],
+                                "value": "codex/e2e-test"
+                              }
+                            ],
+                            "commit_resolution_pending": false,
+                            "has_valid_current_run_pull_request_artifact": false,
+                            "used_task_artifact_fallback": false
+                          },
+                          "failure_type": "invalid_execution_attempt",
+                          "policy": {
+                            "allow_commit_resolution_via_reconciliation": true,
+                            "allow_missing_commit_artifact_with_verified_pull_request": true,
+                            "allow_missing_pull_request": true,
+                            "reject_closed_or_historical_pull_request": true,
+                            "reject_non_numeric_pull_request_url": true,
+                            "reject_reserved_shared_branch": true,
+                            "require_commit": true,
+                            "require_exact_branch": true,
+                            "require_repository": true,
+                            "task_artifact_fallback_requires_single_attempt": true
+                          },
+                          "pull_request_observations": [],
+                          "reasons": [
+                            "Successful execution attempt is missing repository identity for the current run.",
+                            "Successful execution attempt is missing commit SHA for the current run."
+                          ],
+                          "retryable": true,
+                          "rule_failures": [],
+                          "status": "invalid",
+                          "validated_at": "2026-04-11T16:04:28.868130Z",
+                          "validated_by": "execution_validation"
+                        },
+                        "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                      },
+                      "recorded_at": "2026-04-01T08:00:05Z",
+                      "reevaluation": {},
+                      "reported_by": "stub-executor",
+                      "status": "succeeded"
+                    },
+                    {
+                      "artifact_references": [
+                        {
+                          "artifact_type": "execution_log",
+                          "commit_sha": null,
+                          "external_id": null,
+                          "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                          "metadata": {
+                            "advisory": true
+                          },
+                          "reference_id": "attempt-2:log"
+                        }
+                      ],
+                      "attempt_id": "attempt-2",
+                      "completion_claim_id": "attempt-2:claim",
+                      "metadata": {
+                        "attempt_validation": {
+                          "context_observations": {
+                            "commit_resolution_pending": false,
+                            "has_valid_current_run_pull_request_artifact": false,
+                            "used_task_artifact_fallback": false
+                          },
+                          "failure_type": "contract_violation",
+                          "policy": {
+                            "allow_commit_resolution_via_reconciliation": true,
+                            "allow_missing_commit_artifact_with_verified_pull_request": true,
+                            "allow_missing_pull_request": true,
+                            "reject_closed_or_historical_pull_request": true,
+                            "reject_non_numeric_pull_request_url": true,
+                            "reject_reserved_shared_branch": true,
+                            "require_commit": true,
+                            "require_exact_branch": true,
+                            "require_repository": true,
+                            "task_artifact_fallback_requires_single_attempt": true
+                          },
+                          "pull_request_observations": [],
+                          "reasons": [
+                            "Successful execution attempt is missing branch identity for the current run."
+                          ],
+                          "retryable": false,
+                          "rule_failures": [
+                            {
+                              "message": "Successful execution attempt is missing branch identity for the current run.",
+                              "rule": "missing_branch_identity"
+                            }
+                          ],
+                          "status": "invalid",
+                          "validated_at": "2026-04-11T16:04:28.871964Z",
+                          "validated_by": "execution_validation"
+                        },
+                        "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                        "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                        "dispatch_mode": "automatic",
+                        "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                        "dispatch_trigger": "invalid_execution_attempt_retry",
+                        "execution_events": [
+                          {
+                            "event_id": "attempt-2:started",
+                            "event_type": "execution_started",
+                            "metadata": {
+                              "adapter": "stub-executor",
+                              "mode": "stub"
+                            },
+                            "occurred_at": "2026-04-11T16:04:28.870771Z",
+                            "source_system": "stub-executor"
+                          },
+                          {
+                            "event_id": "attempt-2:completed",
+                            "event_type": "execution_succeeded",
+                            "metadata": {
+                              "adapter": "stub-executor",
+                              "executor_run_id": "stub-run-attempt-2"
+                            },
+                            "occurred_at": "2026-04-11T16:04:28.870785Z",
+                            "source_system": "stub-executor"
+                          }
+                        ],
+                        "execution_parameters": {
+                          "prior_invalid_attempt_id": "attempt-1"
+                        },
+                        "executor": "codex"
+                      },
+                      "recorded_at": "2026-04-11T16:04:28.870785Z",
+                      "reevaluation": {},
+                      "reported_by": "codex",
+                      "status": "completed"
+                    }
+                  ],
+                  "schema_required_deferred_fields": [
+                    "parent_task_id",
+                    "child_task_ids",
+                    "dependencies",
+                    "assigned_executor",
+                    "required_capabilities",
+                    "priority",
+                    "artifacts.items",
+                    "artifacts.completion_evidence",
+                    "observability"
+                  ]
+                },
+                "retries": {
+                  "attempt_count": 0,
+                  "last_retry_at": null,
+                  "max_attempts": 0
+                }
+              },
+              "origin": {
+                "ingress_id": null,
+                "ingress_name": null,
+                "requested_by": null,
+                "source_id": "req-happy-overlay-1",
+                "source_system": "openclaw",
+                "source_type": "ingress_request"
+              },
+              "parent_task_id": null,
+              "priority": "normal",
+              "reconciliation": {
+                "active_failure_type": null,
+                "attempts": [],
+                "failed_at": null,
+                "last_attempt_id": null,
+                "last_error": null,
+                "last_pr_url": null,
+                "resolved_at": null,
+                "status": "not_required"
+              },
+              "required_capabilities": [],
+              "status": "assigned",
+              "status_history": [],
+              "timestamps": {
+                "completed_at": null,
+                "created_at": "2026-03-31T14:30:00Z",
+                "updated_at": "2026-04-11T16:04:28.872406Z"
+              },
+              "title": "KNO-181 task-kno-181-scenario-a"
+            },
+            "transition_result": null,
+            "verification_result": null
+          },
+          "error": "Successful execution attempt is missing branch identity for the current run.",
+          "failure_classification": {
+            "category": "contract_violation",
+            "failure_type": "contract_violation",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
+            "recoverable": false,
+            "retryable": false,
+            "source": "executor",
+            "terminal": true
+          },
+          "invalid_input": false,
+          "reasons": [
+            "Successful execution attempt is missing branch identity for the current run."
+          ],
+          "requires_review": false,
+          "target_status": null,
+          "task_envelope": {
+            "acceptance_criteria": [
+              {
+                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                "id": "ac-1",
+                "required": true
+              }
+            ],
+            "artifacts": {
+              "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+              },
+              "items": []
+            },
+            "assigned_executor": {
+              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+              "executor_id": "executor-kno-181-a",
+              "executor_type": "codex"
+            },
+            "child_task_ids": [],
+            "constraints": [],
+            "coordination": {
+              "linear": null
+            },
+            "dependencies": [],
+            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+            "id": "task-kno-181-scenario-a",
+            "objective": {
+              "deliverable_type": "unspecified",
+              "success_signal": "Task satisfies declared acceptance criteria.",
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+            },
+            "observability": {
+              "errors": [],
+              "execution_metadata": {
+                "advisory_completion_claims": [
+                  {
+                    "claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_id": "attempt-1"
+                    },
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-01T08:00:00Z",
+                    "reported_by": "stub-executor"
+                  },
+                  {
+                    "claim_id": "attempt-2:claim",
+                    "metadata": {
+                      "advisory_only": true,
+                      "attempt_id": "attempt-2",
+                      "dispatch_mode": "automatic",
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      }
+                    },
+                    "reason": "Successful execution attempt is missing repository identity for the current run.",
+                    "reported_at": "2026-04-11T16:04:28.870785Z",
+                    "reported_by": "codex"
+                  }
+                ],
+                "execution_attempts": [
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
+                      }
+                    ],
+                    "attempt_id": "attempt-kno-181-a-1",
+                    "completion_claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "invalid_execution_attempt",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing repository identity for the current run.",
+                          "Successful execution attempt is missing commit SHA for the current run."
+                        ],
+                        "retryable": true,
+                        "rule_failures": [],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                    },
+                    "recorded_at": "2026-04-01T08:00:05Z",
+                    "reevaluation": {},
+                    "reported_by": "stub-executor",
+                    "status": "succeeded"
+                  },
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "execution_log",
+                        "commit_sha": null,
+                        "external_id": null,
+                        "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                        "metadata": {
+                          "advisory": true
+                        },
+                        "reference_id": "attempt-2:log"
+                      }
+                    ],
+                    "attempt_id": "attempt-2",
+                    "completion_claim_id": "attempt-2:claim",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "contract_violation",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing branch identity for the current run."
+                        ],
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.871964Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                      "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                      "dispatch_mode": "automatic",
+                      "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                      "dispatch_trigger": "invalid_execution_attempt_retry",
+                      "execution_events": [
+                        {
+                          "event_id": "attempt-2:started",
+                          "event_type": "execution_started",
+                          "metadata": {
+                            "adapter": "stub-executor",
+                            "mode": "stub"
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870771Z",
+                          "source_system": "stub-executor"
+                        },
+                        {
+                          "event_id": "attempt-2:completed",
+                          "event_type": "execution_succeeded",
+                          "metadata": {
+                            "adapter": "stub-executor",
+                            "executor_run_id": "stub-run-attempt-2"
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870785Z",
+                          "source_system": "stub-executor"
+                        }
+                      ],
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      },
+                      "executor": "codex"
+                    },
+                    "recorded_at": "2026-04-11T16:04:28.870785Z",
+                    "reevaluation": {},
+                    "reported_by": "codex",
+                    "status": "completed"
+                  }
+                ],
+                "schema_required_deferred_fields": [
+                  "parent_task_id",
+                  "child_task_ids",
+                  "dependencies",
+                  "assigned_executor",
+                  "required_capabilities",
+                  "priority",
+                  "artifacts.items",
+                  "artifacts.completion_evidence",
+                  "observability"
+                ]
+              },
+              "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+              }
+            },
+            "origin": {
+              "ingress_id": null,
+              "ingress_name": null,
+              "requested_by": null,
+              "source_id": "req-happy-overlay-1",
+              "source_system": "openclaw",
+              "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "normal",
+            "reconciliation": {
+              "active_failure_type": null,
+              "attempts": [],
+              "failed_at": null,
+              "last_attempt_id": null,
+              "last_error": null,
+              "last_pr_url": null,
+              "resolved_at": null,
+              "status": "not_required"
+            },
+            "required_capabilities": [],
+            "status": "assigned",
+            "status_history": [],
+            "timestamps": {
+              "completed_at": null,
+              "created_at": "2026-03-31T14:30:00Z",
+              "updated_at": "2026-04-11T16:04:28.872406Z"
+            },
+            "title": "KNO-181 task-kno-181-scenario-a"
+          }
+        },
+        "task_id": "task-kno-181-scenario-a"
+      },
+      "invalid_attempt_count": 1,
+      "retry_budget": 1,
+      "status": "failed",
+      "validation": {
+        "context_observations": {
+          "commit_resolution_pending": false,
+          "has_valid_current_run_pull_request_artifact": false,
+          "used_task_artifact_fallback": false
+        },
+        "failure_type": "contract_violation",
+        "policy": {
+          "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
+          "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
+          "require_commit": true,
+          "require_exact_branch": true,
+          "require_repository": true,
+          "task_artifact_fallback_requires_single_attempt": true
+        },
+        "pull_request_observations": [],
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
-        "error": "Successful execution attempt is missing repository identity for the current run."
+        "retryable": false,
+        "rule_failures": [
+          {
+            "message": "Successful execution attempt is missing branch identity for the current run.",
+            "rule": "missing_branch_identity"
+          }
+        ],
+        "status": "invalid",
+        "validated_at": "2026-04-11T16:04:28.871964Z",
+        "validated_by": "execution_validation"
       }
     },
     "dispatch": {
-      "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
-      "task_id": "task-kno-181-scenario-a",
       "attempt_id": "attempt-2",
+      "attempt_status": "completed",
+      "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
       "executor": "codex",
-      "attempt_status": "completed"
+      "task_id": "task-kno-181-scenario-a"
+    },
+    "error": "Successful execution attempt is missing branch identity for the current run.",
+    "evaluation_record": {
+      "evaluation_id": "bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+      "recorded_at": "2026-04-11T16:04:28.882026Z",
+      "request": {
+        "acceptance_criteria_satisfied": false,
+        "claimed_completion": true,
+        "external_facts": null,
+        "retry_context": null,
+        "review_decision": null,
+        "review_is_active": false,
+        "review_reasons": [],
+        "review_request": null,
+        "runtime_facts": {
+          "attempt_count": 2,
+          "executor_reported_failure": false,
+          "executor_reported_success": true,
+          "latest_attempt_outcome": "completed",
+          "terminal_failure": false
+        },
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "deferred",
+              "required_artifact_types": [],
+              "status": "deferred",
+              "validated_artifact_ids": [],
+              "validated_at": null,
+              "validation_method": "deferred",
+              "validator": null
+            },
+            "items": []
+          },
+          "assigned_executor": null,
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": null
+          },
+          "dependencies": [],
+          "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+          "id": "task-kno-181-scenario-a",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-181-a-1",
+                  "metadata": {
+                    "attempt_id": "attempt-1"
+                  },
+                  "reason": "executor reported completion",
+                  "reported_at": "2026-04-01T08:00:00Z",
+                  "reported_by": "stub-executor"
+                },
+                {
+                  "claim_id": "attempt-2:claim",
+                  "metadata": {
+                    "advisory_only": true,
+                    "attempt_id": "attempt-2",
+                    "dispatch_mode": "automatic",
+                    "execution_parameters": {
+                      "prior_invalid_attempt_id": "attempt-1"
+                    }
+                  },
+                  "reason": "Successful execution attempt is missing repository identity for the current run.",
+                  "reported_at": "2026-04-11T16:04:28.870785Z",
+                  "reported_by": "codex"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "commit",
+                      "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test"
+                      },
+                      "reference_id": "attempt-kno-181-a-1:commit"
+                    }
+                  ],
+                  "attempt_id": "attempt-kno-181-a-1",
+                  "completion_claim_id": "claim-kno-181-a-1",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "used_task_artifact_fallback": false
+                      },
+                      "failure_type": "invalid_execution_attempt",
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [
+                        "Successful execution attempt is missing repository identity for the current run.",
+                        "Successful execution attempt is missing commit SHA for the current run."
+                      ],
+                      "retryable": true,
+                      "rule_failures": [],
+                      "status": "invalid",
+                      "validated_at": "2026-04-11T16:04:28.868130Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                  },
+                  "recorded_at": "2026-04-01T08:00:05Z",
+                  "reevaluation": {},
+                  "reported_by": "stub-executor",
+                  "status": "succeeded"
+                },
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "execution_log",
+                      "commit_sha": null,
+                      "external_id": null,
+                      "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                      "metadata": {
+                        "advisory": true
+                      },
+                      "reference_id": "attempt-2:log"
+                    }
+                  ],
+                  "attempt_id": "attempt-2",
+                  "completion_claim_id": "attempt-2:claim",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "used_task_artifact_fallback": false
+                      },
+                      "failure_type": "contract_violation",
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [
+                        "Successful execution attempt is missing branch identity for the current run."
+                      ],
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
+                      "status": "invalid",
+                      "validated_at": "2026-04-11T16:04:28.871964Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                    "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                    "dispatch_mode": "automatic",
+                    "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                    "dispatch_trigger": "invalid_execution_attempt_retry",
+                    "execution_events": [
+                      {
+                        "event_id": "attempt-2:started",
+                        "event_type": "execution_started",
+                        "metadata": {
+                          "adapter": "stub-executor",
+                          "mode": "stub"
+                        },
+                        "occurred_at": "2026-04-11T16:04:28.870771Z",
+                        "source_system": "stub-executor"
+                      },
+                      {
+                        "event_id": "attempt-2:completed",
+                        "event_type": "execution_succeeded",
+                        "metadata": {
+                          "adapter": "stub-executor",
+                          "executor_run_id": "stub-run-attempt-2"
+                        },
+                        "occurred_at": "2026-04-11T16:04:28.870785Z",
+                        "source_system": "stub-executor"
+                      }
+                    ],
+                    "execution_parameters": {
+                      "prior_invalid_attempt_id": "attempt-1"
+                    },
+                    "executor": "codex"
+                  },
+                  "recorded_at": "2026-04-11T16:04:28.870785Z",
+                  "reevaluation": {},
+                  "reported_by": "codex",
+                  "status": "completed"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "req-happy-overlay-1",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": null,
+            "attempts": [],
+            "failed_at": null,
+            "last_attempt_id": null,
+            "last_error": null,
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "not_required"
+          },
+          "required_capabilities": [],
+          "status": "failed",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.878677Z",
+              "changed_by": "verification",
+              "from_status": "assigned",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
+              "to_status": "failed"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-03-31T14:30:00Z",
+            "updated_at": "2026-04-11T16:04:28.878677Z"
+          },
+          "title": "KNO-181 task-kno-181-scenario-a"
+        },
+        "unresolved_conditions": []
+      },
+      "result": {
+        "accepted_completion": false,
+        "action": "transition_applied",
+        "enforcement_result": {
+          "action": "transition_applied",
+          "error": "Successful execution attempt is missing branch identity for the current run.",
+          "evidence_result": null,
+          "failure_classification": {
+            "category": "contract_violation",
+            "failure_type": "contract_violation",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
+            "recoverable": false,
+            "retryable": false,
+            "source": "executor",
+            "terminal": true
+          },
+          "reasons": [
+            "Successful execution attempt is missing branch identity for the current run."
+          ],
+          "reconciliation_result": null,
+          "review_decision": null,
+          "review_request": null,
+          "target_status": "failed",
+          "task_envelope": {
+            "acceptance_criteria": [
+              {
+                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                "id": "ac-1",
+                "required": true
+              }
+            ],
+            "artifacts": {
+              "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+              },
+              "items": []
+            },
+            "assigned_executor": null,
+            "child_task_ids": [],
+            "constraints": [],
+            "coordination": {
+              "linear": null
+            },
+            "dependencies": [],
+            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+            "id": "task-kno-181-scenario-a",
+            "objective": {
+              "deliverable_type": "unspecified",
+              "success_signal": "Task satisfies declared acceptance criteria.",
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+            },
+            "observability": {
+              "errors": [],
+              "execution_metadata": {
+                "advisory_completion_claims": [
+                  {
+                    "claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_id": "attempt-1"
+                    },
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-01T08:00:00Z",
+                    "reported_by": "stub-executor"
+                  },
+                  {
+                    "claim_id": "attempt-2:claim",
+                    "metadata": {
+                      "advisory_only": true,
+                      "attempt_id": "attempt-2",
+                      "dispatch_mode": "automatic",
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      }
+                    },
+                    "reason": "Successful execution attempt is missing repository identity for the current run.",
+                    "reported_at": "2026-04-11T16:04:28.870785Z",
+                    "reported_by": "codex"
+                  }
+                ],
+                "execution_attempts": [
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
+                      }
+                    ],
+                    "attempt_id": "attempt-kno-181-a-1",
+                    "completion_claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "invalid_execution_attempt",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing repository identity for the current run.",
+                          "Successful execution attempt is missing commit SHA for the current run."
+                        ],
+                        "retryable": true,
+                        "rule_failures": [],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                    },
+                    "recorded_at": "2026-04-01T08:00:05Z",
+                    "reevaluation": {},
+                    "reported_by": "stub-executor",
+                    "status": "succeeded"
+                  },
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "execution_log",
+                        "commit_sha": null,
+                        "external_id": null,
+                        "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                        "metadata": {
+                          "advisory": true
+                        },
+                        "reference_id": "attempt-2:log"
+                      }
+                    ],
+                    "attempt_id": "attempt-2",
+                    "completion_claim_id": "attempt-2:claim",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "contract_violation",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing branch identity for the current run."
+                        ],
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.871964Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                      "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                      "dispatch_mode": "automatic",
+                      "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                      "dispatch_trigger": "invalid_execution_attempt_retry",
+                      "execution_events": [
+                        {
+                          "event_id": "attempt-2:started",
+                          "event_type": "execution_started",
+                          "metadata": {
+                            "adapter": "stub-executor",
+                            "mode": "stub"
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870771Z",
+                          "source_system": "stub-executor"
+                        },
+                        {
+                          "event_id": "attempt-2:completed",
+                          "event_type": "execution_succeeded",
+                          "metadata": {
+                            "adapter": "stub-executor",
+                            "executor_run_id": "stub-run-attempt-2"
+                          },
+                          "occurred_at": "2026-04-11T16:04:28.870785Z",
+                          "source_system": "stub-executor"
+                        }
+                      ],
+                      "execution_parameters": {
+                        "prior_invalid_attempt_id": "attempt-1"
+                      },
+                      "executor": "codex"
+                    },
+                    "recorded_at": "2026-04-11T16:04:28.870785Z",
+                    "reevaluation": {},
+                    "reported_by": "codex",
+                    "status": "completed"
+                  }
+                ],
+                "schema_required_deferred_fields": [
+                  "parent_task_id",
+                  "child_task_ids",
+                  "dependencies",
+                  "assigned_executor",
+                  "required_capabilities",
+                  "priority",
+                  "artifacts.items",
+                  "artifacts.completion_evidence",
+                  "observability"
+                ]
+              },
+              "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+              }
+            },
+            "origin": {
+              "ingress_id": null,
+              "ingress_name": null,
+              "requested_by": null,
+              "source_id": "req-happy-overlay-1",
+              "source_system": "openclaw",
+              "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "normal",
+            "reconciliation": {
+              "active_failure_type": null,
+              "attempts": [],
+              "failed_at": null,
+              "last_attempt_id": null,
+              "last_error": null,
+              "last_pr_url": null,
+              "resolved_at": null,
+              "status": "not_required"
+            },
+            "required_capabilities": [],
+            "status": "failed",
+            "status_history": [
+              {
+                "changed_at": "2026-04-11T16:04:28.878677Z",
+                "changed_by": "verification",
+                "from_status": "assigned",
+                "reason": "Successful execution attempt is missing branch identity for the current run.",
+                "to_status": "failed"
+              }
+            ],
+            "timestamps": {
+              "completed_at": null,
+              "created_at": "2026-03-31T14:30:00Z",
+              "updated_at": "2026-04-11T16:04:28.878677Z"
+            },
+            "title": "KNO-181 task-kno-181-scenario-a"
+          },
+          "transition_result": null,
+          "verification_result": null
+        },
+        "error": "Successful execution attempt is missing branch identity for the current run.",
+        "failure_classification": {
+          "category": "contract_violation",
+          "failure_type": "contract_violation",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
+          "recoverable": false,
+          "retryable": false,
+          "source": "executor",
+          "terminal": true
+        },
+        "invalid_input": false,
+        "reasons": [
+          "Successful execution attempt is missing branch identity for the current run."
+        ],
+        "requires_review": false,
+        "target_status": "failed",
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "deferred",
+              "required_artifact_types": [],
+              "status": "deferred",
+              "validated_artifact_ids": [],
+              "validated_at": null,
+              "validation_method": "deferred",
+              "validator": null
+            },
+            "items": []
+          },
+          "assigned_executor": null,
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": null
+          },
+          "dependencies": [],
+          "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+          "id": "task-kno-181-scenario-a",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-181-a-1",
+                  "metadata": {
+                    "attempt_id": "attempt-1"
+                  },
+                  "reason": "executor reported completion",
+                  "reported_at": "2026-04-01T08:00:00Z",
+                  "reported_by": "stub-executor"
+                },
+                {
+                  "claim_id": "attempt-2:claim",
+                  "metadata": {
+                    "advisory_only": true,
+                    "attempt_id": "attempt-2",
+                    "dispatch_mode": "automatic",
+                    "execution_parameters": {
+                      "prior_invalid_attempt_id": "attempt-1"
+                    }
+                  },
+                  "reason": "Successful execution attempt is missing repository identity for the current run.",
+                  "reported_at": "2026-04-11T16:04:28.870785Z",
+                  "reported_by": "codex"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "commit",
+                      "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test"
+                      },
+                      "reference_id": "attempt-kno-181-a-1:commit"
+                    }
+                  ],
+                  "attempt_id": "attempt-kno-181-a-1",
+                  "completion_claim_id": "claim-kno-181-a-1",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "used_task_artifact_fallback": false
+                      },
+                      "failure_type": "invalid_execution_attempt",
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [
+                        "Successful execution attempt is missing repository identity for the current run.",
+                        "Successful execution attempt is missing commit SHA for the current run."
+                      ],
+                      "retryable": true,
+                      "rule_failures": [],
+                      "status": "invalid",
+                      "validated_at": "2026-04-11T16:04:28.868130Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                  },
+                  "recorded_at": "2026-04-01T08:00:05Z",
+                  "reevaluation": {},
+                  "reported_by": "stub-executor",
+                  "status": "succeeded"
+                },
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "execution_log",
+                      "commit_sha": null,
+                      "external_id": null,
+                      "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                      "metadata": {
+                        "advisory": true
+                      },
+                      "reference_id": "attempt-2:log"
+                    }
+                  ],
+                  "attempt_id": "attempt-2",
+                  "completion_claim_id": "attempt-2:claim",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "used_task_artifact_fallback": false
+                      },
+                      "failure_type": "contract_violation",
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [
+                        "Successful execution attempt is missing branch identity for the current run."
+                      ],
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
+                      "status": "invalid",
+                      "validated_at": "2026-04-11T16:04:28.871964Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                    "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                    "dispatch_mode": "automatic",
+                    "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                    "dispatch_trigger": "invalid_execution_attempt_retry",
+                    "execution_events": [
+                      {
+                        "event_id": "attempt-2:started",
+                        "event_type": "execution_started",
+                        "metadata": {
+                          "adapter": "stub-executor",
+                          "mode": "stub"
+                        },
+                        "occurred_at": "2026-04-11T16:04:28.870771Z",
+                        "source_system": "stub-executor"
+                      },
+                      {
+                        "event_id": "attempt-2:completed",
+                        "event_type": "execution_succeeded",
+                        "metadata": {
+                          "adapter": "stub-executor",
+                          "executor_run_id": "stub-run-attempt-2"
+                        },
+                        "occurred_at": "2026-04-11T16:04:28.870785Z",
+                        "source_system": "stub-executor"
+                      }
+                    ],
+                    "execution_parameters": {
+                      "prior_invalid_attempt_id": "attempt-1"
+                    },
+                    "executor": "codex"
+                  },
+                  "recorded_at": "2026-04-11T16:04:28.870785Z",
+                  "reevaluation": {},
+                  "reported_by": "codex",
+                  "status": "completed"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "req-happy-overlay-1",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": null,
+            "attempts": [],
+            "failed_at": null,
+            "last_attempt_id": null,
+            "last_error": null,
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "not_required"
+          },
+          "required_capabilities": [],
+          "status": "failed",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.878677Z",
+              "changed_by": "verification",
+              "from_status": "assigned",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
+              "to_status": "failed"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-03-31T14:30:00Z",
+            "updated_at": "2026-04-11T16:04:28.878677Z"
+          },
+          "title": "KNO-181 task-kno-181-scenario-a"
+        }
+      },
+      "task_id": "task-kno-181-scenario-a"
+    },
+    "invalid_execution_attempt": {
+      "evaluation_record": {
+        "evaluation_id": "5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+        "recorded_at": "2026-04-11T16:04:28.868320Z",
+        "request": {
+          "acceptance_criteria_satisfied": false,
+          "claimed_completion": true,
+          "external_facts": null,
+          "retry_context": {
+            "attempt_number": 1,
+            "is_final_attempt": true,
+            "max_retries": 1,
+            "scheduled_at": "2026-04-11T16:04:28.868290Z",
+            "triggered_by_category": "invalid_execution_attempt",
+            "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
+          },
+          "review_decision": null,
+          "review_is_active": false,
+          "review_reasons": [],
+          "review_request": null,
+          "runtime_facts": {
+            "attempt_count": 1,
+            "executor_reported_failure": false,
+            "executor_reported_success": true,
+            "latest_attempt_outcome": null,
+            "terminal_failure": false
+          },
+          "task_envelope": {
+            "acceptance_criteria": [
+              {
+                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                "id": "ac-1",
+                "required": true
+              }
+            ],
+            "artifacts": {
+              "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+              },
+              "items": []
+            },
+            "assigned_executor": {
+              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+              "executor_id": "executor-kno-181-a",
+              "executor_type": "codex"
+            },
+            "child_task_ids": [],
+            "constraints": [],
+            "coordination": {
+              "linear": null
+            },
+            "dependencies": [],
+            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+            "id": "task-kno-181-scenario-a",
+            "objective": {
+              "deliverable_type": "unspecified",
+              "success_signal": "Task satisfies declared acceptance criteria.",
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+            },
+            "observability": {
+              "errors": [],
+              "execution_metadata": {
+                "advisory_completion_claims": [
+                  {
+                    "claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_id": "attempt-1"
+                    },
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-01T08:00:00Z",
+                    "reported_by": "stub-executor"
+                  }
+                ],
+                "execution_attempts": [
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
+                      }
+                    ],
+                    "attempt_id": "attempt-kno-181-a-1",
+                    "completion_claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "invalid_execution_attempt",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing repository identity for the current run.",
+                          "Successful execution attempt is missing commit SHA for the current run."
+                        ],
+                        "retryable": true,
+                        "rule_failures": [],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                    },
+                    "recorded_at": "2026-04-01T08:00:05Z",
+                    "reevaluation": {},
+                    "reported_by": "stub-executor",
+                    "status": "succeeded"
+                  }
+                ],
+                "schema_required_deferred_fields": [
+                  "parent_task_id",
+                  "child_task_ids",
+                  "dependencies",
+                  "assigned_executor",
+                  "required_capabilities",
+                  "priority",
+                  "artifacts.items",
+                  "artifacts.completion_evidence",
+                  "observability"
+                ]
+              },
+              "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+              }
+            },
+            "origin": {
+              "ingress_id": null,
+              "ingress_name": null,
+              "requested_by": null,
+              "source_id": "req-happy-overlay-1",
+              "source_system": "openclaw",
+              "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "normal",
+            "reconciliation": {
+              "active_failure_type": null,
+              "attempts": [],
+              "failed_at": null,
+              "last_attempt_id": null,
+              "last_error": null,
+              "last_pr_url": null,
+              "resolved_at": null,
+              "status": "not_required"
+            },
+            "required_capabilities": [],
+            "status": "assigned",
+            "status_history": [],
+            "timestamps": {
+              "completed_at": null,
+              "created_at": "2026-03-31T14:30:00Z",
+              "updated_at": "2026-04-11T16:04:28.868279Z"
+            },
+            "title": "KNO-181 task-kno-181-scenario-a"
+          },
+          "unresolved_conditions": []
+        },
+        "result": {
+          "accepted_completion": false,
+          "action": "no_op",
+          "enforcement_result": {
+            "action": "no_op",
+            "error": "Successful execution attempt is missing repository identity for the current run.",
+            "evidence_result": null,
+            "failure_classification": {
+              "category": "invalid_execution_attempt",
+              "failure_type": "invalid_execution_attempt",
+              "reason": "Successful execution attempt is missing repository identity for the current run.",
+              "recoverable": true,
+              "retryable": true,
+              "source": "executor",
+              "terminal": false
+            },
+            "reasons": [
+              "Successful execution attempt is missing repository identity for the current run."
+            ],
+            "reconciliation_result": null,
+            "review_decision": null,
+            "review_request": null,
+            "target_status": null,
+            "task_envelope": {
+              "acceptance_criteria": [
+                {
+                  "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                  "id": "ac-1",
+                  "required": true
+                }
+              ],
+              "artifacts": {
+                "completion_evidence": {
+                  "notes": null,
+                  "policy": "deferred",
+                  "required_artifact_types": [],
+                  "status": "deferred",
+                  "validated_artifact_ids": [],
+                  "validated_at": null,
+                  "validation_method": "deferred",
+                  "validator": null
+                },
+                "items": []
+              },
+              "assigned_executor": {
+                "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+                "executor_id": "executor-kno-181-a",
+                "executor_type": "codex"
+              },
+              "child_task_ids": [],
+              "constraints": [],
+              "coordination": {
+                "linear": null
+              },
+              "dependencies": [],
+              "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+              "id": "task-kno-181-scenario-a",
+              "objective": {
+                "deliverable_type": "unspecified",
+                "success_signal": "Task satisfies declared acceptance criteria.",
+                "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+              },
+              "observability": {
+                "errors": [],
+                "execution_metadata": {
+                  "advisory_completion_claims": [
+                    {
+                      "claim_id": "claim-kno-181-a-1",
+                      "metadata": {
+                        "attempt_id": "attempt-1"
+                      },
+                      "reason": "executor reported completion",
+                      "reported_at": "2026-04-01T08:00:00Z",
+                      "reported_by": "stub-executor"
+                    }
+                  ],
+                  "execution_attempts": [
+                    {
+                      "artifact_references": [
+                        {
+                          "artifact_type": "commit",
+                          "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                          "metadata": {
+                            "branch_name": "codex/e2e-test"
+                          },
+                          "reference_id": "attempt-kno-181-a-1:commit"
+                        }
+                      ],
+                      "attempt_id": "attempt-kno-181-a-1",
+                      "completion_claim_id": "claim-kno-181-a-1",
+                      "metadata": {
+                        "attempt_validation": {
+                          "context_observations": {
+                            "branch": [
+                              {
+                                "sources": [
+                                  "execution_attempt.artifact_references[0]"
+                                ],
+                                "value": "codex/e2e-test"
+                              }
+                            ],
+                            "commit_resolution_pending": false,
+                            "has_valid_current_run_pull_request_artifact": false,
+                            "used_task_artifact_fallback": false
+                          },
+                          "failure_type": "invalid_execution_attempt",
+                          "policy": {
+                            "allow_commit_resolution_via_reconciliation": true,
+                            "allow_missing_commit_artifact_with_verified_pull_request": true,
+                            "allow_missing_pull_request": true,
+                            "reject_closed_or_historical_pull_request": true,
+                            "reject_non_numeric_pull_request_url": true,
+                            "reject_reserved_shared_branch": true,
+                            "require_commit": true,
+                            "require_exact_branch": true,
+                            "require_repository": true,
+                            "task_artifact_fallback_requires_single_attempt": true
+                          },
+                          "pull_request_observations": [],
+                          "reasons": [
+                            "Successful execution attempt is missing repository identity for the current run.",
+                            "Successful execution attempt is missing commit SHA for the current run."
+                          ],
+                          "retryable": true,
+                          "rule_failures": [],
+                          "status": "invalid",
+                          "validated_at": "2026-04-11T16:04:28.868130Z",
+                          "validated_by": "execution_validation"
+                        },
+                        "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                      },
+                      "recorded_at": "2026-04-01T08:00:05Z",
+                      "reevaluation": {},
+                      "reported_by": "stub-executor",
+                      "status": "succeeded"
+                    }
+                  ],
+                  "schema_required_deferred_fields": [
+                    "parent_task_id",
+                    "child_task_ids",
+                    "dependencies",
+                    "assigned_executor",
+                    "required_capabilities",
+                    "priority",
+                    "artifacts.items",
+                    "artifacts.completion_evidence",
+                    "observability"
+                  ]
+                },
+                "retries": {
+                  "attempt_count": 0,
+                  "last_retry_at": null,
+                  "max_attempts": 0
+                }
+              },
+              "origin": {
+                "ingress_id": null,
+                "ingress_name": null,
+                "requested_by": null,
+                "source_id": "req-happy-overlay-1",
+                "source_system": "openclaw",
+                "source_type": "ingress_request"
+              },
+              "parent_task_id": null,
+              "priority": "normal",
+              "reconciliation": {
+                "active_failure_type": null,
+                "attempts": [],
+                "failed_at": null,
+                "last_attempt_id": null,
+                "last_error": null,
+                "last_pr_url": null,
+                "resolved_at": null,
+                "status": "not_required"
+              },
+              "required_capabilities": [],
+              "status": "assigned",
+              "status_history": [],
+              "timestamps": {
+                "completed_at": null,
+                "created_at": "2026-03-31T14:30:00Z",
+                "updated_at": "2026-04-11T16:04:28.868279Z"
+              },
+              "title": "KNO-181 task-kno-181-scenario-a"
+            },
+            "transition_result": null,
+            "verification_result": null
+          },
+          "error": "Successful execution attempt is missing repository identity for the current run.",
+          "failure_classification": {
+            "category": "invalid_execution_attempt",
+            "failure_type": "invalid_execution_attempt",
+            "reason": "Successful execution attempt is missing repository identity for the current run.",
+            "recoverable": true,
+            "retryable": true,
+            "source": "executor",
+            "terminal": false
+          },
+          "invalid_input": false,
+          "reasons": [
+            "Successful execution attempt is missing repository identity for the current run."
+          ],
+          "requires_review": false,
+          "target_status": null,
+          "task_envelope": {
+            "acceptance_criteria": [
+              {
+                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                "id": "ac-1",
+                "required": true
+              }
+            ],
+            "artifacts": {
+              "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+              },
+              "items": []
+            },
+            "assigned_executor": {
+              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+              "executor_id": "executor-kno-181-a",
+              "executor_type": "codex"
+            },
+            "child_task_ids": [],
+            "constraints": [],
+            "coordination": {
+              "linear": null
+            },
+            "dependencies": [],
+            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+            "id": "task-kno-181-scenario-a",
+            "objective": {
+              "deliverable_type": "unspecified",
+              "success_signal": "Task satisfies declared acceptance criteria.",
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+            },
+            "observability": {
+              "errors": [],
+              "execution_metadata": {
+                "advisory_completion_claims": [
+                  {
+                    "claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_id": "attempt-1"
+                    },
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-01T08:00:00Z",
+                    "reported_by": "stub-executor"
+                  }
+                ],
+                "execution_attempts": [
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
+                      }
+                    ],
+                    "attempt_id": "attempt-kno-181-a-1",
+                    "completion_claim_id": "claim-kno-181-a-1",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "invalid_execution_attempt",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing repository identity for the current run.",
+                          "Successful execution attempt is missing commit SHA for the current run."
+                        ],
+                        "retryable": true,
+                        "rule_failures": [],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "executor_run_id": "stub-run-attempt-kno-181-a-1"
+                    },
+                    "recorded_at": "2026-04-01T08:00:05Z",
+                    "reevaluation": {},
+                    "reported_by": "stub-executor",
+                    "status": "succeeded"
+                  }
+                ],
+                "schema_required_deferred_fields": [
+                  "parent_task_id",
+                  "child_task_ids",
+                  "dependencies",
+                  "assigned_executor",
+                  "required_capabilities",
+                  "priority",
+                  "artifacts.items",
+                  "artifacts.completion_evidence",
+                  "observability"
+                ]
+              },
+              "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+              }
+            },
+            "origin": {
+              "ingress_id": null,
+              "ingress_name": null,
+              "requested_by": null,
+              "source_id": "req-happy-overlay-1",
+              "source_system": "openclaw",
+              "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "normal",
+            "reconciliation": {
+              "active_failure_type": null,
+              "attempts": [],
+              "failed_at": null,
+              "last_attempt_id": null,
+              "last_error": null,
+              "last_pr_url": null,
+              "resolved_at": null,
+              "status": "not_required"
+            },
+            "required_capabilities": [],
+            "status": "assigned",
+            "status_history": [],
+            "timestamps": {
+              "completed_at": null,
+              "created_at": "2026-03-31T14:30:00Z",
+              "updated_at": "2026-04-11T16:04:28.868279Z"
+            },
+            "title": "KNO-181 task-kno-181-scenario-a"
+          }
+        },
+        "task_id": "task-kno-181-scenario-a"
+      },
+      "retry_context": {
+        "attempt_number": 1,
+        "is_final_attempt": true,
+        "max_retries": 1,
+        "scheduled_at": "2026-04-11T16:04:28.868290Z",
+        "triggered_by_category": "invalid_execution_attempt",
+        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
+      },
+      "status": "retry_scheduled",
+      "validation": {
+        "context_observations": {
+          "branch": [
+            {
+              "sources": [
+                "execution_attempt.artifact_references[0]"
+              ],
+              "value": "codex/e2e-test"
+            }
+          ],
+          "commit_resolution_pending": false,
+          "has_valid_current_run_pull_request_artifact": false,
+          "used_task_artifact_fallback": false
+        },
+        "failure_type": "invalid_execution_attempt",
+        "policy": {
+          "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
+          "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
+          "require_commit": true,
+          "require_exact_branch": true,
+          "require_repository": true,
+          "task_artifact_fallback_requires_single_attempt": true
+        },
+        "pull_request_observations": [],
+        "reasons": [
+          "Successful execution attempt is missing repository identity for the current run.",
+          "Successful execution attempt is missing commit SHA for the current run."
+        ],
+        "retryable": true,
+        "rule_failures": [],
+        "status": "invalid",
+        "validated_at": "2026-04-11T16:04:28.868130Z",
+        "validated_by": "execution_validation"
+      }
+    },
+    "invalid_input": false,
+    "reasons": [
+      "Successful execution attempt is missing branch identity for the current run."
+    ],
+    "requires_review": false,
+    "target_status": "failed",
+    "task_envelope": {
+      "acceptance_criteria": [
+        {
+          "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+          "id": "ac-1",
+          "required": true
+        }
+      ],
+      "artifacts": {
+        "completion_evidence": {
+          "notes": null,
+          "policy": "deferred",
+          "required_artifact_types": [],
+          "status": "deferred",
+          "validated_artifact_ids": [],
+          "validated_at": null,
+          "validation_method": "deferred",
+          "validator": null
+        },
+        "items": []
+      },
+      "assigned_executor": null,
+      "child_task_ids": [],
+      "constraints": [],
+      "coordination": {
+        "linear": null
+      },
+      "dependencies": [],
+      "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+      "id": "task-kno-181-scenario-a",
+      "objective": {
+        "deliverable_type": "unspecified",
+        "success_signal": "Task satisfies declared acceptance criteria.",
+        "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {
+          "advisory_completion_claims": [
+            {
+              "claim_id": "claim-kno-181-a-1",
+              "metadata": {
+                "attempt_id": "attempt-1"
+              },
+              "reason": "executor reported completion",
+              "reported_at": "2026-04-01T08:00:00Z",
+              "reported_by": "stub-executor"
+            },
+            {
+              "claim_id": "attempt-2:claim",
+              "metadata": {
+                "advisory_only": true,
+                "attempt_id": "attempt-2",
+                "dispatch_mode": "automatic",
+                "execution_parameters": {
+                  "prior_invalid_attempt_id": "attempt-1"
+                }
+              },
+              "reason": "Successful execution attempt is missing repository identity for the current run.",
+              "reported_at": "2026-04-11T16:04:28.870785Z",
+              "reported_by": "codex"
+            }
+          ],
+          "execution_attempts": [
+            {
+              "artifact_references": [
+                {
+                  "artifact_type": "commit",
+                  "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                  "metadata": {
+                    "branch_name": "codex/e2e-test"
+                  },
+                  "reference_id": "attempt-kno-181-a-1:commit"
+                }
+              ],
+              "attempt_id": "attempt-kno-181-a-1",
+              "completion_claim_id": "claim-kno-181-a-1",
+              "metadata": {
+                "attempt_validation": {
+                  "context_observations": {
+                    "branch": [
+                      {
+                        "sources": [
+                          "execution_attempt.artifact_references[0]"
+                        ],
+                        "value": "codex/e2e-test"
+                      }
+                    ],
+                    "commit_resolution_pending": false,
+                    "has_valid_current_run_pull_request_artifact": false,
+                    "used_task_artifact_fallback": false
+                  },
+                  "failure_type": "invalid_execution_attempt",
+                  "policy": {
+                    "allow_commit_resolution_via_reconciliation": true,
+                    "allow_missing_commit_artifact_with_verified_pull_request": true,
+                    "allow_missing_pull_request": true,
+                    "reject_closed_or_historical_pull_request": true,
+                    "reject_non_numeric_pull_request_url": true,
+                    "reject_reserved_shared_branch": true,
+                    "require_commit": true,
+                    "require_exact_branch": true,
+                    "require_repository": true,
+                    "task_artifact_fallback_requires_single_attempt": true
+                  },
+                  "pull_request_observations": [],
+                  "reasons": [
+                    "Successful execution attempt is missing repository identity for the current run.",
+                    "Successful execution attempt is missing commit SHA for the current run."
+                  ],
+                  "retryable": true,
+                  "rule_failures": [],
+                  "status": "invalid",
+                  "validated_at": "2026-04-11T16:04:28.868130Z",
+                  "validated_by": "execution_validation"
+                },
+                "executor_run_id": "stub-run-attempt-kno-181-a-1"
+              },
+              "recorded_at": "2026-04-01T08:00:05Z",
+              "reevaluation": {},
+              "reported_by": "stub-executor",
+              "status": "succeeded"
+            },
+            {
+              "artifact_references": [
+                {
+                  "artifact_type": "execution_log",
+                  "commit_sha": null,
+                  "external_id": null,
+                  "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+                  "metadata": {
+                    "advisory": true
+                  },
+                  "reference_id": "attempt-2:log"
+                }
+              ],
+              "attempt_id": "attempt-2",
+              "completion_claim_id": "attempt-2:claim",
+              "metadata": {
+                "attempt_validation": {
+                  "context_observations": {
+                    "commit_resolution_pending": false,
+                    "has_valid_current_run_pull_request_artifact": false,
+                    "used_task_artifact_fallback": false
+                  },
+                  "failure_type": "contract_violation",
+                  "policy": {
+                    "allow_commit_resolution_via_reconciliation": true,
+                    "allow_missing_commit_artifact_with_verified_pull_request": true,
+                    "allow_missing_pull_request": true,
+                    "reject_closed_or_historical_pull_request": true,
+                    "reject_non_numeric_pull_request_url": true,
+                    "reject_reserved_shared_branch": true,
+                    "require_commit": true,
+                    "require_exact_branch": true,
+                    "require_repository": true,
+                    "task_artifact_fallback_requires_single_attempt": true
+                  },
+                  "pull_request_observations": [],
+                  "reasons": [
+                    "Successful execution attempt is missing branch identity for the current run."
+                  ],
+                  "retryable": false,
+                  "rule_failures": [
+                    {
+                      "message": "Successful execution attempt is missing branch identity for the current run.",
+                      "rule": "missing_branch_identity"
+                    }
+                  ],
+                  "status": "invalid",
+                  "validated_at": "2026-04-11T16:04:28.871964Z",
+                  "validated_by": "execution_validation"
+                },
+                "dispatch_at": "2026-04-11T16:04:28.870771Z",
+                "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+                "dispatch_mode": "automatic",
+                "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+                "dispatch_trigger": "invalid_execution_attempt_retry",
+                "execution_events": [
+                  {
+                    "event_id": "attempt-2:started",
+                    "event_type": "execution_started",
+                    "metadata": {
+                      "adapter": "stub-executor",
+                      "mode": "stub"
+                    },
+                    "occurred_at": "2026-04-11T16:04:28.870771Z",
+                    "source_system": "stub-executor"
+                  },
+                  {
+                    "event_id": "attempt-2:completed",
+                    "event_type": "execution_succeeded",
+                    "metadata": {
+                      "adapter": "stub-executor",
+                      "executor_run_id": "stub-run-attempt-2"
+                    },
+                    "occurred_at": "2026-04-11T16:04:28.870785Z",
+                    "source_system": "stub-executor"
+                  }
+                ],
+                "execution_parameters": {
+                  "prior_invalid_attempt_id": "attempt-1"
+                },
+                "executor": "codex"
+              },
+              "recorded_at": "2026-04-11T16:04:28.870785Z",
+              "reevaluation": {},
+              "reported_by": "codex",
+              "status": "completed"
+            }
+          ],
+          "schema_required_deferred_fields": [
+            "parent_task_id",
+            "child_task_ids",
+            "dependencies",
+            "assigned_executor",
+            "required_capabilities",
+            "priority",
+            "artifacts.items",
+            "artifacts.completion_evidence",
+            "observability"
+          ]
+        },
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": null,
+        "requested_by": null,
+        "source_id": "req-happy-overlay-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "reconciliation": {
+        "active_failure_type": null,
+        "attempts": [],
+        "failed_at": null,
+        "last_attempt_id": null,
+        "last_error": null,
+        "last_pr_url": null,
+        "resolved_at": null,
+        "status": "not_required"
+      },
+      "required_capabilities": [],
+      "status": "failed",
+      "status_history": [
+        {
+          "changed_at": "2026-04-11T16:04:28.878677Z",
+          "changed_by": "verification",
+          "from_status": "assigned",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
+          "to_status": "failed"
+        }
+      ],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-03-31T14:30:00Z",
+        "updated_at": "2026-04-11T16:04:28.878677Z"
+      },
+      "title": "KNO-181 task-kno-181-scenario-a"
     }
-  }
+  },
+  "status": 200
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-evaluation-history-final.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-evaluation-history-final.json
@@ -1,381 +1,8 @@
 {
-  "task_id": "task-kno-181-scenario-a",
   "evaluations": [
     {
-      "evaluation_id": "c460c507-1dc8-4525-8355-4126a428b996",
-      "task_id": "task-kno-181-scenario-a",
-      "recorded_at": "2026-04-05T17:30:31.525822Z",
-      "request": {
-        "acceptance_criteria_satisfied": false,
-        "claimed_completion": false,
-        "external_facts": null,
-        "retry_context": null,
-        "review_decision": null,
-        "review_is_active": false,
-        "review_reasons": [],
-        "review_request": null,
-        "runtime_facts": {
-          "attempt_count": 0,
-          "executor_reported_failure": false,
-          "executor_reported_success": false,
-          "latest_attempt_outcome": null,
-          "terminal_failure": false
-        },
-        "task_envelope": {
-          "acceptance_criteria": [
-            {
-              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-              "id": "ac-1",
-              "required": true
-            }
-          ],
-          "artifacts": {
-            "completion_evidence": {
-              "notes": null,
-              "policy": "deferred",
-              "required_artifact_types": [],
-              "status": "deferred",
-              "validated_artifact_ids": [],
-              "validated_at": null,
-              "validation_method": "deferred",
-              "validator": null
-            },
-            "items": []
-          },
-          "assigned_executor": {
-            "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "executor_id": "executor-kno-181-a",
-            "executor_type": "codex"
-          },
-          "child_task_ids": [],
-          "constraints": [],
-          "coordination": {
-            "linear": null
-          },
-          "dependencies": [],
-          "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-          "id": "task-kno-181-scenario-a",
-          "objective": {
-            "deliverable_type": "unspecified",
-            "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
-          },
-          "observability": {
-            "errors": [],
-            "execution_metadata": {
-              "schema_required_deferred_fields": [
-                "parent_task_id",
-                "child_task_ids",
-                "dependencies",
-                "assigned_executor",
-                "required_capabilities",
-                "priority",
-                "artifacts.items",
-                "artifacts.completion_evidence",
-                "observability"
-              ]
-            },
-            "retries": {
-              "attempt_count": 0,
-              "last_retry_at": null,
-              "max_attempts": 0
-            }
-          },
-          "origin": {
-            "ingress_id": null,
-            "ingress_name": null,
-            "requested_by": null,
-            "source_id": "req-happy-overlay-1",
-            "source_system": "openclaw",
-            "source_type": "ingress_request"
-          },
-          "parent_task_id": null,
-          "priority": "normal",
-          "reconciliation": {
-            "active_failure_type": null,
-            "attempts": [],
-            "failed_at": null,
-            "last_attempt_id": null,
-            "last_error": null,
-            "last_pr_url": null,
-            "resolved_at": null,
-            "status": "not_required"
-          },
-          "required_capabilities": [],
-          "status": "intake_ready",
-          "status_history": [],
-          "timestamps": {
-            "completed_at": null,
-            "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-03-31T14:30:00Z"
-          },
-          "title": "KNO-181 task-kno-181-scenario-a"
-        },
-        "unresolved_conditions": []
-      },
-      "result": {
-        "accepted_completion": false,
-        "action": "no_op",
-        "enforcement_result": {
-          "action": "no_op",
-          "error": null,
-          "evidence_result": {
-            "artifact_results": [],
-            "is_sufficient": false,
-            "is_valid": true,
-            "issues": [],
-            "missing_required_artifact_types": [],
-            "unknown_validated_artifact_ids": [],
-            "validated_artifact_ids": []
-          },
-          "failure_classification": {
-            "category": "none",
-            "failure_type": "none",
-            "reason": "No completion claim is currently being evaluated",
-            "recoverable": false,
-            "retryable": false,
-            "source": "none",
-            "terminal": false
-          },
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "reconciliation_result": null,
-          "review_decision": null,
-          "review_request": null,
-          "target_status": null,
-          "task_envelope": {
-            "acceptance_criteria": [
-              {
-                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-                "id": "ac-1",
-                "required": true
-              }
-            ],
-            "artifacts": {
-              "completion_evidence": {
-                "notes": null,
-                "policy": "deferred",
-                "required_artifact_types": [],
-                "status": "deferred",
-                "validated_artifact_ids": [],
-                "validated_at": null,
-                "validation_method": "deferred",
-                "validator": null
-              },
-              "items": []
-            },
-            "assigned_executor": {
-              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-              "executor_id": "executor-kno-181-a",
-              "executor_type": "codex"
-            },
-            "child_task_ids": [],
-            "constraints": [],
-            "coordination": {
-              "linear": null
-            },
-            "dependencies": [],
-            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "id": "task-kno-181-scenario-a",
-            "objective": {
-              "deliverable_type": "unspecified",
-              "success_signal": "Task satisfies declared acceptance criteria.",
-              "summary": "Exercise /evaluate with top-level evidence overlays."
-            },
-            "observability": {
-              "errors": [],
-              "execution_metadata": {
-                "schema_required_deferred_fields": [
-                  "parent_task_id",
-                  "child_task_ids",
-                  "dependencies",
-                  "assigned_executor",
-                  "required_capabilities",
-                  "priority",
-                  "artifacts.items",
-                  "artifacts.completion_evidence",
-                  "observability"
-                ]
-              },
-              "retries": {
-                "attempt_count": 0,
-                "last_retry_at": null,
-                "max_attempts": 0
-              }
-            },
-            "origin": {
-              "ingress_id": null,
-              "ingress_name": null,
-              "requested_by": null,
-              "source_id": "req-happy-overlay-1",
-              "source_system": "openclaw",
-              "source_type": "ingress_request"
-            },
-            "parent_task_id": null,
-            "priority": "normal",
-            "reconciliation": {
-              "active_failure_type": null,
-              "attempts": [],
-              "failed_at": null,
-              "last_attempt_id": null,
-              "last_error": null,
-              "last_pr_url": null,
-              "resolved_at": null,
-              "status": "not_required"
-            },
-            "required_capabilities": [],
-            "status": "intake_ready",
-            "status_history": [],
-            "timestamps": {
-              "completed_at": null,
-              "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-03-31T14:30:00Z"
-            },
-            "title": "KNO-181 task-kno-181-scenario-a"
-          },
-          "transition_result": null,
-          "verification_result": {
-            "accepted_completion": false,
-            "claimed_completion": false,
-            "evidence_is_sufficient": false,
-            "evidence_is_valid": true,
-            "failure_classification": {
-              "category": "none",
-              "failure_type": "none",
-              "reason": "No completion claim is currently being evaluated",
-              "recoverable": false,
-              "retryable": false,
-              "source": "none",
-              "terminal": false
-            },
-            "is_terminal": false,
-            "outcome": "verification_deferred",
-            "reasons": [
-              "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-              "No completion claim is currently being evaluated"
-            ],
-            "reconciliation_status": "pending",
-            "requires_review": false,
-            "target_status": null,
-            "task_id": "task-kno-181-scenario-a",
-            "verification_passed": false
-          }
-        },
-        "error": null,
-        "failure_classification": {
-          "category": "none",
-          "failure_type": "none",
-          "reason": "No completion claim is currently being evaluated",
-          "recoverable": false,
-          "retryable": false,
-          "source": "none",
-          "terminal": false
-        },
-        "invalid_input": false,
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "requires_review": false,
-        "target_status": null,
-        "task_envelope": {
-          "acceptance_criteria": [
-            {
-              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-              "id": "ac-1",
-              "required": true
-            }
-          ],
-          "artifacts": {
-            "completion_evidence": {
-              "notes": null,
-              "policy": "deferred",
-              "required_artifact_types": [],
-              "status": "deferred",
-              "validated_artifact_ids": [],
-              "validated_at": null,
-              "validation_method": "deferred",
-              "validator": null
-            },
-            "items": []
-          },
-          "assigned_executor": {
-            "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "executor_id": "executor-kno-181-a",
-            "executor_type": "codex"
-          },
-          "child_task_ids": [],
-          "constraints": [],
-          "coordination": {
-            "linear": null
-          },
-          "dependencies": [],
-          "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-          "id": "task-kno-181-scenario-a",
-          "objective": {
-            "deliverable_type": "unspecified",
-            "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
-          },
-          "observability": {
-            "errors": [],
-            "execution_metadata": {
-              "schema_required_deferred_fields": [
-                "parent_task_id",
-                "child_task_ids",
-                "dependencies",
-                "assigned_executor",
-                "required_capabilities",
-                "priority",
-                "artifacts.items",
-                "artifacts.completion_evidence",
-                "observability"
-              ]
-            },
-            "retries": {
-              "attempt_count": 0,
-              "last_retry_at": null,
-              "max_attempts": 0
-            }
-          },
-          "origin": {
-            "ingress_id": null,
-            "ingress_name": null,
-            "requested_by": null,
-            "source_id": "req-happy-overlay-1",
-            "source_system": "openclaw",
-            "source_type": "ingress_request"
-          },
-          "parent_task_id": null,
-          "priority": "normal",
-          "reconciliation": {
-            "active_failure_type": null,
-            "attempts": [],
-            "failed_at": null,
-            "last_attempt_id": null,
-            "last_error": null,
-            "last_pr_url": null,
-            "resolved_at": null,
-            "status": "not_required"
-          },
-          "required_capabilities": [],
-          "status": "intake_ready",
-          "status_history": [],
-          "timestamps": {
-            "completed_at": null,
-            "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-03-31T14:30:00Z"
-          },
-          "title": "KNO-181 task-kno-181-scenario-a"
-        }
-      }
-    },
-    {
-      "evaluation_id": "11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-      "task_id": "task-kno-181-scenario-a",
-      "recorded_at": "2026-04-05T17:30:31.543550Z",
+      "evaluation_id": "5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+      "recorded_at": "2026-04-11T16:04:28.868320Z",
       "request": {
         "acceptance_criteria_satisfied": false,
         "claimed_completion": true,
@@ -384,7 +11,7 @@
           "attempt_number": 1,
           "is_final_attempt": true,
           "max_retries": 1,
-          "scheduled_at": "2026-04-05T17:30:31.543299Z",
+          "scheduled_at": "2026-04-11T16:04:28.868290Z",
           "triggered_by_category": "invalid_execution_attempt",
           "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
         },
@@ -436,7 +63,7 @@
           "objective": {
             "deliverable_type": "unspecified",
             "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
+            "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
           },
           "observability": {
             "errors": [],
@@ -456,9 +83,12 @@
                 {
                   "artifact_references": [
                     {
-                      "artifact_type": "execution_log",
-                      "location": "stub://attempts/log",
-                      "reference_id": "attempt-kno-181-a-1:log"
+                      "artifact_type": "commit",
+                      "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test"
+                      },
+                      "reference_id": "attempt-kno-181-a-1:commit"
                     }
                   ],
                   "attempt_id": "attempt-kno-181-a-1",
@@ -466,24 +96,40 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
                       "failure_type": "invalid_execution_attempt",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
                         "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
                         "Successful execution attempt is missing commit SHA for the current run."
                       ],
                       "retryable": true,
+                      "rule_failures": [],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.541310Z",
+                      "validated_at": "2026-04-11T16:04:28.868130Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -533,12 +179,12 @@
             "status": "not_required"
           },
           "required_capabilities": [],
-          "status": "intake_ready",
+          "status": "assigned",
           "status_history": [],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-04-05T17:30:31.541658Z"
+            "updated_at": "2026-04-11T16:04:28.868279Z"
           },
           "title": "KNO-181 task-kno-181-scenario-a"
         },
@@ -604,7 +250,7 @@
             "objective": {
               "deliverable_type": "unspecified",
               "success_signal": "Task satisfies declared acceptance criteria.",
-              "summary": "Exercise /evaluate with top-level evidence overlays."
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
             },
             "observability": {
               "errors": [],
@@ -624,9 +270,12 @@
                   {
                     "artifact_references": [
                       {
-                        "artifact_type": "execution_log",
-                        "location": "stub://attempts/log",
-                        "reference_id": "attempt-kno-181-a-1:log"
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
                       }
                     ],
                     "attempt_id": "attempt-kno-181-a-1",
@@ -634,24 +283,40 @@
                     "metadata": {
                       "attempt_validation": {
                         "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "used_task_artifact_fallback": false
                         },
                         "failure_type": "invalid_execution_attempt",
                         "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [
                           "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
                           "Successful execution attempt is missing commit SHA for the current run."
                         ],
                         "retryable": true,
+                        "rule_failures": [],
                         "status": "invalid",
-                        "validated_at": "2026-04-05T17:30:31.541310Z",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
                         "validated_by": "execution_validation"
                       },
                       "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -701,12 +366,12 @@
               "status": "not_required"
             },
             "required_capabilities": [],
-            "status": "intake_ready",
+            "status": "assigned",
             "status_history": [],
             "timestamps": {
               "completed_at": null,
               "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-04-05T17:30:31.541658Z"
+              "updated_at": "2026-04-11T16:04:28.868279Z"
             },
             "title": "KNO-181 task-kno-181-scenario-a"
           },
@@ -766,7 +431,7 @@
           "objective": {
             "deliverable_type": "unspecified",
             "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
+            "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
           },
           "observability": {
             "errors": [],
@@ -786,9 +451,12 @@
                 {
                   "artifact_references": [
                     {
-                      "artifact_type": "execution_log",
-                      "location": "stub://attempts/log",
-                      "reference_id": "attempt-kno-181-a-1:log"
+                      "artifact_type": "commit",
+                      "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test"
+                      },
+                      "reference_id": "attempt-kno-181-a-1:commit"
                     }
                   ],
                   "attempt_id": "attempt-kno-181-a-1",
@@ -796,24 +464,40 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
                       "failure_type": "invalid_execution_attempt",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
                         "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
                         "Successful execution attempt is missing commit SHA for the current run."
                       ],
                       "retryable": true,
+                      "rule_failures": [],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.541310Z",
+                      "validated_at": "2026-04-11T16:04:28.868130Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -863,21 +547,21 @@
             "status": "not_required"
           },
           "required_capabilities": [],
-          "status": "intake_ready",
+          "status": "assigned",
           "status_history": [],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-04-05T17:30:31.541658Z"
+            "updated_at": "2026-04-11T16:04:28.868279Z"
           },
           "title": "KNO-181 task-kno-181-scenario-a"
         }
-      }
+      },
+      "task_id": "task-kno-181-scenario-a"
     },
     {
-      "evaluation_id": "3ad47b27-9ddb-4de4-917a-f976dcbaf625",
-      "task_id": "task-kno-181-scenario-a",
-      "recorded_at": "2026-04-05T17:30:31.556874Z",
+      "evaluation_id": "952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
+      "recorded_at": "2026-04-11T16:04:28.872467Z",
       "request": {
         "acceptance_criteria_satisfied": false,
         "claimed_completion": true,
@@ -931,7 +615,7 @@
           "objective": {
             "deliverable_type": "unspecified",
             "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
+            "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
           },
           "observability": {
             "errors": [],
@@ -957,7 +641,7 @@
                     }
                   },
                   "reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "reported_at": "2026-04-05T17:30:31.551102Z",
+                  "reported_at": "2026-04-11T16:04:28.870785Z",
                   "reported_by": "codex"
                 }
               ],
@@ -965,9 +649,12 @@
                 {
                   "artifact_references": [
                     {
-                      "artifact_type": "execution_log",
-                      "location": "stub://attempts/log",
-                      "reference_id": "attempt-kno-181-a-1:log"
+                      "artifact_type": "commit",
+                      "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test"
+                      },
+                      "reference_id": "attempt-kno-181-a-1:commit"
                     }
                   ],
                   "attempt_id": "attempt-kno-181-a-1",
@@ -975,24 +662,40 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
                       "failure_type": "invalid_execution_attempt",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
                         "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
                         "Successful execution attempt is missing commit SHA for the current run."
                       ],
                       "retryable": true,
+                      "rule_failures": [],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.541310Z",
+                      "validated_at": "2026-04-11T16:04:28.868130Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -1020,27 +723,39 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
-                      "failure_type": "invalid_execution_attempt",
+                      "failure_type": "contract_violation",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
+                        "Successful execution attempt is missing branch identity for the current run."
                       ],
-                      "retryable": true,
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.553815Z",
+                      "validated_at": "2026-04-11T16:04:28.871964Z",
                       "validated_by": "execution_validation"
                     },
-                    "dispatch_at": "2026-04-05T17:30:31.551127Z",
+                    "dispatch_at": "2026-04-11T16:04:28.870771Z",
                     "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
                     "dispatch_mode": "automatic",
                     "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
@@ -1053,7 +768,7 @@
                           "adapter": "stub-executor",
                           "mode": "stub"
                         },
-                        "occurred_at": "2026-04-05T17:30:31.550824Z",
+                        "occurred_at": "2026-04-11T16:04:28.870771Z",
                         "source_system": "stub-executor"
                       },
                       {
@@ -1063,7 +778,7 @@
                           "adapter": "stub-executor",
                           "executor_run_id": "stub-run-attempt-2"
                         },
-                        "occurred_at": "2026-04-05T17:30:31.550848Z",
+                        "occurred_at": "2026-04-11T16:04:28.870785Z",
                         "source_system": "stub-executor"
                       }
                     ],
@@ -1072,7 +787,7 @@
                     },
                     "executor": "codex"
                   },
-                  "recorded_at": "2026-04-05T17:30:31.551118Z",
+                  "recorded_at": "2026-04-11T16:04:28.870785Z",
                   "reevaluation": {},
                   "reported_by": "codex",
                   "status": "completed"
@@ -1117,12 +832,12 @@
             "status": "not_required"
           },
           "required_capabilities": [],
-          "status": "intake_ready",
+          "status": "assigned",
           "status_history": [],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-04-05T17:30:31.554545Z"
+            "updated_at": "2026-04-11T16:04:28.872406Z"
           },
           "title": "KNO-181 task-kno-181-scenario-a"
         },
@@ -1133,19 +848,19 @@
         "action": "no_op",
         "enforcement_result": {
           "action": "no_op",
-          "error": "Successful execution attempt is missing repository identity for the current run.",
+          "error": "Successful execution attempt is missing branch identity for the current run.",
           "evidence_result": null,
           "failure_classification": {
-            "category": "invalid_execution_attempt",
-            "failure_type": "invalid_execution_attempt",
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
+            "category": "contract_violation",
+            "failure_type": "contract_violation",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
             "recoverable": false,
             "retryable": false,
             "source": "executor",
             "terminal": true
           },
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
           "reconciliation_result": null,
           "review_decision": null,
@@ -1188,7 +903,7 @@
             "objective": {
               "deliverable_type": "unspecified",
               "success_signal": "Task satisfies declared acceptance criteria.",
-              "summary": "Exercise /evaluate with top-level evidence overlays."
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
             },
             "observability": {
               "errors": [],
@@ -1214,7 +929,7 @@
                       }
                     },
                     "reason": "Successful execution attempt is missing repository identity for the current run.",
-                    "reported_at": "2026-04-05T17:30:31.551102Z",
+                    "reported_at": "2026-04-11T16:04:28.870785Z",
                     "reported_by": "codex"
                   }
                 ],
@@ -1222,9 +937,12 @@
                   {
                     "artifact_references": [
                       {
-                        "artifact_type": "execution_log",
-                        "location": "stub://attempts/log",
-                        "reference_id": "attempt-kno-181-a-1:log"
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
                       }
                     ],
                     "attempt_id": "attempt-kno-181-a-1",
@@ -1232,24 +950,40 @@
                     "metadata": {
                       "attempt_validation": {
                         "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "used_task_artifact_fallback": false
                         },
                         "failure_type": "invalid_execution_attempt",
                         "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [
                           "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
                           "Successful execution attempt is missing commit SHA for the current run."
                         ],
                         "retryable": true,
+                        "rule_failures": [],
                         "status": "invalid",
-                        "validated_at": "2026-04-05T17:30:31.541310Z",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
                         "validated_by": "execution_validation"
                       },
                       "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -1277,27 +1011,39 @@
                     "metadata": {
                       "attempt_validation": {
                         "context_observations": {
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "used_task_artifact_fallback": false
                         },
-                        "failure_type": "invalid_execution_attempt",
+                        "failure_type": "contract_violation",
                         "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [
-                          "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
-                          "Successful execution attempt is missing commit SHA for the current run."
+                          "Successful execution attempt is missing branch identity for the current run."
                         ],
-                        "retryable": true,
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
                         "status": "invalid",
-                        "validated_at": "2026-04-05T17:30:31.553815Z",
+                        "validated_at": "2026-04-11T16:04:28.871964Z",
                         "validated_by": "execution_validation"
                       },
-                      "dispatch_at": "2026-04-05T17:30:31.551127Z",
+                      "dispatch_at": "2026-04-11T16:04:28.870771Z",
                       "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
                       "dispatch_mode": "automatic",
                       "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
@@ -1310,7 +1056,7 @@
                             "adapter": "stub-executor",
                             "mode": "stub"
                           },
-                          "occurred_at": "2026-04-05T17:30:31.550824Z",
+                          "occurred_at": "2026-04-11T16:04:28.870771Z",
                           "source_system": "stub-executor"
                         },
                         {
@@ -1320,7 +1066,7 @@
                             "adapter": "stub-executor",
                             "executor_run_id": "stub-run-attempt-2"
                           },
-                          "occurred_at": "2026-04-05T17:30:31.550848Z",
+                          "occurred_at": "2026-04-11T16:04:28.870785Z",
                           "source_system": "stub-executor"
                         }
                       ],
@@ -1329,7 +1075,7 @@
                       },
                       "executor": "codex"
                     },
-                    "recorded_at": "2026-04-05T17:30:31.551118Z",
+                    "recorded_at": "2026-04-11T16:04:28.870785Z",
                     "reevaluation": {},
                     "reported_by": "codex",
                     "status": "completed"
@@ -1374,23 +1120,23 @@
               "status": "not_required"
             },
             "required_capabilities": [],
-            "status": "intake_ready",
+            "status": "assigned",
             "status_history": [],
             "timestamps": {
               "completed_at": null,
               "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-04-05T17:30:31.554545Z"
+              "updated_at": "2026-04-11T16:04:28.872406Z"
             },
             "title": "KNO-181 task-kno-181-scenario-a"
           },
           "transition_result": null,
           "verification_result": null
         },
-        "error": "Successful execution attempt is missing repository identity for the current run.",
+        "error": "Successful execution attempt is missing branch identity for the current run.",
         "failure_classification": {
-          "category": "invalid_execution_attempt",
-          "failure_type": "invalid_execution_attempt",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
+          "category": "contract_violation",
+          "failure_type": "contract_violation",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
           "recoverable": false,
           "retryable": false,
           "source": "executor",
@@ -1398,7 +1144,7 @@
         },
         "invalid_input": false,
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
         "requires_review": false,
         "target_status": null,
@@ -1439,7 +1185,7 @@
           "objective": {
             "deliverable_type": "unspecified",
             "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
+            "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
           },
           "observability": {
             "errors": [],
@@ -1465,7 +1211,7 @@
                     }
                   },
                   "reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "reported_at": "2026-04-05T17:30:31.551102Z",
+                  "reported_at": "2026-04-11T16:04:28.870785Z",
                   "reported_by": "codex"
                 }
               ],
@@ -1473,9 +1219,12 @@
                 {
                   "artifact_references": [
                     {
-                      "artifact_type": "execution_log",
-                      "location": "stub://attempts/log",
-                      "reference_id": "attempt-kno-181-a-1:log"
+                      "artifact_type": "commit",
+                      "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test"
+                      },
+                      "reference_id": "attempt-kno-181-a-1:commit"
                     }
                   ],
                   "attempt_id": "attempt-kno-181-a-1",
@@ -1483,24 +1232,40 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
                       "failure_type": "invalid_execution_attempt",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
                         "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
                         "Successful execution attempt is missing commit SHA for the current run."
                       ],
                       "retryable": true,
+                      "rule_failures": [],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.541310Z",
+                      "validated_at": "2026-04-11T16:04:28.868130Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -1528,27 +1293,39 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
-                      "failure_type": "invalid_execution_attempt",
+                      "failure_type": "contract_violation",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
+                        "Successful execution attempt is missing branch identity for the current run."
                       ],
-                      "retryable": true,
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.553815Z",
+                      "validated_at": "2026-04-11T16:04:28.871964Z",
                       "validated_by": "execution_validation"
                     },
-                    "dispatch_at": "2026-04-05T17:30:31.551127Z",
+                    "dispatch_at": "2026-04-11T16:04:28.870771Z",
                     "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
                     "dispatch_mode": "automatic",
                     "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
@@ -1561,7 +1338,7 @@
                           "adapter": "stub-executor",
                           "mode": "stub"
                         },
-                        "occurred_at": "2026-04-05T17:30:31.550824Z",
+                        "occurred_at": "2026-04-11T16:04:28.870771Z",
                         "source_system": "stub-executor"
                       },
                       {
@@ -1571,7 +1348,7 @@
                           "adapter": "stub-executor",
                           "executor_run_id": "stub-run-attempt-2"
                         },
-                        "occurred_at": "2026-04-05T17:30:31.550848Z",
+                        "occurred_at": "2026-04-11T16:04:28.870785Z",
                         "source_system": "stub-executor"
                       }
                     ],
@@ -1580,7 +1357,7 @@
                     },
                     "executor": "codex"
                   },
-                  "recorded_at": "2026-04-05T17:30:31.551118Z",
+                  "recorded_at": "2026-04-11T16:04:28.870785Z",
                   "reevaluation": {},
                   "reported_by": "codex",
                   "status": "completed"
@@ -1625,21 +1402,21 @@
             "status": "not_required"
           },
           "required_capabilities": [],
-          "status": "intake_ready",
+          "status": "assigned",
           "status_history": [],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-04-05T17:30:31.554545Z"
+            "updated_at": "2026-04-11T16:04:28.872406Z"
           },
           "title": "KNO-181 task-kno-181-scenario-a"
         }
-      }
+      },
+      "task_id": "task-kno-181-scenario-a"
     },
     {
-      "evaluation_id": "1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-      "task_id": "task-kno-181-scenario-a",
-      "recorded_at": "2026-04-05T17:30:31.666755Z",
+      "evaluation_id": "bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+      "recorded_at": "2026-04-11T16:04:28.882026Z",
       "request": {
         "acceptance_criteria_satisfied": false,
         "claimed_completion": true,
@@ -1677,11 +1454,7 @@
             },
             "items": []
           },
-          "assigned_executor": {
-            "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "executor_id": "executor-kno-181-a",
-            "executor_type": "codex"
-          },
+          "assigned_executor": null,
           "child_task_ids": [],
           "constraints": [],
           "coordination": {
@@ -1693,7 +1466,7 @@
           "objective": {
             "deliverable_type": "unspecified",
             "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
+            "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
           },
           "observability": {
             "errors": [],
@@ -1719,7 +1492,7 @@
                     }
                   },
                   "reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "reported_at": "2026-04-05T17:30:31.551102Z",
+                  "reported_at": "2026-04-11T16:04:28.870785Z",
                   "reported_by": "codex"
                 }
               ],
@@ -1727,9 +1500,12 @@
                 {
                   "artifact_references": [
                     {
-                      "artifact_type": "execution_log",
-                      "location": "stub://attempts/log",
-                      "reference_id": "attempt-kno-181-a-1:log"
+                      "artifact_type": "commit",
+                      "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test"
+                      },
+                      "reference_id": "attempt-kno-181-a-1:commit"
                     }
                   ],
                   "attempt_id": "attempt-kno-181-a-1",
@@ -1737,24 +1513,40 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
                       "failure_type": "invalid_execution_attempt",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
                         "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
                         "Successful execution attempt is missing commit SHA for the current run."
                       ],
                       "retryable": true,
+                      "rule_failures": [],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.541310Z",
+                      "validated_at": "2026-04-11T16:04:28.868130Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -1782,27 +1574,39 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
-                      "failure_type": "invalid_execution_attempt",
+                      "failure_type": "contract_violation",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
+                        "Successful execution attempt is missing branch identity for the current run."
                       ],
-                      "retryable": true,
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.553815Z",
+                      "validated_at": "2026-04-11T16:04:28.871964Z",
                       "validated_by": "execution_validation"
                     },
-                    "dispatch_at": "2026-04-05T17:30:31.551127Z",
+                    "dispatch_at": "2026-04-11T16:04:28.870771Z",
                     "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
                     "dispatch_mode": "automatic",
                     "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
@@ -1815,7 +1619,7 @@
                           "adapter": "stub-executor",
                           "mode": "stub"
                         },
-                        "occurred_at": "2026-04-05T17:30:31.550824Z",
+                        "occurred_at": "2026-04-11T16:04:28.870771Z",
                         "source_system": "stub-executor"
                       },
                       {
@@ -1825,7 +1629,7 @@
                           "adapter": "stub-executor",
                           "executor_run_id": "stub-run-attempt-2"
                         },
-                        "occurred_at": "2026-04-05T17:30:31.550848Z",
+                        "occurred_at": "2026-04-11T16:04:28.870785Z",
                         "source_system": "stub-executor"
                       }
                     ],
@@ -1834,7 +1638,7 @@
                     },
                     "executor": "codex"
                   },
-                  "recorded_at": "2026-04-05T17:30:31.551118Z",
+                  "recorded_at": "2026-04-11T16:04:28.870785Z",
                   "reevaluation": {},
                   "reported_by": "codex",
                   "status": "completed"
@@ -1882,17 +1686,17 @@
           "status": "failed",
           "status_history": [
             {
-              "changed_at": "2026-04-05T17:30:31.617375Z",
+              "changed_at": "2026-04-11T16:04:28.878677Z",
               "changed_by": "verification",
-              "from_status": "intake_ready",
-              "reason": "Successful execution attempt is missing repository identity for the current run.",
+              "from_status": "assigned",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
               "to_status": "failed"
             }
           ],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-04-05T17:30:31.617375Z"
+            "updated_at": "2026-04-11T16:04:28.878677Z"
           },
           "title": "KNO-181 task-kno-181-scenario-a"
         },
@@ -1903,19 +1707,19 @@
         "action": "transition_applied",
         "enforcement_result": {
           "action": "transition_applied",
-          "error": "Successful execution attempt is missing repository identity for the current run.",
+          "error": "Successful execution attempt is missing branch identity for the current run.",
           "evidence_result": null,
           "failure_classification": {
-            "category": "invalid_execution_attempt",
-            "failure_type": "invalid_execution_attempt",
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
+            "category": "contract_violation",
+            "failure_type": "contract_violation",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
             "recoverable": false,
             "retryable": false,
             "source": "executor",
             "terminal": true
           },
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
           "reconciliation_result": null,
           "review_decision": null,
@@ -1942,11 +1746,7 @@
               },
               "items": []
             },
-            "assigned_executor": {
-              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-              "executor_id": "executor-kno-181-a",
-              "executor_type": "codex"
-            },
+            "assigned_executor": null,
             "child_task_ids": [],
             "constraints": [],
             "coordination": {
@@ -1958,7 +1758,7 @@
             "objective": {
               "deliverable_type": "unspecified",
               "success_signal": "Task satisfies declared acceptance criteria.",
-              "summary": "Exercise /evaluate with top-level evidence overlays."
+              "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
             },
             "observability": {
               "errors": [],
@@ -1984,7 +1784,7 @@
                       }
                     },
                     "reason": "Successful execution attempt is missing repository identity for the current run.",
-                    "reported_at": "2026-04-05T17:30:31.551102Z",
+                    "reported_at": "2026-04-11T16:04:28.870785Z",
                     "reported_by": "codex"
                   }
                 ],
@@ -1992,9 +1792,12 @@
                   {
                     "artifact_references": [
                       {
-                        "artifact_type": "execution_log",
-                        "location": "stub://attempts/log",
-                        "reference_id": "attempt-kno-181-a-1:log"
+                        "artifact_type": "commit",
+                        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test"
+                        },
+                        "reference_id": "attempt-kno-181-a-1:commit"
                       }
                     ],
                     "attempt_id": "attempt-kno-181-a-1",
@@ -2002,24 +1805,40 @@
                     "metadata": {
                       "attempt_validation": {
                         "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "used_task_artifact_fallback": false
                         },
                         "failure_type": "invalid_execution_attempt",
                         "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [
                           "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
                           "Successful execution attempt is missing commit SHA for the current run."
                         ],
                         "retryable": true,
+                        "rule_failures": [],
                         "status": "invalid",
-                        "validated_at": "2026-04-05T17:30:31.541310Z",
+                        "validated_at": "2026-04-11T16:04:28.868130Z",
                         "validated_by": "execution_validation"
                       },
                       "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -2047,27 +1866,39 @@
                     "metadata": {
                       "attempt_validation": {
                         "context_observations": {
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "used_task_artifact_fallback": false
                         },
-                        "failure_type": "invalid_execution_attempt",
+                        "failure_type": "contract_violation",
                         "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [
-                          "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
-                          "Successful execution attempt is missing commit SHA for the current run."
+                          "Successful execution attempt is missing branch identity for the current run."
                         ],
-                        "retryable": true,
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
                         "status": "invalid",
-                        "validated_at": "2026-04-05T17:30:31.553815Z",
+                        "validated_at": "2026-04-11T16:04:28.871964Z",
                         "validated_by": "execution_validation"
                       },
-                      "dispatch_at": "2026-04-05T17:30:31.551127Z",
+                      "dispatch_at": "2026-04-11T16:04:28.870771Z",
                       "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
                       "dispatch_mode": "automatic",
                       "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
@@ -2080,7 +1911,7 @@
                             "adapter": "stub-executor",
                             "mode": "stub"
                           },
-                          "occurred_at": "2026-04-05T17:30:31.550824Z",
+                          "occurred_at": "2026-04-11T16:04:28.870771Z",
                           "source_system": "stub-executor"
                         },
                         {
@@ -2090,7 +1921,7 @@
                             "adapter": "stub-executor",
                             "executor_run_id": "stub-run-attempt-2"
                           },
-                          "occurred_at": "2026-04-05T17:30:31.550848Z",
+                          "occurred_at": "2026-04-11T16:04:28.870785Z",
                           "source_system": "stub-executor"
                         }
                       ],
@@ -2099,7 +1930,7 @@
                       },
                       "executor": "codex"
                     },
-                    "recorded_at": "2026-04-05T17:30:31.551118Z",
+                    "recorded_at": "2026-04-11T16:04:28.870785Z",
                     "reevaluation": {},
                     "reported_by": "codex",
                     "status": "completed"
@@ -2147,28 +1978,28 @@
             "status": "failed",
             "status_history": [
               {
-                "changed_at": "2026-04-05T17:30:31.617375Z",
+                "changed_at": "2026-04-11T16:04:28.878677Z",
                 "changed_by": "verification",
-                "from_status": "intake_ready",
-                "reason": "Successful execution attempt is missing repository identity for the current run.",
+                "from_status": "assigned",
+                "reason": "Successful execution attempt is missing branch identity for the current run.",
                 "to_status": "failed"
               }
             ],
             "timestamps": {
               "completed_at": null,
               "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-04-05T17:30:31.617375Z"
+              "updated_at": "2026-04-11T16:04:28.878677Z"
             },
             "title": "KNO-181 task-kno-181-scenario-a"
           },
           "transition_result": null,
           "verification_result": null
         },
-        "error": "Successful execution attempt is missing repository identity for the current run.",
+        "error": "Successful execution attempt is missing branch identity for the current run.",
         "failure_classification": {
-          "category": "invalid_execution_attempt",
-          "failure_type": "invalid_execution_attempt",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
+          "category": "contract_violation",
+          "failure_type": "contract_violation",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
           "recoverable": false,
           "retryable": false,
           "source": "executor",
@@ -2176,7 +2007,7 @@
         },
         "invalid_input": false,
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
         "requires_review": false,
         "target_status": "failed",
@@ -2201,11 +2032,7 @@
             },
             "items": []
           },
-          "assigned_executor": {
-            "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "executor_id": "executor-kno-181-a",
-            "executor_type": "codex"
-          },
+          "assigned_executor": null,
           "child_task_ids": [],
           "constraints": [],
           "coordination": {
@@ -2217,7 +2044,7 @@
           "objective": {
             "deliverable_type": "unspecified",
             "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
+            "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
           },
           "observability": {
             "errors": [],
@@ -2243,7 +2070,7 @@
                     }
                   },
                   "reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "reported_at": "2026-04-05T17:30:31.551102Z",
+                  "reported_at": "2026-04-11T16:04:28.870785Z",
                   "reported_by": "codex"
                 }
               ],
@@ -2251,9 +2078,12 @@
                 {
                   "artifact_references": [
                     {
-                      "artifact_type": "execution_log",
-                      "location": "stub://attempts/log",
-                      "reference_id": "attempt-kno-181-a-1:log"
+                      "artifact_type": "commit",
+                      "location": "stub://attempts/attempt-kno-181-a-1/commit",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test"
+                      },
+                      "reference_id": "attempt-kno-181-a-1:commit"
                     }
                   ],
                   "attempt_id": "attempt-kno-181-a-1",
@@ -2261,24 +2091,40 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
                       "failure_type": "invalid_execution_attempt",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
                         "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
                         "Successful execution attempt is missing commit SHA for the current run."
                       ],
                       "retryable": true,
+                      "rule_failures": [],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.541310Z",
+                      "validated_at": "2026-04-11T16:04:28.868130Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "stub-run-attempt-kno-181-a-1"
@@ -2306,27 +2152,39 @@
                   "metadata": {
                     "attempt_validation": {
                       "context_observations": {
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
-                      "failure_type": "invalid_execution_attempt",
+                      "failure_type": "contract_violation",
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
+                        "Successful execution attempt is missing branch identity for the current run."
                       ],
-                      "retryable": true,
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
                       "status": "invalid",
-                      "validated_at": "2026-04-05T17:30:31.553815Z",
+                      "validated_at": "2026-04-11T16:04:28.871964Z",
                       "validated_by": "execution_validation"
                     },
-                    "dispatch_at": "2026-04-05T17:30:31.551127Z",
+                    "dispatch_at": "2026-04-11T16:04:28.870771Z",
                     "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
                     "dispatch_mode": "automatic",
                     "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
@@ -2339,7 +2197,7 @@
                           "adapter": "stub-executor",
                           "mode": "stub"
                         },
-                        "occurred_at": "2026-04-05T17:30:31.550824Z",
+                        "occurred_at": "2026-04-11T16:04:28.870771Z",
                         "source_system": "stub-executor"
                       },
                       {
@@ -2349,7 +2207,7 @@
                           "adapter": "stub-executor",
                           "executor_run_id": "stub-run-attempt-2"
                         },
-                        "occurred_at": "2026-04-05T17:30:31.550848Z",
+                        "occurred_at": "2026-04-11T16:04:28.870785Z",
                         "source_system": "stub-executor"
                       }
                     ],
@@ -2358,7 +2216,7 @@
                     },
                     "executor": "codex"
                   },
-                  "recorded_at": "2026-04-05T17:30:31.551118Z",
+                  "recorded_at": "2026-04-11T16:04:28.870785Z",
                   "reevaluation": {},
                   "reported_by": "codex",
                   "status": "completed"
@@ -2406,21 +2264,23 @@
           "status": "failed",
           "status_history": [
             {
-              "changed_at": "2026-04-05T17:30:31.617375Z",
+              "changed_at": "2026-04-11T16:04:28.878677Z",
               "changed_by": "verification",
-              "from_status": "intake_ready",
-              "reason": "Successful execution attempt is missing repository identity for the current run.",
+              "from_status": "assigned",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
               "to_status": "failed"
             }
           ],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-04-05T17:30:31.617375Z"
+            "updated_at": "2026-04-11T16:04:28.878677Z"
           },
           "title": "KNO-181 task-kno-181-scenario-a"
         }
-      }
+      },
+      "task_id": "task-kno-181-scenario-a"
     }
-  ]
+  ],
+  "task_id": "task-kno-181-scenario-a"
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-read-model-final.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-read-model-final.json
@@ -1,84 +1,70 @@
 {
   "task": {
-    "task_id": "task-kno-181-scenario-a",
-    "title": "KNO-181 task-kno-181-scenario-a",
-    "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+    "assigned_executor": null,
+    "clarification_summary": null,
+    "coordination_summary": {
+      "linear": null
+    },
     "current_status": "failed",
-    "objective_summary": "Exercise /evaluate with top-level evidence overlays.",
-    "origin": {
-      "ingress_id": null,
-      "ingress_name": null,
-      "requested_by": null,
-      "source_id": "req-happy-overlay-1",
-      "source_system": "openclaw",
-      "source_type": "ingress_request"
-    },
-    "relationships": {
-      "parent_task_id": null,
-      "child_task_ids": [],
-      "dependencies": []
-    },
-    "assigned_executor": {
-      "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-      "executor_id": "executor-kno-181-a",
-      "executor_type": "codex"
+    "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+    "evaluation_summary": {
+      "count": 3,
+      "history": [
+        {
+          "action": "no_op",
+          "evaluation_id": "5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+          "recorded_at": "2026-04-11T16:04:28.868320Z",
+          "target_status": null
+        },
+        {
+          "action": "no_op",
+          "evaluation_id": "952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
+          "recorded_at": "2026-04-11T16:04:28.872467Z",
+          "target_status": null
+        },
+        {
+          "action": "transition_applied",
+          "evaluation_id": "bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+          "recorded_at": "2026-04-11T16:04:28.882026Z",
+          "target_status": "failed"
+        }
+      ],
+      "latest_action": "transition_applied",
+      "latest_recorded_at": "2026-04-11T16:04:28.882026Z",
+      "latest_target_status": "failed"
     },
     "evidence_summary": {
       "artifact_count": 0,
       "artifact_type_counts": {},
-      "verification_status_counts": {},
-      "validated_artifact_count": 0,
       "completion_evidence": {
         "policy": "deferred",
-        "status": "deferred",
         "required_artifact_types": [],
+        "status": "deferred",
         "validated_artifact_ids": [],
-        "validation_method": "deferred",
         "validated_at": null,
+        "validation_method": "deferred",
         "validator": null
-      }
-    },
-    "coordination_summary": {
-      "linear": null
-    },
-    "verification_summary": {
-      "accepted_completion": false,
-      "claimed_completion": false,
-      "evidence_is_sufficient": false,
-      "evidence_is_valid": true,
-      "failure_classification": {
-        "category": "none",
-        "failure_type": "none",
-        "reason": "No completion claim is currently being evaluated",
-        "recoverable": false,
-        "retryable": false,
-        "source": "none",
-        "terminal": false
       },
-      "is_terminal": false,
-      "outcome": "verification_deferred",
-      "reasons": [
-        "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-        "No completion claim is currently being evaluated"
-      ],
-      "reconciliation_status": "pending",
-      "requires_review": false,
-      "target_status": null,
-      "task_id": "task-kno-181-scenario-a",
-      "verification_passed": false
-    },
-    "reconciliation_summary": null,
-    "review_summary": {
-      "status": "none",
-      "request_count": 0,
-      "decision_count": 0,
-      "latest_request": null,
-      "latest_decision": null,
-      "requests": [],
-      "decisions": []
+      "validated_artifact_count": 0,
+      "verification_status_counts": {}
     },
     "execution_summary": {
       "attempt_count": 2,
+      "failure_state": "terminal",
+      "invalid_attempt_count": 1,
+      "last_failure_type": "contract_violation",
+      "latest_artifact_references": [
+        {
+          "artifact_type": "execution_log",
+          "commit_sha": null,
+          "external_id": null,
+          "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+          "metadata": {
+            "advisory": true
+          },
+          "reference_id": "attempt-2:log"
+        }
+      ],
       "latest_attempt": {
         "artifact_references": [
           {
@@ -97,27 +83,39 @@
         "metadata": {
           "attempt_validation": {
             "context_observations": {
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "used_task_artifact_fallback": false
             },
-            "failure_type": "invalid_execution_attempt",
+            "failure_type": "contract_violation",
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [
-              "Successful execution attempt is missing repository identity for the current run.",
-              "Successful execution attempt is missing branch identity for the current run.",
-              "Successful execution attempt is missing commit SHA for the current run."
+              "Successful execution attempt is missing branch identity for the current run."
             ],
-            "retryable": true,
+            "retryable": false,
+            "rule_failures": [
+              {
+                "message": "Successful execution attempt is missing branch identity for the current run.",
+                "rule": "missing_branch_identity"
+              }
+            ],
             "status": "invalid",
-            "validated_at": "2026-04-05T17:30:31.553815Z",
+            "validated_at": "2026-04-11T16:04:28.871964Z",
             "validated_by": "execution_validation"
           },
-          "dispatch_at": "2026-04-05T17:30:31.551127Z",
+          "dispatch_at": "2026-04-11T16:04:28.870771Z",
           "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
           "dispatch_mode": "automatic",
           "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
@@ -130,7 +128,7 @@
                 "adapter": "stub-executor",
                 "mode": "stub"
               },
-              "occurred_at": "2026-04-05T17:30:31.550824Z",
+              "occurred_at": "2026-04-11T16:04:28.870771Z",
               "source_system": "stub-executor"
             },
             {
@@ -140,7 +138,7 @@
                 "adapter": "stub-executor",
                 "executor_run_id": "stub-run-attempt-2"
               },
-              "occurred_at": "2026-04-05T17:30:31.550848Z",
+              "occurred_at": "2026-04-11T16:04:28.870785Z",
               "source_system": "stub-executor"
             }
           ],
@@ -149,121 +147,101 @@
           },
           "executor": "codex"
         },
-        "recorded_at": "2026-04-05T17:30:31.551118Z",
+        "recorded_at": "2026-04-11T16:04:28.870785Z",
         "reevaluation": {},
         "reported_by": "codex",
         "status": "completed"
       },
-      "latest_status": "completed",
-      "latest_dispatch_origin": "automatic",
       "latest_attempt_validation": {
         "context_observations": {
+          "commit_resolution_pending": false,
+          "has_valid_current_run_pull_request_artifact": false,
           "used_task_artifact_fallback": false
         },
-        "failure_type": "invalid_execution_attempt",
+        "failure_type": "contract_violation",
         "policy": {
+          "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
           "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
           "require_commit": true,
           "require_exact_branch": true,
           "require_repository": true,
           "task_artifact_fallback_requires_single_attempt": true
         },
+        "pull_request_observations": [],
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run.",
-          "Successful execution attempt is missing branch identity for the current run.",
-          "Successful execution attempt is missing commit SHA for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
-        "retryable": true,
+        "retryable": false,
+        "rule_failures": [
+          {
+            "message": "Successful execution attempt is missing branch identity for the current run.",
+            "rule": "missing_branch_identity"
+          }
+        ],
         "status": "invalid",
-        "validated_at": "2026-04-05T17:30:31.553815Z",
+        "validated_at": "2026-04-11T16:04:28.871964Z",
         "validated_by": "execution_validation"
       },
-      "latest_artifact_references": [
-        {
-          "artifact_type": "execution_log",
-          "commit_sha": null,
-          "external_id": null,
-          "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
-          "metadata": {
-            "advisory": true
-          },
-          "reference_id": "attempt-2:log"
-        }
-      ],
-      "total_attempts": 4,
+      "latest_dispatch_origin": "automatic",
+      "latest_status": "completed",
       "retry_count": 1,
-      "invalid_attempt_count": 2,
-      "last_failure_type": "invalid_execution_attempt",
       "retry_eligible": false,
-      "failure_state": "terminal"
+      "total_attempts": 3
     },
+    "extensions": {},
     "failure_summary": {
-      "state": "failed",
-      "failure_type": "invalid_execution_attempt",
+      "evaluation_id": "bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+      "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
       "failure_source": "executor",
-      "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-      "terminal": true,
+      "failure_type": "contract_violation",
+      "recorded_at": "2026-04-11T16:04:28.882026Z",
       "recoverable": false,
-      "recorded_at": "2026-04-05T17:30:31.666755Z",
-      "evaluation_id": "1c8ffff5-48cb-4136-a832-8f60ecfacd30"
-    },
-    "evaluation_summary": {
-      "count": 4,
-      "latest_recorded_at": "2026-04-05T17:30:31.666755Z",
-      "latest_action": "transition_applied",
-      "latest_target_status": "failed",
-      "history": [
-        {
-          "evaluation_id": "c460c507-1dc8-4525-8355-4126a428b996",
-          "recorded_at": "2026-04-05T17:30:31.525822Z",
-          "action": "no_op",
-          "target_status": null
-        },
-        {
-          "evaluation_id": "11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-          "recorded_at": "2026-04-05T17:30:31.543550Z",
-          "action": "no_op",
-          "target_status": null
-        },
-        {
-          "evaluation_id": "3ad47b27-9ddb-4de4-917a-f976dcbaf625",
-          "recorded_at": "2026-04-05T17:30:31.556874Z",
-          "action": "no_op",
-          "target_status": null
-        },
-        {
-          "evaluation_id": "1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-          "recorded_at": "2026-04-05T17:30:31.666755Z",
-          "action": "transition_applied",
-          "target_status": "failed"
-        }
-      ]
+      "state": "terminal",
+      "terminal": true
     },
     "lifecycle_history": [
       {
-        "changed_at": "2026-04-05T17:30:31.617375Z",
+        "changed_at": "2026-04-11T16:04:28.878677Z",
         "changed_by": "verification",
-        "from_status": "intake_ready",
-        "reason": "Successful execution attempt is missing repository identity for the current run.",
+        "from_status": "assigned",
+        "reason": "Successful execution attempt is missing branch identity for the current run.",
         "to_status": "failed"
       }
     ],
-    "timestamps": {
-      "completed_at": null,
-      "created_at": "2026-03-31T14:30:00Z",
-      "updated_at": "2026-04-05T17:30:31.617375Z"
+    "objective_summary": "Scenario A: invalid execution attempt without current-run code identity proof.",
+    "origin": {
+      "ingress_id": null,
+      "ingress_name": null,
+      "requested_by": null,
+      "source_id": "req-happy-overlay-1",
+      "source_system": "openclaw",
+      "source_type": "ingress_request"
     },
-    "extensions": {},
+    "reconciliation_summary": null,
+    "relationships": {
+      "child_task_ids": [],
+      "dependencies": [],
+      "parent_task_id": null
+    },
+    "review_summary": {
+      "decision_count": 0,
+      "decisions": [],
+      "latest_decision": null,
+      "latest_effective_decision": null,
+      "latest_request": null,
+      "request_count": 0,
+      "requests": [],
+      "resolved_decision_count": 0,
+      "status": "none"
+    },
+    "task_id": "task-kno-181-scenario-a",
     "timeline": [
       {
-        "event_id": "task-kno-181-scenario-a:created",
-        "event_type": "task_created",
-        "occurred_at": "2026-03-31T14:30:00Z",
-        "summary": "Task created",
-        "source": "openclaw",
         "details": {
-          "status": "failed",
-          "title": "KNO-181 task-kno-181-scenario-a",
           "origin": {
             "ingress_id": null,
             "ingress_name": null,
@@ -271,185 +249,160 @@
             "source_id": "req-happy-overlay-1",
             "source_system": "openclaw",
             "source_type": "ingress_request"
-          }
-        }
+          },
+          "status": "failed",
+          "title": "KNO-181 task-kno-181-scenario-a"
+        },
+        "event_id": "task-kno-181-scenario-a:created",
+        "event_type": "task_created",
+        "occurred_at": "2026-03-31T14:30:00Z",
+        "source": "openclaw",
+        "summary": "Task created"
       },
       {
-        "event_id": "task-kno-181-scenario-a:execution_artifact:attempt-kno-181-a-1:attempt-kno-181-a-1:log",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-01T08:00:05Z",
-        "summary": "Execution artifact attached: execution_log",
-        "source": "stub-executor",
         "details": {
-          "artifact_type": "execution_log",
-          "location": "stub://attempts/log",
-          "reference_id": "attempt-kno-181-a-1:log"
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-a:execution_attempt:attempt-kno-181-a-1",
-        "event_type": "execution_attempt_recorded",
-        "occurred_at": "2026-04-01T08:00:05Z",
-        "summary": "Execution attempt recorded: attempt-kno-181-a-1",
-        "source": "stub-executor",
-        "details": {
-          "attempt_id": "attempt-kno-181-a-1",
-          "status": "succeeded",
-          "completion_claim_id": "claim-kno-181-a-1",
           "artifact_references": [
             {
-              "artifact_type": "execution_log",
-              "location": "stub://attempts/log",
-              "reference_id": "attempt-kno-181-a-1:log"
+              "artifact_type": "commit",
+              "location": "stub://attempts/attempt-kno-181-a-1/commit",
+              "metadata": {
+                "branch_name": "codex/e2e-test"
+              },
+              "reference_id": "attempt-kno-181-a-1:commit"
             }
           ],
+          "attempt_id": "attempt-kno-181-a-1",
           "attempt_validation": {
             "context_observations": {
+              "branch": [
+                {
+                  "sources": [
+                    "execution_attempt.artifact_references[0]"
+                  ],
+                  "value": "codex/e2e-test"
+                }
+              ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "used_task_artifact_fallback": false
             },
             "failure_type": "invalid_execution_attempt",
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [
               "Successful execution attempt is missing repository identity for the current run.",
-              "Successful execution attempt is missing branch identity for the current run.",
               "Successful execution attempt is missing commit SHA for the current run."
             ],
             "retryable": true,
+            "rule_failures": [],
             "status": "invalid",
-            "validated_at": "2026-04-05T17:30:31.541310Z",
+            "validated_at": "2026-04-11T16:04:28.868130Z",
             "validated_by": "execution_validation"
           },
-          "reevaluation": {}
-        }
+          "completion_claim_id": "claim-kno-181-a-1",
+          "reevaluation": {},
+          "status": "succeeded"
+        },
+        "event_id": "task-kno-181-scenario-a:execution_attempt:attempt-kno-181-a-1",
+        "event_type": "execution_attempt_recorded",
+        "occurred_at": "2026-04-01T08:00:05Z",
+        "source": "stub-executor",
+        "summary": "Execution attempt recorded: attempt-kno-181-a-1"
       },
       {
-        "event_id": "task-kno-181-scenario-a:evaluation:c460c507-1dc8-4525-8355-4126a428b996",
-        "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-05T17:30:31.525822Z",
-        "summary": "Evaluation recorded: no_op",
-        "source": "harness",
         "details": {
-          "evaluation_id": "c460c507-1dc8-4525-8355-4126a428b996",
-          "action": "no_op",
-          "target_status": null,
-          "accepted_completion": false,
-          "requires_review": false,
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "verification_result": {
-            "accepted_completion": false,
-            "claimed_completion": false,
-            "evidence_is_sufficient": false,
-            "evidence_is_valid": true,
-            "failure_classification": {
-              "category": "none",
-              "failure_type": "none",
-              "reason": "No completion claim is currently being evaluated",
-              "recoverable": false,
-              "retryable": false,
-              "source": "none",
-              "terminal": false
-            },
-            "is_terminal": false,
-            "outcome": "verification_deferred",
-            "reasons": [
-              "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-              "No completion claim is currently being evaluated"
-            ],
-            "reconciliation_status": "pending",
-            "requires_review": false,
-            "target_status": null,
-            "task_id": "task-kno-181-scenario-a",
-            "verification_passed": false
+          "artifact_type": "commit",
+          "location": "stub://attempts/attempt-kno-181-a-1/commit",
+          "metadata": {
+            "branch_name": "codex/e2e-test"
           },
-          "reconciliation_result": null
-        }
+          "reference_id": "attempt-kno-181-a-1:commit"
+        },
+        "event_id": "task-kno-181-scenario-a:execution_artifact:attempt-kno-181-a-1:attempt-kno-181-a-1:commit",
+        "event_type": "execution_artifact_attached",
+        "occurred_at": "2026-04-01T08:00:05Z",
+        "source": "stub-executor",
+        "summary": "Execution artifact attached: commit"
       },
       {
-        "event_id": "task-kno-181-scenario-a:retry-scheduled:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
+        "details": {
+          "attempt_number": 1,
+          "is_final_attempt": true,
+          "max_retries": 1,
+          "scheduled_at": "2026-04-11T16:04:28.868290Z",
+          "triggered_by_category": "invalid_execution_attempt",
+          "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
+        },
+        "event_id": "task-kno-181-scenario-a:retry-scheduled:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
         "event_type": "retry_scheduled",
-        "occurred_at": "2026-04-05T17:30:31.543299Z",
-        "summary": "Retry scheduled: attempt 1",
+        "occurred_at": "2026-04-11T16:04:28.868290Z",
         "source": "harness",
+        "summary": "Retry scheduled: attempt 1"
+      },
+      {
         "details": {
           "attempt_number": 1,
           "is_final_attempt": true,
           "max_retries": 1,
-          "scheduled_at": "2026-04-05T17:30:31.543299Z",
+          "scheduled_at": "2026-04-11T16:04:28.868290Z",
           "triggered_by_category": "invalid_execution_attempt",
           "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-a:retry-started:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
+        },
+        "event_id": "task-kno-181-scenario-a:retry-started:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
         "event_type": "retry_attempt_started",
-        "occurred_at": "2026-04-05T17:30:31.543299Z",
-        "summary": "Retry attempt started: attempt 1",
+        "occurred_at": "2026-04-11T16:04:28.868290Z",
         "source": "harness",
-        "details": {
-          "attempt_number": 1,
-          "is_final_attempt": true,
-          "max_retries": 1,
-          "scheduled_at": "2026-04-05T17:30:31.543299Z",
-          "triggered_by_category": "invalid_execution_attempt",
-          "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-        }
+        "summary": "Retry attempt started: attempt 1"
       },
       {
-        "event_id": "task-kno-181-scenario-a:evaluation:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-        "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-05T17:30:31.543550Z",
-        "summary": "Evaluation recorded: no_op",
-        "source": "harness",
         "details": {
-          "evaluation_id": "11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-          "action": "no_op",
-          "target_status": null,
           "accepted_completion": false,
-          "requires_review": false,
+          "action": "no_op",
+          "evaluation_id": "5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
           "reasons": [
             "Successful execution attempt is missing repository identity for the current run."
           ],
-          "verification_result": null,
-          "reconciliation_result": null
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-a:failure:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-        "event_type": "failure_recorded",
-        "occurred_at": "2026-04-05T17:30:31.543550Z",
-        "summary": "Failure recorded: invalid_execution_attempt",
-        "source": "executor",
-        "details": {
-          "failure_recorded": true,
-          "failure_type": "invalid_execution_attempt",
-          "failure_source": "executor",
-          "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-          "terminal": false,
-          "recoverable": true
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-a:retry-completed:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-        "event_type": "retry_attempt_completed",
-        "occurred_at": "2026-04-05T17:30:31.543550Z",
-        "summary": "Retry attempt completed: attempt 1",
+          "reconciliation_result": null,
+          "requires_review": false,
+          "target_status": null,
+          "verification_result": null
+        },
+        "event_id": "task-kno-181-scenario-a:evaluation:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+        "event_type": "evaluation_recorded",
+        "occurred_at": "2026-04-11T16:04:28.868320Z",
         "source": "harness",
+        "summary": "Evaluation recorded: no_op"
+      },
+      {
         "details": {
+          "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
+          "failure_recorded": true,
+          "failure_source": "executor",
+          "failure_type": "invalid_execution_attempt",
+          "recoverable": true,
+          "terminal": false
+        },
+        "event_id": "task-kno-181-scenario-a:failure:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+        "event_type": "failure_recorded",
+        "occurred_at": "2026-04-11T16:04:28.868320Z",
+        "source": "executor",
+        "summary": "Failure recorded: invalid_execution_attempt"
+      },
+      {
+        "details": {
+          "action": "no_op",
           "attempt_number": 1,
-          "is_final_attempt": true,
-          "max_retries": 1,
-          "scheduled_at": "2026-04-05T17:30:31.543299Z",
-          "triggered_by_category": "invalid_execution_attempt",
-          "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run.",
           "failure_classification": {
             "category": "invalid_execution_attempt",
             "failure_type": "invalid_execution_attempt",
@@ -459,15 +412,37 @@
             "source": "executor",
             "terminal": false
           },
-          "action": "no_op"
-        }
+          "is_final_attempt": true,
+          "max_retries": 1,
+          "scheduled_at": "2026-04-11T16:04:28.868290Z",
+          "triggered_by_category": "invalid_execution_attempt",
+          "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
+        },
+        "event_id": "task-kno-181-scenario-a:retry-completed:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+        "event_type": "retry_attempt_completed",
+        "occurred_at": "2026-04-11T16:04:28.868320Z",
+        "source": "harness",
+        "summary": "Retry attempt completed: attempt 1"
       },
       {
-        "event_id": "task-kno-181-scenario-a:execution_event:attempt-2:0",
-        "event_type": "execution_event_recorded",
-        "occurred_at": "2026-04-05T17:30:31.550824Z",
-        "summary": "Execution event: execution_started",
+        "details": {
+          "attempt_id": "attempt-2",
+          "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+          "dispatch_mode": "automatic",
+          "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+          "dispatch_trigger": "invalid_execution_attempt_retry",
+          "execution_parameters": {
+            "prior_invalid_attempt_id": "attempt-1"
+          },
+          "executor": "codex"
+        },
+        "event_id": "task-kno-181-scenario-a:dispatch:dispatch:task-kno-181-scenario-a:2",
+        "event_type": "task_dispatched",
+        "occurred_at": "2026-04-11T16:04:28.870771Z",
         "source": "codex",
+        "summary": "Task dispatched: attempt-2"
+      },
+      {
         "details": {
           "event_id": "attempt-2:started",
           "event_type": "execution_started",
@@ -475,16 +450,16 @@
             "adapter": "stub-executor",
             "mode": "stub"
           },
-          "occurred_at": "2026-04-05T17:30:31.550824Z",
+          "occurred_at": "2026-04-11T16:04:28.870771Z",
           "source_system": "stub-executor"
-        }
+        },
+        "event_id": "task-kno-181-scenario-a:execution_event:attempt-2:0",
+        "event_type": "execution_event_recorded",
+        "occurred_at": "2026-04-11T16:04:28.870771Z",
+        "source": "codex",
+        "summary": "Execution event: execution_started"
       },
       {
-        "event_id": "task-kno-181-scenario-a:execution_event:attempt-2:1",
-        "event_type": "execution_event_recorded",
-        "occurred_at": "2026-04-05T17:30:31.550848Z",
-        "summary": "Execution event: execution_succeeded",
-        "source": "codex",
         "details": {
           "event_id": "attempt-2:completed",
           "event_type": "execution_succeeded",
@@ -492,37 +467,17 @@
             "adapter": "stub-executor",
             "executor_run_id": "stub-run-attempt-2"
           },
-          "occurred_at": "2026-04-05T17:30:31.550848Z",
+          "occurred_at": "2026-04-11T16:04:28.870785Z",
           "source_system": "stub-executor"
-        }
+        },
+        "event_id": "task-kno-181-scenario-a:execution_event:attempt-2:1",
+        "event_type": "execution_event_recorded",
+        "occurred_at": "2026-04-11T16:04:28.870785Z",
+        "source": "codex",
+        "summary": "Execution event: execution_succeeded"
       },
       {
-        "event_id": "task-kno-181-scenario-a:execution_artifact:attempt-2:attempt-2:log",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-05T17:30:31.551118Z",
-        "summary": "Execution artifact attached: execution_log",
-        "source": "codex",
         "details": {
-          "artifact_type": "execution_log",
-          "commit_sha": null,
-          "external_id": null,
-          "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
-          "metadata": {
-            "advisory": true
-          },
-          "reference_id": "attempt-2:log"
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-a:execution_attempt:attempt-2",
-        "event_type": "execution_attempt_recorded",
-        "occurred_at": "2026-04-05T17:30:31.551118Z",
-        "summary": "Execution attempt recorded: attempt-2",
-        "source": "codex",
-        "details": {
-          "attempt_id": "attempt-2",
-          "status": "completed",
-          "completion_claim_id": "attempt-2:claim",
           "artifact_references": [
             {
               "artifact_type": "execution_log",
@@ -535,131 +490,157 @@
               "reference_id": "attempt-2:log"
             }
           ],
+          "attempt_id": "attempt-2",
           "attempt_validation": {
             "context_observations": {
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "used_task_artifact_fallback": false
             },
-            "failure_type": "invalid_execution_attempt",
+            "failure_type": "contract_violation",
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [
-              "Successful execution attempt is missing repository identity for the current run.",
-              "Successful execution attempt is missing branch identity for the current run.",
-              "Successful execution attempt is missing commit SHA for the current run."
+              "Successful execution attempt is missing branch identity for the current run."
             ],
-            "retryable": true,
+            "retryable": false,
+            "rule_failures": [
+              {
+                "message": "Successful execution attempt is missing branch identity for the current run.",
+                "rule": "missing_branch_identity"
+              }
+            ],
             "status": "invalid",
-            "validated_at": "2026-04-05T17:30:31.553815Z",
+            "validated_at": "2026-04-11T16:04:28.871964Z",
             "validated_by": "execution_validation"
           },
-          "reevaluation": {}
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-a:dispatch:dispatch:task-kno-181-scenario-a:2",
-        "event_type": "task_dispatched",
-        "occurred_at": "2026-04-05T17:30:31.551127Z",
-        "summary": "Task dispatched: attempt-2",
+          "completion_claim_id": "attempt-2:claim",
+          "reevaluation": {},
+          "status": "completed"
+        },
+        "event_id": "task-kno-181-scenario-a:execution_attempt:attempt-2",
+        "event_type": "execution_attempt_recorded",
+        "occurred_at": "2026-04-11T16:04:28.870785Z",
         "source": "codex",
-        "details": {
-          "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
-          "attempt_id": "attempt-2",
-          "executor": "codex",
-          "dispatch_trigger": "invalid_execution_attempt_retry",
-          "dispatch_mode": "automatic",
-          "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-          "execution_parameters": {
-            "prior_invalid_attempt_id": "attempt-1"
-          }
-        }
+        "summary": "Execution attempt recorded: attempt-2"
       },
       {
-        "event_id": "task-kno-181-scenario-a:evaluation:3ad47b27-9ddb-4de4-917a-f976dcbaf625",
-        "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-05T17:30:31.556874Z",
-        "summary": "Evaluation recorded: no_op",
-        "source": "harness",
         "details": {
-          "evaluation_id": "3ad47b27-9ddb-4de4-917a-f976dcbaf625",
-          "action": "no_op",
-          "target_status": null,
+          "artifact_type": "execution_log",
+          "commit_sha": null,
+          "external_id": null,
+          "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+          "metadata": {
+            "advisory": true
+          },
+          "reference_id": "attempt-2:log"
+        },
+        "event_id": "task-kno-181-scenario-a:execution_artifact:attempt-2:attempt-2:log",
+        "event_type": "execution_artifact_attached",
+        "occurred_at": "2026-04-11T16:04:28.870785Z",
+        "source": "codex",
+        "summary": "Execution artifact attached: execution_log"
+      },
+      {
+        "details": {
           "accepted_completion": false,
-          "requires_review": false,
+          "action": "no_op",
+          "evaluation_id": "952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
-          "verification_result": null,
-          "reconciliation_result": null
-        }
+          "reconciliation_result": null,
+          "requires_review": false,
+          "target_status": null,
+          "verification_result": null
+        },
+        "event_id": "task-kno-181-scenario-a:evaluation:952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
+        "event_type": "evaluation_recorded",
+        "occurred_at": "2026-04-11T16:04:28.872467Z",
+        "source": "harness",
+        "summary": "Evaluation recorded: no_op"
       },
       {
-        "event_id": "task-kno-181-scenario-a:failure:3ad47b27-9ddb-4de4-917a-f976dcbaf625",
-        "event_type": "failure_recorded",
-        "occurred_at": "2026-04-05T17:30:31.556874Z",
-        "summary": "Failure recorded: invalid_execution_attempt",
-        "source": "executor",
         "details": {
+          "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
           "failure_recorded": true,
-          "failure_type": "invalid_execution_attempt",
           "failure_source": "executor",
-          "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-          "terminal": true,
-          "recoverable": false
-        }
+          "failure_type": "contract_violation",
+          "recoverable": false,
+          "terminal": true
+        },
+        "event_id": "task-kno-181-scenario-a:failure:952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
+        "event_type": "failure_recorded",
+        "occurred_at": "2026-04-11T16:04:28.872467Z",
+        "source": "executor",
+        "summary": "Failure recorded: contract_violation"
       },
       {
+        "details": {
+          "changed_at": "2026-04-11T16:04:28.878677Z",
+          "changed_by": "verification",
+          "from_status": "assigned",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
+          "to_status": "failed"
+        },
         "event_id": "task-kno-181-scenario-a:status:0",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-05T17:30:31.617375Z",
-        "summary": "Status changed intake_ready -> failed",
+        "occurred_at": "2026-04-11T16:04:28.878677Z",
         "source": "verification",
-        "details": {
-          "changed_at": "2026-04-05T17:30:31.617375Z",
-          "changed_by": "verification",
-          "from_status": "intake_ready",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
-          "to_status": "failed"
-        }
+        "summary": "Status changed assigned -> failed"
       },
       {
-        "event_id": "task-kno-181-scenario-a:evaluation:1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-        "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-05T17:30:31.666755Z",
-        "summary": "Evaluation recorded: transition_applied",
-        "source": "harness",
         "details": {
-          "evaluation_id": "1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-          "action": "transition_applied",
-          "target_status": "failed",
           "accepted_completion": false,
-          "requires_review": false,
+          "action": "transition_applied",
+          "evaluation_id": "bfcc67bd-96a8-4187-9b29-56275d8bcebe",
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
-          "verification_result": null,
-          "reconciliation_result": null
-        }
+          "reconciliation_result": null,
+          "requires_review": false,
+          "target_status": "failed",
+          "verification_result": null
+        },
+        "event_id": "task-kno-181-scenario-a:evaluation:bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+        "event_type": "evaluation_recorded",
+        "occurred_at": "2026-04-11T16:04:28.882026Z",
+        "source": "harness",
+        "summary": "Evaluation recorded: transition_applied"
       },
       {
-        "event_id": "task-kno-181-scenario-a:failure:1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-        "event_type": "failure_recorded",
-        "occurred_at": "2026-04-05T17:30:31.666755Z",
-        "summary": "Failure recorded: invalid_execution_attempt",
-        "source": "executor",
         "details": {
+          "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
           "failure_recorded": true,
-          "failure_type": "invalid_execution_attempt",
           "failure_source": "executor",
-          "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-          "terminal": true,
-          "recoverable": false
-        }
+          "failure_type": "contract_violation",
+          "recoverable": false,
+          "terminal": true
+        },
+        "event_id": "task-kno-181-scenario-a:failure:bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+        "event_type": "failure_recorded",
+        "occurred_at": "2026-04-11T16:04:28.882026Z",
+        "source": "executor",
+        "summary": "Failure recorded: contract_violation"
       }
-    ]
+    ],
+    "timestamps": {
+      "completed_at": null,
+      "created_at": "2026-03-31T14:30:00Z",
+      "updated_at": "2026-04-11T16:04:28.878677Z"
+    },
+    "title": "KNO-181 task-kno-181-scenario-a",
+    "verification_summary": null
   }
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-read-model-initial.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-read-model-initial.json
@@ -1,10 +1,62 @@
 {
   "task": {
-    "task_id": "task-kno-181-scenario-a",
-    "title": "KNO-181 task-kno-181-scenario-a",
+    "assigned_executor": {
+      "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+      "executor_id": "executor-kno-181-a",
+      "executor_type": "codex"
+    },
+    "clarification_summary": null,
+    "coordination_summary": {
+      "linear": null
+    },
+    "current_status": "assigned",
     "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-    "current_status": "intake_ready",
-    "objective_summary": "Exercise /evaluate with top-level evidence overlays.",
+    "evaluation_summary": {
+      "count": 0,
+      "history": [],
+      "latest_action": null,
+      "latest_recorded_at": null,
+      "latest_target_status": null
+    },
+    "evidence_summary": {
+      "artifact_count": 0,
+      "artifact_type_counts": {},
+      "completion_evidence": {
+        "policy": "deferred",
+        "required_artifact_types": [],
+        "status": "deferred",
+        "validated_artifact_ids": [],
+        "validated_at": null,
+        "validation_method": "deferred",
+        "validator": null
+      },
+      "validated_artifact_count": 0,
+      "verification_status_counts": {}
+    },
+    "execution_summary": {
+      "attempt_count": 0,
+      "failure_state": "clear",
+      "invalid_attempt_count": 0,
+      "last_failure_type": "none",
+      "latest_artifact_references": [],
+      "latest_attempt": null,
+      "latest_attempt_validation": null,
+      "latest_dispatch_origin": null,
+      "latest_status": null,
+      "retry_count": 0,
+      "retry_eligible": false,
+      "total_attempts": 0
+    },
+    "extensions": {},
+    "failure_summary": {
+      "failure_source": "none",
+      "failure_type": "none",
+      "recoverable": false,
+      "state": "clear",
+      "terminal": false
+    },
+    "lifecycle_history": [],
+    "objective_summary": "Scenario A: invalid execution attempt without current-run code identity proof.",
     "origin": {
       "ingress_id": null,
       "ingress_name": null,
@@ -13,122 +65,27 @@
       "source_system": "openclaw",
       "source_type": "ingress_request"
     },
-    "relationships": {
-      "parent_task_id": null,
-      "child_task_ids": [],
-      "dependencies": []
-    },
-    "assigned_executor": {
-      "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
-      "executor_id": "executor-kno-181-a",
-      "executor_type": "codex"
-    },
-    "evidence_summary": {
-      "artifact_count": 0,
-      "artifact_type_counts": {},
-      "verification_status_counts": {},
-      "validated_artifact_count": 0,
-      "completion_evidence": {
-        "policy": "deferred",
-        "status": "deferred",
-        "required_artifact_types": [],
-        "validated_artifact_ids": [],
-        "validation_method": "deferred",
-        "validated_at": null,
-        "validator": null
-      }
-    },
-    "coordination_summary": {
-      "linear": null
-    },
-    "verification_summary": {
-      "accepted_completion": false,
-      "claimed_completion": false,
-      "evidence_is_sufficient": false,
-      "evidence_is_valid": true,
-      "failure_classification": {
-        "category": "none",
-        "failure_type": "none",
-        "reason": "No completion claim is currently being evaluated",
-        "recoverable": false,
-        "retryable": false,
-        "source": "none",
-        "terminal": false
-      },
-      "is_terminal": false,
-      "outcome": "verification_deferred",
-      "reasons": [
-        "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-        "No completion claim is currently being evaluated"
-      ],
-      "reconciliation_status": "pending",
-      "requires_review": false,
-      "target_status": null,
-      "task_id": "task-kno-181-scenario-a",
-      "verification_passed": false
-    },
     "reconciliation_summary": null,
+    "relationships": {
+      "child_task_ids": [],
+      "dependencies": [],
+      "parent_task_id": null
+    },
     "review_summary": {
-      "status": "none",
-      "request_count": 0,
       "decision_count": 0,
-      "latest_request": null,
+      "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
+      "latest_request": null,
+      "request_count": 0,
       "requests": [],
-      "decisions": []
+      "resolved_decision_count": 0,
+      "status": "none"
     },
-    "execution_summary": {
-      "attempt_count": 0,
-      "latest_attempt": null,
-      "latest_status": null,
-      "latest_dispatch_origin": null,
-      "latest_attempt_validation": null,
-      "latest_artifact_references": [],
-      "total_attempts": 1,
-      "retry_count": 0,
-      "invalid_attempt_count": 0,
-      "last_failure_type": "none",
-      "retry_eligible": false,
-      "failure_state": "clear"
-    },
-    "failure_summary": {
-      "state": "clear",
-      "failure_type": "none",
-      "failure_source": "none",
-      "terminal": false,
-      "recoverable": false
-    },
-    "evaluation_summary": {
-      "count": 1,
-      "latest_recorded_at": "2026-04-05T17:30:31.525822Z",
-      "latest_action": "no_op",
-      "latest_target_status": null,
-      "history": [
-        {
-          "evaluation_id": "c460c507-1dc8-4525-8355-4126a428b996",
-          "recorded_at": "2026-04-05T17:30:31.525822Z",
-          "action": "no_op",
-          "target_status": null
-        }
-      ]
-    },
-    "lifecycle_history": [],
-    "timestamps": {
-      "completed_at": null,
-      "created_at": "2026-03-31T14:30:00Z",
-      "updated_at": "2026-03-31T14:30:00Z"
-    },
-    "extensions": {},
+    "task_id": "task-kno-181-scenario-a",
     "timeline": [
       {
-        "event_id": "task-kno-181-scenario-a:created",
-        "event_type": "task_created",
-        "occurred_at": "2026-03-31T14:30:00Z",
-        "summary": "Task created",
-        "source": "openclaw",
         "details": {
-          "status": "intake_ready",
-          "title": "KNO-181 task-kno-181-scenario-a",
           "origin": {
             "ingress_id": null,
             "ingress_name": null,
@@ -136,54 +93,23 @@
             "source_id": "req-happy-overlay-1",
             "source_system": "openclaw",
             "source_type": "ingress_request"
-          }
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-a:evaluation:c460c507-1dc8-4525-8355-4126a428b996",
-        "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-05T17:30:31.525822Z",
-        "summary": "Evaluation recorded: no_op",
-        "source": "harness",
-        "details": {
-          "evaluation_id": "c460c507-1dc8-4525-8355-4126a428b996",
-          "action": "no_op",
-          "target_status": null,
-          "accepted_completion": false,
-          "requires_review": false,
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "verification_result": {
-            "accepted_completion": false,
-            "claimed_completion": false,
-            "evidence_is_sufficient": false,
-            "evidence_is_valid": true,
-            "failure_classification": {
-              "category": "none",
-              "failure_type": "none",
-              "reason": "No completion claim is currently being evaluated",
-              "recoverable": false,
-              "retryable": false,
-              "source": "none",
-              "terminal": false
-            },
-            "is_terminal": false,
-            "outcome": "verification_deferred",
-            "reasons": [
-              "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-              "No completion claim is currently being evaluated"
-            ],
-            "reconciliation_status": "pending",
-            "requires_review": false,
-            "target_status": null,
-            "task_id": "task-kno-181-scenario-a",
-            "verification_passed": false
           },
-          "reconciliation_result": null
-        }
+          "status": "assigned",
+          "title": "KNO-181 task-kno-181-scenario-a"
+        },
+        "event_id": "task-kno-181-scenario-a:created",
+        "event_type": "task_created",
+        "occurred_at": "2026-03-31T14:30:00Z",
+        "source": "openclaw",
+        "summary": "Task created"
       }
-    ]
+    ],
+    "timestamps": {
+      "completed_at": null,
+      "created_at": "2026-03-31T14:30:00Z",
+      "updated_at": "2026-03-31T14:30:00Z"
+    },
+    "title": "KNO-181 task-kno-181-scenario-a",
+    "verification_summary": null
   }
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-submit-request.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-submit-request.json
@@ -1,76 +1,47 @@
 {
   "request": {
+    "assigned_executor": {
+      "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+      "executor_id": "executor-kno-181-a",
+      "executor_type": "codex"
+    },
     "task_envelope": {
-      "id": "task-kno-181-scenario-a",
-      "title": "KNO-181 task-kno-181-scenario-a",
-      "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-      "origin": {
-        "source_system": "openclaw",
-        "source_type": "ingress_request",
-        "source_id": "req-happy-overlay-1",
-        "ingress_id": null,
-        "ingress_name": null,
-        "requested_by": null
-      },
-      "status": "intake_ready",
-      "timestamps": {
-        "created_at": "2026-03-31T14:30:00Z",
-        "updated_at": "2026-03-31T14:30:00Z",
-        "completed_at": null
-      },
-      "status_history": [],
-      "objective": {
-        "summary": "Exercise /evaluate with top-level evidence overlays.",
-        "deliverable_type": "unspecified",
-        "success_signal": "Task satisfies declared acceptance criteria."
-      },
-      "constraints": [],
       "acceptance_criteria": [
         {
-          "id": "ac-1",
           "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+          "id": "ac-1",
           "required": true
         }
       ],
-      "parent_task_id": null,
-      "child_task_ids": [],
-      "dependencies": [],
-      "assigned_executor": null,
-      "required_capabilities": [],
-      "priority": "normal",
       "artifacts": {
-        "items": [],
         "completion_evidence": {
+          "notes": null,
           "policy": "deferred",
-          "status": "deferred",
           "required_artifact_types": [],
+          "status": "deferred",
           "validated_artifact_ids": [],
-          "validation_method": "deferred",
           "validated_at": null,
-          "validator": null,
-          "notes": null
-        }
+          "validation_method": "deferred",
+          "validator": null
+        },
+        "items": []
       },
+      "assigned_executor": null,
+      "child_task_ids": [],
+      "constraints": [],
       "coordination": {
         "linear": null
       },
-      "reconciliation": {
-        "status": "not_required",
-        "active_failure_type": null,
-        "attempts": [],
-        "last_attempt_id": null,
-        "last_pr_url": null,
-        "last_error": null,
-        "resolved_at": null,
-        "failed_at": null
+      "dependencies": [],
+      "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+      "id": "task-kno-181-scenario-a",
+      "objective": {
+        "deliverable_type": "unspecified",
+        "success_signal": "Task satisfies declared acceptance criteria.",
+        "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
       },
       "observability": {
         "errors": [],
-        "retries": {
-          "attempt_count": 0,
-          "max_attempts": 0,
-          "last_retry_at": null
-        },
         "execution_metadata": {
           "schema_required_deferred_fields": [
             "parent_task_id",
@@ -83,13 +54,42 @@
             "artifacts.completion_evidence",
             "observability"
           ]
+        },
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
         }
-      }
-    },
-    "assigned_executor": {
-      "executor_type": "codex",
-      "executor_id": "executor-kno-181-a",
-      "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof."
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": null,
+        "requested_by": null,
+        "source_id": "req-happy-overlay-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "reconciliation": {
+        "active_failure_type": null,
+        "attempts": [],
+        "failed_at": null,
+        "last_attempt_id": null,
+        "last_error": null,
+        "last_pr_url": null,
+        "resolved_at": null,
+        "status": "not_required"
+      },
+      "required_capabilities": [],
+      "status": "intake_ready",
+      "status_history": [],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-03-31T14:30:00Z",
+        "updated_at": "2026-03-31T14:30:00Z"
+      },
+      "title": "KNO-181 task-kno-181-scenario-a"
     }
   }
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-submit-response.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-submit-response.json
@@ -1,83 +1,48 @@
 {
-  "status": 200,
   "response": {
-    "action": "no_op",
-    "target_status": null,
+    "action": "seeded_controlled_task",
+    "target_status": "assigned",
     "task_envelope": {
-      "id": "task-kno-181-scenario-a",
-      "title": "KNO-181 task-kno-181-scenario-a",
-      "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-      "origin": {
-        "source_system": "openclaw",
-        "source_type": "ingress_request",
-        "source_id": "req-happy-overlay-1",
-        "ingress_id": null,
-        "ingress_name": null,
-        "requested_by": null
-      },
-      "status": "intake_ready",
-      "timestamps": {
-        "created_at": "2026-03-31T14:30:00Z",
-        "updated_at": "2026-03-31T14:30:00Z",
-        "completed_at": null
-      },
-      "status_history": [],
-      "objective": {
-        "summary": "Exercise /evaluate with top-level evidence overlays.",
-        "deliverable_type": "unspecified",
-        "success_signal": "Task satisfies declared acceptance criteria."
-      },
-      "constraints": [],
       "acceptance_criteria": [
         {
-          "id": "ac-1",
           "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+          "id": "ac-1",
           "required": true
         }
       ],
-      "parent_task_id": null,
-      "child_task_ids": [],
-      "dependencies": [],
-      "assigned_executor": {
-        "executor_type": "codex",
-        "executor_id": "executor-kno-181-a",
-        "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof."
-      },
-      "required_capabilities": [],
-      "priority": "normal",
       "artifacts": {
-        "items": [],
         "completion_evidence": {
+          "notes": null,
           "policy": "deferred",
-          "status": "deferred",
           "required_artifact_types": [],
+          "status": "deferred",
           "validated_artifact_ids": [],
-          "validation_method": "deferred",
           "validated_at": null,
-          "validator": null,
-          "notes": null
-        }
+          "validation_method": "deferred",
+          "validator": null
+        },
+        "items": []
       },
+      "assigned_executor": {
+        "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof.",
+        "executor_id": "executor-kno-181-a",
+        "executor_type": "codex"
+      },
+      "child_task_ids": [],
+      "constraints": [],
       "coordination": {
         "linear": null
       },
-      "reconciliation": {
-        "status": "not_required",
-        "active_failure_type": null,
-        "attempts": [],
-        "last_attempt_id": null,
-        "last_pr_url": null,
-        "last_error": null,
-        "resolved_at": null,
-        "failed_at": null
+      "dependencies": [],
+      "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
+      "id": "task-kno-181-scenario-a",
+      "objective": {
+        "deliverable_type": "unspecified",
+        "success_signal": "Task satisfies declared acceptance criteria.",
+        "summary": "Scenario A: invalid execution attempt without current-run code identity proof."
       },
       "observability": {
         "errors": [],
-        "retries": {
-          "attempt_count": 0,
-          "max_attempts": 0,
-          "last_retry_at": null
-        },
         "execution_metadata": {
           "schema_required_deferred_fields": [
             "parent_task_id",
@@ -90,548 +55,43 @@
             "artifacts.completion_evidence",
             "observability"
           ]
-        }
-      }
-    },
-    "enforcement_result": {
-      "action": "no_op",
-      "task_envelope": {
-        "id": "task-kno-181-scenario-a",
-        "title": "KNO-181 task-kno-181-scenario-a",
-        "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-        "origin": {
-          "source_system": "openclaw",
-          "source_type": "ingress_request",
-          "source_id": "req-happy-overlay-1",
-          "ingress_id": null,
-          "ingress_name": null,
-          "requested_by": null
         },
-        "status": "intake_ready",
-        "timestamps": {
-          "created_at": "2026-03-31T14:30:00Z",
-          "updated_at": "2026-03-31T14:30:00Z",
-          "completed_at": null
-        },
-        "status_history": [],
-        "objective": {
-          "summary": "Exercise /evaluate with top-level evidence overlays.",
-          "deliverable_type": "unspecified",
-          "success_signal": "Task satisfies declared acceptance criteria."
-        },
-        "constraints": [],
-        "acceptance_criteria": [
-          {
-            "id": "ac-1",
-            "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-            "required": true
-          }
-        ],
-        "parent_task_id": null,
-        "child_task_ids": [],
-        "dependencies": [],
-        "assigned_executor": {
-          "executor_type": "codex",
-          "executor_id": "executor-kno-181-a",
-          "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof."
-        },
-        "required_capabilities": [],
-        "priority": "normal",
-        "artifacts": {
-          "items": [],
-          "completion_evidence": {
-            "policy": "deferred",
-            "status": "deferred",
-            "required_artifact_types": [],
-            "validated_artifact_ids": [],
-            "validation_method": "deferred",
-            "validated_at": null,
-            "validator": null,
-            "notes": null
-          }
-        },
-        "coordination": {
-          "linear": null
-        },
-        "reconciliation": {
-          "status": "not_required",
-          "active_failure_type": null,
-          "attempts": [],
-          "last_attempt_id": null,
-          "last_pr_url": null,
-          "last_error": null,
-          "resolved_at": null,
-          "failed_at": null
-        },
-        "observability": {
-          "errors": [],
-          "retries": {
-            "attempt_count": 0,
-            "max_attempts": 0,
-            "last_retry_at": null
-          },
-          "execution_metadata": {
-            "schema_required_deferred_fields": [
-              "parent_task_id",
-              "child_task_ids",
-              "dependencies",
-              "assigned_executor",
-              "required_capabilities",
-              "priority",
-              "artifacts.items",
-              "artifacts.completion_evidence",
-              "observability"
-            ]
-          }
-        }
-      },
-      "evidence_result": {
-        "is_valid": true,
-        "is_sufficient": false,
-        "artifact_results": [],
-        "issues": [],
-        "validated_artifact_ids": [],
-        "missing_required_artifact_types": [],
-        "unknown_validated_artifact_ids": []
-      },
-      "reconciliation_result": null,
-      "verification_result": {
-        "task_id": "task-kno-181-scenario-a",
-        "outcome": "verification_deferred",
-        "target_status": null,
-        "claimed_completion": false,
-        "accepted_completion": false,
-        "requires_review": false,
-        "is_terminal": false,
-        "verification_passed": false,
-        "evidence_is_valid": true,
-        "evidence_is_sufficient": false,
-        "reconciliation_status": "pending",
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "failure_classification": {
-          "failure_type": "none",
-          "source": "none",
-          "reason": "No completion claim is currently being evaluated",
-          "terminal": false,
-          "recoverable": false,
-          "category": "none",
-          "retryable": false
-        }
-      },
-      "review_request": null,
-      "review_decision": null,
-      "transition_result": null,
-      "target_status": null,
-      "reasons": [
-        "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-        "No completion claim is currently being evaluated"
-      ],
-      "failure_classification": {
-        "failure_type": "none",
-        "source": "none",
-        "reason": "No completion claim is currently being evaluated",
-        "terminal": false,
-        "recoverable": false,
-        "category": "none",
-        "retryable": false
-      },
-      "error": null
-    },
-    "accepted_completion": false,
-    "requires_review": false,
-    "invalid_input": false,
-    "failure_classification": {
-      "failure_type": "none",
-      "source": "none",
-      "reason": "No completion claim is currently being evaluated",
-      "terminal": false,
-      "recoverable": false,
-      "category": "none",
-      "retryable": false
-    },
-    "reasons": [
-      "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-      "No completion claim is currently being evaluated"
-    ],
-    "error": null,
-    "evaluation_record": {
-      "evaluation_id": "c460c507-1dc8-4525-8355-4126a428b996",
-      "task_id": "task-kno-181-scenario-a",
-      "recorded_at": "2026-04-05T17:30:31.525822Z",
-      "request": {
-        "task_envelope": {
-          "id": "task-kno-181-scenario-a",
-          "title": "KNO-181 task-kno-181-scenario-a",
-          "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-          "origin": {
-            "source_system": "openclaw",
-            "source_type": "ingress_request",
-            "source_id": "req-happy-overlay-1",
-            "ingress_id": null,
-            "ingress_name": null,
-            "requested_by": null
-          },
-          "status": "intake_ready",
-          "timestamps": {
-            "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-03-31T14:30:00Z",
-            "completed_at": null
-          },
-          "status_history": [],
-          "objective": {
-            "summary": "Exercise /evaluate with top-level evidence overlays.",
-            "deliverable_type": "unspecified",
-            "success_signal": "Task satisfies declared acceptance criteria."
-          },
-          "constraints": [],
-          "acceptance_criteria": [
-            {
-              "id": "ac-1",
-              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-              "required": true
-            }
-          ],
-          "parent_task_id": null,
-          "child_task_ids": [],
-          "dependencies": [],
-          "assigned_executor": {
-            "executor_type": "codex",
-            "executor_id": "executor-kno-181-a",
-            "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof."
-          },
-          "required_capabilities": [],
-          "priority": "normal",
-          "artifacts": {
-            "items": [],
-            "completion_evidence": {
-              "policy": "deferred",
-              "status": "deferred",
-              "required_artifact_types": [],
-              "validated_artifact_ids": [],
-              "validation_method": "deferred",
-              "validated_at": null,
-              "validator": null,
-              "notes": null
-            }
-          },
-          "coordination": {
-            "linear": null
-          },
-          "reconciliation": {
-            "status": "not_required",
-            "active_failure_type": null,
-            "attempts": [],
-            "last_attempt_id": null,
-            "last_pr_url": null,
-            "last_error": null,
-            "resolved_at": null,
-            "failed_at": null
-          },
-          "observability": {
-            "errors": [],
-            "retries": {
-              "attempt_count": 0,
-              "max_attempts": 0,
-              "last_retry_at": null
-            },
-            "execution_metadata": {
-              "schema_required_deferred_fields": [
-                "parent_task_id",
-                "child_task_ids",
-                "dependencies",
-                "assigned_executor",
-                "required_capabilities",
-                "priority",
-                "artifacts.items",
-                "artifacts.completion_evidence",
-                "observability"
-              ]
-            }
-          }
-        },
-        "external_facts": null,
-        "claimed_completion": false,
-        "acceptance_criteria_satisfied": false,
-        "runtime_facts": {
-          "executor_reported_success": false,
-          "executor_reported_failure": false,
-          "terminal_failure": false,
+        "retries": {
           "attempt_count": 0,
-          "latest_attempt_outcome": null
-        },
-        "unresolved_conditions": [],
-        "review_reasons": [],
-        "review_request": null,
-        "review_decision": null,
-        "review_is_active": false,
-        "retry_context": null
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
       },
-      "result": {
-        "action": "no_op",
-        "target_status": null,
-        "task_envelope": {
-          "id": "task-kno-181-scenario-a",
-          "title": "KNO-181 task-kno-181-scenario-a",
-          "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-          "origin": {
-            "source_system": "openclaw",
-            "source_type": "ingress_request",
-            "source_id": "req-happy-overlay-1",
-            "ingress_id": null,
-            "ingress_name": null,
-            "requested_by": null
-          },
-          "status": "intake_ready",
-          "timestamps": {
-            "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-03-31T14:30:00Z",
-            "completed_at": null
-          },
-          "status_history": [],
-          "objective": {
-            "summary": "Exercise /evaluate with top-level evidence overlays.",
-            "deliverable_type": "unspecified",
-            "success_signal": "Task satisfies declared acceptance criteria."
-          },
-          "constraints": [],
-          "acceptance_criteria": [
-            {
-              "id": "ac-1",
-              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-              "required": true
-            }
-          ],
-          "parent_task_id": null,
-          "child_task_ids": [],
-          "dependencies": [],
-          "assigned_executor": {
-            "executor_type": "codex",
-            "executor_id": "executor-kno-181-a",
-            "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof."
-          },
-          "required_capabilities": [],
-          "priority": "normal",
-          "artifacts": {
-            "items": [],
-            "completion_evidence": {
-              "policy": "deferred",
-              "status": "deferred",
-              "required_artifact_types": [],
-              "validated_artifact_ids": [],
-              "validation_method": "deferred",
-              "validated_at": null,
-              "validator": null,
-              "notes": null
-            }
-          },
-          "coordination": {
-            "linear": null
-          },
-          "reconciliation": {
-            "status": "not_required",
-            "active_failure_type": null,
-            "attempts": [],
-            "last_attempt_id": null,
-            "last_pr_url": null,
-            "last_error": null,
-            "resolved_at": null,
-            "failed_at": null
-          },
-          "observability": {
-            "errors": [],
-            "retries": {
-              "attempt_count": 0,
-              "max_attempts": 0,
-              "last_retry_at": null
-            },
-            "execution_metadata": {
-              "schema_required_deferred_fields": [
-                "parent_task_id",
-                "child_task_ids",
-                "dependencies",
-                "assigned_executor",
-                "required_capabilities",
-                "priority",
-                "artifacts.items",
-                "artifacts.completion_evidence",
-                "observability"
-              ]
-            }
-          }
-        },
-        "enforcement_result": {
-          "action": "no_op",
-          "task_envelope": {
-            "id": "task-kno-181-scenario-a",
-            "title": "KNO-181 task-kno-181-scenario-a",
-            "description": "Scenario A: invalid execution attempt without current-run code identity proof.",
-            "origin": {
-              "source_system": "openclaw",
-              "source_type": "ingress_request",
-              "source_id": "req-happy-overlay-1",
-              "ingress_id": null,
-              "ingress_name": null,
-              "requested_by": null
-            },
-            "status": "intake_ready",
-            "timestamps": {
-              "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-03-31T14:30:00Z",
-              "completed_at": null
-            },
-            "status_history": [],
-            "objective": {
-              "summary": "Exercise /evaluate with top-level evidence overlays.",
-              "deliverable_type": "unspecified",
-              "success_signal": "Task satisfies declared acceptance criteria."
-            },
-            "constraints": [],
-            "acceptance_criteria": [
-              {
-                "id": "ac-1",
-                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-                "required": true
-              }
-            ],
-            "parent_task_id": null,
-            "child_task_ids": [],
-            "dependencies": [],
-            "assigned_executor": {
-              "executor_type": "codex",
-              "executor_id": "executor-kno-181-a",
-              "assignment_reason": "Scenario A: invalid execution attempt without current-run code identity proof."
-            },
-            "required_capabilities": [],
-            "priority": "normal",
-            "artifacts": {
-              "items": [],
-              "completion_evidence": {
-                "policy": "deferred",
-                "status": "deferred",
-                "required_artifact_types": [],
-                "validated_artifact_ids": [],
-                "validation_method": "deferred",
-                "validated_at": null,
-                "validator": null,
-                "notes": null
-              }
-            },
-            "coordination": {
-              "linear": null
-            },
-            "reconciliation": {
-              "status": "not_required",
-              "active_failure_type": null,
-              "attempts": [],
-              "last_attempt_id": null,
-              "last_pr_url": null,
-              "last_error": null,
-              "resolved_at": null,
-              "failed_at": null
-            },
-            "observability": {
-              "errors": [],
-              "retries": {
-                "attempt_count": 0,
-                "max_attempts": 0,
-                "last_retry_at": null
-              },
-              "execution_metadata": {
-                "schema_required_deferred_fields": [
-                  "parent_task_id",
-                  "child_task_ids",
-                  "dependencies",
-                  "assigned_executor",
-                  "required_capabilities",
-                  "priority",
-                  "artifacts.items",
-                  "artifacts.completion_evidence",
-                  "observability"
-                ]
-              }
-            }
-          },
-          "evidence_result": {
-            "is_valid": true,
-            "is_sufficient": false,
-            "artifact_results": [],
-            "issues": [],
-            "validated_artifact_ids": [],
-            "missing_required_artifact_types": [],
-            "unknown_validated_artifact_ids": []
-          },
-          "reconciliation_result": null,
-          "verification_result": {
-            "task_id": "task-kno-181-scenario-a",
-            "outcome": "verification_deferred",
-            "target_status": null,
-            "claimed_completion": false,
-            "accepted_completion": false,
-            "requires_review": false,
-            "is_terminal": false,
-            "verification_passed": false,
-            "evidence_is_valid": true,
-            "evidence_is_sufficient": false,
-            "reconciliation_status": "pending",
-            "reasons": [
-              "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-              "No completion claim is currently being evaluated"
-            ],
-            "failure_classification": {
-              "failure_type": "none",
-              "source": "none",
-              "reason": "No completion claim is currently being evaluated",
-              "terminal": false,
-              "recoverable": false,
-              "category": "none",
-              "retryable": false
-            }
-          },
-          "review_request": null,
-          "review_decision": null,
-          "transition_result": null,
-          "target_status": null,
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "failure_classification": {
-            "failure_type": "none",
-            "source": "none",
-            "reason": "No completion claim is currently being evaluated",
-            "terminal": false,
-            "recoverable": false,
-            "category": "none",
-            "retryable": false
-          },
-          "error": null
-        },
-        "accepted_completion": false,
-        "requires_review": false,
-        "invalid_input": false,
-        "failure_classification": {
-          "failure_type": "none",
-          "source": "none",
-          "reason": "No completion claim is currently being evaluated",
-          "terminal": false,
-          "recoverable": false,
-          "category": "none",
-          "retryable": false
-        },
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "error": null
-      }
-    },
-    "automatic_dispatch": {
-      "attempted": false,
-      "dispatchable": false,
-      "reason": "status=intake_ready is not auto-dispatch eligible"
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": null,
+        "requested_by": null,
+        "source_id": "req-happy-overlay-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "reconciliation": {
+        "active_failure_type": null,
+        "attempts": [],
+        "failed_at": null,
+        "last_attempt_id": null,
+        "last_error": null,
+        "last_pr_url": null,
+        "resolved_at": null,
+        "status": "not_required"
+      },
+      "required_capabilities": [],
+      "status": "assigned",
+      "status_history": [],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-03-31T14:30:00Z",
+        "updated_at": "2026-03-31T14:30:00Z"
+      },
+      "title": "KNO-181 task-kno-181-scenario-a"
     }
-  }
+  },
+  "status": 200
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-timeline-final.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-timeline-final.json
@@ -1,17 +1,10 @@
 {
-  "task_id": "task-kno-181-scenario-a",
   "current_status": "failed",
-  "event_count": 19,
+  "event_count": 18,
+  "task_id": "task-kno-181-scenario-a",
   "timeline": [
     {
-      "event_id": "task-kno-181-scenario-a:created",
-      "event_type": "task_created",
-      "occurred_at": "2026-03-31T14:30:00Z",
-      "summary": "Task created",
-      "source": "openclaw",
       "details": {
-        "status": "failed",
-        "title": "KNO-181 task-kno-181-scenario-a",
         "origin": {
           "ingress_id": null,
           "ingress_name": null,
@@ -19,185 +12,160 @@
           "source_id": "req-happy-overlay-1",
           "source_system": "openclaw",
           "source_type": "ingress_request"
-        }
-      }
+        },
+        "status": "failed",
+        "title": "KNO-181 task-kno-181-scenario-a"
+      },
+      "event_id": "task-kno-181-scenario-a:created",
+      "event_type": "task_created",
+      "occurred_at": "2026-03-31T14:30:00Z",
+      "source": "openclaw",
+      "summary": "Task created"
     },
     {
-      "event_id": "task-kno-181-scenario-a:execution_artifact:attempt-kno-181-a-1:attempt-kno-181-a-1:log",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-01T08:00:05Z",
-      "summary": "Execution artifact attached: execution_log",
-      "source": "stub-executor",
       "details": {
-        "artifact_type": "execution_log",
-        "location": "stub://attempts/log",
-        "reference_id": "attempt-kno-181-a-1:log"
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-a:execution_attempt:attempt-kno-181-a-1",
-      "event_type": "execution_attempt_recorded",
-      "occurred_at": "2026-04-01T08:00:05Z",
-      "summary": "Execution attempt recorded: attempt-kno-181-a-1",
-      "source": "stub-executor",
-      "details": {
-        "attempt_id": "attempt-kno-181-a-1",
-        "status": "succeeded",
-        "completion_claim_id": "claim-kno-181-a-1",
         "artifact_references": [
           {
-            "artifact_type": "execution_log",
-            "location": "stub://attempts/log",
-            "reference_id": "attempt-kno-181-a-1:log"
+            "artifact_type": "commit",
+            "location": "stub://attempts/attempt-kno-181-a-1/commit",
+            "metadata": {
+              "branch_name": "codex/e2e-test"
+            },
+            "reference_id": "attempt-kno-181-a-1:commit"
           }
         ],
+        "attempt_id": "attempt-kno-181-a-1",
         "attempt_validation": {
           "context_observations": {
+            "branch": [
+              {
+                "sources": [
+                  "execution_attempt.artifact_references[0]"
+                ],
+                "value": "codex/e2e-test"
+              }
+            ],
+            "commit_resolution_pending": false,
+            "has_valid_current_run_pull_request_artifact": false,
             "used_task_artifact_fallback": false
           },
           "failure_type": "invalid_execution_attempt",
           "policy": {
+            "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [
             "Successful execution attempt is missing repository identity for the current run.",
-            "Successful execution attempt is missing branch identity for the current run.",
             "Successful execution attempt is missing commit SHA for the current run."
           ],
           "retryable": true,
+          "rule_failures": [],
           "status": "invalid",
-          "validated_at": "2026-04-05T17:30:31.541310Z",
+          "validated_at": "2026-04-11T16:04:28.868130Z",
           "validated_by": "execution_validation"
         },
-        "reevaluation": {}
-      }
+        "completion_claim_id": "claim-kno-181-a-1",
+        "reevaluation": {},
+        "status": "succeeded"
+      },
+      "event_id": "task-kno-181-scenario-a:execution_attempt:attempt-kno-181-a-1",
+      "event_type": "execution_attempt_recorded",
+      "occurred_at": "2026-04-01T08:00:05Z",
+      "source": "stub-executor",
+      "summary": "Execution attempt recorded: attempt-kno-181-a-1"
     },
     {
-      "event_id": "task-kno-181-scenario-a:evaluation:c460c507-1dc8-4525-8355-4126a428b996",
-      "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-05T17:30:31.525822Z",
-      "summary": "Evaluation recorded: no_op",
-      "source": "harness",
       "details": {
-        "evaluation_id": "c460c507-1dc8-4525-8355-4126a428b996",
-        "action": "no_op",
-        "target_status": null,
-        "accepted_completion": false,
-        "requires_review": false,
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "verification_result": {
-          "accepted_completion": false,
-          "claimed_completion": false,
-          "evidence_is_sufficient": false,
-          "evidence_is_valid": true,
-          "failure_classification": {
-            "category": "none",
-            "failure_type": "none",
-            "reason": "No completion claim is currently being evaluated",
-            "recoverable": false,
-            "retryable": false,
-            "source": "none",
-            "terminal": false
-          },
-          "is_terminal": false,
-          "outcome": "verification_deferred",
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "reconciliation_status": "pending",
-          "requires_review": false,
-          "target_status": null,
-          "task_id": "task-kno-181-scenario-a",
-          "verification_passed": false
+        "artifact_type": "commit",
+        "location": "stub://attempts/attempt-kno-181-a-1/commit",
+        "metadata": {
+          "branch_name": "codex/e2e-test"
         },
-        "reconciliation_result": null
-      }
+        "reference_id": "attempt-kno-181-a-1:commit"
+      },
+      "event_id": "task-kno-181-scenario-a:execution_artifact:attempt-kno-181-a-1:attempt-kno-181-a-1:commit",
+      "event_type": "execution_artifact_attached",
+      "occurred_at": "2026-04-01T08:00:05Z",
+      "source": "stub-executor",
+      "summary": "Execution artifact attached: commit"
     },
     {
-      "event_id": "task-kno-181-scenario-a:retry-scheduled:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
+      "details": {
+        "attempt_number": 1,
+        "is_final_attempt": true,
+        "max_retries": 1,
+        "scheduled_at": "2026-04-11T16:04:28.868290Z",
+        "triggered_by_category": "invalid_execution_attempt",
+        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
+      },
+      "event_id": "task-kno-181-scenario-a:retry-scheduled:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
       "event_type": "retry_scheduled",
-      "occurred_at": "2026-04-05T17:30:31.543299Z",
-      "summary": "Retry scheduled: attempt 1",
+      "occurred_at": "2026-04-11T16:04:28.868290Z",
       "source": "harness",
+      "summary": "Retry scheduled: attempt 1"
+    },
+    {
       "details": {
         "attempt_number": 1,
         "is_final_attempt": true,
         "max_retries": 1,
-        "scheduled_at": "2026-04-05T17:30:31.543299Z",
+        "scheduled_at": "2026-04-11T16:04:28.868290Z",
         "triggered_by_category": "invalid_execution_attempt",
         "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-a:retry-started:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
+      },
+      "event_id": "task-kno-181-scenario-a:retry-started:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
       "event_type": "retry_attempt_started",
-      "occurred_at": "2026-04-05T17:30:31.543299Z",
-      "summary": "Retry attempt started: attempt 1",
+      "occurred_at": "2026-04-11T16:04:28.868290Z",
       "source": "harness",
-      "details": {
-        "attempt_number": 1,
-        "is_final_attempt": true,
-        "max_retries": 1,
-        "scheduled_at": "2026-04-05T17:30:31.543299Z",
-        "triggered_by_category": "invalid_execution_attempt",
-        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-      }
+      "summary": "Retry attempt started: attempt 1"
     },
     {
-      "event_id": "task-kno-181-scenario-a:evaluation:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-      "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-05T17:30:31.543550Z",
-      "summary": "Evaluation recorded: no_op",
-      "source": "harness",
       "details": {
-        "evaluation_id": "11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-        "action": "no_op",
-        "target_status": null,
         "accepted_completion": false,
-        "requires_review": false,
+        "action": "no_op",
+        "evaluation_id": "5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
         "reasons": [
           "Successful execution attempt is missing repository identity for the current run."
         ],
-        "verification_result": null,
-        "reconciliation_result": null
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-a:failure:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-      "event_type": "failure_recorded",
-      "occurred_at": "2026-04-05T17:30:31.543550Z",
-      "summary": "Failure recorded: invalid_execution_attempt",
-      "source": "executor",
-      "details": {
-        "failure_recorded": true,
-        "failure_type": "invalid_execution_attempt",
-        "failure_source": "executor",
-        "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-        "terminal": false,
-        "recoverable": true
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-a:retry-completed:11b0ea6d-d911-4564-aaca-26d6b90d5a8a",
-      "event_type": "retry_attempt_completed",
-      "occurred_at": "2026-04-05T17:30:31.543550Z",
-      "summary": "Retry attempt completed: attempt 1",
+        "reconciliation_result": null,
+        "requires_review": false,
+        "target_status": null,
+        "verification_result": null
+      },
+      "event_id": "task-kno-181-scenario-a:evaluation:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+      "event_type": "evaluation_recorded",
+      "occurred_at": "2026-04-11T16:04:28.868320Z",
       "source": "harness",
+      "summary": "Evaluation recorded: no_op"
+    },
+    {
       "details": {
+        "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
+        "failure_recorded": true,
+        "failure_source": "executor",
+        "failure_type": "invalid_execution_attempt",
+        "recoverable": true,
+        "terminal": false
+      },
+      "event_id": "task-kno-181-scenario-a:failure:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+      "event_type": "failure_recorded",
+      "occurred_at": "2026-04-11T16:04:28.868320Z",
+      "source": "executor",
+      "summary": "Failure recorded: invalid_execution_attempt"
+    },
+    {
+      "details": {
+        "action": "no_op",
         "attempt_number": 1,
-        "is_final_attempt": true,
-        "max_retries": 1,
-        "scheduled_at": "2026-04-05T17:30:31.543299Z",
-        "triggered_by_category": "invalid_execution_attempt",
-        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run.",
         "failure_classification": {
           "category": "invalid_execution_attempt",
           "failure_type": "invalid_execution_attempt",
@@ -207,15 +175,37 @@
           "source": "executor",
           "terminal": false
         },
-        "action": "no_op"
-      }
+        "is_final_attempt": true,
+        "max_retries": 1,
+        "scheduled_at": "2026-04-11T16:04:28.868290Z",
+        "triggered_by_category": "invalid_execution_attempt",
+        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
+      },
+      "event_id": "task-kno-181-scenario-a:retry-completed:5114b951-d82e-4ddb-8d2c-3c25e8cb741a",
+      "event_type": "retry_attempt_completed",
+      "occurred_at": "2026-04-11T16:04:28.868320Z",
+      "source": "harness",
+      "summary": "Retry attempt completed: attempt 1"
     },
     {
-      "event_id": "task-kno-181-scenario-a:execution_event:attempt-2:0",
-      "event_type": "execution_event_recorded",
-      "occurred_at": "2026-04-05T17:30:31.550824Z",
-      "summary": "Execution event: execution_started",
+      "details": {
+        "attempt_id": "attempt-2",
+        "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
+        "dispatch_mode": "automatic",
+        "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
+        "dispatch_trigger": "invalid_execution_attempt_retry",
+        "execution_parameters": {
+          "prior_invalid_attempt_id": "attempt-1"
+        },
+        "executor": "codex"
+      },
+      "event_id": "task-kno-181-scenario-a:dispatch:dispatch:task-kno-181-scenario-a:2",
+      "event_type": "task_dispatched",
+      "occurred_at": "2026-04-11T16:04:28.870771Z",
       "source": "codex",
+      "summary": "Task dispatched: attempt-2"
+    },
+    {
       "details": {
         "event_id": "attempt-2:started",
         "event_type": "execution_started",
@@ -223,16 +213,16 @@
           "adapter": "stub-executor",
           "mode": "stub"
         },
-        "occurred_at": "2026-04-05T17:30:31.550824Z",
+        "occurred_at": "2026-04-11T16:04:28.870771Z",
         "source_system": "stub-executor"
-      }
+      },
+      "event_id": "task-kno-181-scenario-a:execution_event:attempt-2:0",
+      "event_type": "execution_event_recorded",
+      "occurred_at": "2026-04-11T16:04:28.870771Z",
+      "source": "codex",
+      "summary": "Execution event: execution_started"
     },
     {
-      "event_id": "task-kno-181-scenario-a:execution_event:attempt-2:1",
-      "event_type": "execution_event_recorded",
-      "occurred_at": "2026-04-05T17:30:31.550848Z",
-      "summary": "Execution event: execution_succeeded",
-      "source": "codex",
       "details": {
         "event_id": "attempt-2:completed",
         "event_type": "execution_succeeded",
@@ -240,37 +230,17 @@
           "adapter": "stub-executor",
           "executor_run_id": "stub-run-attempt-2"
         },
-        "occurred_at": "2026-04-05T17:30:31.550848Z",
+        "occurred_at": "2026-04-11T16:04:28.870785Z",
         "source_system": "stub-executor"
-      }
+      },
+      "event_id": "task-kno-181-scenario-a:execution_event:attempt-2:1",
+      "event_type": "execution_event_recorded",
+      "occurred_at": "2026-04-11T16:04:28.870785Z",
+      "source": "codex",
+      "summary": "Execution event: execution_succeeded"
     },
     {
-      "event_id": "task-kno-181-scenario-a:execution_artifact:attempt-2:attempt-2:log",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-05T17:30:31.551118Z",
-      "summary": "Execution artifact attached: execution_log",
-      "source": "codex",
       "details": {
-        "artifact_type": "execution_log",
-        "commit_sha": null,
-        "external_id": null,
-        "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
-        "metadata": {
-          "advisory": true
-        },
-        "reference_id": "attempt-2:log"
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-a:execution_attempt:attempt-2",
-      "event_type": "execution_attempt_recorded",
-      "occurred_at": "2026-04-05T17:30:31.551118Z",
-      "summary": "Execution attempt recorded: attempt-2",
-      "source": "codex",
-      "details": {
-        "attempt_id": "attempt-2",
-        "status": "completed",
-        "completion_claim_id": "attempt-2:claim",
         "artifact_references": [
           {
             "artifact_type": "execution_log",
@@ -283,130 +253,149 @@
             "reference_id": "attempt-2:log"
           }
         ],
+        "attempt_id": "attempt-2",
         "attempt_validation": {
           "context_observations": {
+            "commit_resolution_pending": false,
+            "has_valid_current_run_pull_request_artifact": false,
             "used_task_artifact_fallback": false
           },
-          "failure_type": "invalid_execution_attempt",
+          "failure_type": "contract_violation",
           "policy": {
+            "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run.",
-            "Successful execution attempt is missing branch identity for the current run.",
-            "Successful execution attempt is missing commit SHA for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
-          "retryable": true,
+          "retryable": false,
+          "rule_failures": [
+            {
+              "message": "Successful execution attempt is missing branch identity for the current run.",
+              "rule": "missing_branch_identity"
+            }
+          ],
           "status": "invalid",
-          "validated_at": "2026-04-05T17:30:31.553815Z",
+          "validated_at": "2026-04-11T16:04:28.871964Z",
           "validated_by": "execution_validation"
         },
-        "reevaluation": {}
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-a:dispatch:dispatch:task-kno-181-scenario-a:2",
-      "event_type": "task_dispatched",
-      "occurred_at": "2026-04-05T17:30:31.551127Z",
-      "summary": "Task dispatched: attempt-2",
+        "completion_claim_id": "attempt-2:claim",
+        "reevaluation": {},
+        "status": "completed"
+      },
+      "event_id": "task-kno-181-scenario-a:execution_attempt:attempt-2",
+      "event_type": "execution_attempt_recorded",
+      "occurred_at": "2026-04-11T16:04:28.870785Z",
       "source": "codex",
-      "details": {
-        "dispatch_id": "dispatch:task-kno-181-scenario-a:2",
-        "attempt_id": "attempt-2",
-        "executor": "codex",
-        "dispatch_trigger": "invalid_execution_attempt_retry",
-        "dispatch_mode": "automatic",
-        "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-        "execution_parameters": {
-          "prior_invalid_attempt_id": "attempt-1"
-        }
-      }
+      "summary": "Execution attempt recorded: attempt-2"
     },
     {
-      "event_id": "task-kno-181-scenario-a:evaluation:3ad47b27-9ddb-4de4-917a-f976dcbaf625",
-      "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-05T17:30:31.556874Z",
-      "summary": "Evaluation recorded: no_op",
-      "source": "harness",
       "details": {
-        "evaluation_id": "3ad47b27-9ddb-4de4-917a-f976dcbaf625",
-        "action": "no_op",
-        "target_status": null,
+        "artifact_type": "execution_log",
+        "commit_sha": null,
+        "external_id": null,
+        "location": "stub://executions/task-kno-181-scenario-a/attempt-2/log",
+        "metadata": {
+          "advisory": true
+        },
+        "reference_id": "attempt-2:log"
+      },
+      "event_id": "task-kno-181-scenario-a:execution_artifact:attempt-2:attempt-2:log",
+      "event_type": "execution_artifact_attached",
+      "occurred_at": "2026-04-11T16:04:28.870785Z",
+      "source": "codex",
+      "summary": "Execution artifact attached: execution_log"
+    },
+    {
+      "details": {
         "accepted_completion": false,
-        "requires_review": false,
+        "action": "no_op",
+        "evaluation_id": "952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
-        "verification_result": null,
-        "reconciliation_result": null
-      }
+        "reconciliation_result": null,
+        "requires_review": false,
+        "target_status": null,
+        "verification_result": null
+      },
+      "event_id": "task-kno-181-scenario-a:evaluation:952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
+      "event_type": "evaluation_recorded",
+      "occurred_at": "2026-04-11T16:04:28.872467Z",
+      "source": "harness",
+      "summary": "Evaluation recorded: no_op"
     },
     {
-      "event_id": "task-kno-181-scenario-a:failure:3ad47b27-9ddb-4de4-917a-f976dcbaf625",
-      "event_type": "failure_recorded",
-      "occurred_at": "2026-04-05T17:30:31.556874Z",
-      "summary": "Failure recorded: invalid_execution_attempt",
-      "source": "executor",
       "details": {
+        "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
         "failure_recorded": true,
-        "failure_type": "invalid_execution_attempt",
         "failure_source": "executor",
-        "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-        "terminal": true,
-        "recoverable": false
-      }
+        "failure_type": "contract_violation",
+        "recoverable": false,
+        "terminal": true
+      },
+      "event_id": "task-kno-181-scenario-a:failure:952b7e33-9c4d-4b58-98eb-21d96df0ebc6",
+      "event_type": "failure_recorded",
+      "occurred_at": "2026-04-11T16:04:28.872467Z",
+      "source": "executor",
+      "summary": "Failure recorded: contract_violation"
     },
     {
+      "details": {
+        "changed_at": "2026-04-11T16:04:28.878677Z",
+        "changed_by": "verification",
+        "from_status": "assigned",
+        "reason": "Successful execution attempt is missing branch identity for the current run.",
+        "to_status": "failed"
+      },
       "event_id": "task-kno-181-scenario-a:status:0",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-05T17:30:31.617375Z",
-      "summary": "Status changed intake_ready -> failed",
+      "occurred_at": "2026-04-11T16:04:28.878677Z",
       "source": "verification",
-      "details": {
-        "changed_at": "2026-04-05T17:30:31.617375Z",
-        "changed_by": "verification",
-        "from_status": "intake_ready",
-        "reason": "Successful execution attempt is missing repository identity for the current run.",
-        "to_status": "failed"
-      }
+      "summary": "Status changed assigned -> failed"
     },
     {
-      "event_id": "task-kno-181-scenario-a:evaluation:1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-      "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-05T17:30:31.666755Z",
-      "summary": "Evaluation recorded: transition_applied",
-      "source": "harness",
       "details": {
-        "evaluation_id": "1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-        "action": "transition_applied",
-        "target_status": "failed",
         "accepted_completion": false,
-        "requires_review": false,
+        "action": "transition_applied",
+        "evaluation_id": "bfcc67bd-96a8-4187-9b29-56275d8bcebe",
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
-        "verification_result": null,
-        "reconciliation_result": null
-      }
+        "reconciliation_result": null,
+        "requires_review": false,
+        "target_status": "failed",
+        "verification_result": null
+      },
+      "event_id": "task-kno-181-scenario-a:evaluation:bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+      "event_type": "evaluation_recorded",
+      "occurred_at": "2026-04-11T16:04:28.882026Z",
+      "source": "harness",
+      "summary": "Evaluation recorded: transition_applied"
     },
     {
-      "event_id": "task-kno-181-scenario-a:failure:1c8ffff5-48cb-4136-a832-8f60ecfacd30",
-      "event_type": "failure_recorded",
-      "occurred_at": "2026-04-05T17:30:31.666755Z",
-      "summary": "Failure recorded: invalid_execution_attempt",
-      "source": "executor",
       "details": {
+        "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
         "failure_recorded": true,
-        "failure_type": "invalid_execution_attempt",
         "failure_source": "executor",
-        "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-        "terminal": true,
-        "recoverable": false
-      }
+        "failure_type": "contract_violation",
+        "recoverable": false,
+        "terminal": true
+      },
+      "event_id": "task-kno-181-scenario-a:failure:bfcc67bd-96a8-4187-9b29-56275d8bcebe",
+      "event_type": "failure_recorded",
+      "occurred_at": "2026-04-11T16:04:28.882026Z",
+      "source": "executor",
+      "summary": "Failure recorded: contract_violation"
     }
   ]
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-timeline-initial.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-a-timeline-initial.json
@@ -1,17 +1,10 @@
 {
+  "current_status": "assigned",
+  "event_count": 1,
   "task_id": "task-kno-181-scenario-a",
-  "current_status": "intake_ready",
-  "event_count": 2,
   "timeline": [
     {
-      "event_id": "task-kno-181-scenario-a:created",
-      "event_type": "task_created",
-      "occurred_at": "2026-03-31T14:30:00Z",
-      "summary": "Task created",
-      "source": "openclaw",
       "details": {
-        "status": "intake_ready",
-        "title": "KNO-181 task-kno-181-scenario-a",
         "origin": {
           "ingress_id": null,
           "ingress_name": null,
@@ -19,53 +12,15 @@
           "source_id": "req-happy-overlay-1",
           "source_system": "openclaw",
           "source_type": "ingress_request"
-        }
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-a:evaluation:c460c507-1dc8-4525-8355-4126a428b996",
-      "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-05T17:30:31.525822Z",
-      "summary": "Evaluation recorded: no_op",
-      "source": "harness",
-      "details": {
-        "evaluation_id": "c460c507-1dc8-4525-8355-4126a428b996",
-        "action": "no_op",
-        "target_status": null,
-        "accepted_completion": false,
-        "requires_review": false,
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "verification_result": {
-          "accepted_completion": false,
-          "claimed_completion": false,
-          "evidence_is_sufficient": false,
-          "evidence_is_valid": true,
-          "failure_classification": {
-            "category": "none",
-            "failure_type": "none",
-            "reason": "No completion claim is currently being evaluated",
-            "recoverable": false,
-            "retryable": false,
-            "source": "none",
-            "terminal": false
-          },
-          "is_terminal": false,
-          "outcome": "verification_deferred",
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-a' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "reconciliation_status": "pending",
-          "requires_review": false,
-          "target_status": null,
-          "task_id": "task-kno-181-scenario-a",
-          "verification_passed": false
         },
-        "reconciliation_result": null
-      }
+        "status": "assigned",
+        "title": "KNO-181 task-kno-181-scenario-a"
+      },
+      "event_id": "task-kno-181-scenario-a:created",
+      "event_type": "task_created",
+      "occurred_at": "2026-03-31T14:30:00Z",
+      "source": "openclaw",
+      "summary": "Task created"
     }
   ]
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-completion-claim-request.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-completion-claim-request.json
@@ -2,40 +2,40 @@
   "request": {
     "completion_claim": {
       "claim_id": "claim-kno-181-b-1",
-      "reported_at": "2026-04-01T08:00:00Z",
-      "reported_by": "stub-executor",
-      "reason": "executor reported completion",
       "metadata": {
         "attempt_id": "attempt-1"
-      }
+      },
+      "reason": "executor reported completion",
+      "reported_at": "2026-04-01T08:00:00Z",
+      "reported_by": "stub-executor"
     },
     "execution_attempt": {
-      "attempt_id": "attempt-kno-181-b-1",
-      "recorded_at": "2026-04-01T08:00:05Z",
-      "status": "succeeded",
-      "reported_by": "stub-executor",
       "artifact_references": [
         {
-          "reference_id": "attempt-kno-181-b-1:commit",
           "artifact_type": "commit",
-          "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
           "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+          "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
           "metadata": {
-            "repository_host": "github.com",
-            "repository_owner": "KnoxAnalytics",
-            "repository_name": "HARNESS-DRYRUN",
             "branch_name": "codex/e2e-test",
-            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
-          }
+            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "repository_host": "github.com",
+            "repository_name": "HARNESS-DRYRUN",
+            "repository_owner": "KnoxAnalytics"
+          },
+          "reference_id": "attempt-kno-181-b-1:commit"
         }
       ],
+      "attempt_id": "attempt-kno-181-b-1",
       "metadata": {
         "executor_run_id": "stub-run-attempt-kno-181-b-1"
-      }
+      },
+      "recorded_at": "2026-04-01T08:00:05Z",
+      "reported_by": "stub-executor",
+      "status": "succeeded"
     },
     "runtime_facts": {
-      "executor_reported_success": true,
-      "attempt_count": 1
+      "attempt_count": 1,
+      "executor_reported_success": true
     }
   }
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-completion-claim-response.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-completion-claim-response.json
@@ -1,77 +1,1339 @@
 {
-  "status": 200,
   "response": {
-    "action": "reconciliation_failed",
     "accepted_completion": false,
-    "requires_review": true,
+    "action": "reconciliation_failed",
+    "enforcement_result": {
+      "action": "review_required",
+      "error": "PR creation intentionally disabled for deterministic tests",
+      "evidence_result": null,
+      "failure_classification": {
+        "category": "review_required",
+        "failure_type": "review_required",
+        "reason": "PR creation intentionally disabled for deterministic tests",
+        "recoverable": false,
+        "retryable": false,
+        "source": "evaluation",
+        "terminal": false
+      },
+      "reasons": [
+        "PR creation intentionally disabled for deterministic tests"
+      ],
+      "reconciliation_result": {
+        "blocking": true,
+        "mismatch_categories": [
+          "missing_required_artifact"
+        ],
+        "outcome": "review_required",
+        "reasons": [
+          "PR creation intentionally disabled for deterministic tests"
+        ],
+        "status": "review_required",
+        "task_id": "task-kno-181-scenario-b",
+        "terminal": false
+      },
+      "review_decision": null,
+      "review_request": {
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "requested_at": "2026-04-11T16:04:28.896456Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+        "task_id": "task-kno-181-scenario-b",
+        "trigger": "reconciliation"
+      },
+      "target_status": "in_review",
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "deferred",
+            "required_artifact_types": [],
+            "status": "deferred",
+            "validated_artifact_ids": [],
+            "validated_at": null,
+            "validation_method": "deferred",
+            "validator": null
+          },
+          "items": []
+        },
+        "assigned_executor": {
+          "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
+          "executor_id": "executor-kno-181-b",
+          "executor_type": "codex"
+        },
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": null
+        },
+        "dependencies": [],
+        "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
+        "id": "task-kno-181-scenario-b",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-181-b-1",
+                "metadata": {
+                  "attempt_id": "attempt-1"
+                },
+                "reason": "executor reported completion",
+                "reported_at": "2026-04-01T08:00:00Z",
+                "reported_by": "stub-executor"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [
+                  {
+                    "artifact_type": "commit",
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "metadata": {
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    },
+                    "reference_id": "attempt-kno-181-b-1:commit"
+                  }
+                ],
+                "attempt_id": "attempt-kno-181-b-1",
+                "completion_claim_id": "claim-kno-181-b-1",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "branch": [
+                        {
+                          "sources": [
+                            "execution_attempt.artifact_references[0]"
+                          ],
+                          "value": "codex/e2e-test"
+                        }
+                      ],
+                      "commit": [
+                        {
+                          "sources": [
+                            "execution_attempt.artifact_references[0]"
+                          ],
+                          "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                        }
+                      ],
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "repository": [
+                        {
+                          "sources": [
+                            "execution_attempt.artifact_references[0]"
+                          ],
+                          "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                        }
+                      ],
+                      "used_task_artifact_fallback": false
+                    },
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [],
+                    "retryable": false,
+                    "rule_failures": [],
+                    "status": "valid",
+                    "validated_at": "2026-04-11T16:04:28.890189Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "stub-run-attempt-kno-181-b-1"
+                },
+                "recorded_at": "2026-04-01T08:00:05Z",
+                "reevaluation": {},
+                "reported_by": "stub-executor",
+                "status": "succeeded"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "req-happy-overlay-1",
+          "source_system": "openclaw",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": "missing_pr_after_execution",
+          "attempts": [
+            {
+              "attempt_id": "reconciliation-attempt-1",
+              "completed_at": "2026-04-11T16:04:28.894572Z",
+              "details": {
+                "base_branch": null,
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": true,
+                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "execution_attempt",
+                  "sources": {
+                    "execution_attempt": {
+                      "base_branch": null,
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_pull_request": false,
+                "created_pull_request_revalidated": false,
+                "error": "PR creation intentionally disabled for deterministic tests",
+                "error_disposition": "review_required",
+                "final_decision": {
+                  "reason": "all_candidates_rejected_or_absent",
+                  "result": "no_valid_existing_candidate"
+                },
+                "policy": {
+                  "allow_closed_pr_match": false,
+                  "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
+                  "allow_open_pr_match": true,
+                  "escalate_on_ambiguous_match": true,
+                  "require_exact_branch_match": true,
+                  "require_head_sha_match": true,
+                  "require_run_linkage_for_commit_association": true,
+                  "require_run_linkage_for_multiple_attempts": true,
+                  "require_task_linkage": false
+                },
+                "pull_request_candidates": [],
+                "pull_request_lookup": {
+                  "ambiguous": false,
+                  "candidate_count": 0,
+                  "found": false,
+                  "number": null,
+                  "searched_by_branch": true,
+                  "searched_by_commit": true,
+                  "source": null,
+                  "url": null,
+                  "valid_candidate_count": 0
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_pr_after_execution",
+              "handler_key": "missing_pr_after_execution",
+              "started_at": "2026-04-11T16:04:28.894440Z",
+              "status": "failed"
+            }
+          ],
+          "failed_at": "2026-04-11T16:04:28.894572Z",
+          "last_attempt_id": "reconciliation-attempt-1",
+          "last_error": "PR creation intentionally disabled for deterministic tests",
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "failed"
+        },
+        "required_capabilities": [],
+        "status": "in_review",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.892367Z",
+            "changed_by": "reconciliation",
+            "from_status": "assigned",
+            "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+            "to_status": "reconciling"
+          },
+          {
+            "changed_at": "2026-04-11T16:04:28.896456Z",
+            "changed_by": "reconciliation",
+            "from_status": "reconciling",
+            "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
+            "to_status": "in_review"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-03-31T14:30:00Z",
+          "updated_at": "2026-04-11T16:04:28.896456Z"
+        },
+        "title": "KNO-181 task-kno-181-scenario-b"
+      },
+      "transition_result": null,
+      "verification_result": null
+    },
+    "error": "PR creation intentionally disabled for deterministic tests",
+    "evaluation_record": {
+      "evaluation_id": "af982558-3013-4b15-9032-d71d985469f8",
+      "recorded_at": "2026-04-11T16:04:28.898575Z",
+      "request": {
+        "acceptance_criteria_satisfied": false,
+        "claimed_completion": true,
+        "external_facts": null,
+        "retry_context": null,
+        "review_decision": null,
+        "review_is_active": false,
+        "review_reasons": [],
+        "review_request": {
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "requested_at": "2026-04-11T16:04:28.896456Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+          "task_id": "task-kno-181-scenario-b",
+          "trigger": "reconciliation"
+        },
+        "runtime_facts": {
+          "attempt_count": 1,
+          "executor_reported_failure": false,
+          "executor_reported_success": true,
+          "latest_attempt_outcome": null,
+          "terminal_failure": false
+        },
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "deferred",
+              "required_artifact_types": [],
+              "status": "deferred",
+              "validated_artifact_ids": [],
+              "validated_at": null,
+              "validation_method": "deferred",
+              "validator": null
+            },
+            "items": []
+          },
+          "assigned_executor": {
+            "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
+            "executor_id": "executor-kno-181-b",
+            "executor_type": "codex"
+          },
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": null
+          },
+          "dependencies": [],
+          "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
+          "id": "task-kno-181-scenario-b",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-181-b-1",
+                  "metadata": {
+                    "attempt_id": "attempt-1"
+                  },
+                  "reason": "executor reported completion",
+                  "reported_at": "2026-04-01T08:00:00Z",
+                  "reported_by": "stub-executor"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "commit",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      },
+                      "reference_id": "attempt-kno-181-b-1:commit"
+                    }
+                  ],
+                  "attempt_id": "attempt-kno-181-b-1",
+                  "completion_claim_id": "claim-kno-181-b-1",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "repository": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                          }
+                        ],
+                        "used_task_artifact_fallback": false
+                      },
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [],
+                      "retryable": false,
+                      "rule_failures": [],
+                      "status": "valid",
+                      "validated_at": "2026-04-11T16:04:28.890189Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "stub-run-attempt-kno-181-b-1"
+                  },
+                  "recorded_at": "2026-04-01T08:00:05Z",
+                  "reevaluation": {},
+                  "reported_by": "stub-executor",
+                  "status": "succeeded"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "req-happy-overlay-1",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": "missing_pr_after_execution",
+            "attempts": [
+              {
+                "attempt_id": "reconciliation-attempt-1",
+                "completed_at": "2026-04-11T16:04:28.894572Z",
+                "details": {
+                  "base_branch": null,
+                  "branch_exists": true,
+                  "branch_head_commit_sha": null,
+                  "branch_name": "codex/e2e-test",
+                  "commit_exists": true,
+                  "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "context_resolution": {
+                    "conflicts": [],
+                    "selected_source": "execution_attempt",
+                    "sources": {
+                      "execution_attempt": {
+                        "base_branch": null,
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      }
+                    }
+                  },
+                  "created_pull_request": false,
+                  "created_pull_request_revalidated": false,
+                  "error": "PR creation intentionally disabled for deterministic tests",
+                  "error_disposition": "review_required",
+                  "final_decision": {
+                    "reason": "all_candidates_rejected_or_absent",
+                    "result": "no_valid_existing_candidate"
+                  },
+                  "policy": {
+                    "allow_closed_pr_match": false,
+                    "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
+                    "allow_open_pr_match": true,
+                    "escalate_on_ambiguous_match": true,
+                    "require_exact_branch_match": true,
+                    "require_head_sha_match": true,
+                    "require_run_linkage_for_commit_association": true,
+                    "require_run_linkage_for_multiple_attempts": true,
+                    "require_task_linkage": false
+                  },
+                  "pull_request_candidates": [],
+                  "pull_request_lookup": {
+                    "ambiguous": false,
+                    "candidate_count": 0,
+                    "found": false,
+                    "number": null,
+                    "searched_by_branch": true,
+                    "searched_by_commit": true,
+                    "source": null,
+                    "url": null,
+                    "valid_candidate_count": 0
+                  },
+                  "repository": {
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  }
+                },
+                "failure_type": "missing_pr_after_execution",
+                "handler_key": "missing_pr_after_execution",
+                "started_at": "2026-04-11T16:04:28.894440Z",
+                "status": "failed"
+              }
+            ],
+            "failed_at": "2026-04-11T16:04:28.894572Z",
+            "last_attempt_id": "reconciliation-attempt-1",
+            "last_error": "PR creation intentionally disabled for deterministic tests",
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "failed"
+          },
+          "required_capabilities": [],
+          "status": "in_review",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.892367Z",
+              "changed_by": "reconciliation",
+              "from_status": "assigned",
+              "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+              "to_status": "reconciling"
+            },
+            {
+              "changed_at": "2026-04-11T16:04:28.896456Z",
+              "changed_by": "reconciliation",
+              "from_status": "reconciling",
+              "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
+              "to_status": "in_review"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-03-31T14:30:00Z",
+            "updated_at": "2026-04-11T16:04:28.896456Z"
+          },
+          "title": "KNO-181 task-kno-181-scenario-b"
+        },
+        "unresolved_conditions": []
+      },
+      "result": {
+        "accepted_completion": false,
+        "action": "review_required",
+        "enforcement_result": {
+          "action": "review_required",
+          "error": "PR creation intentionally disabled for deterministic tests",
+          "evidence_result": null,
+          "failure_classification": {
+            "category": "review_required",
+            "failure_type": "review_required",
+            "reason": "PR creation intentionally disabled for deterministic tests",
+            "recoverable": false,
+            "retryable": false,
+            "source": "evaluation",
+            "terminal": false
+          },
+          "reasons": [
+            "PR creation intentionally disabled for deterministic tests"
+          ],
+          "reconciliation_result": {
+            "blocking": true,
+            "mismatch_categories": [
+              "missing_required_artifact"
+            ],
+            "outcome": "review_required",
+            "reasons": [
+              "PR creation intentionally disabled for deterministic tests"
+            ],
+            "status": "review_required",
+            "task_id": "task-kno-181-scenario-b",
+            "terminal": false
+          },
+          "review_decision": null,
+          "review_request": {
+            "allowed_outcomes": [
+              "accept_completion",
+              "keep_blocked",
+              "mark_failed",
+              "authorize_redispatch"
+            ],
+            "metadata": {
+              "reconciliation_attempt_id": "reconciliation-attempt-1",
+              "reconciliation_failure_type": "missing_pr_after_execution"
+            },
+            "presented_sections": [
+              "task_state",
+              "execution",
+              "evidence",
+              "reconciliation"
+            ],
+            "prior_review_ids": [],
+            "requested_at": "2026-04-11T16:04:28.896456Z",
+            "requested_by": "reconciliation",
+            "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+            "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+            "task_id": "task-kno-181-scenario-b",
+            "trigger": "reconciliation"
+          },
+          "target_status": "in_review",
+          "task_envelope": {
+            "acceptance_criteria": [
+              {
+                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+                "id": "ac-1",
+                "required": true
+              }
+            ],
+            "artifacts": {
+              "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
+              },
+              "items": []
+            },
+            "assigned_executor": {
+              "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
+              "executor_id": "executor-kno-181-b",
+              "executor_type": "codex"
+            },
+            "child_task_ids": [],
+            "constraints": [],
+            "coordination": {
+              "linear": null
+            },
+            "dependencies": [],
+            "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
+            "id": "task-kno-181-scenario-b",
+            "objective": {
+              "deliverable_type": "unspecified",
+              "success_signal": "Task satisfies declared acceptance criteria.",
+              "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
+            },
+            "observability": {
+              "errors": [],
+              "execution_metadata": {
+                "advisory_completion_claims": [
+                  {
+                    "claim_id": "claim-kno-181-b-1",
+                    "metadata": {
+                      "attempt_id": "attempt-1"
+                    },
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-01T08:00:00Z",
+                    "reported_by": "stub-executor"
+                  }
+                ],
+                "execution_attempts": [
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "commit",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "repository_host": "github.com",
+                          "repository_name": "HARNESS-DRYRUN",
+                          "repository_owner": "KnoxAnalytics"
+                        },
+                        "reference_id": "attempt-kno-181-b-1:commit"
+                      }
+                    ],
+                    "attempt_id": "attempt-kno-181-b-1",
+                    "completion_claim_id": "claim-kno-181-b-1",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "repository": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                            }
+                          ],
+                          "used_task_artifact_fallback": false
+                        },
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [],
+                        "retryable": false,
+                        "rule_failures": [],
+                        "status": "valid",
+                        "validated_at": "2026-04-11T16:04:28.890189Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "executor_run_id": "stub-run-attempt-kno-181-b-1"
+                    },
+                    "recorded_at": "2026-04-01T08:00:05Z",
+                    "reevaluation": {},
+                    "reported_by": "stub-executor",
+                    "status": "succeeded"
+                  }
+                ],
+                "schema_required_deferred_fields": [
+                  "parent_task_id",
+                  "child_task_ids",
+                  "dependencies",
+                  "assigned_executor",
+                  "required_capabilities",
+                  "priority",
+                  "artifacts.items",
+                  "artifacts.completion_evidence",
+                  "observability"
+                ]
+              },
+              "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+              }
+            },
+            "origin": {
+              "ingress_id": null,
+              "ingress_name": null,
+              "requested_by": null,
+              "source_id": "req-happy-overlay-1",
+              "source_system": "openclaw",
+              "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "normal",
+            "reconciliation": {
+              "active_failure_type": "missing_pr_after_execution",
+              "attempts": [
+                {
+                  "attempt_id": "reconciliation-attempt-1",
+                  "completed_at": "2026-04-11T16:04:28.894572Z",
+                  "details": {
+                    "base_branch": null,
+                    "branch_exists": true,
+                    "branch_head_commit_sha": null,
+                    "branch_name": "codex/e2e-test",
+                    "commit_exists": true,
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "context_resolution": {
+                      "conflicts": [],
+                      "selected_source": "execution_attempt",
+                      "sources": {
+                        "execution_attempt": {
+                          "base_branch": null,
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "repository_host": "github.com",
+                          "repository_name": "HARNESS-DRYRUN",
+                          "repository_owner": "KnoxAnalytics"
+                        }
+                      }
+                    },
+                    "created_pull_request": false,
+                    "created_pull_request_revalidated": false,
+                    "error": "PR creation intentionally disabled for deterministic tests",
+                    "error_disposition": "review_required",
+                    "final_decision": {
+                      "reason": "all_candidates_rejected_or_absent",
+                      "result": "no_valid_existing_candidate"
+                    },
+                    "policy": {
+                      "allow_closed_pr_match": false,
+                      "allow_commit_association_match": true,
+                      "allow_non_head_commit_association_match": false,
+                      "allow_open_pr_match": true,
+                      "escalate_on_ambiguous_match": true,
+                      "require_exact_branch_match": true,
+                      "require_head_sha_match": true,
+                      "require_run_linkage_for_commit_association": true,
+                      "require_run_linkage_for_multiple_attempts": true,
+                      "require_task_linkage": false
+                    },
+                    "pull_request_candidates": [],
+                    "pull_request_lookup": {
+                      "ambiguous": false,
+                      "candidate_count": 0,
+                      "found": false,
+                      "number": null,
+                      "searched_by_branch": true,
+                      "searched_by_commit": true,
+                      "source": null,
+                      "url": null,
+                      "valid_candidate_count": 0
+                    },
+                    "repository": {
+                      "host": "github.com",
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    }
+                  },
+                  "failure_type": "missing_pr_after_execution",
+                  "handler_key": "missing_pr_after_execution",
+                  "started_at": "2026-04-11T16:04:28.894440Z",
+                  "status": "failed"
+                }
+              ],
+              "failed_at": "2026-04-11T16:04:28.894572Z",
+              "last_attempt_id": "reconciliation-attempt-1",
+              "last_error": "PR creation intentionally disabled for deterministic tests",
+              "last_pr_url": null,
+              "resolved_at": null,
+              "status": "failed"
+            },
+            "required_capabilities": [],
+            "status": "in_review",
+            "status_history": [
+              {
+                "changed_at": "2026-04-11T16:04:28.892367Z",
+                "changed_by": "reconciliation",
+                "from_status": "assigned",
+                "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+                "to_status": "reconciling"
+              },
+              {
+                "changed_at": "2026-04-11T16:04:28.896456Z",
+                "changed_by": "reconciliation",
+                "from_status": "reconciling",
+                "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
+                "to_status": "in_review"
+              }
+            ],
+            "timestamps": {
+              "completed_at": null,
+              "created_at": "2026-03-31T14:30:00Z",
+              "updated_at": "2026-04-11T16:04:28.896456Z"
+            },
+            "title": "KNO-181 task-kno-181-scenario-b"
+          },
+          "transition_result": null,
+          "verification_result": null
+        },
+        "error": "PR creation intentionally disabled for deterministic tests",
+        "failure_classification": {
+          "category": "review_required",
+          "failure_type": "review_required",
+          "reason": "PR creation intentionally disabled for deterministic tests",
+          "recoverable": false,
+          "retryable": false,
+          "source": "evaluation",
+          "terminal": false
+        },
+        "invalid_input": false,
+        "reasons": [
+          "PR creation intentionally disabled for deterministic tests"
+        ],
+        "requires_review": true,
+        "target_status": "in_review",
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "deferred",
+              "required_artifact_types": [],
+              "status": "deferred",
+              "validated_artifact_ids": [],
+              "validated_at": null,
+              "validation_method": "deferred",
+              "validator": null
+            },
+            "items": []
+          },
+          "assigned_executor": {
+            "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
+            "executor_id": "executor-kno-181-b",
+            "executor_type": "codex"
+          },
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": null
+          },
+          "dependencies": [],
+          "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
+          "id": "task-kno-181-scenario-b",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-181-b-1",
+                  "metadata": {
+                    "attempt_id": "attempt-1"
+                  },
+                  "reason": "executor reported completion",
+                  "reported_at": "2026-04-01T08:00:00Z",
+                  "reported_by": "stub-executor"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "commit",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      },
+                      "reference_id": "attempt-kno-181-b-1:commit"
+                    }
+                  ],
+                  "attempt_id": "attempt-kno-181-b-1",
+                  "completion_claim_id": "claim-kno-181-b-1",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "repository": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                          }
+                        ],
+                        "used_task_artifact_fallback": false
+                      },
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [],
+                      "retryable": false,
+                      "rule_failures": [],
+                      "status": "valid",
+                      "validated_at": "2026-04-11T16:04:28.890189Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "stub-run-attempt-kno-181-b-1"
+                  },
+                  "recorded_at": "2026-04-01T08:00:05Z",
+                  "reevaluation": {},
+                  "reported_by": "stub-executor",
+                  "status": "succeeded"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "req-happy-overlay-1",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": "missing_pr_after_execution",
+            "attempts": [
+              {
+                "attempt_id": "reconciliation-attempt-1",
+                "completed_at": "2026-04-11T16:04:28.894572Z",
+                "details": {
+                  "base_branch": null,
+                  "branch_exists": true,
+                  "branch_head_commit_sha": null,
+                  "branch_name": "codex/e2e-test",
+                  "commit_exists": true,
+                  "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "context_resolution": {
+                    "conflicts": [],
+                    "selected_source": "execution_attempt",
+                    "sources": {
+                      "execution_attempt": {
+                        "base_branch": null,
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      }
+                    }
+                  },
+                  "created_pull_request": false,
+                  "created_pull_request_revalidated": false,
+                  "error": "PR creation intentionally disabled for deterministic tests",
+                  "error_disposition": "review_required",
+                  "final_decision": {
+                    "reason": "all_candidates_rejected_or_absent",
+                    "result": "no_valid_existing_candidate"
+                  },
+                  "policy": {
+                    "allow_closed_pr_match": false,
+                    "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
+                    "allow_open_pr_match": true,
+                    "escalate_on_ambiguous_match": true,
+                    "require_exact_branch_match": true,
+                    "require_head_sha_match": true,
+                    "require_run_linkage_for_commit_association": true,
+                    "require_run_linkage_for_multiple_attempts": true,
+                    "require_task_linkage": false
+                  },
+                  "pull_request_candidates": [],
+                  "pull_request_lookup": {
+                    "ambiguous": false,
+                    "candidate_count": 0,
+                    "found": false,
+                    "number": null,
+                    "searched_by_branch": true,
+                    "searched_by_commit": true,
+                    "source": null,
+                    "url": null,
+                    "valid_candidate_count": 0
+                  },
+                  "repository": {
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  }
+                },
+                "failure_type": "missing_pr_after_execution",
+                "handler_key": "missing_pr_after_execution",
+                "started_at": "2026-04-11T16:04:28.894440Z",
+                "status": "failed"
+              }
+            ],
+            "failed_at": "2026-04-11T16:04:28.894572Z",
+            "last_attempt_id": "reconciliation-attempt-1",
+            "last_error": "PR creation intentionally disabled for deterministic tests",
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "failed"
+          },
+          "required_capabilities": [],
+          "status": "in_review",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.892367Z",
+              "changed_by": "reconciliation",
+              "from_status": "assigned",
+              "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+              "to_status": "reconciling"
+            },
+            {
+              "changed_at": "2026-04-11T16:04:28.896456Z",
+              "changed_by": "reconciliation",
+              "from_status": "reconciling",
+              "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
+              "to_status": "in_review"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-03-31T14:30:00Z",
+            "updated_at": "2026-04-11T16:04:28.896456Z"
+          },
+          "title": "KNO-181 task-kno-181-scenario-b"
+        }
+      },
+      "task_id": "task-kno-181-scenario-b"
+    },
     "invalid_input": false,
-    "target_status": "in_review",
-    "error": "PR creation intentionally disabled for deterministic local demo proof",
     "reasons": [
-      "PR creation intentionally disabled for deterministic local demo proof"
+      "PR creation intentionally disabled for deterministic tests"
     ],
     "reconciliation_attempt": {
       "attempt_id": "reconciliation-attempt-1",
-      "failure_type": "missing_pr_after_execution",
-      "handler_key": "missing_pr_after_execution",
-      "status": "failed",
-      "started_at": "2026-04-05T17:30:31.845905Z",
-      "completed_at": "2026-04-05T17:30:31.846841Z",
+      "completed_at": "2026-04-11T16:04:28.894572Z",
       "details": {
-        "repository": {
-          "host": "github.com",
-          "owner": "KnoxAnalytics",
-          "name": "HARNESS-DRYRUN"
-        },
+        "base_branch": null,
+        "branch_exists": true,
+        "branch_head_commit_sha": null,
+        "branch_name": "codex/e2e-test",
+        "commit_exists": true,
+        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
         "context_resolution": {
+          "conflicts": [],
           "selected_source": "execution_attempt",
           "sources": {
             "execution_attempt": {
-              "repository_host": "github.com",
-              "repository_owner": "KnoxAnalytics",
-              "repository_name": "HARNESS-DRYRUN",
-              "branch_name": "codex/e2e-test",
               "base_branch": null,
-              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+              "branch_name": "codex/e2e-test",
+              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "repository_host": "github.com",
+              "repository_name": "HARNESS-DRYRUN",
+              "repository_owner": "KnoxAnalytics"
             }
-          },
-          "conflicts": []
+          }
         },
-        "branch_name": "codex/e2e-test",
-        "base_branch": null,
-        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-        "policy": {
-          "allow_open_pr_match": true,
-          "allow_closed_pr_match": false,
-          "require_head_sha_match": true,
-          "require_exact_branch_match": true,
-          "allow_commit_association_match": true,
-          "escalate_on_ambiguous_match": true,
-          "require_task_linkage": false
-        },
-        "branch_exists": true,
-        "commit_exists": true,
-        "pull_request_lookup": {
-          "searched_by_branch": true,
-          "searched_by_commit": true,
-          "found": false,
-          "source": null,
-          "number": null,
-          "url": null,
-          "candidate_count": 0,
-          "valid_candidate_count": 0,
-          "ambiguous": false
-        },
-        "pull_request_candidates": [],
         "created_pull_request": false,
+        "created_pull_request_revalidated": false,
+        "error": "PR creation intentionally disabled for deterministic tests",
         "error_disposition": "review_required",
         "final_decision": {
-          "result": "no_valid_existing_candidate",
-          "reason": "all_candidates_rejected_or_absent"
+          "reason": "all_candidates_rejected_or_absent",
+          "result": "no_valid_existing_candidate"
         },
-        "error": "PR creation intentionally disabled for deterministic local demo proof"
-      }
+        "policy": {
+          "allow_closed_pr_match": false,
+          "allow_commit_association_match": true,
+          "allow_non_head_commit_association_match": false,
+          "allow_open_pr_match": true,
+          "escalate_on_ambiguous_match": true,
+          "require_exact_branch_match": true,
+          "require_head_sha_match": true,
+          "require_run_linkage_for_commit_association": true,
+          "require_run_linkage_for_multiple_attempts": true,
+          "require_task_linkage": false
+        },
+        "pull_request_candidates": [],
+        "pull_request_lookup": {
+          "ambiguous": false,
+          "candidate_count": 0,
+          "found": false,
+          "number": null,
+          "searched_by_branch": true,
+          "searched_by_commit": true,
+          "source": null,
+          "url": null,
+          "valid_candidate_count": 0
+        },
+        "repository": {
+          "host": "github.com",
+          "name": "HARNESS-DRYRUN",
+          "owner": "KnoxAnalytics"
+        }
+      },
+      "failure_type": "missing_pr_after_execution",
+      "handler_key": "missing_pr_after_execution",
+      "started_at": "2026-04-11T16:04:28.894440Z",
+      "status": "failed"
     },
+    "requires_review": true,
+    "review_request": {
+      "allowed_outcomes": [
+        "accept_completion",
+        "keep_blocked",
+        "mark_failed",
+        "authorize_redispatch"
+      ],
+      "metadata": {
+        "reconciliation_attempt_id": "reconciliation-attempt-1",
+        "reconciliation_failure_type": "missing_pr_after_execution"
+      },
+      "presented_sections": [
+        "task_state",
+        "execution",
+        "evidence",
+        "reconciliation"
+      ],
+      "prior_review_ids": [],
+      "requested_at": "2026-04-11T16:04:28.896456Z",
+      "requested_by": "reconciliation",
+      "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+      "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+      "task_id": "task-kno-181-scenario-b",
+      "trigger": "reconciliation"
+    },
+    "target_status": "in_review",
     "task_envelope": {
       "acceptance_criteria": [
         {
@@ -109,11 +1371,100 @@
       "objective": {
         "deliverable_type": "unspecified",
         "success_signal": "Task satisfies declared acceptance criteria.",
-        "summary": "Exercise /evaluate with top-level evidence overlays."
+        "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
       },
       "observability": {
         "errors": [],
         "execution_metadata": {
+          "advisory_completion_claims": [
+            {
+              "claim_id": "claim-kno-181-b-1",
+              "metadata": {
+                "attempt_id": "attempt-1"
+              },
+              "reason": "executor reported completion",
+              "reported_at": "2026-04-01T08:00:00Z",
+              "reported_by": "stub-executor"
+            }
+          ],
+          "execution_attempts": [
+            {
+              "artifact_references": [
+                {
+                  "artifact_type": "commit",
+                  "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "metadata": {
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
+                  },
+                  "reference_id": "attempt-kno-181-b-1:commit"
+                }
+              ],
+              "attempt_id": "attempt-kno-181-b-1",
+              "completion_claim_id": "claim-kno-181-b-1",
+              "metadata": {
+                "attempt_validation": {
+                  "context_observations": {
+                    "branch": [
+                      {
+                        "sources": [
+                          "execution_attempt.artifact_references[0]"
+                        ],
+                        "value": "codex/e2e-test"
+                      }
+                    ],
+                    "commit": [
+                      {
+                        "sources": [
+                          "execution_attempt.artifact_references[0]"
+                        ],
+                        "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                      }
+                    ],
+                    "commit_resolution_pending": false,
+                    "has_valid_current_run_pull_request_artifact": false,
+                    "repository": [
+                      {
+                        "sources": [
+                          "execution_attempt.artifact_references[0]"
+                        ],
+                        "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                      }
+                    ],
+                    "used_task_artifact_fallback": false
+                  },
+                  "policy": {
+                    "allow_commit_resolution_via_reconciliation": true,
+                    "allow_missing_commit_artifact_with_verified_pull_request": true,
+                    "allow_missing_pull_request": true,
+                    "reject_closed_or_historical_pull_request": true,
+                    "reject_non_numeric_pull_request_url": true,
+                    "reject_reserved_shared_branch": true,
+                    "require_commit": true,
+                    "require_exact_branch": true,
+                    "require_repository": true,
+                    "task_artifact_fallback_requires_single_attempt": true
+                  },
+                  "pull_request_observations": [],
+                  "reasons": [],
+                  "retryable": false,
+                  "rule_failures": [],
+                  "status": "valid",
+                  "validated_at": "2026-04-11T16:04:28.890189Z",
+                  "validated_by": "execution_validation"
+                },
+                "executor_run_id": "stub-run-attempt-kno-181-b-1"
+              },
+              "recorded_at": "2026-04-01T08:00:05Z",
+              "reevaluation": {},
+              "reported_by": "stub-executor",
+              "status": "succeeded"
+            }
+          ],
           "schema_required_deferred_fields": [
             "parent_task_id",
             "child_task_ids",
@@ -124,86 +1475,6 @@
             "artifacts.items",
             "artifacts.completion_evidence",
             "observability"
-          ],
-          "advisory_completion_claims": [
-            {
-              "claim_id": "claim-kno-181-b-1",
-              "reported_at": "2026-04-01T08:00:00Z",
-              "reported_by": "stub-executor",
-              "reason": "executor reported completion",
-              "metadata": {
-                "attempt_id": "attempt-1"
-              }
-            }
-          ],
-          "execution_attempts": [
-            {
-              "attempt_id": "attempt-kno-181-b-1",
-              "recorded_at": "2026-04-01T08:00:05Z",
-              "status": "succeeded",
-              "reported_by": "stub-executor",
-              "completion_claim_id": "claim-kno-181-b-1",
-              "artifact_references": [
-                {
-                  "reference_id": "attempt-kno-181-b-1:commit",
-                  "artifact_type": "commit",
-                  "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-                  "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-                  "metadata": {
-                    "repository_host": "github.com",
-                    "repository_owner": "KnoxAnalytics",
-                    "repository_name": "HARNESS-DRYRUN",
-                    "branch_name": "codex/e2e-test",
-                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
-                  }
-                }
-              ],
-              "metadata": {
-                "executor_run_id": "stub-run-attempt-kno-181-b-1",
-                "attempt_validation": {
-                  "validated_at": "2026-04-05T17:30:31.786474Z",
-                  "validated_by": "execution_validation",
-                  "policy": {
-                    "require_repository": true,
-                    "require_exact_branch": true,
-                    "require_commit": true,
-                    "allow_missing_pull_request": true,
-                    "task_artifact_fallback_requires_single_attempt": true
-                  },
-                  "context_observations": {
-                    "repository": [
-                      {
-                        "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN",
-                        "sources": [
-                          "execution_attempt.artifact_references[0]"
-                        ]
-                      }
-                    ],
-                    "branch": [
-                      {
-                        "value": "codex/e2e-test",
-                        "sources": [
-                          "execution_attempt.artifact_references[0]"
-                        ]
-                      }
-                    ],
-                    "commit": [
-                      {
-                        "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-                        "sources": [
-                          "execution_attempt.artifact_references[0]"
-                        ]
-                      }
-                    ],
-                    "used_task_artifact_fallback": false
-                  },
-                  "status": "valid",
-                  "retryable": false,
-                  "reasons": []
-                }
-              },
-              "reevaluation": {}
-            }
           ]
         },
         "retries": {
@@ -223,102 +1494,108 @@
       "parent_task_id": null,
       "priority": "normal",
       "reconciliation": {
-        "status": "failed",
         "active_failure_type": "missing_pr_after_execution",
         "attempts": [
           {
             "attempt_id": "reconciliation-attempt-1",
-            "failure_type": "missing_pr_after_execution",
-            "handler_key": "missing_pr_after_execution",
-            "status": "failed",
-            "started_at": "2026-04-05T17:30:31.845905Z",
-            "completed_at": "2026-04-05T17:30:31.846841Z",
+            "completed_at": "2026-04-11T16:04:28.894572Z",
             "details": {
-              "repository": {
-                "host": "github.com",
-                "owner": "KnoxAnalytics",
-                "name": "HARNESS-DRYRUN"
-              },
+              "base_branch": null,
+              "branch_exists": true,
+              "branch_head_commit_sha": null,
+              "branch_name": "codex/e2e-test",
+              "commit_exists": true,
+              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
               "context_resolution": {
+                "conflicts": [],
                 "selected_source": "execution_attempt",
                 "sources": {
                   "execution_attempt": {
-                    "repository_host": "github.com",
-                    "repository_owner": "KnoxAnalytics",
-                    "repository_name": "HARNESS-DRYRUN",
-                    "branch_name": "codex/e2e-test",
                     "base_branch": null,
-                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
                   }
-                },
-                "conflicts": []
+                }
               },
-              "branch_name": "codex/e2e-test",
-              "base_branch": null,
-              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-              "policy": {
-                "allow_open_pr_match": true,
-                "allow_closed_pr_match": false,
-                "require_head_sha_match": true,
-                "require_exact_branch_match": true,
-                "allow_commit_association_match": true,
-                "escalate_on_ambiguous_match": true,
-                "require_task_linkage": false
-              },
-              "branch_exists": true,
-              "commit_exists": true,
-              "pull_request_lookup": {
-                "searched_by_branch": true,
-                "searched_by_commit": true,
-                "found": false,
-                "source": null,
-                "number": null,
-                "url": null,
-                "candidate_count": 0,
-                "valid_candidate_count": 0,
-                "ambiguous": false
-              },
-              "pull_request_candidates": [],
               "created_pull_request": false,
+              "created_pull_request_revalidated": false,
+              "error": "PR creation intentionally disabled for deterministic tests",
               "error_disposition": "review_required",
               "final_decision": {
-                "result": "no_valid_existing_candidate",
-                "reason": "all_candidates_rejected_or_absent"
+                "reason": "all_candidates_rejected_or_absent",
+                "result": "no_valid_existing_candidate"
               },
-              "error": "PR creation intentionally disabled for deterministic local demo proof"
-            }
+              "policy": {
+                "allow_closed_pr_match": false,
+                "allow_commit_association_match": true,
+                "allow_non_head_commit_association_match": false,
+                "allow_open_pr_match": true,
+                "escalate_on_ambiguous_match": true,
+                "require_exact_branch_match": true,
+                "require_head_sha_match": true,
+                "require_run_linkage_for_commit_association": true,
+                "require_run_linkage_for_multiple_attempts": true,
+                "require_task_linkage": false
+              },
+              "pull_request_candidates": [],
+              "pull_request_lookup": {
+                "ambiguous": false,
+                "candidate_count": 0,
+                "found": false,
+                "number": null,
+                "searched_by_branch": true,
+                "searched_by_commit": true,
+                "source": null,
+                "url": null,
+                "valid_candidate_count": 0
+              },
+              "repository": {
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              }
+            },
+            "failure_type": "missing_pr_after_execution",
+            "handler_key": "missing_pr_after_execution",
+            "started_at": "2026-04-11T16:04:28.894440Z",
+            "status": "failed"
           }
         ],
+        "failed_at": "2026-04-11T16:04:28.894572Z",
         "last_attempt_id": "reconciliation-attempt-1",
+        "last_error": "PR creation intentionally disabled for deterministic tests",
         "last_pr_url": null,
-        "last_error": "PR creation intentionally disabled for deterministic local demo proof",
         "resolved_at": null,
-        "failed_at": "2026-04-05T17:30:31.846841Z"
+        "status": "failed"
       },
       "required_capabilities": [],
       "status": "in_review",
       "status_history": [
         {
-          "from_status": "intake_ready",
-          "to_status": "reconciling",
-          "changed_at": "2026-04-05T17:30:31.815978Z",
+          "changed_at": "2026-04-11T16:04:28.892367Z",
+          "changed_by": "reconciliation",
+          "from_status": "assigned",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
-          "changed_by": "reconciliation"
+          "to_status": "reconciling"
         },
         {
+          "changed_at": "2026-04-11T16:04:28.896456Z",
+          "changed_by": "reconciliation",
           "from_status": "reconciling",
-          "to_status": "in_review",
-          "changed_at": "2026-04-05T17:30:31.878104Z",
-          "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic local demo proof",
-          "changed_by": "reconciliation"
+          "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
+          "to_status": "in_review"
         }
       ],
       "timestamps": {
         "completed_at": null,
         "created_at": "2026-03-31T14:30:00Z",
-        "updated_at": "2026-04-05T17:30:31.878104Z"
+        "updated_at": "2026-04-11T16:04:28.896456Z"
       },
       "title": "KNO-181 task-kno-181-scenario-b"
     }
-  }
+  },
+  "status": 200
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-evaluation-history-final.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-evaluation-history-final.json
@@ -1,23 +1,45 @@
 {
-  "task_id": "task-kno-181-scenario-b",
   "evaluations": [
     {
-      "evaluation_id": "5e90ceee-579d-4795-93e3-26aa0508dfdc",
-      "task_id": "task-kno-181-scenario-b",
-      "recorded_at": "2026-04-05T17:30:31.776247Z",
+      "evaluation_id": "af982558-3013-4b15-9032-d71d985469f8",
+      "recorded_at": "2026-04-11T16:04:28.898575Z",
       "request": {
         "acceptance_criteria_satisfied": false,
-        "claimed_completion": false,
+        "claimed_completion": true,
         "external_facts": null,
         "retry_context": null,
         "review_decision": null,
         "review_is_active": false,
         "review_reasons": [],
-        "review_request": null,
+        "review_request": {
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "requested_at": "2026-04-11T16:04:28.896456Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+          "task_id": "task-kno-181-scenario-b",
+          "trigger": "reconciliation"
+        },
         "runtime_facts": {
-          "attempt_count": 0,
+          "attempt_count": 1,
           "executor_reported_failure": false,
-          "executor_reported_success": false,
+          "executor_reported_success": true,
           "latest_attempt_outcome": null,
           "terminal_failure": false
         },
@@ -58,11 +80,100 @@
           "objective": {
             "deliverable_type": "unspecified",
             "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
+            "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
           },
           "observability": {
             "errors": [],
             "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-181-b-1",
+                  "metadata": {
+                    "attempt_id": "attempt-1"
+                  },
+                  "reason": "executor reported completion",
+                  "reported_at": "2026-04-01T08:00:00Z",
+                  "reported_by": "stub-executor"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "commit",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      },
+                      "reference_id": "attempt-kno-181-b-1:commit"
+                    }
+                  ],
+                  "attempt_id": "attempt-kno-181-b-1",
+                  "completion_claim_id": "claim-kno-181-b-1",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "repository": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                          }
+                        ],
+                        "used_task_artifact_fallback": false
+                      },
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [],
+                      "retryable": false,
+                      "rule_failures": [],
+                      "status": "valid",
+                      "validated_at": "2026-04-11T16:04:28.890189Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "stub-run-attempt-kno-181-b-1"
+                  },
+                  "recorded_at": "2026-04-01T08:00:05Z",
+                  "reevaluation": {},
+                  "reported_by": "stub-executor",
+                  "status": "succeeded"
+                }
+              ],
               "schema_required_deferred_fields": [
                 "parent_task_id",
                 "child_task_ids",
@@ -92,22 +203,105 @@
           "parent_task_id": null,
           "priority": "normal",
           "reconciliation": {
-            "active_failure_type": null,
-            "attempts": [],
-            "failed_at": null,
-            "last_attempt_id": null,
-            "last_error": null,
+            "active_failure_type": "missing_pr_after_execution",
+            "attempts": [
+              {
+                "attempt_id": "reconciliation-attempt-1",
+                "completed_at": "2026-04-11T16:04:28.894572Z",
+                "details": {
+                  "base_branch": null,
+                  "branch_exists": true,
+                  "branch_head_commit_sha": null,
+                  "branch_name": "codex/e2e-test",
+                  "commit_exists": true,
+                  "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "context_resolution": {
+                    "conflicts": [],
+                    "selected_source": "execution_attempt",
+                    "sources": {
+                      "execution_attempt": {
+                        "base_branch": null,
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      }
+                    }
+                  },
+                  "created_pull_request": false,
+                  "created_pull_request_revalidated": false,
+                  "error": "PR creation intentionally disabled for deterministic tests",
+                  "error_disposition": "review_required",
+                  "final_decision": {
+                    "reason": "all_candidates_rejected_or_absent",
+                    "result": "no_valid_existing_candidate"
+                  },
+                  "policy": {
+                    "allow_closed_pr_match": false,
+                    "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
+                    "allow_open_pr_match": true,
+                    "escalate_on_ambiguous_match": true,
+                    "require_exact_branch_match": true,
+                    "require_head_sha_match": true,
+                    "require_run_linkage_for_commit_association": true,
+                    "require_run_linkage_for_multiple_attempts": true,
+                    "require_task_linkage": false
+                  },
+                  "pull_request_candidates": [],
+                  "pull_request_lookup": {
+                    "ambiguous": false,
+                    "candidate_count": 0,
+                    "found": false,
+                    "number": null,
+                    "searched_by_branch": true,
+                    "searched_by_commit": true,
+                    "source": null,
+                    "url": null,
+                    "valid_candidate_count": 0
+                  },
+                  "repository": {
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  }
+                },
+                "failure_type": "missing_pr_after_execution",
+                "handler_key": "missing_pr_after_execution",
+                "started_at": "2026-04-11T16:04:28.894440Z",
+                "status": "failed"
+              }
+            ],
+            "failed_at": "2026-04-11T16:04:28.894572Z",
+            "last_attempt_id": "reconciliation-attempt-1",
+            "last_error": "PR creation intentionally disabled for deterministic tests",
             "last_pr_url": null,
             "resolved_at": null,
-            "status": "not_required"
+            "status": "failed"
           },
           "required_capabilities": [],
-          "status": "intake_ready",
-          "status_history": [],
+          "status": "in_review",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.892367Z",
+              "changed_by": "reconciliation",
+              "from_status": "assigned",
+              "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+              "to_status": "reconciling"
+            },
+            {
+              "changed_at": "2026-04-11T16:04:28.896456Z",
+              "changed_by": "reconciliation",
+              "from_status": "reconciling",
+              "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
+              "to_status": "in_review"
+            }
+          ],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-03-31T14:30:00Z"
+            "updated_at": "2026-04-11T16:04:28.896456Z"
           },
           "title": "KNO-181 task-kno-181-scenario-b"
         },
@@ -115,36 +309,63 @@
       },
       "result": {
         "accepted_completion": false,
-        "action": "no_op",
+        "action": "review_required",
         "enforcement_result": {
-          "action": "no_op",
-          "error": null,
-          "evidence_result": {
-            "artifact_results": [],
-            "is_sufficient": false,
-            "is_valid": true,
-            "issues": [],
-            "missing_required_artifact_types": [],
-            "unknown_validated_artifact_ids": [],
-            "validated_artifact_ids": []
-          },
+          "action": "review_required",
+          "error": "PR creation intentionally disabled for deterministic tests",
+          "evidence_result": null,
           "failure_classification": {
-            "category": "none",
-            "failure_type": "none",
-            "reason": "No completion claim is currently being evaluated",
+            "category": "review_required",
+            "failure_type": "review_required",
+            "reason": "PR creation intentionally disabled for deterministic tests",
             "recoverable": false,
             "retryable": false,
-            "source": "none",
+            "source": "evaluation",
             "terminal": false
           },
           "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-            "No completion claim is currently being evaluated"
+            "PR creation intentionally disabled for deterministic tests"
           ],
-          "reconciliation_result": null,
+          "reconciliation_result": {
+            "blocking": true,
+            "mismatch_categories": [
+              "missing_required_artifact"
+            ],
+            "outcome": "review_required",
+            "reasons": [
+              "PR creation intentionally disabled for deterministic tests"
+            ],
+            "status": "review_required",
+            "task_id": "task-kno-181-scenario-b",
+            "terminal": false
+          },
           "review_decision": null,
-          "review_request": null,
-          "target_status": null,
+          "review_request": {
+            "allowed_outcomes": [
+              "accept_completion",
+              "keep_blocked",
+              "mark_failed",
+              "authorize_redispatch"
+            ],
+            "metadata": {
+              "reconciliation_attempt_id": "reconciliation-attempt-1",
+              "reconciliation_failure_type": "missing_pr_after_execution"
+            },
+            "presented_sections": [
+              "task_state",
+              "execution",
+              "evidence",
+              "reconciliation"
+            ],
+            "prior_review_ids": [],
+            "requested_at": "2026-04-11T16:04:28.896456Z",
+            "requested_by": "reconciliation",
+            "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+            "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+            "task_id": "task-kno-181-scenario-b",
+            "trigger": "reconciliation"
+          },
+          "target_status": "in_review",
           "task_envelope": {
             "acceptance_criteria": [
               {
@@ -182,11 +403,100 @@
             "objective": {
               "deliverable_type": "unspecified",
               "success_signal": "Task satisfies declared acceptance criteria.",
-              "summary": "Exercise /evaluate with top-level evidence overlays."
+              "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
             },
             "observability": {
               "errors": [],
               "execution_metadata": {
+                "advisory_completion_claims": [
+                  {
+                    "claim_id": "claim-kno-181-b-1",
+                    "metadata": {
+                      "attempt_id": "attempt-1"
+                    },
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-01T08:00:00Z",
+                    "reported_by": "stub-executor"
+                  }
+                ],
+                "execution_attempts": [
+                  {
+                    "artifact_references": [
+                      {
+                        "artifact_type": "commit",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "metadata": {
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "repository_host": "github.com",
+                          "repository_name": "HARNESS-DRYRUN",
+                          "repository_owner": "KnoxAnalytics"
+                        },
+                        "reference_id": "attempt-kno-181-b-1:commit"
+                      }
+                    ],
+                    "attempt_id": "attempt-kno-181-b-1",
+                    "completion_claim_id": "claim-kno-181-b-1",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "branch": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "codex/e2e-test"
+                            }
+                          ],
+                          "commit": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                            }
+                          ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "repository": [
+                            {
+                              "sources": [
+                                "execution_attempt.artifact_references[0]"
+                              ],
+                              "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                            }
+                          ],
+                          "used_task_artifact_fallback": false
+                        },
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [],
+                        "retryable": false,
+                        "rule_failures": [],
+                        "status": "valid",
+                        "validated_at": "2026-04-11T16:04:28.890189Z",
+                        "validated_by": "execution_validation"
+                      },
+                      "executor_run_id": "stub-run-attempt-kno-181-b-1"
+                    },
+                    "recorded_at": "2026-04-01T08:00:05Z",
+                    "reevaluation": {},
+                    "reported_by": "stub-executor",
+                    "status": "succeeded"
+                  }
+                ],
                 "schema_required_deferred_fields": [
                   "parent_task_id",
                   "child_task_ids",
@@ -216,70 +526,127 @@
             "parent_task_id": null,
             "priority": "normal",
             "reconciliation": {
-              "active_failure_type": null,
-              "attempts": [],
-              "failed_at": null,
-              "last_attempt_id": null,
-              "last_error": null,
+              "active_failure_type": "missing_pr_after_execution",
+              "attempts": [
+                {
+                  "attempt_id": "reconciliation-attempt-1",
+                  "completed_at": "2026-04-11T16:04:28.894572Z",
+                  "details": {
+                    "base_branch": null,
+                    "branch_exists": true,
+                    "branch_head_commit_sha": null,
+                    "branch_name": "codex/e2e-test",
+                    "commit_exists": true,
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "context_resolution": {
+                      "conflicts": [],
+                      "selected_source": "execution_attempt",
+                      "sources": {
+                        "execution_attempt": {
+                          "base_branch": null,
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "repository_host": "github.com",
+                          "repository_name": "HARNESS-DRYRUN",
+                          "repository_owner": "KnoxAnalytics"
+                        }
+                      }
+                    },
+                    "created_pull_request": false,
+                    "created_pull_request_revalidated": false,
+                    "error": "PR creation intentionally disabled for deterministic tests",
+                    "error_disposition": "review_required",
+                    "final_decision": {
+                      "reason": "all_candidates_rejected_or_absent",
+                      "result": "no_valid_existing_candidate"
+                    },
+                    "policy": {
+                      "allow_closed_pr_match": false,
+                      "allow_commit_association_match": true,
+                      "allow_non_head_commit_association_match": false,
+                      "allow_open_pr_match": true,
+                      "escalate_on_ambiguous_match": true,
+                      "require_exact_branch_match": true,
+                      "require_head_sha_match": true,
+                      "require_run_linkage_for_commit_association": true,
+                      "require_run_linkage_for_multiple_attempts": true,
+                      "require_task_linkage": false
+                    },
+                    "pull_request_candidates": [],
+                    "pull_request_lookup": {
+                      "ambiguous": false,
+                      "candidate_count": 0,
+                      "found": false,
+                      "number": null,
+                      "searched_by_branch": true,
+                      "searched_by_commit": true,
+                      "source": null,
+                      "url": null,
+                      "valid_candidate_count": 0
+                    },
+                    "repository": {
+                      "host": "github.com",
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    }
+                  },
+                  "failure_type": "missing_pr_after_execution",
+                  "handler_key": "missing_pr_after_execution",
+                  "started_at": "2026-04-11T16:04:28.894440Z",
+                  "status": "failed"
+                }
+              ],
+              "failed_at": "2026-04-11T16:04:28.894572Z",
+              "last_attempt_id": "reconciliation-attempt-1",
+              "last_error": "PR creation intentionally disabled for deterministic tests",
               "last_pr_url": null,
               "resolved_at": null,
-              "status": "not_required"
+              "status": "failed"
             },
             "required_capabilities": [],
-            "status": "intake_ready",
-            "status_history": [],
+            "status": "in_review",
+            "status_history": [
+              {
+                "changed_at": "2026-04-11T16:04:28.892367Z",
+                "changed_by": "reconciliation",
+                "from_status": "assigned",
+                "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+                "to_status": "reconciling"
+              },
+              {
+                "changed_at": "2026-04-11T16:04:28.896456Z",
+                "changed_by": "reconciliation",
+                "from_status": "reconciling",
+                "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
+                "to_status": "in_review"
+              }
+            ],
             "timestamps": {
               "completed_at": null,
               "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-03-31T14:30:00Z"
+              "updated_at": "2026-04-11T16:04:28.896456Z"
             },
             "title": "KNO-181 task-kno-181-scenario-b"
           },
           "transition_result": null,
-          "verification_result": {
-            "accepted_completion": false,
-            "claimed_completion": false,
-            "evidence_is_sufficient": false,
-            "evidence_is_valid": true,
-            "failure_classification": {
-              "category": "none",
-              "failure_type": "none",
-              "reason": "No completion claim is currently being evaluated",
-              "recoverable": false,
-              "retryable": false,
-              "source": "none",
-              "terminal": false
-            },
-            "is_terminal": false,
-            "outcome": "verification_deferred",
-            "reasons": [
-              "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-              "No completion claim is currently being evaluated"
-            ],
-            "reconciliation_status": "pending",
-            "requires_review": false,
-            "target_status": null,
-            "task_id": "task-kno-181-scenario-b",
-            "verification_passed": false
-          }
+          "verification_result": null
         },
-        "error": null,
+        "error": "PR creation intentionally disabled for deterministic tests",
         "failure_classification": {
-          "category": "none",
-          "failure_type": "none",
-          "reason": "No completion claim is currently being evaluated",
+          "category": "review_required",
+          "failure_type": "review_required",
+          "reason": "PR creation intentionally disabled for deterministic tests",
           "recoverable": false,
           "retryable": false,
-          "source": "none",
+          "source": "evaluation",
           "terminal": false
         },
         "invalid_input": false,
         "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-          "No completion claim is currently being evaluated"
+          "PR creation intentionally disabled for deterministic tests"
         ],
-        "requires_review": false,
-        "target_status": null,
+        "requires_review": true,
+        "target_status": "in_review",
         "task_envelope": {
           "acceptance_criteria": [
             {
@@ -317,11 +684,100 @@
           "objective": {
             "deliverable_type": "unspecified",
             "success_signal": "Task satisfies declared acceptance criteria.",
-            "summary": "Exercise /evaluate with top-level evidence overlays."
+            "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
           },
           "observability": {
             "errors": [],
             "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-181-b-1",
+                  "metadata": {
+                    "attempt_id": "attempt-1"
+                  },
+                  "reason": "executor reported completion",
+                  "reported_at": "2026-04-01T08:00:00Z",
+                  "reported_by": "stub-executor"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "commit",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "metadata": {
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      },
+                      "reference_id": "attempt-kno-181-b-1:commit"
+                    }
+                  ],
+                  "attempt_id": "attempt-kno-181-b-1",
+                  "completion_claim_id": "claim-kno-181-b-1",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "repository": [
+                          {
+                            "sources": [
+                              "execution_attempt.artifact_references[0]"
+                            ],
+                            "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                          }
+                        ],
+                        "used_task_artifact_fallback": false
+                      },
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [],
+                      "retryable": false,
+                      "rule_failures": [],
+                      "status": "valid",
+                      "validated_at": "2026-04-11T16:04:28.890189Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "stub-run-attempt-kno-181-b-1"
+                  },
+                  "recorded_at": "2026-04-01T08:00:05Z",
+                  "reevaluation": {},
+                  "reported_by": "stub-executor",
+                  "status": "succeeded"
+                }
+              ],
               "schema_required_deferred_fields": [
                 "parent_task_id",
                 "child_task_ids",
@@ -351,26 +807,111 @@
           "parent_task_id": null,
           "priority": "normal",
           "reconciliation": {
-            "active_failure_type": null,
-            "attempts": [],
-            "failed_at": null,
-            "last_attempt_id": null,
-            "last_error": null,
+            "active_failure_type": "missing_pr_after_execution",
+            "attempts": [
+              {
+                "attempt_id": "reconciliation-attempt-1",
+                "completed_at": "2026-04-11T16:04:28.894572Z",
+                "details": {
+                  "base_branch": null,
+                  "branch_exists": true,
+                  "branch_head_commit_sha": null,
+                  "branch_name": "codex/e2e-test",
+                  "commit_exists": true,
+                  "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "context_resolution": {
+                    "conflicts": [],
+                    "selected_source": "execution_attempt",
+                    "sources": {
+                      "execution_attempt": {
+                        "base_branch": null,
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      }
+                    }
+                  },
+                  "created_pull_request": false,
+                  "created_pull_request_revalidated": false,
+                  "error": "PR creation intentionally disabled for deterministic tests",
+                  "error_disposition": "review_required",
+                  "final_decision": {
+                    "reason": "all_candidates_rejected_or_absent",
+                    "result": "no_valid_existing_candidate"
+                  },
+                  "policy": {
+                    "allow_closed_pr_match": false,
+                    "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
+                    "allow_open_pr_match": true,
+                    "escalate_on_ambiguous_match": true,
+                    "require_exact_branch_match": true,
+                    "require_head_sha_match": true,
+                    "require_run_linkage_for_commit_association": true,
+                    "require_run_linkage_for_multiple_attempts": true,
+                    "require_task_linkage": false
+                  },
+                  "pull_request_candidates": [],
+                  "pull_request_lookup": {
+                    "ambiguous": false,
+                    "candidate_count": 0,
+                    "found": false,
+                    "number": null,
+                    "searched_by_branch": true,
+                    "searched_by_commit": true,
+                    "source": null,
+                    "url": null,
+                    "valid_candidate_count": 0
+                  },
+                  "repository": {
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  }
+                },
+                "failure_type": "missing_pr_after_execution",
+                "handler_key": "missing_pr_after_execution",
+                "started_at": "2026-04-11T16:04:28.894440Z",
+                "status": "failed"
+              }
+            ],
+            "failed_at": "2026-04-11T16:04:28.894572Z",
+            "last_attempt_id": "reconciliation-attempt-1",
+            "last_error": "PR creation intentionally disabled for deterministic tests",
             "last_pr_url": null,
             "resolved_at": null,
-            "status": "not_required"
+            "status": "failed"
           },
           "required_capabilities": [],
-          "status": "intake_ready",
-          "status_history": [],
+          "status": "in_review",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.892367Z",
+              "changed_by": "reconciliation",
+              "from_status": "assigned",
+              "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+              "to_status": "reconciling"
+            },
+            {
+              "changed_at": "2026-04-11T16:04:28.896456Z",
+              "changed_by": "reconciliation",
+              "from_status": "reconciling",
+              "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
+              "to_status": "in_review"
+            }
+          ],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-03-31T14:30:00Z"
+            "updated_at": "2026-04-11T16:04:28.896456Z"
           },
           "title": "KNO-181 task-kno-181-scenario-b"
         }
-      }
+      },
+      "task_id": "task-kno-181-scenario-b"
     }
-  ]
+  ],
+  "task_id": "task-kno-181-scenario-b"
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-read-model-final.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-read-model-final.json
@@ -1,84 +1,61 @@
 {
   "task": {
-    "task_id": "task-kno-181-scenario-b",
-    "title": "KNO-181 task-kno-181-scenario-b",
-    "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
+    "assigned_executor": null,
+    "clarification_summary": null,
+    "coordination_summary": {
+      "linear": null
+    },
     "current_status": "in_review",
-    "objective_summary": "Exercise /evaluate with top-level evidence overlays.",
-    "origin": {
-      "ingress_id": null,
-      "ingress_name": null,
-      "requested_by": null,
-      "source_id": "req-happy-overlay-1",
-      "source_system": "openclaw",
-      "source_type": "ingress_request"
-    },
-    "relationships": {
-      "parent_task_id": null,
-      "child_task_ids": [],
-      "dependencies": []
-    },
-    "assigned_executor": {
-      "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
-      "executor_id": "executor-kno-181-b",
-      "executor_type": "codex"
+    "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
+    "evaluation_summary": {
+      "count": 1,
+      "history": [
+        {
+          "action": "review_required",
+          "evaluation_id": "af982558-3013-4b15-9032-d71d985469f8",
+          "recorded_at": "2026-04-11T16:04:28.898575Z",
+          "target_status": "in_review"
+        }
+      ],
+      "latest_action": "review_required",
+      "latest_recorded_at": "2026-04-11T16:04:28.898575Z",
+      "latest_target_status": "in_review"
     },
     "evidence_summary": {
       "artifact_count": 0,
       "artifact_type_counts": {},
-      "verification_status_counts": {},
-      "validated_artifact_count": 0,
       "completion_evidence": {
         "policy": "deferred",
-        "status": "deferred",
         "required_artifact_types": [],
+        "status": "deferred",
         "validated_artifact_ids": [],
-        "validation_method": "deferred",
         "validated_at": null,
+        "validation_method": "deferred",
         "validator": null
-      }
-    },
-    "coordination_summary": {
-      "linear": null
-    },
-    "verification_summary": {
-      "accepted_completion": false,
-      "claimed_completion": false,
-      "evidence_is_sufficient": false,
-      "evidence_is_valid": true,
-      "failure_classification": {
-        "category": "none",
-        "failure_type": "none",
-        "reason": "No completion claim is currently being evaluated",
-        "recoverable": false,
-        "retryable": false,
-        "source": "none",
-        "terminal": false
       },
-      "is_terminal": false,
-      "outcome": "verification_deferred",
-      "reasons": [
-        "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-        "No completion claim is currently being evaluated"
-      ],
-      "reconciliation_status": "pending",
-      "requires_review": false,
-      "target_status": null,
-      "task_id": "task-kno-181-scenario-b",
-      "verification_passed": false
-    },
-    "reconciliation_summary": null,
-    "review_summary": {
-      "status": "none",
-      "request_count": 0,
-      "decision_count": 0,
-      "latest_request": null,
-      "latest_decision": null,
-      "requests": [],
-      "decisions": []
+      "validated_artifact_count": 0,
+      "verification_status_counts": {}
     },
     "execution_summary": {
       "attempt_count": 1,
+      "failure_state": "review_required",
+      "invalid_attempt_count": 0,
+      "last_failure_type": "review_required",
+      "latest_artifact_references": [
+        {
+          "artifact_type": "commit",
+          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+          "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+          "metadata": {
+            "branch_name": "codex/e2e-test",
+            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "repository_host": "github.com",
+            "repository_name": "HARNESS-DRYRUN",
+            "repository_owner": "KnoxAnalytics"
+          },
+          "reference_id": "attempt-kno-181-b-1:commit"
+        }
+      ],
       "latest_attempt": {
         "artifact_references": [
           {
@@ -116,6 +93,8 @@
                   "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                 }
               ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -127,16 +106,23 @@
               "used_task_artifact_fallback": false
             },
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-05T17:30:31.786474Z",
+            "validated_at": "2026-04-11T16:04:28.890189Z",
             "validated_by": "execution_validation"
           },
           "executor_run_id": "stub-run-attempt-kno-181-b-1"
@@ -146,8 +132,6 @@
         "reported_by": "stub-executor",
         "status": "succeeded"
       },
-      "latest_status": "succeeded",
-      "latest_dispatch_origin": null,
       "latest_attempt_validation": {
         "context_observations": {
           "branch": [
@@ -166,6 +150,8 @@
               "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
             }
           ],
+          "commit_resolution_pending": false,
+          "has_valid_current_run_pull_request_artifact": false,
           "repository": [
             {
               "sources": [
@@ -177,93 +163,150 @@
           "used_task_artifact_fallback": false
         },
         "policy": {
+          "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
           "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
           "require_commit": true,
           "require_exact_branch": true,
           "require_repository": true,
           "task_artifact_fallback_requires_single_attempt": true
         },
+        "pull_request_observations": [],
         "reasons": [],
         "retryable": false,
+        "rule_failures": [],
         "status": "valid",
-        "validated_at": "2026-04-05T17:30:31.786474Z",
+        "validated_at": "2026-04-11T16:04:28.890189Z",
         "validated_by": "execution_validation"
       },
-      "latest_artifact_references": [
-        {
-          "artifact_type": "commit",
-          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-          "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-          "metadata": {
-            "branch_name": "codex/e2e-test",
-            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-            "repository_host": "github.com",
-            "repository_name": "HARNESS-DRYRUN",
-            "repository_owner": "KnoxAnalytics"
-          },
-          "reference_id": "attempt-kno-181-b-1:commit"
-        }
-      ],
-      "total_attempts": 1,
+      "latest_dispatch_origin": null,
+      "latest_status": "succeeded",
       "retry_count": 0,
-      "invalid_attempt_count": 0,
-      "last_failure_type": "none",
       "retry_eligible": false,
-      "failure_state": "clear"
+      "total_attempts": 1
     },
+    "extensions": {},
     "failure_summary": {
-      "state": "clear",
-      "failure_type": "none",
-      "failure_source": "none",
-      "terminal": false,
-      "recoverable": false
-    },
-    "evaluation_summary": {
-      "count": 1,
-      "latest_recorded_at": "2026-04-05T17:30:31.776247Z",
-      "latest_action": "no_op",
-      "latest_target_status": null,
-      "history": [
-        {
-          "evaluation_id": "5e90ceee-579d-4795-93e3-26aa0508dfdc",
-          "recorded_at": "2026-04-05T17:30:31.776247Z",
-          "action": "no_op",
-          "target_status": null
-        }
-      ]
+      "evaluation_id": "af982558-3013-4b15-9032-d71d985469f8",
+      "failure_reason": "PR creation intentionally disabled for deterministic tests",
+      "failure_source": "evaluation",
+      "failure_type": "review_required",
+      "recorded_at": "2026-04-11T16:04:28.898575Z",
+      "recoverable": false,
+      "state": "review_required",
+      "terminal": false
     },
     "lifecycle_history": [
       {
-        "changed_at": "2026-04-05T17:30:31.815978Z",
+        "changed_at": "2026-04-11T16:04:28.892367Z",
         "changed_by": "reconciliation",
-        "from_status": "intake_ready",
+        "from_status": "assigned",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-05T17:30:31.878104Z",
+        "changed_at": "2026-04-11T16:04:28.896456Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
-        "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic local demo proof",
+        "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
         "to_status": "in_review"
       }
     ],
-    "timestamps": {
-      "completed_at": null,
-      "created_at": "2026-03-31T14:30:00Z",
-      "updated_at": "2026-04-05T17:30:31.878104Z"
+    "objective_summary": "Scenario B: valid attributable execution attempt with missing PR proof.",
+    "origin": {
+      "ingress_id": null,
+      "ingress_name": null,
+      "requested_by": null,
+      "source_id": "req-happy-overlay-1",
+      "source_system": "openclaw",
+      "source_type": "ingress_request"
     },
-    "extensions": {},
+    "reconciliation_summary": {
+      "blocking": true,
+      "mismatch_categories": [
+        "missing_required_artifact"
+      ],
+      "outcome": "review_required",
+      "reasons": [
+        "PR creation intentionally disabled for deterministic tests"
+      ],
+      "status": "review_required",
+      "task_id": "task-kno-181-scenario-b",
+      "terminal": false
+    },
+    "relationships": {
+      "child_task_ids": [],
+      "dependencies": [],
+      "parent_task_id": null
+    },
+    "review_summary": {
+      "decision_count": 0,
+      "decisions": [],
+      "latest_decision": null,
+      "latest_effective_decision": null,
+      "latest_request": {
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "requested_at": "2026-04-11T16:04:28.896456Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+        "task_id": "task-kno-181-scenario-b",
+        "trigger": "reconciliation"
+      },
+      "request_count": 1,
+      "requests": [
+        {
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "requested_at": "2026-04-11T16:04:28.896456Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+          "task_id": "task-kno-181-scenario-b",
+          "trigger": "reconciliation"
+        }
+      ],
+      "resolved_decision_count": 0,
+      "status": "requested"
+    },
+    "task_id": "task-kno-181-scenario-b",
     "timeline": [
       {
-        "event_id": "task-kno-181-scenario-b:created",
-        "event_type": "task_created",
-        "occurred_at": "2026-03-31T14:30:00Z",
-        "summary": "Task created",
-        "source": "openclaw",
         "details": {
-          "status": "in_review",
-          "title": "KNO-181 task-kno-181-scenario-b",
           "origin": {
             "ingress_id": null,
             "ingress_name": null,
@@ -271,39 +314,18 @@
             "source_id": "req-happy-overlay-1",
             "source_system": "openclaw",
             "source_type": "ingress_request"
-          }
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-b:execution_artifact:attempt-kno-181-b-1:attempt-kno-181-b-1:commit",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-01T08:00:05Z",
-        "summary": "Execution artifact attached: commit",
-        "source": "stub-executor",
-        "details": {
-          "artifact_type": "commit",
-          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-          "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-          "metadata": {
-            "branch_name": "codex/e2e-test",
-            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-            "repository_host": "github.com",
-            "repository_name": "HARNESS-DRYRUN",
-            "repository_owner": "KnoxAnalytics"
           },
-          "reference_id": "attempt-kno-181-b-1:commit"
-        }
+          "status": "in_review",
+          "title": "KNO-181 task-kno-181-scenario-b"
+        },
+        "event_id": "task-kno-181-scenario-b:created",
+        "event_type": "task_created",
+        "occurred_at": "2026-03-31T14:30:00Z",
+        "source": "openclaw",
+        "summary": "Task created"
       },
       {
-        "event_id": "task-kno-181-scenario-b:execution_attempt:attempt-kno-181-b-1",
-        "event_type": "execution_attempt_recorded",
-        "occurred_at": "2026-04-01T08:00:05Z",
-        "summary": "Execution attempt recorded: attempt-kno-181-b-1",
-        "source": "stub-executor",
         "details": {
-          "attempt_id": "attempt-kno-181-b-1",
-          "status": "succeeded",
-          "completion_claim_id": "claim-kno-181-b-1",
           "artifact_references": [
             {
               "artifact_type": "commit",
@@ -319,6 +341,7 @@
               "reference_id": "attempt-kno-181-b-1:commit"
             }
           ],
+          "attempt_id": "attempt-kno-181-b-1",
           "attempt_validation": {
             "context_observations": {
               "branch": [
@@ -337,6 +360,8 @@
                   "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                 }
               ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -348,92 +373,77 @@
               "used_task_artifact_fallback": false
             },
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-05T17:30:31.786474Z",
+            "validated_at": "2026-04-11T16:04:28.890189Z",
             "validated_by": "execution_validation"
           },
-          "reevaluation": {}
-        }
+          "completion_claim_id": "claim-kno-181-b-1",
+          "reevaluation": {},
+          "status": "succeeded"
+        },
+        "event_id": "task-kno-181-scenario-b:execution_attempt:attempt-kno-181-b-1",
+        "event_type": "execution_attempt_recorded",
+        "occurred_at": "2026-04-01T08:00:05Z",
+        "source": "stub-executor",
+        "summary": "Execution attempt recorded: attempt-kno-181-b-1"
       },
       {
-        "event_id": "task-kno-181-scenario-b:evaluation:5e90ceee-579d-4795-93e3-26aa0508dfdc",
-        "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-05T17:30:31.776247Z",
-        "summary": "Evaluation recorded: no_op",
-        "source": "harness",
         "details": {
-          "evaluation_id": "5e90ceee-579d-4795-93e3-26aa0508dfdc",
-          "action": "no_op",
-          "target_status": null,
-          "accepted_completion": false,
-          "requires_review": false,
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "verification_result": {
-            "accepted_completion": false,
-            "claimed_completion": false,
-            "evidence_is_sufficient": false,
-            "evidence_is_valid": true,
-            "failure_classification": {
-              "category": "none",
-              "failure_type": "none",
-              "reason": "No completion claim is currently being evaluated",
-              "recoverable": false,
-              "retryable": false,
-              "source": "none",
-              "terminal": false
-            },
-            "is_terminal": false,
-            "outcome": "verification_deferred",
-            "reasons": [
-              "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-              "No completion claim is currently being evaluated"
-            ],
-            "reconciliation_status": "pending",
-            "requires_review": false,
-            "target_status": null,
-            "task_id": "task-kno-181-scenario-b",
-            "verification_passed": false
+          "artifact_type": "commit",
+          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+          "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+          "metadata": {
+            "branch_name": "codex/e2e-test",
+            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "repository_host": "github.com",
+            "repository_name": "HARNESS-DRYRUN",
+            "repository_owner": "KnoxAnalytics"
           },
-          "reconciliation_result": null
-        }
+          "reference_id": "attempt-kno-181-b-1:commit"
+        },
+        "event_id": "task-kno-181-scenario-b:execution_artifact:attempt-kno-181-b-1:attempt-kno-181-b-1:commit",
+        "event_type": "execution_artifact_attached",
+        "occurred_at": "2026-04-01T08:00:05Z",
+        "source": "stub-executor",
+        "summary": "Execution artifact attached: commit"
       },
       {
-        "event_id": "task-kno-181-scenario-b:status:0",
-        "event_type": "status_transition",
-        "occurred_at": "2026-04-05T17:30:31.815978Z",
-        "summary": "Status changed intake_ready -> reconciling",
-        "source": "reconciliation",
         "details": {
-          "changed_at": "2026-04-05T17:30:31.815978Z",
+          "changed_at": "2026-04-11T16:04:28.892367Z",
           "changed_by": "reconciliation",
-          "from_status": "intake_ready",
+          "from_status": "assigned",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
           "to_status": "reconciling"
-        }
+        },
+        "event_id": "task-kno-181-scenario-b:status:0",
+        "event_type": "status_transition",
+        "occurred_at": "2026-04-11T16:04:28.892367Z",
+        "source": "reconciliation",
+        "summary": "Status changed assigned -> reconciling"
       },
       {
-        "event_id": "task-kno-181-scenario-b:reconciliation:reconciliation-attempt-1",
-        "event_type": "reconciliation_attempt_recorded",
-        "occurred_at": "2026-04-05T17:30:31.846841Z",
-        "summary": "Reconciliation attempt: missing_pr_after_execution",
-        "source": "reconciliation",
         "details": {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-05T17:30:31.846841Z",
+          "completed_at": "2026-04-11T16:04:28.894572Z",
           "details": {
             "base_branch": null,
             "branch_exists": true,
+            "branch_head_commit_sha": null,
             "branch_name": "codex/e2e-test",
             "commit_exists": true,
             "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
@@ -452,7 +462,8 @@
               }
             },
             "created_pull_request": false,
-            "error": "PR creation intentionally disabled for deterministic local demo proof",
+            "created_pull_request_revalidated": false,
+            "error": "PR creation intentionally disabled for deterministic tests",
             "error_disposition": "review_required",
             "final_decision": {
               "reason": "all_candidates_rejected_or_absent",
@@ -461,10 +472,13 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
               "require_head_sha_match": true,
+              "require_run_linkage_for_commit_association": true,
+              "require_run_linkage_for_multiple_attempts": true,
               "require_task_linkage": false
             },
             "pull_request_candidates": [],
@@ -487,24 +501,115 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-05T17:30:31.845905Z",
+          "started_at": "2026-04-11T16:04:28.894440Z",
           "status": "failed"
-        }
+        },
+        "event_id": "task-kno-181-scenario-b:reconciliation:reconciliation-attempt-1",
+        "event_type": "reconciliation_attempt_recorded",
+        "occurred_at": "2026-04-11T16:04:28.894572Z",
+        "source": "reconciliation",
+        "summary": "Reconciliation attempt: missing_pr_after_execution"
       },
       {
-        "event_id": "task-kno-181-scenario-b:status:1",
-        "event_type": "status_transition",
-        "occurred_at": "2026-04-05T17:30:31.878104Z",
-        "summary": "Status changed reconciling -> in_review",
-        "source": "reconciliation",
         "details": {
-          "changed_at": "2026-04-05T17:30:31.878104Z",
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "reason": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+          "requested_at": "2026-04-11T16:04:28.896456Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+          "task_id": "task-kno-181-scenario-b",
+          "trigger": "reconciliation"
+        },
+        "event_id": "task-kno-181-scenario-b:review-request:review-request-task-kno-181-scenario-b-reconciliation-1",
+        "event_type": "review_requested",
+        "occurred_at": "2026-04-11T16:04:28.896456Z",
+        "source": "reconciliation",
+        "summary": "Manual review requested"
+      },
+      {
+        "details": {
+          "changed_at": "2026-04-11T16:04:28.896456Z",
           "changed_by": "reconciliation",
           "from_status": "reconciling",
-          "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic local demo proof",
+          "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
           "to_status": "in_review"
-        }
+        },
+        "event_id": "task-kno-181-scenario-b:status:1",
+        "event_type": "status_transition",
+        "occurred_at": "2026-04-11T16:04:28.896456Z",
+        "source": "reconciliation",
+        "summary": "Status changed reconciling -> in_review"
+      },
+      {
+        "details": {
+          "accepted_completion": false,
+          "action": "review_required",
+          "evaluation_id": "af982558-3013-4b15-9032-d71d985469f8",
+          "reasons": [
+            "PR creation intentionally disabled for deterministic tests"
+          ],
+          "reconciliation_result": {
+            "blocking": true,
+            "mismatch_categories": [
+              "missing_required_artifact"
+            ],
+            "outcome": "review_required",
+            "reasons": [
+              "PR creation intentionally disabled for deterministic tests"
+            ],
+            "status": "review_required",
+            "task_id": "task-kno-181-scenario-b",
+            "terminal": false
+          },
+          "requires_review": true,
+          "target_status": "in_review",
+          "verification_result": null
+        },
+        "event_id": "task-kno-181-scenario-b:evaluation:af982558-3013-4b15-9032-d71d985469f8",
+        "event_type": "evaluation_recorded",
+        "occurred_at": "2026-04-11T16:04:28.898575Z",
+        "source": "harness",
+        "summary": "Evaluation recorded: review_required"
+      },
+      {
+        "details": {
+          "failure_reason": "PR creation intentionally disabled for deterministic tests",
+          "failure_recorded": true,
+          "failure_source": "evaluation",
+          "failure_type": "review_required",
+          "recoverable": false,
+          "terminal": false
+        },
+        "event_id": "task-kno-181-scenario-b:failure:af982558-3013-4b15-9032-d71d985469f8",
+        "event_type": "failure_recorded",
+        "occurred_at": "2026-04-11T16:04:28.898575Z",
+        "source": "evaluation",
+        "summary": "Failure recorded: review_required"
       }
-    ]
+    ],
+    "timestamps": {
+      "completed_at": null,
+      "created_at": "2026-03-31T14:30:00Z",
+      "updated_at": "2026-04-11T16:04:28.896456Z"
+    },
+    "title": "KNO-181 task-kno-181-scenario-b",
+    "verification_summary": null
   }
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-read-model-initial.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-read-model-initial.json
@@ -1,10 +1,62 @@
 {
   "task": {
-    "task_id": "task-kno-181-scenario-b",
-    "title": "KNO-181 task-kno-181-scenario-b",
+    "assigned_executor": {
+      "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
+      "executor_id": "executor-kno-181-b",
+      "executor_type": "codex"
+    },
+    "clarification_summary": null,
+    "coordination_summary": {
+      "linear": null
+    },
+    "current_status": "assigned",
     "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
-    "current_status": "intake_ready",
-    "objective_summary": "Exercise /evaluate with top-level evidence overlays.",
+    "evaluation_summary": {
+      "count": 0,
+      "history": [],
+      "latest_action": null,
+      "latest_recorded_at": null,
+      "latest_target_status": null
+    },
+    "evidence_summary": {
+      "artifact_count": 0,
+      "artifact_type_counts": {},
+      "completion_evidence": {
+        "policy": "deferred",
+        "required_artifact_types": [],
+        "status": "deferred",
+        "validated_artifact_ids": [],
+        "validated_at": null,
+        "validation_method": "deferred",
+        "validator": null
+      },
+      "validated_artifact_count": 0,
+      "verification_status_counts": {}
+    },
+    "execution_summary": {
+      "attempt_count": 0,
+      "failure_state": "clear",
+      "invalid_attempt_count": 0,
+      "last_failure_type": "none",
+      "latest_artifact_references": [],
+      "latest_attempt": null,
+      "latest_attempt_validation": null,
+      "latest_dispatch_origin": null,
+      "latest_status": null,
+      "retry_count": 0,
+      "retry_eligible": false,
+      "total_attempts": 0
+    },
+    "extensions": {},
+    "failure_summary": {
+      "failure_source": "none",
+      "failure_type": "none",
+      "recoverable": false,
+      "state": "clear",
+      "terminal": false
+    },
+    "lifecycle_history": [],
+    "objective_summary": "Scenario B: valid attributable execution attempt with missing PR proof.",
     "origin": {
       "ingress_id": null,
       "ingress_name": null,
@@ -13,122 +65,27 @@
       "source_system": "openclaw",
       "source_type": "ingress_request"
     },
-    "relationships": {
-      "parent_task_id": null,
-      "child_task_ids": [],
-      "dependencies": []
-    },
-    "assigned_executor": {
-      "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
-      "executor_id": "executor-kno-181-b",
-      "executor_type": "codex"
-    },
-    "evidence_summary": {
-      "artifact_count": 0,
-      "artifact_type_counts": {},
-      "verification_status_counts": {},
-      "validated_artifact_count": 0,
-      "completion_evidence": {
-        "policy": "deferred",
-        "status": "deferred",
-        "required_artifact_types": [],
-        "validated_artifact_ids": [],
-        "validation_method": "deferred",
-        "validated_at": null,
-        "validator": null
-      }
-    },
-    "coordination_summary": {
-      "linear": null
-    },
-    "verification_summary": {
-      "accepted_completion": false,
-      "claimed_completion": false,
-      "evidence_is_sufficient": false,
-      "evidence_is_valid": true,
-      "failure_classification": {
-        "category": "none",
-        "failure_type": "none",
-        "reason": "No completion claim is currently being evaluated",
-        "recoverable": false,
-        "retryable": false,
-        "source": "none",
-        "terminal": false
-      },
-      "is_terminal": false,
-      "outcome": "verification_deferred",
-      "reasons": [
-        "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-        "No completion claim is currently being evaluated"
-      ],
-      "reconciliation_status": "pending",
-      "requires_review": false,
-      "target_status": null,
-      "task_id": "task-kno-181-scenario-b",
-      "verification_passed": false
-    },
     "reconciliation_summary": null,
+    "relationships": {
+      "child_task_ids": [],
+      "dependencies": [],
+      "parent_task_id": null
+    },
     "review_summary": {
-      "status": "none",
-      "request_count": 0,
       "decision_count": 0,
-      "latest_request": null,
+      "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
+      "latest_request": null,
+      "request_count": 0,
       "requests": [],
-      "decisions": []
+      "resolved_decision_count": 0,
+      "status": "none"
     },
-    "execution_summary": {
-      "attempt_count": 0,
-      "latest_attempt": null,
-      "latest_status": null,
-      "latest_dispatch_origin": null,
-      "latest_attempt_validation": null,
-      "latest_artifact_references": [],
-      "total_attempts": 1,
-      "retry_count": 0,
-      "invalid_attempt_count": 0,
-      "last_failure_type": "none",
-      "retry_eligible": false,
-      "failure_state": "clear"
-    },
-    "failure_summary": {
-      "state": "clear",
-      "failure_type": "none",
-      "failure_source": "none",
-      "terminal": false,
-      "recoverable": false
-    },
-    "evaluation_summary": {
-      "count": 1,
-      "latest_recorded_at": "2026-04-05T17:30:31.776247Z",
-      "latest_action": "no_op",
-      "latest_target_status": null,
-      "history": [
-        {
-          "evaluation_id": "5e90ceee-579d-4795-93e3-26aa0508dfdc",
-          "recorded_at": "2026-04-05T17:30:31.776247Z",
-          "action": "no_op",
-          "target_status": null
-        }
-      ]
-    },
-    "lifecycle_history": [],
-    "timestamps": {
-      "completed_at": null,
-      "created_at": "2026-03-31T14:30:00Z",
-      "updated_at": "2026-03-31T14:30:00Z"
-    },
-    "extensions": {},
+    "task_id": "task-kno-181-scenario-b",
     "timeline": [
       {
-        "event_id": "task-kno-181-scenario-b:created",
-        "event_type": "task_created",
-        "occurred_at": "2026-03-31T14:30:00Z",
-        "summary": "Task created",
-        "source": "openclaw",
         "details": {
-          "status": "intake_ready",
-          "title": "KNO-181 task-kno-181-scenario-b",
           "origin": {
             "ingress_id": null,
             "ingress_name": null,
@@ -136,54 +93,23 @@
             "source_id": "req-happy-overlay-1",
             "source_system": "openclaw",
             "source_type": "ingress_request"
-          }
-        }
-      },
-      {
-        "event_id": "task-kno-181-scenario-b:evaluation:5e90ceee-579d-4795-93e3-26aa0508dfdc",
-        "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-05T17:30:31.776247Z",
-        "summary": "Evaluation recorded: no_op",
-        "source": "harness",
-        "details": {
-          "evaluation_id": "5e90ceee-579d-4795-93e3-26aa0508dfdc",
-          "action": "no_op",
-          "target_status": null,
-          "accepted_completion": false,
-          "requires_review": false,
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "verification_result": {
-            "accepted_completion": false,
-            "claimed_completion": false,
-            "evidence_is_sufficient": false,
-            "evidence_is_valid": true,
-            "failure_classification": {
-              "category": "none",
-              "failure_type": "none",
-              "reason": "No completion claim is currently being evaluated",
-              "recoverable": false,
-              "retryable": false,
-              "source": "none",
-              "terminal": false
-            },
-            "is_terminal": false,
-            "outcome": "verification_deferred",
-            "reasons": [
-              "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-              "No completion claim is currently being evaluated"
-            ],
-            "reconciliation_status": "pending",
-            "requires_review": false,
-            "target_status": null,
-            "task_id": "task-kno-181-scenario-b",
-            "verification_passed": false
           },
-          "reconciliation_result": null
-        }
+          "status": "assigned",
+          "title": "KNO-181 task-kno-181-scenario-b"
+        },
+        "event_id": "task-kno-181-scenario-b:created",
+        "event_type": "task_created",
+        "occurred_at": "2026-03-31T14:30:00Z",
+        "source": "openclaw",
+        "summary": "Task created"
       }
-    ]
+    ],
+    "timestamps": {
+      "completed_at": null,
+      "created_at": "2026-03-31T14:30:00Z",
+      "updated_at": "2026-03-31T14:30:00Z"
+    },
+    "title": "KNO-181 task-kno-181-scenario-b",
+    "verification_summary": null
   }
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-submit-request.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-submit-request.json
@@ -1,76 +1,47 @@
 {
   "request": {
+    "assigned_executor": {
+      "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
+      "executor_id": "executor-kno-181-b",
+      "executor_type": "codex"
+    },
     "task_envelope": {
-      "id": "task-kno-181-scenario-b",
-      "title": "KNO-181 task-kno-181-scenario-b",
-      "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
-      "origin": {
-        "source_system": "openclaw",
-        "source_type": "ingress_request",
-        "source_id": "req-happy-overlay-1",
-        "ingress_id": null,
-        "ingress_name": null,
-        "requested_by": null
-      },
-      "status": "intake_ready",
-      "timestamps": {
-        "created_at": "2026-03-31T14:30:00Z",
-        "updated_at": "2026-03-31T14:30:00Z",
-        "completed_at": null
-      },
-      "status_history": [],
-      "objective": {
-        "summary": "Exercise /evaluate with top-level evidence overlays.",
-        "deliverable_type": "unspecified",
-        "success_signal": "Task satisfies declared acceptance criteria."
-      },
-      "constraints": [],
       "acceptance_criteria": [
         {
-          "id": "ac-1",
           "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+          "id": "ac-1",
           "required": true
         }
       ],
-      "parent_task_id": null,
-      "child_task_ids": [],
-      "dependencies": [],
-      "assigned_executor": null,
-      "required_capabilities": [],
-      "priority": "normal",
       "artifacts": {
-        "items": [],
         "completion_evidence": {
+          "notes": null,
           "policy": "deferred",
-          "status": "deferred",
           "required_artifact_types": [],
+          "status": "deferred",
           "validated_artifact_ids": [],
-          "validation_method": "deferred",
           "validated_at": null,
-          "validator": null,
-          "notes": null
-        }
+          "validation_method": "deferred",
+          "validator": null
+        },
+        "items": []
       },
+      "assigned_executor": null,
+      "child_task_ids": [],
+      "constraints": [],
       "coordination": {
         "linear": null
       },
-      "reconciliation": {
-        "status": "not_required",
-        "active_failure_type": null,
-        "attempts": [],
-        "last_attempt_id": null,
-        "last_pr_url": null,
-        "last_error": null,
-        "resolved_at": null,
-        "failed_at": null
+      "dependencies": [],
+      "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
+      "id": "task-kno-181-scenario-b",
+      "objective": {
+        "deliverable_type": "unspecified",
+        "success_signal": "Task satisfies declared acceptance criteria.",
+        "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
       },
       "observability": {
         "errors": [],
-        "retries": {
-          "attempt_count": 0,
-          "max_attempts": 0,
-          "last_retry_at": null
-        },
         "execution_metadata": {
           "schema_required_deferred_fields": [
             "parent_task_id",
@@ -83,13 +54,42 @@
             "artifacts.completion_evidence",
             "observability"
           ]
+        },
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
         }
-      }
-    },
-    "assigned_executor": {
-      "executor_type": "codex",
-      "executor_id": "executor-kno-181-b",
-      "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof."
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": null,
+        "requested_by": null,
+        "source_id": "req-happy-overlay-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "reconciliation": {
+        "active_failure_type": null,
+        "attempts": [],
+        "failed_at": null,
+        "last_attempt_id": null,
+        "last_error": null,
+        "last_pr_url": null,
+        "resolved_at": null,
+        "status": "not_required"
+      },
+      "required_capabilities": [],
+      "status": "intake_ready",
+      "status_history": [],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-03-31T14:30:00Z",
+        "updated_at": "2026-03-31T14:30:00Z"
+      },
+      "title": "KNO-181 task-kno-181-scenario-b"
     }
   }
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-submit-response.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-submit-response.json
@@ -1,83 +1,48 @@
 {
-  "status": 200,
   "response": {
-    "action": "no_op",
-    "target_status": null,
+    "action": "seeded_controlled_task",
+    "target_status": "assigned",
     "task_envelope": {
-      "id": "task-kno-181-scenario-b",
-      "title": "KNO-181 task-kno-181-scenario-b",
-      "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
-      "origin": {
-        "source_system": "openclaw",
-        "source_type": "ingress_request",
-        "source_id": "req-happy-overlay-1",
-        "ingress_id": null,
-        "ingress_name": null,
-        "requested_by": null
-      },
-      "status": "intake_ready",
-      "timestamps": {
-        "created_at": "2026-03-31T14:30:00Z",
-        "updated_at": "2026-03-31T14:30:00Z",
-        "completed_at": null
-      },
-      "status_history": [],
-      "objective": {
-        "summary": "Exercise /evaluate with top-level evidence overlays.",
-        "deliverable_type": "unspecified",
-        "success_signal": "Task satisfies declared acceptance criteria."
-      },
-      "constraints": [],
       "acceptance_criteria": [
         {
-          "id": "ac-1",
           "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
+          "id": "ac-1",
           "required": true
         }
       ],
-      "parent_task_id": null,
-      "child_task_ids": [],
-      "dependencies": [],
-      "assigned_executor": {
-        "executor_type": "codex",
-        "executor_id": "executor-kno-181-b",
-        "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof."
-      },
-      "required_capabilities": [],
-      "priority": "normal",
       "artifacts": {
-        "items": [],
         "completion_evidence": {
+          "notes": null,
           "policy": "deferred",
-          "status": "deferred",
           "required_artifact_types": [],
+          "status": "deferred",
           "validated_artifact_ids": [],
-          "validation_method": "deferred",
           "validated_at": null,
-          "validator": null,
-          "notes": null
-        }
+          "validation_method": "deferred",
+          "validator": null
+        },
+        "items": []
       },
+      "assigned_executor": {
+        "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof.",
+        "executor_id": "executor-kno-181-b",
+        "executor_type": "codex"
+      },
+      "child_task_ids": [],
+      "constraints": [],
       "coordination": {
         "linear": null
       },
-      "reconciliation": {
-        "status": "not_required",
-        "active_failure_type": null,
-        "attempts": [],
-        "last_attempt_id": null,
-        "last_pr_url": null,
-        "last_error": null,
-        "resolved_at": null,
-        "failed_at": null
+      "dependencies": [],
+      "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
+      "id": "task-kno-181-scenario-b",
+      "objective": {
+        "deliverable_type": "unspecified",
+        "success_signal": "Task satisfies declared acceptance criteria.",
+        "summary": "Scenario B: valid attributable execution attempt with missing PR proof."
       },
       "observability": {
         "errors": [],
-        "retries": {
-          "attempt_count": 0,
-          "max_attempts": 0,
-          "last_retry_at": null
-        },
         "execution_metadata": {
           "schema_required_deferred_fields": [
             "parent_task_id",
@@ -90,548 +55,43 @@
             "artifacts.completion_evidence",
             "observability"
           ]
-        }
-      }
-    },
-    "enforcement_result": {
-      "action": "no_op",
-      "task_envelope": {
-        "id": "task-kno-181-scenario-b",
-        "title": "KNO-181 task-kno-181-scenario-b",
-        "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
-        "origin": {
-          "source_system": "openclaw",
-          "source_type": "ingress_request",
-          "source_id": "req-happy-overlay-1",
-          "ingress_id": null,
-          "ingress_name": null,
-          "requested_by": null
         },
-        "status": "intake_ready",
-        "timestamps": {
-          "created_at": "2026-03-31T14:30:00Z",
-          "updated_at": "2026-03-31T14:30:00Z",
-          "completed_at": null
-        },
-        "status_history": [],
-        "objective": {
-          "summary": "Exercise /evaluate with top-level evidence overlays.",
-          "deliverable_type": "unspecified",
-          "success_signal": "Task satisfies declared acceptance criteria."
-        },
-        "constraints": [],
-        "acceptance_criteria": [
-          {
-            "id": "ac-1",
-            "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-            "required": true
-          }
-        ],
-        "parent_task_id": null,
-        "child_task_ids": [],
-        "dependencies": [],
-        "assigned_executor": {
-          "executor_type": "codex",
-          "executor_id": "executor-kno-181-b",
-          "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof."
-        },
-        "required_capabilities": [],
-        "priority": "normal",
-        "artifacts": {
-          "items": [],
-          "completion_evidence": {
-            "policy": "deferred",
-            "status": "deferred",
-            "required_artifact_types": [],
-            "validated_artifact_ids": [],
-            "validation_method": "deferred",
-            "validated_at": null,
-            "validator": null,
-            "notes": null
-          }
-        },
-        "coordination": {
-          "linear": null
-        },
-        "reconciliation": {
-          "status": "not_required",
-          "active_failure_type": null,
-          "attempts": [],
-          "last_attempt_id": null,
-          "last_pr_url": null,
-          "last_error": null,
-          "resolved_at": null,
-          "failed_at": null
-        },
-        "observability": {
-          "errors": [],
-          "retries": {
-            "attempt_count": 0,
-            "max_attempts": 0,
-            "last_retry_at": null
-          },
-          "execution_metadata": {
-            "schema_required_deferred_fields": [
-              "parent_task_id",
-              "child_task_ids",
-              "dependencies",
-              "assigned_executor",
-              "required_capabilities",
-              "priority",
-              "artifacts.items",
-              "artifacts.completion_evidence",
-              "observability"
-            ]
-          }
-        }
-      },
-      "evidence_result": {
-        "is_valid": true,
-        "is_sufficient": false,
-        "artifact_results": [],
-        "issues": [],
-        "validated_artifact_ids": [],
-        "missing_required_artifact_types": [],
-        "unknown_validated_artifact_ids": []
-      },
-      "reconciliation_result": null,
-      "verification_result": {
-        "task_id": "task-kno-181-scenario-b",
-        "outcome": "verification_deferred",
-        "target_status": null,
-        "claimed_completion": false,
-        "accepted_completion": false,
-        "requires_review": false,
-        "is_terminal": false,
-        "verification_passed": false,
-        "evidence_is_valid": true,
-        "evidence_is_sufficient": false,
-        "reconciliation_status": "pending",
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "failure_classification": {
-          "failure_type": "none",
-          "source": "none",
-          "reason": "No completion claim is currently being evaluated",
-          "terminal": false,
-          "recoverable": false,
-          "category": "none",
-          "retryable": false
-        }
-      },
-      "review_request": null,
-      "review_decision": null,
-      "transition_result": null,
-      "target_status": null,
-      "reasons": [
-        "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-        "No completion claim is currently being evaluated"
-      ],
-      "failure_classification": {
-        "failure_type": "none",
-        "source": "none",
-        "reason": "No completion claim is currently being evaluated",
-        "terminal": false,
-        "recoverable": false,
-        "category": "none",
-        "retryable": false
-      },
-      "error": null
-    },
-    "accepted_completion": false,
-    "requires_review": false,
-    "invalid_input": false,
-    "failure_classification": {
-      "failure_type": "none",
-      "source": "none",
-      "reason": "No completion claim is currently being evaluated",
-      "terminal": false,
-      "recoverable": false,
-      "category": "none",
-      "retryable": false
-    },
-    "reasons": [
-      "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-      "No completion claim is currently being evaluated"
-    ],
-    "error": null,
-    "evaluation_record": {
-      "evaluation_id": "5e90ceee-579d-4795-93e3-26aa0508dfdc",
-      "task_id": "task-kno-181-scenario-b",
-      "recorded_at": "2026-04-05T17:30:31.776247Z",
-      "request": {
-        "task_envelope": {
-          "id": "task-kno-181-scenario-b",
-          "title": "KNO-181 task-kno-181-scenario-b",
-          "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
-          "origin": {
-            "source_system": "openclaw",
-            "source_type": "ingress_request",
-            "source_id": "req-happy-overlay-1",
-            "ingress_id": null,
-            "ingress_name": null,
-            "requested_by": null
-          },
-          "status": "intake_ready",
-          "timestamps": {
-            "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-03-31T14:30:00Z",
-            "completed_at": null
-          },
-          "status_history": [],
-          "objective": {
-            "summary": "Exercise /evaluate with top-level evidence overlays.",
-            "deliverable_type": "unspecified",
-            "success_signal": "Task satisfies declared acceptance criteria."
-          },
-          "constraints": [],
-          "acceptance_criteria": [
-            {
-              "id": "ac-1",
-              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-              "required": true
-            }
-          ],
-          "parent_task_id": null,
-          "child_task_ids": [],
-          "dependencies": [],
-          "assigned_executor": {
-            "executor_type": "codex",
-            "executor_id": "executor-kno-181-b",
-            "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof."
-          },
-          "required_capabilities": [],
-          "priority": "normal",
-          "artifacts": {
-            "items": [],
-            "completion_evidence": {
-              "policy": "deferred",
-              "status": "deferred",
-              "required_artifact_types": [],
-              "validated_artifact_ids": [],
-              "validation_method": "deferred",
-              "validated_at": null,
-              "validator": null,
-              "notes": null
-            }
-          },
-          "coordination": {
-            "linear": null
-          },
-          "reconciliation": {
-            "status": "not_required",
-            "active_failure_type": null,
-            "attempts": [],
-            "last_attempt_id": null,
-            "last_pr_url": null,
-            "last_error": null,
-            "resolved_at": null,
-            "failed_at": null
-          },
-          "observability": {
-            "errors": [],
-            "retries": {
-              "attempt_count": 0,
-              "max_attempts": 0,
-              "last_retry_at": null
-            },
-            "execution_metadata": {
-              "schema_required_deferred_fields": [
-                "parent_task_id",
-                "child_task_ids",
-                "dependencies",
-                "assigned_executor",
-                "required_capabilities",
-                "priority",
-                "artifacts.items",
-                "artifacts.completion_evidence",
-                "observability"
-              ]
-            }
-          }
-        },
-        "external_facts": null,
-        "claimed_completion": false,
-        "acceptance_criteria_satisfied": false,
-        "runtime_facts": {
-          "executor_reported_success": false,
-          "executor_reported_failure": false,
-          "terminal_failure": false,
+        "retries": {
           "attempt_count": 0,
-          "latest_attempt_outcome": null
-        },
-        "unresolved_conditions": [],
-        "review_reasons": [],
-        "review_request": null,
-        "review_decision": null,
-        "review_is_active": false,
-        "retry_context": null
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
       },
-      "result": {
-        "action": "no_op",
-        "target_status": null,
-        "task_envelope": {
-          "id": "task-kno-181-scenario-b",
-          "title": "KNO-181 task-kno-181-scenario-b",
-          "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
-          "origin": {
-            "source_system": "openclaw",
-            "source_type": "ingress_request",
-            "source_id": "req-happy-overlay-1",
-            "ingress_id": null,
-            "ingress_name": null,
-            "requested_by": null
-          },
-          "status": "intake_ready",
-          "timestamps": {
-            "created_at": "2026-03-31T14:30:00Z",
-            "updated_at": "2026-03-31T14:30:00Z",
-            "completed_at": null
-          },
-          "status_history": [],
-          "objective": {
-            "summary": "Exercise /evaluate with top-level evidence overlays.",
-            "deliverable_type": "unspecified",
-            "success_signal": "Task satisfies declared acceptance criteria."
-          },
-          "constraints": [],
-          "acceptance_criteria": [
-            {
-              "id": "ac-1",
-              "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-              "required": true
-            }
-          ],
-          "parent_task_id": null,
-          "child_task_ids": [],
-          "dependencies": [],
-          "assigned_executor": {
-            "executor_type": "codex",
-            "executor_id": "executor-kno-181-b",
-            "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof."
-          },
-          "required_capabilities": [],
-          "priority": "normal",
-          "artifacts": {
-            "items": [],
-            "completion_evidence": {
-              "policy": "deferred",
-              "status": "deferred",
-              "required_artifact_types": [],
-              "validated_artifact_ids": [],
-              "validation_method": "deferred",
-              "validated_at": null,
-              "validator": null,
-              "notes": null
-            }
-          },
-          "coordination": {
-            "linear": null
-          },
-          "reconciliation": {
-            "status": "not_required",
-            "active_failure_type": null,
-            "attempts": [],
-            "last_attempt_id": null,
-            "last_pr_url": null,
-            "last_error": null,
-            "resolved_at": null,
-            "failed_at": null
-          },
-          "observability": {
-            "errors": [],
-            "retries": {
-              "attempt_count": 0,
-              "max_attempts": 0,
-              "last_retry_at": null
-            },
-            "execution_metadata": {
-              "schema_required_deferred_fields": [
-                "parent_task_id",
-                "child_task_ids",
-                "dependencies",
-                "assigned_executor",
-                "required_capabilities",
-                "priority",
-                "artifacts.items",
-                "artifacts.completion_evidence",
-                "observability"
-              ]
-            }
-          }
-        },
-        "enforcement_result": {
-          "action": "no_op",
-          "task_envelope": {
-            "id": "task-kno-181-scenario-b",
-            "title": "KNO-181 task-kno-181-scenario-b",
-            "description": "Scenario B: valid attributable execution attempt with missing PR proof.",
-            "origin": {
-              "source_system": "openclaw",
-              "source_type": "ingress_request",
-              "source_id": "req-happy-overlay-1",
-              "ingress_id": null,
-              "ingress_name": null,
-              "requested_by": null
-            },
-            "status": "intake_ready",
-            "timestamps": {
-              "created_at": "2026-03-31T14:30:00Z",
-              "updated_at": "2026-03-31T14:30:00Z",
-              "completed_at": null
-            },
-            "status_history": [],
-            "objective": {
-              "summary": "Exercise /evaluate with top-level evidence overlays.",
-              "deliverable_type": "unspecified",
-              "success_signal": "Task satisfies declared acceptance criteria."
-            },
-            "constraints": [],
-            "acceptance_criteria": [
-              {
-                "id": "ac-1",
-                "description": "Harness accepts a fully reconciled, evidence-backed completion claim.",
-                "required": true
-              }
-            ],
-            "parent_task_id": null,
-            "child_task_ids": [],
-            "dependencies": [],
-            "assigned_executor": {
-              "executor_type": "codex",
-              "executor_id": "executor-kno-181-b",
-              "assignment_reason": "Scenario B: valid attributable execution attempt with missing PR proof."
-            },
-            "required_capabilities": [],
-            "priority": "normal",
-            "artifacts": {
-              "items": [],
-              "completion_evidence": {
-                "policy": "deferred",
-                "status": "deferred",
-                "required_artifact_types": [],
-                "validated_artifact_ids": [],
-                "validation_method": "deferred",
-                "validated_at": null,
-                "validator": null,
-                "notes": null
-              }
-            },
-            "coordination": {
-              "linear": null
-            },
-            "reconciliation": {
-              "status": "not_required",
-              "active_failure_type": null,
-              "attempts": [],
-              "last_attempt_id": null,
-              "last_pr_url": null,
-              "last_error": null,
-              "resolved_at": null,
-              "failed_at": null
-            },
-            "observability": {
-              "errors": [],
-              "retries": {
-                "attempt_count": 0,
-                "max_attempts": 0,
-                "last_retry_at": null
-              },
-              "execution_metadata": {
-                "schema_required_deferred_fields": [
-                  "parent_task_id",
-                  "child_task_ids",
-                  "dependencies",
-                  "assigned_executor",
-                  "required_capabilities",
-                  "priority",
-                  "artifacts.items",
-                  "artifacts.completion_evidence",
-                  "observability"
-                ]
-              }
-            }
-          },
-          "evidence_result": {
-            "is_valid": true,
-            "is_sufficient": false,
-            "artifact_results": [],
-            "issues": [],
-            "validated_artifact_ids": [],
-            "missing_required_artifact_types": [],
-            "unknown_validated_artifact_ids": []
-          },
-          "reconciliation_result": null,
-          "verification_result": {
-            "task_id": "task-kno-181-scenario-b",
-            "outcome": "verification_deferred",
-            "target_status": null,
-            "claimed_completion": false,
-            "accepted_completion": false,
-            "requires_review": false,
-            "is_terminal": false,
-            "verification_passed": false,
-            "evidence_is_valid": true,
-            "evidence_is_sufficient": false,
-            "reconciliation_status": "pending",
-            "reasons": [
-              "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-              "No completion claim is currently being evaluated"
-            ],
-            "failure_classification": {
-              "failure_type": "none",
-              "source": "none",
-              "reason": "No completion claim is currently being evaluated",
-              "terminal": false,
-              "recoverable": false,
-              "category": "none",
-              "retryable": false
-            }
-          },
-          "review_request": null,
-          "review_decision": null,
-          "transition_result": null,
-          "target_status": null,
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "failure_classification": {
-            "failure_type": "none",
-            "source": "none",
-            "reason": "No completion claim is currently being evaluated",
-            "terminal": false,
-            "recoverable": false,
-            "category": "none",
-            "retryable": false
-          },
-          "error": null
-        },
-        "accepted_completion": false,
-        "requires_review": false,
-        "invalid_input": false,
-        "failure_classification": {
-          "failure_type": "none",
-          "source": "none",
-          "reason": "No completion claim is currently being evaluated",
-          "terminal": false,
-          "recoverable": false,
-          "category": "none",
-          "retryable": false
-        },
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "error": null
-      }
-    },
-    "automatic_dispatch": {
-      "attempted": false,
-      "dispatchable": false,
-      "reason": "status=intake_ready is not auto-dispatch eligible"
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": null,
+        "requested_by": null,
+        "source_id": "req-happy-overlay-1",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "reconciliation": {
+        "active_failure_type": null,
+        "attempts": [],
+        "failed_at": null,
+        "last_attempt_id": null,
+        "last_error": null,
+        "last_pr_url": null,
+        "resolved_at": null,
+        "status": "not_required"
+      },
+      "required_capabilities": [],
+      "status": "assigned",
+      "status_history": [],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-03-31T14:30:00Z",
+        "updated_at": "2026-03-31T14:30:00Z"
+      },
+      "title": "KNO-181 task-kno-181-scenario-b"
     }
-  }
+  },
+  "status": 200
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-timeline-final.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-timeline-final.json
@@ -1,17 +1,10 @@
 {
-  "task_id": "task-kno-181-scenario-b",
   "current_status": "in_review",
-  "event_count": 7,
+  "event_count": 9,
+  "task_id": "task-kno-181-scenario-b",
   "timeline": [
     {
-      "event_id": "task-kno-181-scenario-b:created",
-      "event_type": "task_created",
-      "occurred_at": "2026-03-31T14:30:00Z",
-      "summary": "Task created",
-      "source": "openclaw",
       "details": {
-        "status": "in_review",
-        "title": "KNO-181 task-kno-181-scenario-b",
         "origin": {
           "ingress_id": null,
           "ingress_name": null,
@@ -19,39 +12,18 @@
           "source_id": "req-happy-overlay-1",
           "source_system": "openclaw",
           "source_type": "ingress_request"
-        }
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-b:execution_artifact:attempt-kno-181-b-1:attempt-kno-181-b-1:commit",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-01T08:00:05Z",
-      "summary": "Execution artifact attached: commit",
-      "source": "stub-executor",
-      "details": {
-        "artifact_type": "commit",
-        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-        "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-        "metadata": {
-          "branch_name": "codex/e2e-test",
-          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
-          "repository_host": "github.com",
-          "repository_name": "HARNESS-DRYRUN",
-          "repository_owner": "KnoxAnalytics"
         },
-        "reference_id": "attempt-kno-181-b-1:commit"
-      }
+        "status": "in_review",
+        "title": "KNO-181 task-kno-181-scenario-b"
+      },
+      "event_id": "task-kno-181-scenario-b:created",
+      "event_type": "task_created",
+      "occurred_at": "2026-03-31T14:30:00Z",
+      "source": "openclaw",
+      "summary": "Task created"
     },
     {
-      "event_id": "task-kno-181-scenario-b:execution_attempt:attempt-kno-181-b-1",
-      "event_type": "execution_attempt_recorded",
-      "occurred_at": "2026-04-01T08:00:05Z",
-      "summary": "Execution attempt recorded: attempt-kno-181-b-1",
-      "source": "stub-executor",
       "details": {
-        "attempt_id": "attempt-kno-181-b-1",
-        "status": "succeeded",
-        "completion_claim_id": "claim-kno-181-b-1",
         "artifact_references": [
           {
             "artifact_type": "commit",
@@ -67,6 +39,7 @@
             "reference_id": "attempt-kno-181-b-1:commit"
           }
         ],
+        "attempt_id": "attempt-kno-181-b-1",
         "attempt_validation": {
           "context_observations": {
             "branch": [
@@ -85,6 +58,8 @@
                 "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
               }
             ],
+            "commit_resolution_pending": false,
+            "has_valid_current_run_pull_request_artifact": false,
             "repository": [
               {
                 "sources": [
@@ -96,92 +71,77 @@
             "used_task_artifact_fallback": false
           },
           "policy": {
+            "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [],
           "retryable": false,
+          "rule_failures": [],
           "status": "valid",
-          "validated_at": "2026-04-05T17:30:31.786474Z",
+          "validated_at": "2026-04-11T16:04:28.890189Z",
           "validated_by": "execution_validation"
         },
-        "reevaluation": {}
-      }
+        "completion_claim_id": "claim-kno-181-b-1",
+        "reevaluation": {},
+        "status": "succeeded"
+      },
+      "event_id": "task-kno-181-scenario-b:execution_attempt:attempt-kno-181-b-1",
+      "event_type": "execution_attempt_recorded",
+      "occurred_at": "2026-04-01T08:00:05Z",
+      "source": "stub-executor",
+      "summary": "Execution attempt recorded: attempt-kno-181-b-1"
     },
     {
-      "event_id": "task-kno-181-scenario-b:evaluation:5e90ceee-579d-4795-93e3-26aa0508dfdc",
-      "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-05T17:30:31.776247Z",
-      "summary": "Evaluation recorded: no_op",
-      "source": "harness",
       "details": {
-        "evaluation_id": "5e90ceee-579d-4795-93e3-26aa0508dfdc",
-        "action": "no_op",
-        "target_status": null,
-        "accepted_completion": false,
-        "requires_review": false,
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "verification_result": {
-          "accepted_completion": false,
-          "claimed_completion": false,
-          "evidence_is_sufficient": false,
-          "evidence_is_valid": true,
-          "failure_classification": {
-            "category": "none",
-            "failure_type": "none",
-            "reason": "No completion claim is currently being evaluated",
-            "recoverable": false,
-            "retryable": false,
-            "source": "none",
-            "terminal": false
-          },
-          "is_terminal": false,
-          "outcome": "verification_deferred",
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "reconciliation_status": "pending",
-          "requires_review": false,
-          "target_status": null,
-          "task_id": "task-kno-181-scenario-b",
-          "verification_passed": false
+        "artifact_type": "commit",
+        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+        "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+        "metadata": {
+          "branch_name": "codex/e2e-test",
+          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+          "repository_host": "github.com",
+          "repository_name": "HARNESS-DRYRUN",
+          "repository_owner": "KnoxAnalytics"
         },
-        "reconciliation_result": null
-      }
+        "reference_id": "attempt-kno-181-b-1:commit"
+      },
+      "event_id": "task-kno-181-scenario-b:execution_artifact:attempt-kno-181-b-1:attempt-kno-181-b-1:commit",
+      "event_type": "execution_artifact_attached",
+      "occurred_at": "2026-04-01T08:00:05Z",
+      "source": "stub-executor",
+      "summary": "Execution artifact attached: commit"
     },
     {
-      "event_id": "task-kno-181-scenario-b:status:0",
-      "event_type": "status_transition",
-      "occurred_at": "2026-04-05T17:30:31.815978Z",
-      "summary": "Status changed intake_ready -> reconciling",
-      "source": "reconciliation",
       "details": {
-        "changed_at": "2026-04-05T17:30:31.815978Z",
+        "changed_at": "2026-04-11T16:04:28.892367Z",
         "changed_by": "reconciliation",
-        "from_status": "intake_ready",
+        "from_status": "assigned",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
-      }
+      },
+      "event_id": "task-kno-181-scenario-b:status:0",
+      "event_type": "status_transition",
+      "occurred_at": "2026-04-11T16:04:28.892367Z",
+      "source": "reconciliation",
+      "summary": "Status changed assigned -> reconciling"
     },
     {
-      "event_id": "task-kno-181-scenario-b:reconciliation:reconciliation-attempt-1",
-      "event_type": "reconciliation_attempt_recorded",
-      "occurred_at": "2026-04-05T17:30:31.846841Z",
-      "summary": "Reconciliation attempt: missing_pr_after_execution",
-      "source": "reconciliation",
       "details": {
         "attempt_id": "reconciliation-attempt-1",
-        "completed_at": "2026-04-05T17:30:31.846841Z",
+        "completed_at": "2026-04-11T16:04:28.894572Z",
         "details": {
           "base_branch": null,
           "branch_exists": true,
+          "branch_head_commit_sha": null,
           "branch_name": "codex/e2e-test",
           "commit_exists": true,
           "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
@@ -200,7 +160,8 @@
             }
           },
           "created_pull_request": false,
-          "error": "PR creation intentionally disabled for deterministic local demo proof",
+          "created_pull_request_revalidated": false,
+          "error": "PR creation intentionally disabled for deterministic tests",
           "error_disposition": "review_required",
           "final_decision": {
             "reason": "all_candidates_rejected_or_absent",
@@ -209,10 +170,13 @@
           "policy": {
             "allow_closed_pr_match": false,
             "allow_commit_association_match": true,
+            "allow_non_head_commit_association_match": false,
             "allow_open_pr_match": true,
             "escalate_on_ambiguous_match": true,
             "require_exact_branch_match": true,
             "require_head_sha_match": true,
+            "require_run_linkage_for_commit_association": true,
+            "require_run_linkage_for_multiple_attempts": true,
             "require_task_linkage": false
           },
           "pull_request_candidates": [],
@@ -235,23 +199,107 @@
         },
         "failure_type": "missing_pr_after_execution",
         "handler_key": "missing_pr_after_execution",
-        "started_at": "2026-04-05T17:30:31.845905Z",
+        "started_at": "2026-04-11T16:04:28.894440Z",
         "status": "failed"
-      }
+      },
+      "event_id": "task-kno-181-scenario-b:reconciliation:reconciliation-attempt-1",
+      "event_type": "reconciliation_attempt_recorded",
+      "occurred_at": "2026-04-11T16:04:28.894572Z",
+      "source": "reconciliation",
+      "summary": "Reconciliation attempt: missing_pr_after_execution"
     },
     {
-      "event_id": "task-kno-181-scenario-b:status:1",
-      "event_type": "status_transition",
-      "occurred_at": "2026-04-05T17:30:31.878104Z",
-      "summary": "Status changed reconciling -> in_review",
-      "source": "reconciliation",
       "details": {
-        "changed_at": "2026-04-05T17:30:31.878104Z",
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "reason": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+        "requested_at": "2026-04-11T16:04:28.896456Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-181-scenario-b-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: PR creation intentionally disabled for deterministic tests",
+        "task_id": "task-kno-181-scenario-b",
+        "trigger": "reconciliation"
+      },
+      "event_id": "task-kno-181-scenario-b:review-request:review-request-task-kno-181-scenario-b-reconciliation-1",
+      "event_type": "review_requested",
+      "occurred_at": "2026-04-11T16:04:28.896456Z",
+      "source": "reconciliation",
+      "summary": "Manual review requested"
+    },
+    {
+      "details": {
+        "changed_at": "2026-04-11T16:04:28.896456Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
-        "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic local demo proof",
+        "reason": "Post-execution reconciliation failed: PR creation intentionally disabled for deterministic tests",
         "to_status": "in_review"
-      }
+      },
+      "event_id": "task-kno-181-scenario-b:status:1",
+      "event_type": "status_transition",
+      "occurred_at": "2026-04-11T16:04:28.896456Z",
+      "source": "reconciliation",
+      "summary": "Status changed reconciling -> in_review"
+    },
+    {
+      "details": {
+        "accepted_completion": false,
+        "action": "review_required",
+        "evaluation_id": "af982558-3013-4b15-9032-d71d985469f8",
+        "reasons": [
+          "PR creation intentionally disabled for deterministic tests"
+        ],
+        "reconciliation_result": {
+          "blocking": true,
+          "mismatch_categories": [
+            "missing_required_artifact"
+          ],
+          "outcome": "review_required",
+          "reasons": [
+            "PR creation intentionally disabled for deterministic tests"
+          ],
+          "status": "review_required",
+          "task_id": "task-kno-181-scenario-b",
+          "terminal": false
+        },
+        "requires_review": true,
+        "target_status": "in_review",
+        "verification_result": null
+      },
+      "event_id": "task-kno-181-scenario-b:evaluation:af982558-3013-4b15-9032-d71d985469f8",
+      "event_type": "evaluation_recorded",
+      "occurred_at": "2026-04-11T16:04:28.898575Z",
+      "source": "harness",
+      "summary": "Evaluation recorded: review_required"
+    },
+    {
+      "details": {
+        "failure_reason": "PR creation intentionally disabled for deterministic tests",
+        "failure_recorded": true,
+        "failure_source": "evaluation",
+        "failure_type": "review_required",
+        "recoverable": false,
+        "terminal": false
+      },
+      "event_id": "task-kno-181-scenario-b:failure:af982558-3013-4b15-9032-d71d985469f8",
+      "event_type": "failure_recorded",
+      "occurred_at": "2026-04-11T16:04:28.898575Z",
+      "source": "evaluation",
+      "summary": "Failure recorded: review_required"
     }
   ]
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-timeline-initial.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/scenario-b-timeline-initial.json
@@ -1,17 +1,10 @@
 {
+  "current_status": "assigned",
+  "event_count": 1,
   "task_id": "task-kno-181-scenario-b",
-  "current_status": "intake_ready",
-  "event_count": 2,
   "timeline": [
     {
-      "event_id": "task-kno-181-scenario-b:created",
-      "event_type": "task_created",
-      "occurred_at": "2026-03-31T14:30:00Z",
-      "summary": "Task created",
-      "source": "openclaw",
       "details": {
-        "status": "intake_ready",
-        "title": "KNO-181 task-kno-181-scenario-b",
         "origin": {
           "ingress_id": null,
           "ingress_name": null,
@@ -19,53 +12,15 @@
           "source_id": "req-happy-overlay-1",
           "source_system": "openclaw",
           "source_type": "ingress_request"
-        }
-      }
-    },
-    {
-      "event_id": "task-kno-181-scenario-b:evaluation:5e90ceee-579d-4795-93e3-26aa0508dfdc",
-      "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-05T17:30:31.776247Z",
-      "summary": "Evaluation recorded: no_op",
-      "source": "harness",
-      "details": {
-        "evaluation_id": "5e90ceee-579d-4795-93e3-26aa0508dfdc",
-        "action": "no_op",
-        "target_status": null,
-        "accepted_completion": false,
-        "requires_review": false,
-        "reasons": [
-          "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-          "No completion claim is currently being evaluated"
-        ],
-        "verification_result": {
-          "accepted_completion": false,
-          "claimed_completion": false,
-          "evidence_is_sufficient": false,
-          "evidence_is_valid": true,
-          "failure_classification": {
-            "category": "none",
-            "failure_type": "none",
-            "reason": "No completion claim is currently being evaluated",
-            "recoverable": false,
-            "retryable": false,
-            "source": "none",
-            "terminal": false
-          },
-          "is_terminal": false,
-          "outcome": "verification_deferred",
-          "reasons": [
-            "Verification evaluated task 'task-kno-181-scenario-b' against canonical completion policy",
-            "No completion claim is currently being evaluated"
-          ],
-          "reconciliation_status": "pending",
-          "requires_review": false,
-          "target_status": null,
-          "task_id": "task-kno-181-scenario-b",
-          "verification_passed": false
         },
-        "reconciliation_result": null
-      }
+        "status": "assigned",
+        "title": "KNO-181 task-kno-181-scenario-b"
+      },
+      "event_id": "task-kno-181-scenario-b:created",
+      "event_type": "task_created",
+      "occurred_at": "2026-03-31T14:30:00Z",
+      "source": "openclaw",
+      "summary": "Task created"
     }
   ]
 }

--- a/docs/demo/kno-181-invalid-execution-attempt-gate/summary.json
+++ b/docs/demo/kno-181-invalid-execution-attempt-gate/summary.json
@@ -1,0 +1,39 @@
+{
+  "execution_mode": "local-controlled",
+  "hosted_validation": "not_performed",
+  "overall": {
+    "all_scenarios_passed": true,
+    "conclusion": "validated"
+  },
+  "proof_name": "kno-181-invalid-execution-attempt-gate",
+  "scenarios": [
+    {
+      "all_checks_passed": true,
+      "checks": {
+        "action_contract_violation_failed": true,
+        "claim_http_200": true,
+        "history_http_200": true,
+        "invalid_execution_attempt_present": true,
+        "read_model_http_200": true,
+        "task_failed": true,
+        "timeline_http_200": true
+      },
+      "scenario": "a"
+    },
+    {
+      "all_checks_passed": true,
+      "checks": {
+        "action_reconciliation_failed": true,
+        "claim_http_200": true,
+        "history_http_200": true,
+        "read_model_assignment_hidden": true,
+        "read_model_http_200": true,
+        "read_model_review_requested": true,
+        "review_request_present": true,
+        "task_in_review": true,
+        "timeline_http_200": true
+      },
+      "scenario": "b"
+    }
+  ]
+}

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-a-completion-claim-response.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-a-completion-claim-response.json
@@ -124,7 +124,7 @@
               "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
               "name": "codex/e2e-test"
             },
-            "captured_at": "2026-04-06T13:58:02.001833Z",
+            "captured_at": "2026-04-11T16:04:28.873866Z",
             "changed_files": [],
             "commit_sha": null,
             "content_type": null,
@@ -157,11 +157,7 @@
           }
         ]
       },
-      "assigned_executor": {
-        "assignment_reason": "Runtime coverage for reconciliation.",
-        "executor_id": "executor-1",
-        "executor_type": "codex"
-      },
+      "assigned_executor": null,
       "child_task_ids": [],
       "constraints": [],
       "coordination": {
@@ -170,7 +166,7 @@
           "issue_key": "HAR-1",
           "project": null,
           "provenance": {
-            "linked_at": "2026-04-06T13:58:01.973948Z",
+            "linked_at": "2026-04-11T16:04:28.867556Z",
             "linked_by": "reevaluation",
             "source": "completion_claim.external_facts"
           },
@@ -239,6 +235,8 @@
                         "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                       }
                     ],
+                    "commit_resolution_pending": false,
+                    "has_valid_current_run_pull_request_artifact": false,
                     "repository": [
                       {
                         "sources": [
@@ -251,16 +249,23 @@
                     "used_task_artifact_fallback": false
                   },
                   "policy": {
+                    "allow_commit_resolution_via_reconciliation": true,
+                    "allow_missing_commit_artifact_with_verified_pull_request": true,
                     "allow_missing_pull_request": true,
+                    "reject_closed_or_historical_pull_request": true,
+                    "reject_non_numeric_pull_request_url": true,
+                    "reject_reserved_shared_branch": true,
                     "require_commit": true,
                     "require_exact_branch": true,
                     "require_repository": true,
                     "task_artifact_fallback_requires_single_attempt": true
                   },
+                  "pull_request_observations": [],
                   "reasons": [],
                   "retryable": false,
+                  "rule_failures": [],
                   "status": "valid",
-                  "validated_at": "2026-04-06T13:58:01.974132Z",
+                  "validated_at": "2026-04-11T16:04:28.867699Z",
                   "validated_by": "execution_validation"
                 },
                 "executor_run_id": "run-claim-kno-183-a"
@@ -304,16 +309,17 @@
         "attempts": [
           {
             "attempt_id": "reconciliation-attempt-1",
-            "completed_at": "2026-04-06T13:58:02.001833Z",
+            "completed_at": "2026-04-11T16:04:28.873866Z",
             "details": {
               "base_branch": "main",
               "branch_exists": true,
+              "branch_head_commit_sha": null,
               "branch_name": "codex/e2e-test",
               "commit_exists": true,
               "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
               "context_resolution": {
                 "conflicts": [],
-                "selected_source": "external_facts",
+                "selected_source": "merged",
                 "sources": {
                   "artifacts": {
                     "base_branch": "main",
@@ -344,6 +350,7 @@
               "policy": {
                 "allow_closed_pr_match": false,
                 "allow_commit_association_match": true,
+                "allow_non_head_commit_association_match": false,
                 "allow_open_pr_match": true,
                 "escalate_on_ambiguous_match": true,
                 "require_exact_branch_match": true,
@@ -517,7 +524,7 @@
             },
             "failure_type": "missing_pr_after_execution",
             "handler_key": "missing_pr_after_execution",
-            "started_at": "2026-04-06T13:58:02.001274Z",
+            "started_at": "2026-04-11T16:04:28.873649Z",
             "status": "resolved"
           }
         ],
@@ -525,21 +532,21 @@
         "last_attempt_id": "reconciliation-attempt-1",
         "last_error": null,
         "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/631",
-        "resolved_at": "2026-04-06T13:58:02.001833Z",
+        "resolved_at": "2026-04-11T16:04:28.873866Z",
         "status": "resolved"
       },
       "required_capabilities": [],
       "status": "completed",
       "status_history": [
         {
-          "changed_at": "2026-04-06T13:58:01.988300Z",
+          "changed_at": "2026-04-11T16:04:28.871447Z",
           "changed_by": "reconciliation",
           "from_status": "executing",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
           "to_status": "reconciling"
         },
         {
-          "changed_at": "2026-04-06T13:58:02.087201Z",
+          "changed_at": "2026-04-11T16:04:28.888997Z",
           "changed_by": "verification",
           "from_status": "reconciling",
           "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -547,19 +554,19 @@
         }
       ],
       "timestamps": {
-        "completed_at": "2026-04-06T13:58:02.087201Z",
+        "completed_at": "2026-04-11T16:04:28.888997Z",
         "created_at": "2026-04-04T12:00:00Z",
-        "updated_at": "2026-04-06T13:58:02.087201Z"
+        "updated_at": "2026-04-11T16:04:28.888997Z"
       },
       "title": "Reconcile missing pull request"
     },
     "transition_result": {
       "actor": "verification",
-      "changed_at": "2026-04-06T13:58:02.087201Z",
+      "changed_at": "2026-04-11T16:04:28.888997Z",
       "from_status": "reconciling",
       "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
       "status_history_entry": {
-        "changed_at": "2026-04-06T13:58:02.087201Z",
+        "changed_at": "2026-04-11T16:04:28.888997Z",
         "changed_by": "verification",
         "from_status": "reconciling",
         "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -634,7 +641,7 @@
                 "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                 "name": "codex/e2e-test"
               },
-              "captured_at": "2026-04-06T13:58:02.001833Z",
+              "captured_at": "2026-04-11T16:04:28.873866Z",
               "changed_files": [],
               "commit_sha": null,
               "content_type": null,
@@ -667,11 +674,7 @@
             }
           ]
         },
-        "assigned_executor": {
-          "assignment_reason": "Runtime coverage for reconciliation.",
-          "executor_id": "executor-1",
-          "executor_type": "codex"
-        },
+        "assigned_executor": null,
         "child_task_ids": [],
         "constraints": [],
         "coordination": {
@@ -680,7 +683,7 @@
             "issue_key": "HAR-1",
             "project": null,
             "provenance": {
-              "linked_at": "2026-04-06T13:58:01.973948Z",
+              "linked_at": "2026-04-11T16:04:28.867556Z",
               "linked_by": "reevaluation",
               "source": "completion_claim.external_facts"
             },
@@ -749,6 +752,8 @@
                           "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                         }
                       ],
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
                       "repository": [
                         {
                           "sources": [
@@ -761,16 +766,23 @@
                       "used_task_artifact_fallback": false
                     },
                     "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
                       "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
                       "require_commit": true,
                       "require_exact_branch": true,
                       "require_repository": true,
                       "task_artifact_fallback_requires_single_attempt": true
                     },
+                    "pull_request_observations": [],
                     "reasons": [],
                     "retryable": false,
+                    "rule_failures": [],
                     "status": "valid",
-                    "validated_at": "2026-04-06T13:58:01.974132Z",
+                    "validated_at": "2026-04-11T16:04:28.867699Z",
                     "validated_by": "execution_validation"
                   },
                   "executor_run_id": "run-claim-kno-183-a"
@@ -814,16 +826,17 @@
           "attempts": [
             {
               "attempt_id": "reconciliation-attempt-1",
-              "completed_at": "2026-04-06T13:58:02.001833Z",
+              "completed_at": "2026-04-11T16:04:28.873866Z",
               "details": {
                 "base_branch": "main",
                 "branch_exists": true,
+                "branch_head_commit_sha": null,
                 "branch_name": "codex/e2e-test",
                 "commit_exists": true,
                 "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                 "context_resolution": {
                   "conflicts": [],
-                  "selected_source": "external_facts",
+                  "selected_source": "merged",
                   "sources": {
                     "artifacts": {
                       "base_branch": "main",
@@ -854,6 +867,7 @@
                 "policy": {
                   "allow_closed_pr_match": false,
                   "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
                   "allow_open_pr_match": true,
                   "escalate_on_ambiguous_match": true,
                   "require_exact_branch_match": true,
@@ -1027,7 +1041,7 @@
               },
               "failure_type": "missing_pr_after_execution",
               "handler_key": "missing_pr_after_execution",
-              "started_at": "2026-04-06T13:58:02.001274Z",
+              "started_at": "2026-04-11T16:04:28.873649Z",
               "status": "resolved"
             }
           ],
@@ -1035,21 +1049,21 @@
           "last_attempt_id": "reconciliation-attempt-1",
           "last_error": null,
           "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/631",
-          "resolved_at": "2026-04-06T13:58:02.001833Z",
+          "resolved_at": "2026-04-11T16:04:28.873866Z",
           "status": "resolved"
         },
         "required_capabilities": [],
         "status": "completed",
         "status_history": [
           {
-            "changed_at": "2026-04-06T13:58:01.988300Z",
+            "changed_at": "2026-04-11T16:04:28.871447Z",
             "changed_by": "reconciliation",
             "from_status": "executing",
             "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
             "to_status": "reconciling"
           },
           {
-            "changed_at": "2026-04-06T13:58:02.087201Z",
+            "changed_at": "2026-04-11T16:04:28.888997Z",
             "changed_by": "verification",
             "from_status": "reconciling",
             "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -1057,15 +1071,22 @@
           }
         ],
         "timestamps": {
-          "completed_at": "2026-04-06T13:58:02.087201Z",
+          "completed_at": "2026-04-11T16:04:28.888997Z",
           "created_at": "2026-04-04T12:00:00Z",
-          "updated_at": "2026-04-06T13:58:02.087201Z"
+          "updated_at": "2026-04-11T16:04:28.888997Z"
         },
         "title": "Reconcile missing pull request"
       },
       "to_status": "completed"
     },
     "verification_result": {
+      "acceptance_criteria_assessment": {
+        "automatic_completion_safe": true,
+        "concrete_required_criteria_count": 1,
+        "flagged_criteria": [],
+        "reasons": [],
+        "required_criteria_count": 1
+      },
       "accepted_completion": true,
       "claimed_completion": true,
       "evidence_is_sufficient": true,
@@ -1095,8 +1116,8 @@
   },
   "error": null,
   "evaluation_record": {
-    "evaluation_id": "9c94d069-2010-4981-9a73-5c01b787c328",
-    "recorded_at": "2026-04-06T13:58:02.105513Z",
+    "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
+    "recorded_at": "2026-04-11T16:04:28.895854Z",
     "request": {
       "acceptance_criteria_satisfied": true,
       "claimed_completion": true,
@@ -1233,7 +1254,7 @@
                 "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                 "name": "codex/e2e-test"
               },
-              "captured_at": "2026-04-06T13:58:02.001833Z",
+              "captured_at": "2026-04-11T16:04:28.873866Z",
               "changed_files": [],
               "commit_sha": null,
               "content_type": null,
@@ -1279,7 +1300,7 @@
             "issue_key": "HAR-1",
             "project": null,
             "provenance": {
-              "linked_at": "2026-04-06T13:58:01.973948Z",
+              "linked_at": "2026-04-11T16:04:28.867556Z",
               "linked_by": "reevaluation",
               "source": "completion_claim.external_facts"
             },
@@ -1348,6 +1369,8 @@
                           "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                         }
                       ],
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
                       "repository": [
                         {
                           "sources": [
@@ -1360,16 +1383,23 @@
                       "used_task_artifact_fallback": false
                     },
                     "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
                       "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
                       "require_commit": true,
                       "require_exact_branch": true,
                       "require_repository": true,
                       "task_artifact_fallback_requires_single_attempt": true
                     },
+                    "pull_request_observations": [],
                     "reasons": [],
                     "retryable": false,
+                    "rule_failures": [],
                     "status": "valid",
-                    "validated_at": "2026-04-06T13:58:01.974132Z",
+                    "validated_at": "2026-04-11T16:04:28.867699Z",
                     "validated_by": "execution_validation"
                   },
                   "executor_run_id": "run-claim-kno-183-a"
@@ -1413,16 +1443,17 @@
           "attempts": [
             {
               "attempt_id": "reconciliation-attempt-1",
-              "completed_at": "2026-04-06T13:58:02.001833Z",
+              "completed_at": "2026-04-11T16:04:28.873866Z",
               "details": {
                 "base_branch": "main",
                 "branch_exists": true,
+                "branch_head_commit_sha": null,
                 "branch_name": "codex/e2e-test",
                 "commit_exists": true,
                 "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                 "context_resolution": {
                   "conflicts": [],
-                  "selected_source": "external_facts",
+                  "selected_source": "merged",
                   "sources": {
                     "artifacts": {
                       "base_branch": "main",
@@ -1453,6 +1484,7 @@
                 "policy": {
                   "allow_closed_pr_match": false,
                   "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
                   "allow_open_pr_match": true,
                   "escalate_on_ambiguous_match": true,
                   "require_exact_branch_match": true,
@@ -1626,7 +1658,7 @@
               },
               "failure_type": "missing_pr_after_execution",
               "handler_key": "missing_pr_after_execution",
-              "started_at": "2026-04-06T13:58:02.001274Z",
+              "started_at": "2026-04-11T16:04:28.873649Z",
               "status": "resolved"
             }
           ],
@@ -1634,14 +1666,14 @@
           "last_attempt_id": "reconciliation-attempt-1",
           "last_error": null,
           "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/631",
-          "resolved_at": "2026-04-06T13:58:02.001833Z",
+          "resolved_at": "2026-04-11T16:04:28.873866Z",
           "status": "resolved"
         },
         "required_capabilities": [],
         "status": "reconciling",
         "status_history": [
           {
-            "changed_at": "2026-04-06T13:58:01.988300Z",
+            "changed_at": "2026-04-11T16:04:28.871447Z",
             "changed_by": "reconciliation",
             "from_status": "executing",
             "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -1651,7 +1683,7 @@
         "timestamps": {
           "completed_at": null,
           "created_at": "2026-04-04T12:00:00Z",
-          "updated_at": "2026-04-06T13:58:02.001833Z"
+          "updated_at": "2026-04-11T16:04:28.873866Z"
         },
         "title": "Reconcile missing pull request"
       },
@@ -1783,7 +1815,7 @@
                   "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                   "name": "codex/e2e-test"
                 },
-                "captured_at": "2026-04-06T13:58:02.001833Z",
+                "captured_at": "2026-04-11T16:04:28.873866Z",
                 "changed_files": [],
                 "commit_sha": null,
                 "content_type": null,
@@ -1816,11 +1848,7 @@
               }
             ]
           },
-          "assigned_executor": {
-            "assignment_reason": "Runtime coverage for reconciliation.",
-            "executor_id": "executor-1",
-            "executor_type": "codex"
-          },
+          "assigned_executor": null,
           "child_task_ids": [],
           "constraints": [],
           "coordination": {
@@ -1829,7 +1857,7 @@
               "issue_key": "HAR-1",
               "project": null,
               "provenance": {
-                "linked_at": "2026-04-06T13:58:01.973948Z",
+                "linked_at": "2026-04-11T16:04:28.867556Z",
                 "linked_by": "reevaluation",
                 "source": "completion_claim.external_facts"
               },
@@ -1898,6 +1926,8 @@
                             "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                           }
                         ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "repository": [
                           {
                             "sources": [
@@ -1910,16 +1940,23 @@
                         "used_task_artifact_fallback": false
                       },
                       "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [],
                       "retryable": false,
+                      "rule_failures": [],
                       "status": "valid",
-                      "validated_at": "2026-04-06T13:58:01.974132Z",
+                      "validated_at": "2026-04-11T16:04:28.867699Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "run-claim-kno-183-a"
@@ -1963,16 +2000,17 @@
             "attempts": [
               {
                 "attempt_id": "reconciliation-attempt-1",
-                "completed_at": "2026-04-06T13:58:02.001833Z",
+                "completed_at": "2026-04-11T16:04:28.873866Z",
                 "details": {
                   "base_branch": "main",
                   "branch_exists": true,
+                  "branch_head_commit_sha": null,
                   "branch_name": "codex/e2e-test",
                   "commit_exists": true,
                   "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                   "context_resolution": {
                     "conflicts": [],
-                    "selected_source": "external_facts",
+                    "selected_source": "merged",
                     "sources": {
                       "artifacts": {
                         "base_branch": "main",
@@ -2003,6 +2041,7 @@
                   "policy": {
                     "allow_closed_pr_match": false,
                     "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
                     "allow_open_pr_match": true,
                     "escalate_on_ambiguous_match": true,
                     "require_exact_branch_match": true,
@@ -2176,7 +2215,7 @@
                 },
                 "failure_type": "missing_pr_after_execution",
                 "handler_key": "missing_pr_after_execution",
-                "started_at": "2026-04-06T13:58:02.001274Z",
+                "started_at": "2026-04-11T16:04:28.873649Z",
                 "status": "resolved"
               }
             ],
@@ -2184,21 +2223,21 @@
             "last_attempt_id": "reconciliation-attempt-1",
             "last_error": null,
             "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/631",
-            "resolved_at": "2026-04-06T13:58:02.001833Z",
+            "resolved_at": "2026-04-11T16:04:28.873866Z",
             "status": "resolved"
           },
           "required_capabilities": [],
           "status": "completed",
           "status_history": [
             {
-              "changed_at": "2026-04-06T13:58:01.988300Z",
+              "changed_at": "2026-04-11T16:04:28.871447Z",
               "changed_by": "reconciliation",
               "from_status": "executing",
               "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
               "to_status": "reconciling"
             },
             {
-              "changed_at": "2026-04-06T13:58:02.087201Z",
+              "changed_at": "2026-04-11T16:04:28.888997Z",
               "changed_by": "verification",
               "from_status": "reconciling",
               "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -2206,19 +2245,19 @@
             }
           ],
           "timestamps": {
-            "completed_at": "2026-04-06T13:58:02.087201Z",
+            "completed_at": "2026-04-11T16:04:28.888997Z",
             "created_at": "2026-04-04T12:00:00Z",
-            "updated_at": "2026-04-06T13:58:02.087201Z"
+            "updated_at": "2026-04-11T16:04:28.888997Z"
           },
           "title": "Reconcile missing pull request"
         },
         "transition_result": {
           "actor": "verification",
-          "changed_at": "2026-04-06T13:58:02.087201Z",
+          "changed_at": "2026-04-11T16:04:28.888997Z",
           "from_status": "reconciling",
           "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
           "status_history_entry": {
-            "changed_at": "2026-04-06T13:58:02.087201Z",
+            "changed_at": "2026-04-11T16:04:28.888997Z",
             "changed_by": "verification",
             "from_status": "reconciling",
             "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -2293,7 +2332,7 @@
                     "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                     "name": "codex/e2e-test"
                   },
-                  "captured_at": "2026-04-06T13:58:02.001833Z",
+                  "captured_at": "2026-04-11T16:04:28.873866Z",
                   "changed_files": [],
                   "commit_sha": null,
                   "content_type": null,
@@ -2326,11 +2365,7 @@
                 }
               ]
             },
-            "assigned_executor": {
-              "assignment_reason": "Runtime coverage for reconciliation.",
-              "executor_id": "executor-1",
-              "executor_type": "codex"
-            },
+            "assigned_executor": null,
             "child_task_ids": [],
             "constraints": [],
             "coordination": {
@@ -2339,7 +2374,7 @@
                 "issue_key": "HAR-1",
                 "project": null,
                 "provenance": {
-                  "linked_at": "2026-04-06T13:58:01.973948Z",
+                  "linked_at": "2026-04-11T16:04:28.867556Z",
                   "linked_by": "reevaluation",
                   "source": "completion_claim.external_facts"
                 },
@@ -2408,6 +2443,8 @@
                               "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                             }
                           ],
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "repository": [
                             {
                               "sources": [
@@ -2420,16 +2457,23 @@
                           "used_task_artifact_fallback": false
                         },
                         "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [],
                         "retryable": false,
+                        "rule_failures": [],
                         "status": "valid",
-                        "validated_at": "2026-04-06T13:58:01.974132Z",
+                        "validated_at": "2026-04-11T16:04:28.867699Z",
                         "validated_by": "execution_validation"
                       },
                       "executor_run_id": "run-claim-kno-183-a"
@@ -2473,16 +2517,17 @@
               "attempts": [
                 {
                   "attempt_id": "reconciliation-attempt-1",
-                  "completed_at": "2026-04-06T13:58:02.001833Z",
+                  "completed_at": "2026-04-11T16:04:28.873866Z",
                   "details": {
                     "base_branch": "main",
                     "branch_exists": true,
+                    "branch_head_commit_sha": null,
                     "branch_name": "codex/e2e-test",
                     "commit_exists": true,
                     "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                     "context_resolution": {
                       "conflicts": [],
-                      "selected_source": "external_facts",
+                      "selected_source": "merged",
                       "sources": {
                         "artifacts": {
                           "base_branch": "main",
@@ -2513,6 +2558,7 @@
                     "policy": {
                       "allow_closed_pr_match": false,
                       "allow_commit_association_match": true,
+                      "allow_non_head_commit_association_match": false,
                       "allow_open_pr_match": true,
                       "escalate_on_ambiguous_match": true,
                       "require_exact_branch_match": true,
@@ -2686,7 +2732,7 @@
                   },
                   "failure_type": "missing_pr_after_execution",
                   "handler_key": "missing_pr_after_execution",
-                  "started_at": "2026-04-06T13:58:02.001274Z",
+                  "started_at": "2026-04-11T16:04:28.873649Z",
                   "status": "resolved"
                 }
               ],
@@ -2694,21 +2740,21 @@
               "last_attempt_id": "reconciliation-attempt-1",
               "last_error": null,
               "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/631",
-              "resolved_at": "2026-04-06T13:58:02.001833Z",
+              "resolved_at": "2026-04-11T16:04:28.873866Z",
               "status": "resolved"
             },
             "required_capabilities": [],
             "status": "completed",
             "status_history": [
               {
-                "changed_at": "2026-04-06T13:58:01.988300Z",
+                "changed_at": "2026-04-11T16:04:28.871447Z",
                 "changed_by": "reconciliation",
                 "from_status": "executing",
                 "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
                 "to_status": "reconciling"
               },
               {
-                "changed_at": "2026-04-06T13:58:02.087201Z",
+                "changed_at": "2026-04-11T16:04:28.888997Z",
                 "changed_by": "verification",
                 "from_status": "reconciling",
                 "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -2716,15 +2762,22 @@
               }
             ],
             "timestamps": {
-              "completed_at": "2026-04-06T13:58:02.087201Z",
+              "completed_at": "2026-04-11T16:04:28.888997Z",
               "created_at": "2026-04-04T12:00:00Z",
-              "updated_at": "2026-04-06T13:58:02.087201Z"
+              "updated_at": "2026-04-11T16:04:28.888997Z"
             },
             "title": "Reconcile missing pull request"
           },
           "to_status": "completed"
         },
         "verification_result": {
+          "acceptance_criteria_assessment": {
+            "automatic_completion_safe": true,
+            "concrete_required_criteria_count": 1,
+            "flagged_criteria": [],
+            "reasons": [],
+            "required_criteria_count": 1
+          },
           "accepted_completion": true,
           "claimed_completion": true,
           "evidence_is_sufficient": true,
@@ -2837,7 +2890,7 @@
                 "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                 "name": "codex/e2e-test"
               },
-              "captured_at": "2026-04-06T13:58:02.001833Z",
+              "captured_at": "2026-04-11T16:04:28.873866Z",
               "changed_files": [],
               "commit_sha": null,
               "content_type": null,
@@ -2870,11 +2923,7 @@
             }
           ]
         },
-        "assigned_executor": {
-          "assignment_reason": "Runtime coverage for reconciliation.",
-          "executor_id": "executor-1",
-          "executor_type": "codex"
-        },
+        "assigned_executor": null,
         "child_task_ids": [],
         "constraints": [],
         "coordination": {
@@ -2883,7 +2932,7 @@
             "issue_key": "HAR-1",
             "project": null,
             "provenance": {
-              "linked_at": "2026-04-06T13:58:01.973948Z",
+              "linked_at": "2026-04-11T16:04:28.867556Z",
               "linked_by": "reevaluation",
               "source": "completion_claim.external_facts"
             },
@@ -2952,6 +3001,8 @@
                           "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                         }
                       ],
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
                       "repository": [
                         {
                           "sources": [
@@ -2964,16 +3015,23 @@
                       "used_task_artifact_fallback": false
                     },
                     "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
                       "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
                       "require_commit": true,
                       "require_exact_branch": true,
                       "require_repository": true,
                       "task_artifact_fallback_requires_single_attempt": true
                     },
+                    "pull_request_observations": [],
                     "reasons": [],
                     "retryable": false,
+                    "rule_failures": [],
                     "status": "valid",
-                    "validated_at": "2026-04-06T13:58:01.974132Z",
+                    "validated_at": "2026-04-11T16:04:28.867699Z",
                     "validated_by": "execution_validation"
                   },
                   "executor_run_id": "run-claim-kno-183-a"
@@ -3017,16 +3075,17 @@
           "attempts": [
             {
               "attempt_id": "reconciliation-attempt-1",
-              "completed_at": "2026-04-06T13:58:02.001833Z",
+              "completed_at": "2026-04-11T16:04:28.873866Z",
               "details": {
                 "base_branch": "main",
                 "branch_exists": true,
+                "branch_head_commit_sha": null,
                 "branch_name": "codex/e2e-test",
                 "commit_exists": true,
                 "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                 "context_resolution": {
                   "conflicts": [],
-                  "selected_source": "external_facts",
+                  "selected_source": "merged",
                   "sources": {
                     "artifacts": {
                       "base_branch": "main",
@@ -3057,6 +3116,7 @@
                 "policy": {
                   "allow_closed_pr_match": false,
                   "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
                   "allow_open_pr_match": true,
                   "escalate_on_ambiguous_match": true,
                   "require_exact_branch_match": true,
@@ -3230,7 +3290,7 @@
               },
               "failure_type": "missing_pr_after_execution",
               "handler_key": "missing_pr_after_execution",
-              "started_at": "2026-04-06T13:58:02.001274Z",
+              "started_at": "2026-04-11T16:04:28.873649Z",
               "status": "resolved"
             }
           ],
@@ -3238,21 +3298,21 @@
           "last_attempt_id": "reconciliation-attempt-1",
           "last_error": null,
           "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/631",
-          "resolved_at": "2026-04-06T13:58:02.001833Z",
+          "resolved_at": "2026-04-11T16:04:28.873866Z",
           "status": "resolved"
         },
         "required_capabilities": [],
         "status": "completed",
         "status_history": [
           {
-            "changed_at": "2026-04-06T13:58:01.988300Z",
+            "changed_at": "2026-04-11T16:04:28.871447Z",
             "changed_by": "reconciliation",
             "from_status": "executing",
             "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
             "to_status": "reconciling"
           },
           {
-            "changed_at": "2026-04-06T13:58:02.087201Z",
+            "changed_at": "2026-04-11T16:04:28.888997Z",
             "changed_by": "verification",
             "from_status": "reconciling",
             "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -3260,9 +3320,9 @@
           }
         ],
         "timestamps": {
-          "completed_at": "2026-04-06T13:58:02.087201Z",
+          "completed_at": "2026-04-11T16:04:28.888997Z",
           "created_at": "2026-04-04T12:00:00Z",
-          "updated_at": "2026-04-06T13:58:02.087201Z"
+          "updated_at": "2026-04-11T16:04:28.888997Z"
         },
         "title": "Reconcile missing pull request"
       }
@@ -3353,7 +3413,7 @@
             "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
             "name": "codex/e2e-test"
           },
-          "captured_at": "2026-04-06T13:58:02.001833Z",
+          "captured_at": "2026-04-11T16:04:28.873866Z",
           "changed_files": [],
           "commit_sha": null,
           "content_type": null,
@@ -3386,11 +3446,7 @@
         }
       ]
     },
-    "assigned_executor": {
-      "assignment_reason": "Runtime coverage for reconciliation.",
-      "executor_id": "executor-1",
-      "executor_type": "codex"
-    },
+    "assigned_executor": null,
     "child_task_ids": [],
     "constraints": [],
     "coordination": {
@@ -3399,7 +3455,7 @@
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:01.973948Z",
+          "linked_at": "2026-04-11T16:04:28.867556Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -3468,6 +3524,8 @@
                       "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                     }
                   ],
+                  "commit_resolution_pending": false,
+                  "has_valid_current_run_pull_request_artifact": false,
                   "repository": [
                     {
                       "sources": [
@@ -3480,16 +3538,23 @@
                   "used_task_artifact_fallback": false
                 },
                 "policy": {
+                  "allow_commit_resolution_via_reconciliation": true,
+                  "allow_missing_commit_artifact_with_verified_pull_request": true,
                   "allow_missing_pull_request": true,
+                  "reject_closed_or_historical_pull_request": true,
+                  "reject_non_numeric_pull_request_url": true,
+                  "reject_reserved_shared_branch": true,
                   "require_commit": true,
                   "require_exact_branch": true,
                   "require_repository": true,
                   "task_artifact_fallback_requires_single_attempt": true
                 },
+                "pull_request_observations": [],
                 "reasons": [],
                 "retryable": false,
+                "rule_failures": [],
                 "status": "valid",
-                "validated_at": "2026-04-06T13:58:01.974132Z",
+                "validated_at": "2026-04-11T16:04:28.867699Z",
                 "validated_by": "execution_validation"
               },
               "executor_run_id": "run-claim-kno-183-a"
@@ -3497,8 +3562,8 @@
             "recorded_at": "2026-04-04T12:02:05Z",
             "reevaluation": {
               "action": "transition_applied",
-              "evaluation_id": "9c94d069-2010-4981-9a73-5c01b787c328",
-              "linked_at": "2026-04-06T13:58:02.105513Z"
+              "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
+              "linked_at": "2026-04-11T16:04:28.895854Z"
             },
             "reported_by": "codex",
             "status": "completed"
@@ -3537,16 +3602,17 @@
       "attempts": [
         {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T13:58:02.001833Z",
+          "completed_at": "2026-04-11T16:04:28.873866Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
+            "branch_head_commit_sha": null,
             "branch_name": "codex/e2e-test",
             "commit_exists": true,
             "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
             "context_resolution": {
               "conflicts": [],
-              "selected_source": "external_facts",
+              "selected_source": "merged",
               "sources": {
                 "artifacts": {
                   "base_branch": "main",
@@ -3577,6 +3643,7 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -3750,7 +3817,7 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T13:58:02.001274Z",
+          "started_at": "2026-04-11T16:04:28.873649Z",
           "status": "resolved"
         }
       ],
@@ -3758,21 +3825,21 @@
       "last_attempt_id": "reconciliation-attempt-1",
       "last_error": null,
       "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/631",
-      "resolved_at": "2026-04-06T13:58:02.001833Z",
+      "resolved_at": "2026-04-11T16:04:28.873866Z",
       "status": "resolved"
     },
     "required_capabilities": [],
     "status": "completed",
     "status_history": [
       {
-        "changed_at": "2026-04-06T13:58:01.988300Z",
+        "changed_at": "2026-04-11T16:04:28.871447Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T13:58:02.087201Z",
+        "changed_at": "2026-04-11T16:04:28.888997Z",
         "changed_by": "verification",
         "from_status": "reconciling",
         "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -3780,9 +3847,9 @@
       }
     ],
     "timestamps": {
-      "completed_at": "2026-04-06T13:58:02.087201Z",
+      "completed_at": "2026-04-11T16:04:28.888997Z",
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T13:58:02.119069Z"
+      "updated_at": "2026-04-11T16:04:28.897790Z"
     },
     "title": "Reconcile missing pull request"
   }

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-a-read-model-final.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-a-read-model-final.json
@@ -1,17 +1,14 @@
 {
   "task": {
-    "assigned_executor": {
-      "assignment_reason": "Runtime coverage for reconciliation.",
-      "executor_id": "executor-1",
-      "executor_type": "codex"
-    },
+    "assigned_executor": null,
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:01.973948Z",
+          "linked_at": "2026-04-11T16:04:28.867556Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -33,13 +30,13 @@
       "history": [
         {
           "action": "transition_applied",
-          "evaluation_id": "9c94d069-2010-4981-9a73-5c01b787c328",
-          "recorded_at": "2026-04-06T13:58:02.105513Z",
+          "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
+          "recorded_at": "2026-04-11T16:04:28.895854Z",
           "target_status": "completed"
         }
       ],
       "latest_action": "transition_applied",
-      "latest_recorded_at": "2026-04-06T13:58:02.105513Z",
+      "latest_recorded_at": "2026-04-11T16:04:28.895854Z",
       "latest_target_status": "completed"
     },
     "evidence_summary": {
@@ -114,6 +111,8 @@
                   "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                 }
               ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -126,16 +125,23 @@
               "used_task_artifact_fallback": false
             },
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T13:58:01.974132Z",
+            "validated_at": "2026-04-11T16:04:28.867699Z",
             "validated_by": "execution_validation"
           },
           "executor_run_id": "run-claim-kno-183-a"
@@ -143,8 +149,8 @@
         "recorded_at": "2026-04-04T12:02:05Z",
         "reevaluation": {
           "action": "transition_applied",
-          "evaluation_id": "9c94d069-2010-4981-9a73-5c01b787c328",
-          "linked_at": "2026-04-06T13:58:02.105513Z"
+          "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
+          "linked_at": "2026-04-11T16:04:28.895854Z"
         },
         "reported_by": "codex",
         "status": "completed"
@@ -169,6 +175,8 @@
               "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
             }
           ],
+          "commit_resolution_pending": false,
+          "has_valid_current_run_pull_request_artifact": false,
           "repository": [
             {
               "sources": [
@@ -181,16 +189,23 @@
           "used_task_artifact_fallback": false
         },
         "policy": {
+          "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
           "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
           "require_commit": true,
           "require_exact_branch": true,
           "require_repository": true,
           "task_artifact_fallback_requires_single_attempt": true
         },
+        "pull_request_observations": [],
         "reasons": [],
         "retryable": false,
+        "rule_failures": [],
         "status": "valid",
-        "validated_at": "2026-04-06T13:58:01.974132Z",
+        "validated_at": "2026-04-11T16:04:28.867699Z",
         "validated_by": "execution_validation"
       },
       "latest_dispatch_origin": null,
@@ -201,22 +216,25 @@
     },
     "extensions": {},
     "failure_summary": {
+      "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
+      "failure_reason": "Acceptance criteria, evidence, and reconciliation all support completion",
       "failure_source": "none",
       "failure_type": "none",
+      "recorded_at": "2026-04-11T16:04:28.895854Z",
       "recoverable": false,
       "state": "clear",
       "terminal": false
     },
     "lifecycle_history": [
       {
-        "changed_at": "2026-04-06T13:58:01.988300Z",
+        "changed_at": "2026-04-11T16:04:28.871447Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T13:58:02.087201Z",
+        "changed_at": "2026-04-11T16:04:28.888997Z",
         "changed_by": "verification",
         "from_status": "reconciling",
         "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -253,9 +271,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-183-scenario-a",
@@ -307,18 +327,6 @@
       },
       {
         "details": {
-          "artifact_type": "execution_log",
-          "location": "stub://attempts/log",
-          "reference_id": "claim-kno-183-a:attempt:log"
-        },
-        "event_id": "task-kno-183-scenario-a:execution_artifact:claim-kno-183-a:attempt:claim-kno-183-a:attempt:log",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-04T12:02:05Z",
-        "source": "codex",
-        "summary": "Execution artifact attached: execution_log"
-      },
-      {
-        "details": {
           "artifact_references": [
             {
               "artifact_type": "execution_log",
@@ -347,6 +355,8 @@
                   "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                 }
               ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -359,23 +369,30 @@
               "used_task_artifact_fallback": false
             },
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T13:58:01.974132Z",
+            "validated_at": "2026-04-11T16:04:28.867699Z",
             "validated_by": "execution_validation"
           },
           "completion_claim_id": "claim-kno-183-a",
           "reevaluation": {
             "action": "transition_applied",
-            "evaluation_id": "9c94d069-2010-4981-9a73-5c01b787c328",
-            "linked_at": "2026-04-06T13:58:02.105513Z"
+            "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
+            "linked_at": "2026-04-11T16:04:28.895854Z"
           },
           "status": "completed"
         },
@@ -387,11 +404,23 @@
       },
       {
         "details": {
+          "artifact_type": "execution_log",
+          "location": "stub://attempts/log",
+          "reference_id": "claim-kno-183-a:attempt:log"
+        },
+        "event_id": "task-kno-183-scenario-a:execution_artifact:claim-kno-183-a:attempt:claim-kno-183-a:attempt:log",
+        "event_type": "execution_artifact_attached",
+        "occurred_at": "2026-04-04T12:02:05Z",
+        "source": "codex",
+        "summary": "Execution artifact attached: execution_log"
+      },
+      {
+        "details": {
           "issue_id": "lin-1",
           "issue_key": "HAR-1",
           "project": null,
           "provenance": {
-            "linked_at": "2026-04-06T13:58:01.973948Z",
+            "linked_at": "2026-04-11T16:04:28.867556Z",
             "linked_by": "reevaluation",
             "source": "completion_claim.external_facts"
           },
@@ -407,13 +436,13 @@
         },
         "event_id": "task-kno-183-scenario-a:linear_linkage",
         "event_type": "linear_linkage_recorded",
-        "occurred_at": "2026-04-06T13:58:01.973948Z",
+        "occurred_at": "2026-04-11T16:04:28.867556Z",
         "source": "reevaluation",
         "summary": "Linear linkage recorded"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T13:58:01.988300Z",
+          "changed_at": "2026-04-11T16:04:28.871447Z",
           "changed_by": "reconciliation",
           "from_status": "executing",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -421,7 +450,7 @@
         },
         "event_id": "task-kno-183-scenario-a:status:0",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T13:58:01.988300Z",
+        "occurred_at": "2026-04-11T16:04:28.871447Z",
         "source": "reconciliation",
         "summary": "Status changed executing -> reconciling"
       },
@@ -447,23 +476,24 @@
         },
         "event_id": "task-kno-183-scenario-a:artifact:artifact-pr-631",
         "event_type": "artifact_captured",
-        "occurred_at": "2026-04-06T13:58:02.001833Z",
+        "occurred_at": "2026-04-11T16:04:28.873866Z",
         "source": "github",
         "summary": "Artifact captured: pull_request"
       },
       {
         "details": {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T13:58:02.001833Z",
+          "completed_at": "2026-04-11T16:04:28.873866Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
+            "branch_head_commit_sha": null,
             "branch_name": "codex/e2e-test",
             "commit_exists": true,
             "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
             "context_resolution": {
               "conflicts": [],
-              "selected_source": "external_facts",
+              "selected_source": "merged",
               "sources": {
                 "artifacts": {
                   "base_branch": "main",
@@ -494,6 +524,7 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -667,18 +698,18 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T13:58:02.001274Z",
+          "started_at": "2026-04-11T16:04:28.873649Z",
           "status": "resolved"
         },
         "event_id": "task-kno-183-scenario-a:reconciliation:reconciliation-attempt-1",
         "event_type": "reconciliation_attempt_recorded",
-        "occurred_at": "2026-04-06T13:58:02.001833Z",
+        "occurred_at": "2026-04-11T16:04:28.873866Z",
         "source": "reconciliation",
         "summary": "Reconciliation attempt: missing_pr_after_execution"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T13:58:02.087201Z",
+          "changed_at": "2026-04-11T16:04:28.888997Z",
           "changed_by": "verification",
           "from_status": "reconciling",
           "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -686,7 +717,7 @@
         },
         "event_id": "task-kno-183-scenario-a:status:1",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T13:58:02.087201Z",
+        "occurred_at": "2026-04-11T16:04:28.888997Z",
         "source": "verification",
         "summary": "Status changed reconciling -> completed"
       },
@@ -694,7 +725,7 @@
         "details": {
           "accepted_completion": true,
           "action": "transition_applied",
-          "evaluation_id": "9c94d069-2010-4981-9a73-5c01b787c328",
+          "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
           "reasons": [
             "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
           ],
@@ -713,6 +744,13 @@
           "requires_review": false,
           "target_status": "completed",
           "verification_result": {
+            "acceptance_criteria_assessment": {
+              "automatic_completion_safe": true,
+              "concrete_required_criteria_count": 1,
+              "flagged_criteria": [],
+              "reasons": [],
+              "required_criteria_count": 1
+            },
             "accepted_completion": true,
             "claimed_completion": true,
             "evidence_is_sufficient": true,
@@ -740,20 +778,27 @@
             "verification_passed": true
           }
         },
-        "event_id": "task-kno-183-scenario-a:evaluation:9c94d069-2010-4981-9a73-5c01b787c328",
+        "event_id": "task-kno-183-scenario-a:evaluation:fe0c42be-c388-4dd9-9d46-34ae66c60e90",
         "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-06T13:58:02.105513Z",
+        "occurred_at": "2026-04-11T16:04:28.895854Z",
         "source": "harness",
         "summary": "Evaluation recorded: transition_applied"
       }
     ],
     "timestamps": {
-      "completed_at": "2026-04-06T13:58:02.087201Z",
+      "completed_at": "2026-04-11T16:04:28.888997Z",
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T13:58:02.119069Z"
+      "updated_at": "2026-04-11T16:04:28.897790Z"
     },
     "title": "Reconcile missing pull request",
     "verification_summary": {
+      "acceptance_criteria_assessment": {
+        "automatic_completion_safe": true,
+        "concrete_required_criteria_count": 1,
+        "flagged_criteria": [],
+        "reasons": [],
+        "required_criteria_count": 1
+      },
       "accepted_completion": true,
       "claimed_completion": true,
       "evidence_is_sufficient": true,

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-a-read-model-initial.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-a-read-model-initial.json
@@ -5,6 +5,7 @@
       "executor_id": "executor-1",
       "executor_type": "codex"
     },
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": null
     },
@@ -87,9 +88,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-183-scenario-a",

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-a-timeline-final.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-a-timeline-final.json
@@ -50,18 +50,6 @@
     },
     {
       "details": {
-        "artifact_type": "execution_log",
-        "location": "stub://attempts/log",
-        "reference_id": "claim-kno-183-a:attempt:log"
-      },
-      "event_id": "task-kno-183-scenario-a:execution_artifact:claim-kno-183-a:attempt:claim-kno-183-a:attempt:log",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-04T12:02:05Z",
-      "source": "codex",
-      "summary": "Execution artifact attached: execution_log"
-    },
-    {
-      "details": {
         "artifact_references": [
           {
             "artifact_type": "execution_log",
@@ -90,6 +78,8 @@
                 "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
               }
             ],
+            "commit_resolution_pending": false,
+            "has_valid_current_run_pull_request_artifact": false,
             "repository": [
               {
                 "sources": [
@@ -102,23 +92,30 @@
             "used_task_artifact_fallback": false
           },
           "policy": {
+            "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [],
           "retryable": false,
+          "rule_failures": [],
           "status": "valid",
-          "validated_at": "2026-04-06T13:58:01.974132Z",
+          "validated_at": "2026-04-11T16:04:28.867699Z",
           "validated_by": "execution_validation"
         },
         "completion_claim_id": "claim-kno-183-a",
         "reevaluation": {
           "action": "transition_applied",
-          "evaluation_id": "9c94d069-2010-4981-9a73-5c01b787c328",
-          "linked_at": "2026-04-06T13:58:02.105513Z"
+          "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
+          "linked_at": "2026-04-11T16:04:28.895854Z"
         },
         "status": "completed"
       },
@@ -130,11 +127,23 @@
     },
     {
       "details": {
+        "artifact_type": "execution_log",
+        "location": "stub://attempts/log",
+        "reference_id": "claim-kno-183-a:attempt:log"
+      },
+      "event_id": "task-kno-183-scenario-a:execution_artifact:claim-kno-183-a:attempt:claim-kno-183-a:attempt:log",
+      "event_type": "execution_artifact_attached",
+      "occurred_at": "2026-04-04T12:02:05Z",
+      "source": "codex",
+      "summary": "Execution artifact attached: execution_log"
+    },
+    {
+      "details": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:01.973948Z",
+          "linked_at": "2026-04-11T16:04:28.867556Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -150,13 +159,13 @@
       },
       "event_id": "task-kno-183-scenario-a:linear_linkage",
       "event_type": "linear_linkage_recorded",
-      "occurred_at": "2026-04-06T13:58:01.973948Z",
+      "occurred_at": "2026-04-11T16:04:28.867556Z",
       "source": "reevaluation",
       "summary": "Linear linkage recorded"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T13:58:01.988300Z",
+        "changed_at": "2026-04-11T16:04:28.871447Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -164,7 +173,7 @@
       },
       "event_id": "task-kno-183-scenario-a:status:0",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T13:58:01.988300Z",
+      "occurred_at": "2026-04-11T16:04:28.871447Z",
       "source": "reconciliation",
       "summary": "Status changed executing -> reconciling"
     },
@@ -190,23 +199,24 @@
       },
       "event_id": "task-kno-183-scenario-a:artifact:artifact-pr-631",
       "event_type": "artifact_captured",
-      "occurred_at": "2026-04-06T13:58:02.001833Z",
+      "occurred_at": "2026-04-11T16:04:28.873866Z",
       "source": "github",
       "summary": "Artifact captured: pull_request"
     },
     {
       "details": {
         "attempt_id": "reconciliation-attempt-1",
-        "completed_at": "2026-04-06T13:58:02.001833Z",
+        "completed_at": "2026-04-11T16:04:28.873866Z",
         "details": {
           "base_branch": "main",
           "branch_exists": true,
+          "branch_head_commit_sha": null,
           "branch_name": "codex/e2e-test",
           "commit_exists": true,
           "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
           "context_resolution": {
             "conflicts": [],
-            "selected_source": "external_facts",
+            "selected_source": "merged",
             "sources": {
               "artifacts": {
                 "base_branch": "main",
@@ -237,6 +247,7 @@
           "policy": {
             "allow_closed_pr_match": false,
             "allow_commit_association_match": true,
+            "allow_non_head_commit_association_match": false,
             "allow_open_pr_match": true,
             "escalate_on_ambiguous_match": true,
             "require_exact_branch_match": true,
@@ -410,18 +421,18 @@
         },
         "failure_type": "missing_pr_after_execution",
         "handler_key": "missing_pr_after_execution",
-        "started_at": "2026-04-06T13:58:02.001274Z",
+        "started_at": "2026-04-11T16:04:28.873649Z",
         "status": "resolved"
       },
       "event_id": "task-kno-183-scenario-a:reconciliation:reconciliation-attempt-1",
       "event_type": "reconciliation_attempt_recorded",
-      "occurred_at": "2026-04-06T13:58:02.001833Z",
+      "occurred_at": "2026-04-11T16:04:28.873866Z",
       "source": "reconciliation",
       "summary": "Reconciliation attempt: missing_pr_after_execution"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T13:58:02.087201Z",
+        "changed_at": "2026-04-11T16:04:28.888997Z",
         "changed_by": "verification",
         "from_status": "reconciling",
         "reason": "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion",
@@ -429,7 +440,7 @@
       },
       "event_id": "task-kno-183-scenario-a:status:1",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T13:58:02.087201Z",
+      "occurred_at": "2026-04-11T16:04:28.888997Z",
       "source": "verification",
       "summary": "Status changed reconciling -> completed"
     },
@@ -437,7 +448,7 @@
       "details": {
         "accepted_completion": true,
         "action": "transition_applied",
-        "evaluation_id": "9c94d069-2010-4981-9a73-5c01b787c328",
+        "evaluation_id": "fe0c42be-c388-4dd9-9d46-34ae66c60e90",
         "reasons": [
           "Verification evaluated task 'task-kno-183-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Acceptance criteria, evidence, and reconciliation all support completion"
         ],
@@ -456,6 +467,13 @@
         "requires_review": false,
         "target_status": "completed",
         "verification_result": {
+          "acceptance_criteria_assessment": {
+            "automatic_completion_safe": true,
+            "concrete_required_criteria_count": 1,
+            "flagged_criteria": [],
+            "reasons": [],
+            "required_criteria_count": 1
+          },
           "accepted_completion": true,
           "claimed_completion": true,
           "evidence_is_sufficient": true,
@@ -483,9 +501,9 @@
           "verification_passed": true
         }
       },
-      "event_id": "task-kno-183-scenario-a:evaluation:9c94d069-2010-4981-9a73-5c01b787c328",
+      "event_id": "task-kno-183-scenario-a:evaluation:fe0c42be-c388-4dd9-9d46-34ae66c60e90",
       "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-06T13:58:02.105513Z",
+      "occurred_at": "2026-04-11T16:04:28.895854Z",
       "source": "harness",
       "summary": "Evaluation recorded: transition_applied"
     }

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-b-completion-claim-response.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-b-completion-claim-response.json
@@ -1,23 +1,1860 @@
 {
   "accepted_completion": false,
   "action": "reconciliation_failed",
+  "enforcement_result": {
+    "action": "review_required",
+    "error": "Created pull request could not be revalidated from persisted GitHub state",
+    "evidence_result": null,
+    "failure_classification": {
+      "category": "review_required",
+      "failure_type": "review_required",
+      "reason": "Created pull request could not be revalidated from persisted GitHub state",
+      "recoverable": false,
+      "retryable": false,
+      "source": "evaluation",
+      "terminal": false
+    },
+    "reasons": [
+      "Created pull request could not be revalidated from persisted GitHub state"
+    ],
+    "reconciliation_result": {
+      "blocking": true,
+      "mismatch_categories": [
+        "missing_required_artifact"
+      ],
+      "outcome": "review_required",
+      "reasons": [
+        "Created pull request could not be revalidated from persisted GitHub state"
+      ],
+      "status": "review_required",
+      "task_id": "task-kno-183-scenario-b",
+      "terminal": false
+    },
+    "review_decision": null,
+    "review_request": {
+      "allowed_outcomes": [
+        "accept_completion",
+        "keep_blocked",
+        "mark_failed",
+        "authorize_redispatch"
+      ],
+      "metadata": {
+        "reconciliation_attempt_id": "reconciliation-attempt-1",
+        "reconciliation_failure_type": "missing_pr_after_execution"
+      },
+      "presented_sections": [
+        "task_state",
+        "execution",
+        "evidence",
+        "reconciliation"
+      ],
+      "prior_review_ids": [],
+      "requested_at": "2026-04-11T16:04:28.910546Z",
+      "requested_by": "reconciliation",
+      "review_request_id": "review-request-task-kno-183-scenario-b-reconciliation-1",
+      "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+      "task_id": "task-kno-183-scenario-b",
+      "trigger": "reconciliation"
+    },
+    "target_status": "in_review",
+    "task_envelope": {
+      "acceptance_criteria": [
+        {
+          "description": "Harness can reconcile a missing PR after execution.",
+          "id": "ac-1",
+          "required": true
+        }
+      ],
+      "artifacts": {
+        "completion_evidence": {
+          "notes": null,
+          "policy": "required",
+          "required_artifact_types": [
+            "commit"
+          ],
+          "status": "satisfied",
+          "validated_artifact_ids": [
+            "artifact-commit-1"
+          ],
+          "validated_at": "2026-04-04T12:01:30Z",
+          "validation_method": "external_reconciliation",
+          "validator": {
+            "captured_by": "github-sync",
+            "source_id": "verification-existing-1",
+            "source_system": "harness",
+            "source_type": "verification"
+          }
+        },
+        "items": [
+          {
+            "branch": {
+              "base_branch": "main",
+              "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "name": "codex/e2e-test"
+            },
+            "captured_at": "2026-04-04T12:01:00Z",
+            "changed_files": [],
+            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "content_type": null,
+            "description": null,
+            "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "external_refs": [],
+            "id": "artifact-commit-1",
+            "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "metadata": {},
+            "provenance": {
+              "captured_by": "github-sync",
+              "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": null,
+            "repository": {
+              "external_id": "repo-dryrun-1",
+              "host": "github.com",
+              "name": "HARNESS-DRYRUN",
+              "owner": "KnoxAnalytics"
+            },
+            "review_state": null,
+            "title": null,
+            "type": "commit",
+            "verification_status": "verified"
+          }
+        ]
+      },
+      "assigned_executor": {
+        "assignment_reason": "Runtime coverage for reconciliation.",
+        "executor_id": "executor-1",
+        "executor_type": "codex"
+      },
+      "child_task_ids": [],
+      "constraints": [],
+      "coordination": {
+        "linear": {
+          "issue_id": "lin-1",
+          "issue_key": "HAR-1",
+          "project": null,
+          "provenance": {
+            "linked_at": "2026-04-11T16:04:28.903663Z",
+            "linked_by": "reevaluation",
+            "source": "completion_claim.external_facts"
+          },
+          "reasons": [],
+          "record_found": true,
+          "state": "completed",
+          "task_reference": null,
+          "workflow": {
+            "state_type": "completed",
+            "workflow_id": "workflow-completed",
+            "workflow_name": "completed"
+          }
+        }
+      },
+      "dependencies": [],
+      "description": "Exercise post-execution PR reconciliation.",
+      "id": "task-kno-183-scenario-b",
+      "objective": {
+        "deliverable_type": "unspecified",
+        "success_signal": "Task satisfies declared acceptance criteria.",
+        "summary": "Exercise post-execution PR reconciliation."
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {
+          "advisory_completion_claims": [
+            {
+              "claim_id": "claim-kno-183-b",
+              "metadata": {
+                "attempt_id": "claim-kno-183-b:attempt"
+              },
+              "reason": "Execution completed successfully.",
+              "reported_at": "2026-04-04T12:02:00Z",
+              "reported_by": "codex"
+            }
+          ],
+          "execution_attempts": [
+            {
+              "artifact_references": [
+                {
+                  "artifact_type": "execution_log",
+                  "location": "stub://attempts/log",
+                  "reference_id": "claim-kno-183-b:attempt:log"
+                }
+              ],
+              "attempt_id": "claim-kno-183-b:attempt",
+              "completion_claim_id": "claim-kno-183-b",
+              "metadata": {
+                "attempt_validation": {
+                  "context_observations": {
+                    "branch": [
+                      {
+                        "sources": [
+                          "external_facts.expected_code_context",
+                          "external_facts.github_facts.branch"
+                        ],
+                        "value": "codex/e2e-test"
+                      }
+                    ],
+                    "commit": [
+                      {
+                        "sources": [
+                          "external_facts.github_facts.branch",
+                          "external_facts.github_facts.commit"
+                        ],
+                        "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                      }
+                    ],
+                    "commit_resolution_pending": false,
+                    "has_valid_current_run_pull_request_artifact": false,
+                    "repository": [
+                      {
+                        "sources": [
+                          "external_facts.expected_code_context",
+                          "external_facts.github_facts.repository"
+                        ],
+                        "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                      }
+                    ],
+                    "used_task_artifact_fallback": false
+                  },
+                  "policy": {
+                    "allow_commit_resolution_via_reconciliation": true,
+                    "allow_missing_commit_artifact_with_verified_pull_request": true,
+                    "allow_missing_pull_request": true,
+                    "reject_closed_or_historical_pull_request": true,
+                    "reject_non_numeric_pull_request_url": true,
+                    "reject_reserved_shared_branch": true,
+                    "require_commit": true,
+                    "require_exact_branch": true,
+                    "require_repository": true,
+                    "task_artifact_fallback_requires_single_attempt": true
+                  },
+                  "pull_request_observations": [],
+                  "reasons": [],
+                  "retryable": false,
+                  "rule_failures": [],
+                  "status": "valid",
+                  "validated_at": "2026-04-11T16:04:28.903770Z",
+                  "validated_by": "execution_validation"
+                },
+                "executor_run_id": "run-claim-kno-183-b"
+              },
+              "recorded_at": "2026-04-04T12:02:05Z",
+              "reevaluation": {},
+              "reported_by": "codex",
+              "status": "completed"
+            }
+          ],
+          "schema_required_deferred_fields": [
+            "parent_task_id",
+            "child_task_ids",
+            "dependencies",
+            "assigned_executor",
+            "required_capabilities",
+            "priority",
+            "artifacts.items",
+            "artifacts.completion_evidence",
+            "observability"
+          ]
+        },
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": null,
+        "requested_by": null,
+        "source_id": "req-task-kno-183-scenario-b",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "reconciliation": {
+        "active_failure_type": "missing_pr_after_execution",
+        "attempts": [
+          {
+            "attempt_id": "reconciliation-attempt-1",
+            "completed_at": "2026-04-11T16:04:28.908098Z",
+            "details": {
+              "base_branch": "main",
+              "branch_exists": true,
+              "branch_head_commit_sha": null,
+              "branch_name": "codex/e2e-test",
+              "commit_exists": true,
+              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "context_resolution": {
+                "conflicts": [],
+                "selected_source": "merged",
+                "sources": {
+                  "artifacts": {
+                    "base_branch": "main",
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
+                  },
+                  "external_facts": {
+                    "base_branch": "main",
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
+                  }
+                }
+              },
+              "created_pull_request": true,
+              "created_pull_request_revalidated": false,
+              "error": "Created pull request could not be revalidated from persisted GitHub state",
+              "error_disposition": "review_required",
+              "final_decision": {
+                "reason": "created_pull_request_not_visible_after_create",
+                "result": "created_pull_request_revalidation_failed"
+              },
+              "policy": {
+                "allow_closed_pr_match": false,
+                "allow_commit_association_match": true,
+                "allow_non_head_commit_association_match": false,
+                "allow_open_pr_match": true,
+                "escalate_on_ambiguous_match": true,
+                "require_exact_branch_match": true,
+                "require_head_sha_match": true,
+                "require_run_linkage_for_commit_association": true,
+                "require_run_linkage_for_multiple_attempts": true,
+                "require_task_linkage": false
+              },
+              "pull_request_candidates": [
+                {
+                  "base_branch": "main",
+                  "head": {
+                    "branch": "codex/e2e-test",
+                    "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                  },
+                  "lookup_sources": [
+                    "created_response"
+                  ],
+                  "merged": false,
+                  "number": 632,
+                  "repository": {
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  },
+                  "review_state": null,
+                  "state": "open",
+                  "title": "Reconcile missing pull request (task-kno-183-scenario-b)",
+                  "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/632",
+                  "validation": {
+                    "accepted": true,
+                    "matched_by": [
+                      "head_sha_match",
+                      "task_linkage",
+                      "attempt_linkage",
+                      "completion_claim_linkage"
+                    ],
+                    "reasons": [],
+                    "signals": {
+                      "branch_match": true,
+                      "commit_association_match": false,
+                      "head_sha_match": true,
+                      "linkage_policy": {
+                        "reasons": [],
+                        "require_run_linkage": false
+                      },
+                      "repository_match": true,
+                      "run_linkage": {
+                        "attempt_id_present": true,
+                        "branch_name_present": true,
+                        "commit_sha_present": true,
+                        "completion_claim_id_present": true,
+                        "current_run": {
+                          "attempt_count": 1,
+                          "attempt_id": "claim-kno-183-b:attempt",
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "completion_claim_id": "claim-kno-183-b",
+                          "multiple_attempts": false,
+                          "task_id": "task-kno-183-scenario-b",
+                          "task_title": "Reconcile missing pull request"
+                        },
+                        "linked": true,
+                        "markers": {
+                          "harness-attempt-id": "claim-kno-183-b:attempt",
+                          "harness-branch": "codex/e2e-test",
+                          "harness-commit-sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "harness-completion-claim-id": "claim-kno-183-b",
+                          "harness-task-id": "task-kno-183-scenario-b"
+                        },
+                        "task_id_marker_present": true
+                      },
+                      "state": "open",
+                      "state_acceptable": true,
+                      "task_linkage": {
+                        "linked": true,
+                        "task_id_present": true,
+                        "task_title_present": true
+                      }
+                    }
+                  }
+                }
+              ],
+              "pull_request_lookup": {
+                "ambiguous": false,
+                "candidate_count": 1,
+                "found": false,
+                "number": null,
+                "searched_by_branch": true,
+                "searched_by_commit": true,
+                "source": null,
+                "url": null,
+                "valid_candidate_count": 0
+              },
+              "repository": {
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              }
+            },
+            "failure_type": "missing_pr_after_execution",
+            "handler_key": "missing_pr_after_execution",
+            "started_at": "2026-04-11T16:04:28.907925Z",
+            "status": "failed"
+          }
+        ],
+        "failed_at": "2026-04-11T16:04:28.908098Z",
+        "last_attempt_id": "reconciliation-attempt-1",
+        "last_error": "Created pull request could not be revalidated from persisted GitHub state",
+        "last_pr_url": null,
+        "resolved_at": null,
+        "status": "failed"
+      },
+      "required_capabilities": [],
+      "status": "in_review",
+      "status_history": [
+        {
+          "changed_at": "2026-04-11T16:04:28.905910Z",
+          "changed_by": "reconciliation",
+          "from_status": "executing",
+          "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+          "to_status": "reconciling"
+        },
+        {
+          "changed_at": "2026-04-11T16:04:28.910546Z",
+          "changed_by": "reconciliation",
+          "from_status": "reconciling",
+          "reason": "Post-execution reconciliation failed: Created pull request could not be revalidated from persisted GitHub state",
+          "to_status": "in_review"
+        }
+      ],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-04-04T12:00:00Z",
+        "updated_at": "2026-04-11T16:04:28.910546Z"
+      },
+      "title": "Reconcile missing pull request"
+    },
+    "transition_result": null,
+    "verification_result": null
+  },
   "error": "Created pull request could not be revalidated from persisted GitHub state",
+  "evaluation_record": {
+    "evaluation_id": "1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+    "recorded_at": "2026-04-11T16:04:28.913215Z",
+    "request": {
+      "acceptance_criteria_satisfied": true,
+      "claimed_completion": true,
+      "external_facts": {
+        "expected_code_context": {
+          "base_branch": "main",
+          "branch_name": "codex/e2e-test",
+          "repository_host": "github.com",
+          "repository_name": "HARNESS-DRYRUN",
+          "repository_owner": "KnoxAnalytics"
+        },
+        "github_facts": {
+          "artifact_found": true,
+          "artifact_refs": [
+            {
+              "artifact_type": "commit",
+              "external_id": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "url": null
+            }
+          ],
+          "branch": {
+            "base_branch": "main",
+            "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "name": "codex/e2e-test"
+          },
+          "changed_files": null,
+          "commit": {
+            "message_summary": null,
+            "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "url": null
+          },
+          "pull_request": null,
+          "reasons": [],
+          "repository": {
+            "external_id": null,
+            "host": "github.com",
+            "name": "HARNESS-DRYRUN",
+            "owner": "KnoxAnalytics"
+          }
+        },
+        "linear_facts": {
+          "issue_id": "lin-1",
+          "issue_key": "HAR-1",
+          "project": null,
+          "reasons": [],
+          "record_found": true,
+          "state": "completed",
+          "task_reference": null,
+          "workflow": {
+            "state_type": "completed",
+            "workflow_id": "workflow-completed",
+            "workflow_name": "completed"
+          }
+        }
+      },
+      "retry_context": null,
+      "review_decision": null,
+      "review_is_active": false,
+      "review_reasons": [],
+      "review_request": {
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "requested_at": "2026-04-11T16:04:28.910546Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-183-scenario-b-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+        "task_id": "task-kno-183-scenario-b",
+        "trigger": "reconciliation"
+      },
+      "runtime_facts": {
+        "attempt_count": 1,
+        "executor_reported_failure": false,
+        "executor_reported_success": true,
+        "latest_attempt_outcome": "completed",
+        "terminal_failure": false
+      },
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "Harness can reconcile a missing PR after execution.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "required",
+            "required_artifact_types": [
+              "commit"
+            ],
+            "status": "satisfied",
+            "validated_artifact_ids": [
+              "artifact-commit-1"
+            ],
+            "validated_at": "2026-04-04T12:01:30Z",
+            "validation_method": "external_reconciliation",
+            "validator": {
+              "captured_by": "github-sync",
+              "source_id": "verification-existing-1",
+              "source_system": "harness",
+              "source_type": "verification"
+            }
+          },
+          "items": [
+            {
+              "branch": {
+                "base_branch": "main",
+                "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "name": "codex/e2e-test"
+              },
+              "captured_at": "2026-04-04T12:01:00Z",
+              "changed_files": [],
+              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "content_type": null,
+              "description": null,
+              "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "external_refs": [],
+              "id": "artifact-commit-1",
+              "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "metadata": {},
+              "provenance": {
+                "captured_by": "github-sync",
+                "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "source_system": "github",
+                "source_type": "api"
+              },
+              "pull_request_number": null,
+              "repository": {
+                "external_id": "repo-dryrun-1",
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              },
+              "review_state": null,
+              "title": null,
+              "type": "commit",
+              "verification_status": "verified"
+            }
+          ]
+        },
+        "assigned_executor": {
+          "assignment_reason": "Runtime coverage for reconciliation.",
+          "executor_id": "executor-1",
+          "executor_type": "codex"
+        },
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": {
+            "issue_id": "lin-1",
+            "issue_key": "HAR-1",
+            "project": null,
+            "provenance": {
+              "linked_at": "2026-04-11T16:04:28.903663Z",
+              "linked_by": "reevaluation",
+              "source": "completion_claim.external_facts"
+            },
+            "reasons": [],
+            "record_found": true,
+            "state": "completed",
+            "task_reference": null,
+            "workflow": {
+              "state_type": "completed",
+              "workflow_id": "workflow-completed",
+              "workflow_name": "completed"
+            }
+          }
+        },
+        "dependencies": [],
+        "description": "Exercise post-execution PR reconciliation.",
+        "id": "task-kno-183-scenario-b",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Exercise post-execution PR reconciliation."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-183-b",
+                "metadata": {
+                  "attempt_id": "claim-kno-183-b:attempt"
+                },
+                "reason": "Execution completed successfully.",
+                "reported_at": "2026-04-04T12:02:00Z",
+                "reported_by": "codex"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [
+                  {
+                    "artifact_type": "execution_log",
+                    "location": "stub://attempts/log",
+                    "reference_id": "claim-kno-183-b:attempt:log"
+                  }
+                ],
+                "attempt_id": "claim-kno-183-b:attempt",
+                "completion_claim_id": "claim-kno-183-b",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "branch": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context",
+                            "external_facts.github_facts.branch"
+                          ],
+                          "value": "codex/e2e-test"
+                        }
+                      ],
+                      "commit": [
+                        {
+                          "sources": [
+                            "external_facts.github_facts.branch",
+                            "external_facts.github_facts.commit"
+                          ],
+                          "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                        }
+                      ],
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "repository": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context",
+                            "external_facts.github_facts.repository"
+                          ],
+                          "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                        }
+                      ],
+                      "used_task_artifact_fallback": false
+                    },
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [],
+                    "retryable": false,
+                    "rule_failures": [],
+                    "status": "valid",
+                    "validated_at": "2026-04-11T16:04:28.903770Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "run-claim-kno-183-b"
+                },
+                "recorded_at": "2026-04-04T12:02:05Z",
+                "reevaluation": {},
+                "reported_by": "codex",
+                "status": "completed"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "req-task-kno-183-scenario-b",
+          "source_system": "openclaw",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": "missing_pr_after_execution",
+          "attempts": [
+            {
+              "attempt_id": "reconciliation-attempt-1",
+              "completed_at": "2026-04-11T16:04:28.908098Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": true,
+                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "merged",
+                  "sources": {
+                    "artifacts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    },
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_pull_request": true,
+                "created_pull_request_revalidated": false,
+                "error": "Created pull request could not be revalidated from persisted GitHub state",
+                "error_disposition": "review_required",
+                "final_decision": {
+                  "reason": "created_pull_request_not_visible_after_create",
+                  "result": "created_pull_request_revalidation_failed"
+                },
+                "policy": {
+                  "allow_closed_pr_match": false,
+                  "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
+                  "allow_open_pr_match": true,
+                  "escalate_on_ambiguous_match": true,
+                  "require_exact_branch_match": true,
+                  "require_head_sha_match": true,
+                  "require_run_linkage_for_commit_association": true,
+                  "require_run_linkage_for_multiple_attempts": true,
+                  "require_task_linkage": false
+                },
+                "pull_request_candidates": [
+                  {
+                    "base_branch": "main",
+                    "head": {
+                      "branch": "codex/e2e-test",
+                      "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                    },
+                    "lookup_sources": [
+                      "created_response"
+                    ],
+                    "merged": false,
+                    "number": 632,
+                    "repository": {
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    },
+                    "review_state": null,
+                    "state": "open",
+                    "title": "Reconcile missing pull request (task-kno-183-scenario-b)",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/632",
+                    "validation": {
+                      "accepted": true,
+                      "matched_by": [
+                        "head_sha_match",
+                        "task_linkage",
+                        "attempt_linkage",
+                        "completion_claim_linkage"
+                      ],
+                      "reasons": [],
+                      "signals": {
+                        "branch_match": true,
+                        "commit_association_match": false,
+                        "head_sha_match": true,
+                        "linkage_policy": {
+                          "reasons": [],
+                          "require_run_linkage": false
+                        },
+                        "repository_match": true,
+                        "run_linkage": {
+                          "attempt_id_present": true,
+                          "branch_name_present": true,
+                          "commit_sha_present": true,
+                          "completion_claim_id_present": true,
+                          "current_run": {
+                            "attempt_count": 1,
+                            "attempt_id": "claim-kno-183-b:attempt",
+                            "branch_name": "codex/e2e-test",
+                            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "completion_claim_id": "claim-kno-183-b",
+                            "multiple_attempts": false,
+                            "task_id": "task-kno-183-scenario-b",
+                            "task_title": "Reconcile missing pull request"
+                          },
+                          "linked": true,
+                          "markers": {
+                            "harness-attempt-id": "claim-kno-183-b:attempt",
+                            "harness-branch": "codex/e2e-test",
+                            "harness-commit-sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "harness-completion-claim-id": "claim-kno-183-b",
+                            "harness-task-id": "task-kno-183-scenario-b"
+                          },
+                          "task_id_marker_present": true
+                        },
+                        "state": "open",
+                        "state_acceptable": true,
+                        "task_linkage": {
+                          "linked": true,
+                          "task_id_present": true,
+                          "task_title_present": true
+                        }
+                      }
+                    }
+                  }
+                ],
+                "pull_request_lookup": {
+                  "ambiguous": false,
+                  "candidate_count": 1,
+                  "found": false,
+                  "number": null,
+                  "searched_by_branch": true,
+                  "searched_by_commit": true,
+                  "source": null,
+                  "url": null,
+                  "valid_candidate_count": 0
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_pr_after_execution",
+              "handler_key": "missing_pr_after_execution",
+              "started_at": "2026-04-11T16:04:28.907925Z",
+              "status": "failed"
+            }
+          ],
+          "failed_at": "2026-04-11T16:04:28.908098Z",
+          "last_attempt_id": "reconciliation-attempt-1",
+          "last_error": "Created pull request could not be revalidated from persisted GitHub state",
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "failed"
+        },
+        "required_capabilities": [],
+        "status": "in_review",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.905910Z",
+            "changed_by": "reconciliation",
+            "from_status": "executing",
+            "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+            "to_status": "reconciling"
+          },
+          {
+            "changed_at": "2026-04-11T16:04:28.910546Z",
+            "changed_by": "reconciliation",
+            "from_status": "reconciling",
+            "reason": "Post-execution reconciliation failed: Created pull request could not be revalidated from persisted GitHub state",
+            "to_status": "in_review"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-04-04T12:00:00Z",
+          "updated_at": "2026-04-11T16:04:28.910546Z"
+        },
+        "title": "Reconcile missing pull request"
+      },
+      "unresolved_conditions": []
+    },
+    "result": {
+      "accepted_completion": false,
+      "action": "review_required",
+      "enforcement_result": {
+        "action": "review_required",
+        "error": "Created pull request could not be revalidated from persisted GitHub state",
+        "evidence_result": null,
+        "failure_classification": {
+          "category": "review_required",
+          "failure_type": "review_required",
+          "reason": "Created pull request could not be revalidated from persisted GitHub state",
+          "recoverable": false,
+          "retryable": false,
+          "source": "evaluation",
+          "terminal": false
+        },
+        "reasons": [
+          "Created pull request could not be revalidated from persisted GitHub state"
+        ],
+        "reconciliation_result": {
+          "blocking": true,
+          "mismatch_categories": [
+            "missing_required_artifact"
+          ],
+          "outcome": "review_required",
+          "reasons": [
+            "Created pull request could not be revalidated from persisted GitHub state"
+          ],
+          "status": "review_required",
+          "task_id": "task-kno-183-scenario-b",
+          "terminal": false
+        },
+        "review_decision": null,
+        "review_request": {
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "requested_at": "2026-04-11T16:04:28.910546Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-183-scenario-b-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+          "task_id": "task-kno-183-scenario-b",
+          "trigger": "reconciliation"
+        },
+        "target_status": "in_review",
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "Harness can reconcile a missing PR after execution.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "required",
+              "required_artifact_types": [
+                "commit"
+              ],
+              "status": "satisfied",
+              "validated_artifact_ids": [
+                "artifact-commit-1"
+              ],
+              "validated_at": "2026-04-04T12:01:30Z",
+              "validation_method": "external_reconciliation",
+              "validator": {
+                "captured_by": "github-sync",
+                "source_id": "verification-existing-1",
+                "source_system": "harness",
+                "source_type": "verification"
+              }
+            },
+            "items": [
+              {
+                "branch": {
+                  "base_branch": "main",
+                  "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "name": "codex/e2e-test"
+                },
+                "captured_at": "2026-04-04T12:01:00Z",
+                "changed_files": [],
+                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "content_type": null,
+                "description": null,
+                "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "external_refs": [],
+                "id": "artifact-commit-1",
+                "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "metadata": {},
+                "provenance": {
+                  "captured_by": "github-sync",
+                  "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "source_system": "github",
+                  "source_type": "api"
+                },
+                "pull_request_number": null,
+                "repository": {
+                  "external_id": "repo-dryrun-1",
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                },
+                "review_state": null,
+                "title": null,
+                "type": "commit",
+                "verification_status": "verified"
+              }
+            ]
+          },
+          "assigned_executor": {
+            "assignment_reason": "Runtime coverage for reconciliation.",
+            "executor_id": "executor-1",
+            "executor_type": "codex"
+          },
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": {
+              "issue_id": "lin-1",
+              "issue_key": "HAR-1",
+              "project": null,
+              "provenance": {
+                "linked_at": "2026-04-11T16:04:28.903663Z",
+                "linked_by": "reevaluation",
+                "source": "completion_claim.external_facts"
+              },
+              "reasons": [],
+              "record_found": true,
+              "state": "completed",
+              "task_reference": null,
+              "workflow": {
+                "state_type": "completed",
+                "workflow_id": "workflow-completed",
+                "workflow_name": "completed"
+              }
+            }
+          },
+          "dependencies": [],
+          "description": "Exercise post-execution PR reconciliation.",
+          "id": "task-kno-183-scenario-b",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Exercise post-execution PR reconciliation."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-183-b",
+                  "metadata": {
+                    "attempt_id": "claim-kno-183-b:attempt"
+                  },
+                  "reason": "Execution completed successfully.",
+                  "reported_at": "2026-04-04T12:02:00Z",
+                  "reported_by": "codex"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "execution_log",
+                      "location": "stub://attempts/log",
+                      "reference_id": "claim-kno-183-b:attempt:log"
+                    }
+                  ],
+                  "attempt_id": "claim-kno-183-b:attempt",
+                  "completion_claim_id": "claim-kno-183-b",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "external_facts.expected_code_context",
+                              "external_facts.github_facts.branch"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit": [
+                          {
+                            "sources": [
+                              "external_facts.github_facts.branch",
+                              "external_facts.github_facts.commit"
+                            ],
+                            "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "repository": [
+                          {
+                            "sources": [
+                              "external_facts.expected_code_context",
+                              "external_facts.github_facts.repository"
+                            ],
+                            "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                          }
+                        ],
+                        "used_task_artifact_fallback": false
+                      },
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [],
+                      "retryable": false,
+                      "rule_failures": [],
+                      "status": "valid",
+                      "validated_at": "2026-04-11T16:04:28.903770Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "run-claim-kno-183-b"
+                  },
+                  "recorded_at": "2026-04-04T12:02:05Z",
+                  "reevaluation": {},
+                  "reported_by": "codex",
+                  "status": "completed"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "req-task-kno-183-scenario-b",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": "missing_pr_after_execution",
+            "attempts": [
+              {
+                "attempt_id": "reconciliation-attempt-1",
+                "completed_at": "2026-04-11T16:04:28.908098Z",
+                "details": {
+                  "base_branch": "main",
+                  "branch_exists": true,
+                  "branch_head_commit_sha": null,
+                  "branch_name": "codex/e2e-test",
+                  "commit_exists": true,
+                  "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "context_resolution": {
+                    "conflicts": [],
+                    "selected_source": "merged",
+                    "sources": {
+                      "artifacts": {
+                        "base_branch": "main",
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      },
+                      "external_facts": {
+                        "base_branch": "main",
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      }
+                    }
+                  },
+                  "created_pull_request": true,
+                  "created_pull_request_revalidated": false,
+                  "error": "Created pull request could not be revalidated from persisted GitHub state",
+                  "error_disposition": "review_required",
+                  "final_decision": {
+                    "reason": "created_pull_request_not_visible_after_create",
+                    "result": "created_pull_request_revalidation_failed"
+                  },
+                  "policy": {
+                    "allow_closed_pr_match": false,
+                    "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
+                    "allow_open_pr_match": true,
+                    "escalate_on_ambiguous_match": true,
+                    "require_exact_branch_match": true,
+                    "require_head_sha_match": true,
+                    "require_run_linkage_for_commit_association": true,
+                    "require_run_linkage_for_multiple_attempts": true,
+                    "require_task_linkage": false
+                  },
+                  "pull_request_candidates": [
+                    {
+                      "base_branch": "main",
+                      "head": {
+                        "branch": "codex/e2e-test",
+                        "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                      },
+                      "lookup_sources": [
+                        "created_response"
+                      ],
+                      "merged": false,
+                      "number": 632,
+                      "repository": {
+                        "name": "HARNESS-DRYRUN",
+                        "owner": "KnoxAnalytics"
+                      },
+                      "review_state": null,
+                      "state": "open",
+                      "title": "Reconcile missing pull request (task-kno-183-scenario-b)",
+                      "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/632",
+                      "validation": {
+                        "accepted": true,
+                        "matched_by": [
+                          "head_sha_match",
+                          "task_linkage",
+                          "attempt_linkage",
+                          "completion_claim_linkage"
+                        ],
+                        "reasons": [],
+                        "signals": {
+                          "branch_match": true,
+                          "commit_association_match": false,
+                          "head_sha_match": true,
+                          "linkage_policy": {
+                            "reasons": [],
+                            "require_run_linkage": false
+                          },
+                          "repository_match": true,
+                          "run_linkage": {
+                            "attempt_id_present": true,
+                            "branch_name_present": true,
+                            "commit_sha_present": true,
+                            "completion_claim_id_present": true,
+                            "current_run": {
+                              "attempt_count": 1,
+                              "attempt_id": "claim-kno-183-b:attempt",
+                              "branch_name": "codex/e2e-test",
+                              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                              "completion_claim_id": "claim-kno-183-b",
+                              "multiple_attempts": false,
+                              "task_id": "task-kno-183-scenario-b",
+                              "task_title": "Reconcile missing pull request"
+                            },
+                            "linked": true,
+                            "markers": {
+                              "harness-attempt-id": "claim-kno-183-b:attempt",
+                              "harness-branch": "codex/e2e-test",
+                              "harness-commit-sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                              "harness-completion-claim-id": "claim-kno-183-b",
+                              "harness-task-id": "task-kno-183-scenario-b"
+                            },
+                            "task_id_marker_present": true
+                          },
+                          "state": "open",
+                          "state_acceptable": true,
+                          "task_linkage": {
+                            "linked": true,
+                            "task_id_present": true,
+                            "task_title_present": true
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "pull_request_lookup": {
+                    "ambiguous": false,
+                    "candidate_count": 1,
+                    "found": false,
+                    "number": null,
+                    "searched_by_branch": true,
+                    "searched_by_commit": true,
+                    "source": null,
+                    "url": null,
+                    "valid_candidate_count": 0
+                  },
+                  "repository": {
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  }
+                },
+                "failure_type": "missing_pr_after_execution",
+                "handler_key": "missing_pr_after_execution",
+                "started_at": "2026-04-11T16:04:28.907925Z",
+                "status": "failed"
+              }
+            ],
+            "failed_at": "2026-04-11T16:04:28.908098Z",
+            "last_attempt_id": "reconciliation-attempt-1",
+            "last_error": "Created pull request could not be revalidated from persisted GitHub state",
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "failed"
+          },
+          "required_capabilities": [],
+          "status": "in_review",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.905910Z",
+              "changed_by": "reconciliation",
+              "from_status": "executing",
+              "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+              "to_status": "reconciling"
+            },
+            {
+              "changed_at": "2026-04-11T16:04:28.910546Z",
+              "changed_by": "reconciliation",
+              "from_status": "reconciling",
+              "reason": "Post-execution reconciliation failed: Created pull request could not be revalidated from persisted GitHub state",
+              "to_status": "in_review"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-04-04T12:00:00Z",
+            "updated_at": "2026-04-11T16:04:28.910546Z"
+          },
+          "title": "Reconcile missing pull request"
+        },
+        "transition_result": null,
+        "verification_result": null
+      },
+      "error": "Created pull request could not be revalidated from persisted GitHub state",
+      "failure_classification": {
+        "category": "review_required",
+        "failure_type": "review_required",
+        "reason": "Created pull request could not be revalidated from persisted GitHub state",
+        "recoverable": false,
+        "retryable": false,
+        "source": "evaluation",
+        "terminal": false
+      },
+      "invalid_input": false,
+      "reasons": [
+        "Created pull request could not be revalidated from persisted GitHub state"
+      ],
+      "requires_review": true,
+      "target_status": "in_review",
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "Harness can reconcile a missing PR after execution.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "required",
+            "required_artifact_types": [
+              "commit"
+            ],
+            "status": "satisfied",
+            "validated_artifact_ids": [
+              "artifact-commit-1"
+            ],
+            "validated_at": "2026-04-04T12:01:30Z",
+            "validation_method": "external_reconciliation",
+            "validator": {
+              "captured_by": "github-sync",
+              "source_id": "verification-existing-1",
+              "source_system": "harness",
+              "source_type": "verification"
+            }
+          },
+          "items": [
+            {
+              "branch": {
+                "base_branch": "main",
+                "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "name": "codex/e2e-test"
+              },
+              "captured_at": "2026-04-04T12:01:00Z",
+              "changed_files": [],
+              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "content_type": null,
+              "description": null,
+              "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "external_refs": [],
+              "id": "artifact-commit-1",
+              "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "metadata": {},
+              "provenance": {
+                "captured_by": "github-sync",
+                "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "source_system": "github",
+                "source_type": "api"
+              },
+              "pull_request_number": null,
+              "repository": {
+                "external_id": "repo-dryrun-1",
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              },
+              "review_state": null,
+              "title": null,
+              "type": "commit",
+              "verification_status": "verified"
+            }
+          ]
+        },
+        "assigned_executor": {
+          "assignment_reason": "Runtime coverage for reconciliation.",
+          "executor_id": "executor-1",
+          "executor_type": "codex"
+        },
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": {
+            "issue_id": "lin-1",
+            "issue_key": "HAR-1",
+            "project": null,
+            "provenance": {
+              "linked_at": "2026-04-11T16:04:28.903663Z",
+              "linked_by": "reevaluation",
+              "source": "completion_claim.external_facts"
+            },
+            "reasons": [],
+            "record_found": true,
+            "state": "completed",
+            "task_reference": null,
+            "workflow": {
+              "state_type": "completed",
+              "workflow_id": "workflow-completed",
+              "workflow_name": "completed"
+            }
+          }
+        },
+        "dependencies": [],
+        "description": "Exercise post-execution PR reconciliation.",
+        "id": "task-kno-183-scenario-b",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Exercise post-execution PR reconciliation."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-183-b",
+                "metadata": {
+                  "attempt_id": "claim-kno-183-b:attempt"
+                },
+                "reason": "Execution completed successfully.",
+                "reported_at": "2026-04-04T12:02:00Z",
+                "reported_by": "codex"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [
+                  {
+                    "artifact_type": "execution_log",
+                    "location": "stub://attempts/log",
+                    "reference_id": "claim-kno-183-b:attempt:log"
+                  }
+                ],
+                "attempt_id": "claim-kno-183-b:attempt",
+                "completion_claim_id": "claim-kno-183-b",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "branch": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context",
+                            "external_facts.github_facts.branch"
+                          ],
+                          "value": "codex/e2e-test"
+                        }
+                      ],
+                      "commit": [
+                        {
+                          "sources": [
+                            "external_facts.github_facts.branch",
+                            "external_facts.github_facts.commit"
+                          ],
+                          "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                        }
+                      ],
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "repository": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context",
+                            "external_facts.github_facts.repository"
+                          ],
+                          "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                        }
+                      ],
+                      "used_task_artifact_fallback": false
+                    },
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [],
+                    "retryable": false,
+                    "rule_failures": [],
+                    "status": "valid",
+                    "validated_at": "2026-04-11T16:04:28.903770Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "run-claim-kno-183-b"
+                },
+                "recorded_at": "2026-04-04T12:02:05Z",
+                "reevaluation": {},
+                "reported_by": "codex",
+                "status": "completed"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "req-task-kno-183-scenario-b",
+          "source_system": "openclaw",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": "missing_pr_after_execution",
+          "attempts": [
+            {
+              "attempt_id": "reconciliation-attempt-1",
+              "completed_at": "2026-04-11T16:04:28.908098Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": true,
+                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "merged",
+                  "sources": {
+                    "artifacts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    },
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_pull_request": true,
+                "created_pull_request_revalidated": false,
+                "error": "Created pull request could not be revalidated from persisted GitHub state",
+                "error_disposition": "review_required",
+                "final_decision": {
+                  "reason": "created_pull_request_not_visible_after_create",
+                  "result": "created_pull_request_revalidation_failed"
+                },
+                "policy": {
+                  "allow_closed_pr_match": false,
+                  "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
+                  "allow_open_pr_match": true,
+                  "escalate_on_ambiguous_match": true,
+                  "require_exact_branch_match": true,
+                  "require_head_sha_match": true,
+                  "require_run_linkage_for_commit_association": true,
+                  "require_run_linkage_for_multiple_attempts": true,
+                  "require_task_linkage": false
+                },
+                "pull_request_candidates": [
+                  {
+                    "base_branch": "main",
+                    "head": {
+                      "branch": "codex/e2e-test",
+                      "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                    },
+                    "lookup_sources": [
+                      "created_response"
+                    ],
+                    "merged": false,
+                    "number": 632,
+                    "repository": {
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    },
+                    "review_state": null,
+                    "state": "open",
+                    "title": "Reconcile missing pull request (task-kno-183-scenario-b)",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/632",
+                    "validation": {
+                      "accepted": true,
+                      "matched_by": [
+                        "head_sha_match",
+                        "task_linkage",
+                        "attempt_linkage",
+                        "completion_claim_linkage"
+                      ],
+                      "reasons": [],
+                      "signals": {
+                        "branch_match": true,
+                        "commit_association_match": false,
+                        "head_sha_match": true,
+                        "linkage_policy": {
+                          "reasons": [],
+                          "require_run_linkage": false
+                        },
+                        "repository_match": true,
+                        "run_linkage": {
+                          "attempt_id_present": true,
+                          "branch_name_present": true,
+                          "commit_sha_present": true,
+                          "completion_claim_id_present": true,
+                          "current_run": {
+                            "attempt_count": 1,
+                            "attempt_id": "claim-kno-183-b:attempt",
+                            "branch_name": "codex/e2e-test",
+                            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "completion_claim_id": "claim-kno-183-b",
+                            "multiple_attempts": false,
+                            "task_id": "task-kno-183-scenario-b",
+                            "task_title": "Reconcile missing pull request"
+                          },
+                          "linked": true,
+                          "markers": {
+                            "harness-attempt-id": "claim-kno-183-b:attempt",
+                            "harness-branch": "codex/e2e-test",
+                            "harness-commit-sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "harness-completion-claim-id": "claim-kno-183-b",
+                            "harness-task-id": "task-kno-183-scenario-b"
+                          },
+                          "task_id_marker_present": true
+                        },
+                        "state": "open",
+                        "state_acceptable": true,
+                        "task_linkage": {
+                          "linked": true,
+                          "task_id_present": true,
+                          "task_title_present": true
+                        }
+                      }
+                    }
+                  }
+                ],
+                "pull_request_lookup": {
+                  "ambiguous": false,
+                  "candidate_count": 1,
+                  "found": false,
+                  "number": null,
+                  "searched_by_branch": true,
+                  "searched_by_commit": true,
+                  "source": null,
+                  "url": null,
+                  "valid_candidate_count": 0
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_pr_after_execution",
+              "handler_key": "missing_pr_after_execution",
+              "started_at": "2026-04-11T16:04:28.907925Z",
+              "status": "failed"
+            }
+          ],
+          "failed_at": "2026-04-11T16:04:28.908098Z",
+          "last_attempt_id": "reconciliation-attempt-1",
+          "last_error": "Created pull request could not be revalidated from persisted GitHub state",
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "failed"
+        },
+        "required_capabilities": [],
+        "status": "in_review",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.905910Z",
+            "changed_by": "reconciliation",
+            "from_status": "executing",
+            "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+            "to_status": "reconciling"
+          },
+          {
+            "changed_at": "2026-04-11T16:04:28.910546Z",
+            "changed_by": "reconciliation",
+            "from_status": "reconciling",
+            "reason": "Post-execution reconciliation failed: Created pull request could not be revalidated from persisted GitHub state",
+            "to_status": "in_review"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-04-04T12:00:00Z",
+          "updated_at": "2026-04-11T16:04:28.910546Z"
+        },
+        "title": "Reconcile missing pull request"
+      }
+    },
+    "task_id": "task-kno-183-scenario-b"
+  },
   "invalid_input": false,
   "reasons": [
     "Created pull request could not be revalidated from persisted GitHub state"
   ],
   "reconciliation_attempt": {
     "attempt_id": "reconciliation-attempt-1",
-    "completed_at": "2026-04-06T13:58:02.173411Z",
+    "completed_at": "2026-04-11T16:04:28.908098Z",
     "details": {
       "base_branch": "main",
       "branch_exists": true,
+      "branch_head_commit_sha": null,
       "branch_name": "codex/e2e-test",
       "commit_exists": true,
       "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
       "context_resolution": {
         "conflicts": [],
-        "selected_source": "external_facts",
+        "selected_source": "merged",
         "sources": {
           "artifacts": {
             "base_branch": "main",
@@ -48,6 +1885,7 @@
       "policy": {
         "allow_closed_pr_match": false,
         "allow_commit_association_match": true,
+        "allow_non_head_commit_association_match": false,
         "allow_open_pr_match": true,
         "escalate_on_ambiguous_match": true,
         "require_exact_branch_match": true,
@@ -149,10 +1987,35 @@
     },
     "failure_type": "missing_pr_after_execution",
     "handler_key": "missing_pr_after_execution",
-    "started_at": "2026-04-06T13:58:02.172935Z",
+    "started_at": "2026-04-11T16:04:28.907925Z",
     "status": "failed"
   },
   "requires_review": true,
+  "review_request": {
+    "allowed_outcomes": [
+      "accept_completion",
+      "keep_blocked",
+      "mark_failed",
+      "authorize_redispatch"
+    ],
+    "metadata": {
+      "reconciliation_attempt_id": "reconciliation-attempt-1",
+      "reconciliation_failure_type": "missing_pr_after_execution"
+    },
+    "presented_sections": [
+      "task_state",
+      "execution",
+      "evidence",
+      "reconciliation"
+    ],
+    "prior_review_ids": [],
+    "requested_at": "2026-04-11T16:04:28.910546Z",
+    "requested_by": "reconciliation",
+    "review_request_id": "review-request-task-kno-183-scenario-b-reconciliation-1",
+    "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+    "task_id": "task-kno-183-scenario-b",
+    "trigger": "reconciliation"
+  },
   "target_status": "in_review",
   "task_envelope": {
     "acceptance_criteria": [
@@ -232,7 +2095,7 @@
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:02.145864Z",
+          "linked_at": "2026-04-11T16:04:28.903663Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -301,6 +2164,8 @@
                       "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                     }
                   ],
+                  "commit_resolution_pending": false,
+                  "has_valid_current_run_pull_request_artifact": false,
                   "repository": [
                     {
                       "sources": [
@@ -313,16 +2178,23 @@
                   "used_task_artifact_fallback": false
                 },
                 "policy": {
+                  "allow_commit_resolution_via_reconciliation": true,
+                  "allow_missing_commit_artifact_with_verified_pull_request": true,
                   "allow_missing_pull_request": true,
+                  "reject_closed_or_historical_pull_request": true,
+                  "reject_non_numeric_pull_request_url": true,
+                  "reject_reserved_shared_branch": true,
                   "require_commit": true,
                   "require_exact_branch": true,
                   "require_repository": true,
                   "task_artifact_fallback_requires_single_attempt": true
                 },
+                "pull_request_observations": [],
                 "reasons": [],
                 "retryable": false,
+                "rule_failures": [],
                 "status": "valid",
-                "validated_at": "2026-04-06T13:58:02.146075Z",
+                "validated_at": "2026-04-11T16:04:28.903770Z",
                 "validated_by": "execution_validation"
               },
               "executor_run_id": "run-claim-kno-183-b"
@@ -366,16 +2238,17 @@
       "attempts": [
         {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T13:58:02.173411Z",
+          "completed_at": "2026-04-11T16:04:28.908098Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
+            "branch_head_commit_sha": null,
             "branch_name": "codex/e2e-test",
             "commit_exists": true,
             "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
             "context_resolution": {
               "conflicts": [],
-              "selected_source": "external_facts",
+              "selected_source": "merged",
               "sources": {
                 "artifacts": {
                   "base_branch": "main",
@@ -406,6 +2279,7 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -507,11 +2381,11 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T13:58:02.172935Z",
+          "started_at": "2026-04-11T16:04:28.907925Z",
           "status": "failed"
         }
       ],
-      "failed_at": "2026-04-06T13:58:02.173411Z",
+      "failed_at": "2026-04-11T16:04:28.908098Z",
       "last_attempt_id": "reconciliation-attempt-1",
       "last_error": "Created pull request could not be revalidated from persisted GitHub state",
       "last_pr_url": null,
@@ -522,14 +2396,14 @@
     "status": "in_review",
     "status_history": [
       {
-        "changed_at": "2026-04-06T13:58:02.159776Z",
+        "changed_at": "2026-04-11T16:04:28.905910Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T13:58:02.186622Z",
+        "changed_at": "2026-04-11T16:04:28.910546Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
         "reason": "Post-execution reconciliation failed: Created pull request could not be revalidated from persisted GitHub state",
@@ -539,7 +2413,7 @@
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T13:58:02.186622Z"
+      "updated_at": "2026-04-11T16:04:28.910546Z"
     },
     "title": "Reconcile missing pull request"
   }

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-b-read-model-final.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-b-read-model-final.json
@@ -1,17 +1,14 @@
 {
   "task": {
-    "assigned_executor": {
-      "assignment_reason": "Runtime coverage for reconciliation.",
-      "executor_id": "executor-1",
-      "executor_type": "codex"
-    },
+    "assigned_executor": null,
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:02.145864Z",
+          "linked_at": "2026-04-11T16:04:28.903663Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -29,11 +26,18 @@
     "current_status": "in_review",
     "description": "Exercise post-execution PR reconciliation.",
     "evaluation_summary": {
-      "count": 0,
-      "history": [],
-      "latest_action": null,
-      "latest_recorded_at": null,
-      "latest_target_status": null
+      "count": 1,
+      "history": [
+        {
+          "action": "review_required",
+          "evaluation_id": "1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+          "recorded_at": "2026-04-11T16:04:28.913215Z",
+          "target_status": "in_review"
+        }
+      ],
+      "latest_action": "review_required",
+      "latest_recorded_at": "2026-04-11T16:04:28.913215Z",
+      "latest_target_status": "in_review"
     },
     "evidence_summary": {
       "artifact_count": 1,
@@ -65,9 +69,9 @@
     },
     "execution_summary": {
       "attempt_count": 1,
-      "failure_state": "clear",
+      "failure_state": "review_required",
       "invalid_attempt_count": 0,
-      "last_failure_type": "none",
+      "last_failure_type": "review_required",
       "latest_artifact_references": [
         {
           "artifact_type": "execution_log",
@@ -106,6 +110,8 @@
                   "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                 }
               ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -118,16 +124,23 @@
               "used_task_artifact_fallback": false
             },
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T13:58:02.146075Z",
+            "validated_at": "2026-04-11T16:04:28.903770Z",
             "validated_by": "execution_validation"
           },
           "executor_run_id": "run-claim-kno-183-b"
@@ -157,6 +170,8 @@
               "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
             }
           ],
+          "commit_resolution_pending": false,
+          "has_valid_current_run_pull_request_artifact": false,
           "repository": [
             {
               "sources": [
@@ -169,42 +184,52 @@
           "used_task_artifact_fallback": false
         },
         "policy": {
+          "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
           "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
           "require_commit": true,
           "require_exact_branch": true,
           "require_repository": true,
           "task_artifact_fallback_requires_single_attempt": true
         },
+        "pull_request_observations": [],
         "reasons": [],
         "retryable": false,
+        "rule_failures": [],
         "status": "valid",
-        "validated_at": "2026-04-06T13:58:02.146075Z",
+        "validated_at": "2026-04-11T16:04:28.903770Z",
         "validated_by": "execution_validation"
       },
       "latest_dispatch_origin": null,
       "latest_status": "completed",
       "retry_count": 0,
       "retry_eligible": false,
-      "total_attempts": 0
+      "total_attempts": 1
     },
     "extensions": {},
     "failure_summary": {
-      "failure_source": "none",
-      "failure_type": "none",
+      "evaluation_id": "1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+      "failure_reason": "Created pull request could not be revalidated from persisted GitHub state",
+      "failure_source": "evaluation",
+      "failure_type": "review_required",
+      "recorded_at": "2026-04-11T16:04:28.913215Z",
       "recoverable": false,
-      "state": "clear",
+      "state": "review_required",
       "terminal": false
     },
     "lifecycle_history": [
       {
-        "changed_at": "2026-04-06T13:58:02.159776Z",
+        "changed_at": "2026-04-11T16:04:28.905910Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T13:58:02.186622Z",
+        "changed_at": "2026-04-11T16:04:28.910546Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
         "reason": "Post-execution reconciliation failed: Created pull request could not be revalidated from persisted GitHub state",
@@ -220,7 +245,19 @@
       "source_system": "openclaw",
       "source_type": "ingress_request"
     },
-    "reconciliation_summary": null,
+    "reconciliation_summary": {
+      "blocking": true,
+      "mismatch_categories": [
+        "missing_required_artifact"
+      ],
+      "outcome": "review_required",
+      "reasons": [
+        "Created pull request could not be revalidated from persisted GitHub state"
+      ],
+      "status": "review_required",
+      "task_id": "task-kno-183-scenario-b",
+      "terminal": false
+    },
     "relationships": {
       "child_task_ids": [],
       "dependencies": [],
@@ -230,10 +267,62 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
-      "latest_request": null,
-      "request_count": 0,
-      "requests": [],
-      "status": "none"
+      "latest_effective_decision": null,
+      "latest_request": {
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "requested_at": "2026-04-11T16:04:28.910546Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-183-scenario-b-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+        "task_id": "task-kno-183-scenario-b",
+        "trigger": "reconciliation"
+      },
+      "request_count": 1,
+      "requests": [
+        {
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "requested_at": "2026-04-11T16:04:28.910546Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-183-scenario-b-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+          "task_id": "task-kno-183-scenario-b",
+          "trigger": "reconciliation"
+        }
+      ],
+      "resolved_decision_count": 0,
+      "status": "requested"
     },
     "task_id": "task-kno-183-scenario-b",
     "timeline": [
@@ -284,18 +373,6 @@
       },
       {
         "details": {
-          "artifact_type": "execution_log",
-          "location": "stub://attempts/log",
-          "reference_id": "claim-kno-183-b:attempt:log"
-        },
-        "event_id": "task-kno-183-scenario-b:execution_artifact:claim-kno-183-b:attempt:claim-kno-183-b:attempt:log",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-04T12:02:05Z",
-        "source": "codex",
-        "summary": "Execution artifact attached: execution_log"
-      },
-      {
-        "details": {
           "artifact_references": [
             {
               "artifact_type": "execution_log",
@@ -324,6 +401,8 @@
                   "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                 }
               ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -336,16 +415,23 @@
               "used_task_artifact_fallback": false
             },
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T13:58:02.146075Z",
+            "validated_at": "2026-04-11T16:04:28.903770Z",
             "validated_by": "execution_validation"
           },
           "completion_claim_id": "claim-kno-183-b",
@@ -360,11 +446,23 @@
       },
       {
         "details": {
+          "artifact_type": "execution_log",
+          "location": "stub://attempts/log",
+          "reference_id": "claim-kno-183-b:attempt:log"
+        },
+        "event_id": "task-kno-183-scenario-b:execution_artifact:claim-kno-183-b:attempt:claim-kno-183-b:attempt:log",
+        "event_type": "execution_artifact_attached",
+        "occurred_at": "2026-04-04T12:02:05Z",
+        "source": "codex",
+        "summary": "Execution artifact attached: execution_log"
+      },
+      {
+        "details": {
           "issue_id": "lin-1",
           "issue_key": "HAR-1",
           "project": null,
           "provenance": {
-            "linked_at": "2026-04-06T13:58:02.145864Z",
+            "linked_at": "2026-04-11T16:04:28.903663Z",
             "linked_by": "reevaluation",
             "source": "completion_claim.external_facts"
           },
@@ -380,13 +478,13 @@
         },
         "event_id": "task-kno-183-scenario-b:linear_linkage",
         "event_type": "linear_linkage_recorded",
-        "occurred_at": "2026-04-06T13:58:02.145864Z",
+        "occurred_at": "2026-04-11T16:04:28.903663Z",
         "source": "reevaluation",
         "summary": "Linear linkage recorded"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T13:58:02.159776Z",
+          "changed_at": "2026-04-11T16:04:28.905910Z",
           "changed_by": "reconciliation",
           "from_status": "executing",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -394,23 +492,24 @@
         },
         "event_id": "task-kno-183-scenario-b:status:0",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T13:58:02.159776Z",
+        "occurred_at": "2026-04-11T16:04:28.905910Z",
         "source": "reconciliation",
         "summary": "Status changed executing -> reconciling"
       },
       {
         "details": {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T13:58:02.173411Z",
+          "completed_at": "2026-04-11T16:04:28.908098Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
+            "branch_head_commit_sha": null,
             "branch_name": "codex/e2e-test",
             "commit_exists": true,
             "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
             "context_resolution": {
               "conflicts": [],
-              "selected_source": "external_facts",
+              "selected_source": "merged",
               "sources": {
                 "artifacts": {
                   "base_branch": "main",
@@ -441,6 +540,7 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -542,18 +642,51 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T13:58:02.172935Z",
+          "started_at": "2026-04-11T16:04:28.907925Z",
           "status": "failed"
         },
         "event_id": "task-kno-183-scenario-b:reconciliation:reconciliation-attempt-1",
         "event_type": "reconciliation_attempt_recorded",
-        "occurred_at": "2026-04-06T13:58:02.173411Z",
+        "occurred_at": "2026-04-11T16:04:28.908098Z",
         "source": "reconciliation",
         "summary": "Reconciliation attempt: missing_pr_after_execution"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T13:58:02.186622Z",
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "reason": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+          "requested_at": "2026-04-11T16:04:28.910546Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-183-scenario-b-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+          "task_id": "task-kno-183-scenario-b",
+          "trigger": "reconciliation"
+        },
+        "event_id": "task-kno-183-scenario-b:review-request:review-request-task-kno-183-scenario-b-reconciliation-1",
+        "event_type": "review_requested",
+        "occurred_at": "2026-04-11T16:04:28.910546Z",
+        "source": "reconciliation",
+        "summary": "Manual review requested"
+      },
+      {
+        "details": {
+          "changed_at": "2026-04-11T16:04:28.910546Z",
           "changed_by": "reconciliation",
           "from_status": "reconciling",
           "reason": "Post-execution reconciliation failed: Created pull request could not be revalidated from persisted GitHub state",
@@ -561,15 +694,61 @@
         },
         "event_id": "task-kno-183-scenario-b:status:1",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T13:58:02.186622Z",
+        "occurred_at": "2026-04-11T16:04:28.910546Z",
         "source": "reconciliation",
         "summary": "Status changed reconciling -> in_review"
+      },
+      {
+        "details": {
+          "accepted_completion": false,
+          "action": "review_required",
+          "evaluation_id": "1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+          "reasons": [
+            "Created pull request could not be revalidated from persisted GitHub state"
+          ],
+          "reconciliation_result": {
+            "blocking": true,
+            "mismatch_categories": [
+              "missing_required_artifact"
+            ],
+            "outcome": "review_required",
+            "reasons": [
+              "Created pull request could not be revalidated from persisted GitHub state"
+            ],
+            "status": "review_required",
+            "task_id": "task-kno-183-scenario-b",
+            "terminal": false
+          },
+          "requires_review": true,
+          "target_status": "in_review",
+          "verification_result": null
+        },
+        "event_id": "task-kno-183-scenario-b:evaluation:1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+        "event_type": "evaluation_recorded",
+        "occurred_at": "2026-04-11T16:04:28.913215Z",
+        "source": "harness",
+        "summary": "Evaluation recorded: review_required"
+      },
+      {
+        "details": {
+          "failure_reason": "Created pull request could not be revalidated from persisted GitHub state",
+          "failure_recorded": true,
+          "failure_source": "evaluation",
+          "failure_type": "review_required",
+          "recoverable": false,
+          "terminal": false
+        },
+        "event_id": "task-kno-183-scenario-b:failure:1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+        "event_type": "failure_recorded",
+        "occurred_at": "2026-04-11T16:04:28.913215Z",
+        "source": "evaluation",
+        "summary": "Failure recorded: review_required"
       }
     ],
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T13:58:02.186622Z"
+      "updated_at": "2026-04-11T16:04:28.910546Z"
     },
     "title": "Reconcile missing pull request",
     "verification_summary": null

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-b-read-model-initial.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-b-read-model-initial.json
@@ -5,6 +5,7 @@
       "executor_id": "executor-1",
       "executor_type": "codex"
     },
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": null
     },
@@ -87,9 +88,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-183-scenario-b",

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-b-timeline-final.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-b-timeline-final.json
@@ -1,6 +1,6 @@
 {
   "current_status": "in_review",
-  "event_count": 8,
+  "event_count": 11,
   "task_id": "task-kno-183-scenario-b",
   "timeline": [
     {
@@ -50,18 +50,6 @@
     },
     {
       "details": {
-        "artifact_type": "execution_log",
-        "location": "stub://attempts/log",
-        "reference_id": "claim-kno-183-b:attempt:log"
-      },
-      "event_id": "task-kno-183-scenario-b:execution_artifact:claim-kno-183-b:attempt:claim-kno-183-b:attempt:log",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-04T12:02:05Z",
-      "source": "codex",
-      "summary": "Execution artifact attached: execution_log"
-    },
-    {
-      "details": {
         "artifact_references": [
           {
             "artifact_type": "execution_log",
@@ -90,6 +78,8 @@
                 "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
               }
             ],
+            "commit_resolution_pending": false,
+            "has_valid_current_run_pull_request_artifact": false,
             "repository": [
               {
                 "sources": [
@@ -102,16 +92,23 @@
             "used_task_artifact_fallback": false
           },
           "policy": {
+            "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [],
           "retryable": false,
+          "rule_failures": [],
           "status": "valid",
-          "validated_at": "2026-04-06T13:58:02.146075Z",
+          "validated_at": "2026-04-11T16:04:28.903770Z",
           "validated_by": "execution_validation"
         },
         "completion_claim_id": "claim-kno-183-b",
@@ -126,11 +123,23 @@
     },
     {
       "details": {
+        "artifact_type": "execution_log",
+        "location": "stub://attempts/log",
+        "reference_id": "claim-kno-183-b:attempt:log"
+      },
+      "event_id": "task-kno-183-scenario-b:execution_artifact:claim-kno-183-b:attempt:claim-kno-183-b:attempt:log",
+      "event_type": "execution_artifact_attached",
+      "occurred_at": "2026-04-04T12:02:05Z",
+      "source": "codex",
+      "summary": "Execution artifact attached: execution_log"
+    },
+    {
+      "details": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:02.145864Z",
+          "linked_at": "2026-04-11T16:04:28.903663Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -146,13 +155,13 @@
       },
       "event_id": "task-kno-183-scenario-b:linear_linkage",
       "event_type": "linear_linkage_recorded",
-      "occurred_at": "2026-04-06T13:58:02.145864Z",
+      "occurred_at": "2026-04-11T16:04:28.903663Z",
       "source": "reevaluation",
       "summary": "Linear linkage recorded"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T13:58:02.159776Z",
+        "changed_at": "2026-04-11T16:04:28.905910Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -160,23 +169,24 @@
       },
       "event_id": "task-kno-183-scenario-b:status:0",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T13:58:02.159776Z",
+      "occurred_at": "2026-04-11T16:04:28.905910Z",
       "source": "reconciliation",
       "summary": "Status changed executing -> reconciling"
     },
     {
       "details": {
         "attempt_id": "reconciliation-attempt-1",
-        "completed_at": "2026-04-06T13:58:02.173411Z",
+        "completed_at": "2026-04-11T16:04:28.908098Z",
         "details": {
           "base_branch": "main",
           "branch_exists": true,
+          "branch_head_commit_sha": null,
           "branch_name": "codex/e2e-test",
           "commit_exists": true,
           "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
           "context_resolution": {
             "conflicts": [],
-            "selected_source": "external_facts",
+            "selected_source": "merged",
             "sources": {
               "artifacts": {
                 "base_branch": "main",
@@ -207,6 +217,7 @@
           "policy": {
             "allow_closed_pr_match": false,
             "allow_commit_association_match": true,
+            "allow_non_head_commit_association_match": false,
             "allow_open_pr_match": true,
             "escalate_on_ambiguous_match": true,
             "require_exact_branch_match": true,
@@ -308,18 +319,51 @@
         },
         "failure_type": "missing_pr_after_execution",
         "handler_key": "missing_pr_after_execution",
-        "started_at": "2026-04-06T13:58:02.172935Z",
+        "started_at": "2026-04-11T16:04:28.907925Z",
         "status": "failed"
       },
       "event_id": "task-kno-183-scenario-b:reconciliation:reconciliation-attempt-1",
       "event_type": "reconciliation_attempt_recorded",
-      "occurred_at": "2026-04-06T13:58:02.173411Z",
+      "occurred_at": "2026-04-11T16:04:28.908098Z",
       "source": "reconciliation",
       "summary": "Reconciliation attempt: missing_pr_after_execution"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T13:58:02.186622Z",
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "reason": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+        "requested_at": "2026-04-11T16:04:28.910546Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-183-scenario-b-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request could not be revalidated from persisted GitHub state",
+        "task_id": "task-kno-183-scenario-b",
+        "trigger": "reconciliation"
+      },
+      "event_id": "task-kno-183-scenario-b:review-request:review-request-task-kno-183-scenario-b-reconciliation-1",
+      "event_type": "review_requested",
+      "occurred_at": "2026-04-11T16:04:28.910546Z",
+      "source": "reconciliation",
+      "summary": "Manual review requested"
+    },
+    {
+      "details": {
+        "changed_at": "2026-04-11T16:04:28.910546Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
         "reason": "Post-execution reconciliation failed: Created pull request could not be revalidated from persisted GitHub state",
@@ -327,9 +371,55 @@
       },
       "event_id": "task-kno-183-scenario-b:status:1",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T13:58:02.186622Z",
+      "occurred_at": "2026-04-11T16:04:28.910546Z",
       "source": "reconciliation",
       "summary": "Status changed reconciling -> in_review"
+    },
+    {
+      "details": {
+        "accepted_completion": false,
+        "action": "review_required",
+        "evaluation_id": "1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+        "reasons": [
+          "Created pull request could not be revalidated from persisted GitHub state"
+        ],
+        "reconciliation_result": {
+          "blocking": true,
+          "mismatch_categories": [
+            "missing_required_artifact"
+          ],
+          "outcome": "review_required",
+          "reasons": [
+            "Created pull request could not be revalidated from persisted GitHub state"
+          ],
+          "status": "review_required",
+          "task_id": "task-kno-183-scenario-b",
+          "terminal": false
+        },
+        "requires_review": true,
+        "target_status": "in_review",
+        "verification_result": null
+      },
+      "event_id": "task-kno-183-scenario-b:evaluation:1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+      "event_type": "evaluation_recorded",
+      "occurred_at": "2026-04-11T16:04:28.913215Z",
+      "source": "harness",
+      "summary": "Evaluation recorded: review_required"
+    },
+    {
+      "details": {
+        "failure_reason": "Created pull request could not be revalidated from persisted GitHub state",
+        "failure_recorded": true,
+        "failure_source": "evaluation",
+        "failure_type": "review_required",
+        "recoverable": false,
+        "terminal": false
+      },
+      "event_id": "task-kno-183-scenario-b:failure:1c17afef-0271-4d23-a02c-7cec5ccb0d78",
+      "event_type": "failure_recorded",
+      "occurred_at": "2026-04-11T16:04:28.913215Z",
+      "source": "evaluation",
+      "summary": "Failure recorded: review_required"
     }
   ]
 }

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-c-completion-claim-response.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-c-completion-claim-response.json
@@ -1,23 +1,2120 @@
 {
   "accepted_completion": false,
   "action": "reconciliation_failed",
+  "enforcement_result": {
+    "action": "review_required",
+    "error": "Created pull request did not satisfy current-run validation policy after read-back",
+    "evidence_result": null,
+    "failure_classification": {
+      "category": "review_required",
+      "failure_type": "review_required",
+      "reason": "Created pull request did not satisfy current-run validation policy after read-back",
+      "recoverable": false,
+      "retryable": false,
+      "source": "evaluation",
+      "terminal": false
+    },
+    "reasons": [
+      "Created pull request did not satisfy current-run validation policy after read-back"
+    ],
+    "reconciliation_result": {
+      "blocking": true,
+      "mismatch_categories": [
+        "missing_required_artifact"
+      ],
+      "outcome": "review_required",
+      "reasons": [
+        "Created pull request did not satisfy current-run validation policy after read-back"
+      ],
+      "status": "review_required",
+      "task_id": "task-kno-183-scenario-c",
+      "terminal": false
+    },
+    "review_decision": null,
+    "review_request": {
+      "allowed_outcomes": [
+        "accept_completion",
+        "keep_blocked",
+        "mark_failed",
+        "authorize_redispatch"
+      ],
+      "metadata": {
+        "reconciliation_attempt_id": "reconciliation-attempt-1",
+        "reconciliation_failure_type": "missing_pr_after_execution"
+      },
+      "presented_sections": [
+        "task_state",
+        "execution",
+        "evidence",
+        "reconciliation"
+      ],
+      "prior_review_ids": [],
+      "requested_at": "2026-04-11T16:04:28.927511Z",
+      "requested_by": "reconciliation",
+      "review_request_id": "review-request-task-kno-183-scenario-c-reconciliation-1",
+      "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+      "task_id": "task-kno-183-scenario-c",
+      "trigger": "reconciliation"
+    },
+    "target_status": "in_review",
+    "task_envelope": {
+      "acceptance_criteria": [
+        {
+          "description": "Harness can reconcile a missing PR after execution.",
+          "id": "ac-1",
+          "required": true
+        }
+      ],
+      "artifacts": {
+        "completion_evidence": {
+          "notes": null,
+          "policy": "required",
+          "required_artifact_types": [
+            "commit"
+          ],
+          "status": "satisfied",
+          "validated_artifact_ids": [
+            "artifact-commit-1"
+          ],
+          "validated_at": "2026-04-04T12:01:30Z",
+          "validation_method": "external_reconciliation",
+          "validator": {
+            "captured_by": "github-sync",
+            "source_id": "verification-existing-1",
+            "source_system": "harness",
+            "source_type": "verification"
+          }
+        },
+        "items": [
+          {
+            "branch": {
+              "base_branch": "main",
+              "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "name": "codex/e2e-test"
+            },
+            "captured_at": "2026-04-04T12:01:00Z",
+            "changed_files": [],
+            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "content_type": null,
+            "description": null,
+            "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "external_refs": [],
+            "id": "artifact-commit-1",
+            "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "metadata": {},
+            "provenance": {
+              "captured_by": "github-sync",
+              "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": null,
+            "repository": {
+              "external_id": "repo-dryrun-1",
+              "host": "github.com",
+              "name": "HARNESS-DRYRUN",
+              "owner": "KnoxAnalytics"
+            },
+            "review_state": null,
+            "title": null,
+            "type": "commit",
+            "verification_status": "verified"
+          }
+        ]
+      },
+      "assigned_executor": {
+        "assignment_reason": "Runtime coverage for reconciliation.",
+        "executor_id": "executor-1",
+        "executor_type": "codex"
+      },
+      "child_task_ids": [],
+      "constraints": [],
+      "coordination": {
+        "linear": {
+          "issue_id": "lin-1",
+          "issue_key": "HAR-1",
+          "project": null,
+          "provenance": {
+            "linked_at": "2026-04-11T16:04:28.921111Z",
+            "linked_by": "reevaluation",
+            "source": "completion_claim.external_facts"
+          },
+          "reasons": [],
+          "record_found": true,
+          "state": "completed",
+          "task_reference": null,
+          "workflow": {
+            "state_type": "completed",
+            "workflow_id": "workflow-completed",
+            "workflow_name": "completed"
+          }
+        }
+      },
+      "dependencies": [],
+      "description": "Exercise post-execution PR reconciliation.",
+      "id": "task-kno-183-scenario-c",
+      "objective": {
+        "deliverable_type": "unspecified",
+        "success_signal": "Task satisfies declared acceptance criteria.",
+        "summary": "Exercise post-execution PR reconciliation."
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {
+          "advisory_completion_claims": [
+            {
+              "claim_id": "claim-kno-183-c",
+              "metadata": {
+                "attempt_id": "claim-kno-183-c:attempt"
+              },
+              "reason": "Execution completed successfully.",
+              "reported_at": "2026-04-04T12:02:00Z",
+              "reported_by": "codex"
+            }
+          ],
+          "execution_attempts": [
+            {
+              "artifact_references": [
+                {
+                  "artifact_type": "execution_log",
+                  "location": "stub://attempts/log",
+                  "reference_id": "claim-kno-183-c:attempt:log"
+                }
+              ],
+              "attempt_id": "claim-kno-183-c:attempt",
+              "completion_claim_id": "claim-kno-183-c",
+              "metadata": {
+                "attempt_validation": {
+                  "context_observations": {
+                    "branch": [
+                      {
+                        "sources": [
+                          "external_facts.expected_code_context",
+                          "external_facts.github_facts.branch"
+                        ],
+                        "value": "codex/e2e-test"
+                      }
+                    ],
+                    "commit": [
+                      {
+                        "sources": [
+                          "external_facts.github_facts.branch",
+                          "external_facts.github_facts.commit"
+                        ],
+                        "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                      }
+                    ],
+                    "commit_resolution_pending": false,
+                    "has_valid_current_run_pull_request_artifact": false,
+                    "repository": [
+                      {
+                        "sources": [
+                          "external_facts.expected_code_context",
+                          "external_facts.github_facts.repository"
+                        ],
+                        "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                      }
+                    ],
+                    "used_task_artifact_fallback": false
+                  },
+                  "policy": {
+                    "allow_commit_resolution_via_reconciliation": true,
+                    "allow_missing_commit_artifact_with_verified_pull_request": true,
+                    "allow_missing_pull_request": true,
+                    "reject_closed_or_historical_pull_request": true,
+                    "reject_non_numeric_pull_request_url": true,
+                    "reject_reserved_shared_branch": true,
+                    "require_commit": true,
+                    "require_exact_branch": true,
+                    "require_repository": true,
+                    "task_artifact_fallback_requires_single_attempt": true
+                  },
+                  "pull_request_observations": [],
+                  "reasons": [],
+                  "retryable": false,
+                  "rule_failures": [],
+                  "status": "valid",
+                  "validated_at": "2026-04-11T16:04:28.921225Z",
+                  "validated_by": "execution_validation"
+                },
+                "executor_run_id": "run-claim-kno-183-c"
+              },
+              "recorded_at": "2026-04-04T12:02:05Z",
+              "reevaluation": {},
+              "reported_by": "codex",
+              "status": "completed"
+            }
+          ],
+          "schema_required_deferred_fields": [
+            "parent_task_id",
+            "child_task_ids",
+            "dependencies",
+            "assigned_executor",
+            "required_capabilities",
+            "priority",
+            "artifacts.items",
+            "artifacts.completion_evidence",
+            "observability"
+          ]
+        },
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": null,
+        "requested_by": null,
+        "source_id": "req-task-kno-183-scenario-c",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "reconciliation": {
+        "active_failure_type": "missing_pr_after_execution",
+        "attempts": [
+          {
+            "attempt_id": "reconciliation-attempt-1",
+            "completed_at": "2026-04-11T16:04:28.925470Z",
+            "details": {
+              "base_branch": "main",
+              "branch_exists": true,
+              "branch_head_commit_sha": null,
+              "branch_name": "codex/e2e-test",
+              "commit_exists": true,
+              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "context_resolution": {
+                "conflicts": [],
+                "selected_source": "merged",
+                "sources": {
+                  "artifacts": {
+                    "base_branch": "main",
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
+                  },
+                  "external_facts": {
+                    "base_branch": "main",
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
+                  }
+                }
+              },
+              "created_pull_request": true,
+              "created_pull_request_revalidated": false,
+              "error": "Created pull request did not satisfy current-run validation policy after read-back",
+              "error_disposition": "review_required",
+              "final_decision": {
+                "reason": "persisted_pull_request_failed_validation",
+                "result": "created_pull_request_revalidation_failed"
+              },
+              "policy": {
+                "allow_closed_pr_match": false,
+                "allow_commit_association_match": true,
+                "allow_non_head_commit_association_match": false,
+                "allow_open_pr_match": true,
+                "escalate_on_ambiguous_match": true,
+                "require_exact_branch_match": true,
+                "require_head_sha_match": true,
+                "require_run_linkage_for_commit_association": true,
+                "require_run_linkage_for_multiple_attempts": true,
+                "require_task_linkage": false
+              },
+              "pull_request_candidates": [
+                {
+                  "base_branch": "main",
+                  "head": {
+                    "branch": "codex/e2e-test",
+                    "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                  },
+                  "lookup_sources": [
+                    "created_response"
+                  ],
+                  "merged": false,
+                  "number": 633,
+                  "repository": {
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  },
+                  "review_state": null,
+                  "state": "open",
+                  "title": "Reconcile missing pull request (task-kno-183-scenario-c)",
+                  "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/633",
+                  "validation": {
+                    "accepted": true,
+                    "matched_by": [
+                      "head_sha_match",
+                      "task_linkage",
+                      "attempt_linkage",
+                      "completion_claim_linkage"
+                    ],
+                    "reasons": [],
+                    "signals": {
+                      "branch_match": true,
+                      "commit_association_match": false,
+                      "head_sha_match": true,
+                      "linkage_policy": {
+                        "reasons": [],
+                        "require_run_linkage": false
+                      },
+                      "repository_match": true,
+                      "run_linkage": {
+                        "attempt_id_present": true,
+                        "branch_name_present": true,
+                        "commit_sha_present": true,
+                        "completion_claim_id_present": true,
+                        "current_run": {
+                          "attempt_count": 1,
+                          "attempt_id": "claim-kno-183-c:attempt",
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "completion_claim_id": "claim-kno-183-c",
+                          "multiple_attempts": false,
+                          "task_id": "task-kno-183-scenario-c",
+                          "task_title": "Reconcile missing pull request"
+                        },
+                        "linked": true,
+                        "markers": {
+                          "harness-attempt-id": "claim-kno-183-c:attempt",
+                          "harness-branch": "codex/e2e-test",
+                          "harness-commit-sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "harness-completion-claim-id": "claim-kno-183-c",
+                          "harness-task-id": "task-kno-183-scenario-c"
+                        },
+                        "task_id_marker_present": true
+                      },
+                      "state": "open",
+                      "state_acceptable": true,
+                      "task_linkage": {
+                        "linked": true,
+                        "task_id_present": true,
+                        "task_title_present": true
+                      }
+                    }
+                  }
+                },
+                {
+                  "base_branch": "main",
+                  "head": {
+                    "branch": "codex/e2e-test",
+                    "sha": "1111111111111111111111111111111111111111"
+                  },
+                  "lookup_sources": [
+                    "created_persisted"
+                  ],
+                  "merged": false,
+                  "number": 633,
+                  "repository": {
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  },
+                  "review_state": null,
+                  "state": "open",
+                  "title": "Reconcile missing pull request",
+                  "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/633",
+                  "validation": {
+                    "accepted": false,
+                    "matched_by": [
+                      "task_linkage"
+                    ],
+                    "reasons": [
+                      "head_sha_mismatch"
+                    ],
+                    "signals": {
+                      "branch_match": true,
+                      "commit_association_match": false,
+                      "head_sha_match": false,
+                      "linkage_policy": {
+                        "reasons": [],
+                        "require_run_linkage": false
+                      },
+                      "repository_match": true,
+                      "run_linkage": {
+                        "attempt_id_present": false,
+                        "branch_name_present": false,
+                        "commit_sha_present": false,
+                        "completion_claim_id_present": false,
+                        "current_run": {
+                          "attempt_count": 1,
+                          "attempt_id": "claim-kno-183-c:attempt",
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                          "completion_claim_id": "claim-kno-183-c",
+                          "multiple_attempts": false,
+                          "task_id": "task-kno-183-scenario-c",
+                          "task_title": "Reconcile missing pull request"
+                        },
+                        "linked": false,
+                        "markers": {},
+                        "task_id_marker_present": false
+                      },
+                      "state": "open",
+                      "state_acceptable": true,
+                      "task_linkage": {
+                        "linked": true,
+                        "task_id_present": false,
+                        "task_title_present": true
+                      }
+                    }
+                  }
+                }
+              ],
+              "pull_request_lookup": {
+                "ambiguous": false,
+                "candidate_count": 2,
+                "found": false,
+                "number": null,
+                "searched_by_branch": true,
+                "searched_by_commit": true,
+                "source": null,
+                "url": null,
+                "valid_candidate_count": 0
+              },
+              "repository": {
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              }
+            },
+            "failure_type": "missing_pr_after_execution",
+            "handler_key": "missing_pr_after_execution",
+            "started_at": "2026-04-11T16:04:28.925303Z",
+            "status": "failed"
+          }
+        ],
+        "failed_at": "2026-04-11T16:04:28.925470Z",
+        "last_attempt_id": "reconciliation-attempt-1",
+        "last_error": "Created pull request did not satisfy current-run validation policy after read-back",
+        "last_pr_url": null,
+        "resolved_at": null,
+        "status": "failed"
+      },
+      "required_capabilities": [],
+      "status": "in_review",
+      "status_history": [
+        {
+          "changed_at": "2026-04-11T16:04:28.923324Z",
+          "changed_by": "reconciliation",
+          "from_status": "executing",
+          "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+          "to_status": "reconciling"
+        },
+        {
+          "changed_at": "2026-04-11T16:04:28.927511Z",
+          "changed_by": "reconciliation",
+          "from_status": "reconciling",
+          "reason": "Post-execution reconciliation failed: Created pull request did not satisfy current-run validation policy after read-back",
+          "to_status": "in_review"
+        }
+      ],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-04-04T12:00:00Z",
+        "updated_at": "2026-04-11T16:04:28.927511Z"
+      },
+      "title": "Reconcile missing pull request"
+    },
+    "transition_result": null,
+    "verification_result": null
+  },
   "error": "Created pull request did not satisfy current-run validation policy after read-back",
+  "evaluation_record": {
+    "evaluation_id": "6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+    "recorded_at": "2026-04-11T16:04:28.929710Z",
+    "request": {
+      "acceptance_criteria_satisfied": true,
+      "claimed_completion": true,
+      "external_facts": {
+        "expected_code_context": {
+          "base_branch": "main",
+          "branch_name": "codex/e2e-test",
+          "repository_host": "github.com",
+          "repository_name": "HARNESS-DRYRUN",
+          "repository_owner": "KnoxAnalytics"
+        },
+        "github_facts": {
+          "artifact_found": true,
+          "artifact_refs": [
+            {
+              "artifact_type": "commit",
+              "external_id": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "url": null
+            }
+          ],
+          "branch": {
+            "base_branch": "main",
+            "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "name": "codex/e2e-test"
+          },
+          "changed_files": null,
+          "commit": {
+            "message_summary": null,
+            "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+            "url": null
+          },
+          "pull_request": null,
+          "reasons": [],
+          "repository": {
+            "external_id": null,
+            "host": "github.com",
+            "name": "HARNESS-DRYRUN",
+            "owner": "KnoxAnalytics"
+          }
+        },
+        "linear_facts": {
+          "issue_id": "lin-1",
+          "issue_key": "HAR-1",
+          "project": null,
+          "reasons": [],
+          "record_found": true,
+          "state": "completed",
+          "task_reference": null,
+          "workflow": {
+            "state_type": "completed",
+            "workflow_id": "workflow-completed",
+            "workflow_name": "completed"
+          }
+        }
+      },
+      "retry_context": null,
+      "review_decision": null,
+      "review_is_active": false,
+      "review_reasons": [],
+      "review_request": {
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "requested_at": "2026-04-11T16:04:28.927511Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-183-scenario-c-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+        "task_id": "task-kno-183-scenario-c",
+        "trigger": "reconciliation"
+      },
+      "runtime_facts": {
+        "attempt_count": 1,
+        "executor_reported_failure": false,
+        "executor_reported_success": true,
+        "latest_attempt_outcome": "completed",
+        "terminal_failure": false
+      },
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "Harness can reconcile a missing PR after execution.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "required",
+            "required_artifact_types": [
+              "commit"
+            ],
+            "status": "satisfied",
+            "validated_artifact_ids": [
+              "artifact-commit-1"
+            ],
+            "validated_at": "2026-04-04T12:01:30Z",
+            "validation_method": "external_reconciliation",
+            "validator": {
+              "captured_by": "github-sync",
+              "source_id": "verification-existing-1",
+              "source_system": "harness",
+              "source_type": "verification"
+            }
+          },
+          "items": [
+            {
+              "branch": {
+                "base_branch": "main",
+                "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "name": "codex/e2e-test"
+              },
+              "captured_at": "2026-04-04T12:01:00Z",
+              "changed_files": [],
+              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "content_type": null,
+              "description": null,
+              "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "external_refs": [],
+              "id": "artifact-commit-1",
+              "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "metadata": {},
+              "provenance": {
+                "captured_by": "github-sync",
+                "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "source_system": "github",
+                "source_type": "api"
+              },
+              "pull_request_number": null,
+              "repository": {
+                "external_id": "repo-dryrun-1",
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              },
+              "review_state": null,
+              "title": null,
+              "type": "commit",
+              "verification_status": "verified"
+            }
+          ]
+        },
+        "assigned_executor": {
+          "assignment_reason": "Runtime coverage for reconciliation.",
+          "executor_id": "executor-1",
+          "executor_type": "codex"
+        },
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": {
+            "issue_id": "lin-1",
+            "issue_key": "HAR-1",
+            "project": null,
+            "provenance": {
+              "linked_at": "2026-04-11T16:04:28.921111Z",
+              "linked_by": "reevaluation",
+              "source": "completion_claim.external_facts"
+            },
+            "reasons": [],
+            "record_found": true,
+            "state": "completed",
+            "task_reference": null,
+            "workflow": {
+              "state_type": "completed",
+              "workflow_id": "workflow-completed",
+              "workflow_name": "completed"
+            }
+          }
+        },
+        "dependencies": [],
+        "description": "Exercise post-execution PR reconciliation.",
+        "id": "task-kno-183-scenario-c",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Exercise post-execution PR reconciliation."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-183-c",
+                "metadata": {
+                  "attempt_id": "claim-kno-183-c:attempt"
+                },
+                "reason": "Execution completed successfully.",
+                "reported_at": "2026-04-04T12:02:00Z",
+                "reported_by": "codex"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [
+                  {
+                    "artifact_type": "execution_log",
+                    "location": "stub://attempts/log",
+                    "reference_id": "claim-kno-183-c:attempt:log"
+                  }
+                ],
+                "attempt_id": "claim-kno-183-c:attempt",
+                "completion_claim_id": "claim-kno-183-c",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "branch": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context",
+                            "external_facts.github_facts.branch"
+                          ],
+                          "value": "codex/e2e-test"
+                        }
+                      ],
+                      "commit": [
+                        {
+                          "sources": [
+                            "external_facts.github_facts.branch",
+                            "external_facts.github_facts.commit"
+                          ],
+                          "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                        }
+                      ],
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "repository": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context",
+                            "external_facts.github_facts.repository"
+                          ],
+                          "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                        }
+                      ],
+                      "used_task_artifact_fallback": false
+                    },
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [],
+                    "retryable": false,
+                    "rule_failures": [],
+                    "status": "valid",
+                    "validated_at": "2026-04-11T16:04:28.921225Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "run-claim-kno-183-c"
+                },
+                "recorded_at": "2026-04-04T12:02:05Z",
+                "reevaluation": {},
+                "reported_by": "codex",
+                "status": "completed"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "req-task-kno-183-scenario-c",
+          "source_system": "openclaw",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": "missing_pr_after_execution",
+          "attempts": [
+            {
+              "attempt_id": "reconciliation-attempt-1",
+              "completed_at": "2026-04-11T16:04:28.925470Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": true,
+                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "merged",
+                  "sources": {
+                    "artifacts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    },
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_pull_request": true,
+                "created_pull_request_revalidated": false,
+                "error": "Created pull request did not satisfy current-run validation policy after read-back",
+                "error_disposition": "review_required",
+                "final_decision": {
+                  "reason": "persisted_pull_request_failed_validation",
+                  "result": "created_pull_request_revalidation_failed"
+                },
+                "policy": {
+                  "allow_closed_pr_match": false,
+                  "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
+                  "allow_open_pr_match": true,
+                  "escalate_on_ambiguous_match": true,
+                  "require_exact_branch_match": true,
+                  "require_head_sha_match": true,
+                  "require_run_linkage_for_commit_association": true,
+                  "require_run_linkage_for_multiple_attempts": true,
+                  "require_task_linkage": false
+                },
+                "pull_request_candidates": [
+                  {
+                    "base_branch": "main",
+                    "head": {
+                      "branch": "codex/e2e-test",
+                      "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                    },
+                    "lookup_sources": [
+                      "created_response"
+                    ],
+                    "merged": false,
+                    "number": 633,
+                    "repository": {
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    },
+                    "review_state": null,
+                    "state": "open",
+                    "title": "Reconcile missing pull request (task-kno-183-scenario-c)",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/633",
+                    "validation": {
+                      "accepted": true,
+                      "matched_by": [
+                        "head_sha_match",
+                        "task_linkage",
+                        "attempt_linkage",
+                        "completion_claim_linkage"
+                      ],
+                      "reasons": [],
+                      "signals": {
+                        "branch_match": true,
+                        "commit_association_match": false,
+                        "head_sha_match": true,
+                        "linkage_policy": {
+                          "reasons": [],
+                          "require_run_linkage": false
+                        },
+                        "repository_match": true,
+                        "run_linkage": {
+                          "attempt_id_present": true,
+                          "branch_name_present": true,
+                          "commit_sha_present": true,
+                          "completion_claim_id_present": true,
+                          "current_run": {
+                            "attempt_count": 1,
+                            "attempt_id": "claim-kno-183-c:attempt",
+                            "branch_name": "codex/e2e-test",
+                            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "completion_claim_id": "claim-kno-183-c",
+                            "multiple_attempts": false,
+                            "task_id": "task-kno-183-scenario-c",
+                            "task_title": "Reconcile missing pull request"
+                          },
+                          "linked": true,
+                          "markers": {
+                            "harness-attempt-id": "claim-kno-183-c:attempt",
+                            "harness-branch": "codex/e2e-test",
+                            "harness-commit-sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "harness-completion-claim-id": "claim-kno-183-c",
+                            "harness-task-id": "task-kno-183-scenario-c"
+                          },
+                          "task_id_marker_present": true
+                        },
+                        "state": "open",
+                        "state_acceptable": true,
+                        "task_linkage": {
+                          "linked": true,
+                          "task_id_present": true,
+                          "task_title_present": true
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "base_branch": "main",
+                    "head": {
+                      "branch": "codex/e2e-test",
+                      "sha": "1111111111111111111111111111111111111111"
+                    },
+                    "lookup_sources": [
+                      "created_persisted"
+                    ],
+                    "merged": false,
+                    "number": 633,
+                    "repository": {
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    },
+                    "review_state": null,
+                    "state": "open",
+                    "title": "Reconcile missing pull request",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/633",
+                    "validation": {
+                      "accepted": false,
+                      "matched_by": [
+                        "task_linkage"
+                      ],
+                      "reasons": [
+                        "head_sha_mismatch"
+                      ],
+                      "signals": {
+                        "branch_match": true,
+                        "commit_association_match": false,
+                        "head_sha_match": false,
+                        "linkage_policy": {
+                          "reasons": [],
+                          "require_run_linkage": false
+                        },
+                        "repository_match": true,
+                        "run_linkage": {
+                          "attempt_id_present": false,
+                          "branch_name_present": false,
+                          "commit_sha_present": false,
+                          "completion_claim_id_present": false,
+                          "current_run": {
+                            "attempt_count": 1,
+                            "attempt_id": "claim-kno-183-c:attempt",
+                            "branch_name": "codex/e2e-test",
+                            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "completion_claim_id": "claim-kno-183-c",
+                            "multiple_attempts": false,
+                            "task_id": "task-kno-183-scenario-c",
+                            "task_title": "Reconcile missing pull request"
+                          },
+                          "linked": false,
+                          "markers": {},
+                          "task_id_marker_present": false
+                        },
+                        "state": "open",
+                        "state_acceptable": true,
+                        "task_linkage": {
+                          "linked": true,
+                          "task_id_present": false,
+                          "task_title_present": true
+                        }
+                      }
+                    }
+                  }
+                ],
+                "pull_request_lookup": {
+                  "ambiguous": false,
+                  "candidate_count": 2,
+                  "found": false,
+                  "number": null,
+                  "searched_by_branch": true,
+                  "searched_by_commit": true,
+                  "source": null,
+                  "url": null,
+                  "valid_candidate_count": 0
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_pr_after_execution",
+              "handler_key": "missing_pr_after_execution",
+              "started_at": "2026-04-11T16:04:28.925303Z",
+              "status": "failed"
+            }
+          ],
+          "failed_at": "2026-04-11T16:04:28.925470Z",
+          "last_attempt_id": "reconciliation-attempt-1",
+          "last_error": "Created pull request did not satisfy current-run validation policy after read-back",
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "failed"
+        },
+        "required_capabilities": [],
+        "status": "in_review",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.923324Z",
+            "changed_by": "reconciliation",
+            "from_status": "executing",
+            "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+            "to_status": "reconciling"
+          },
+          {
+            "changed_at": "2026-04-11T16:04:28.927511Z",
+            "changed_by": "reconciliation",
+            "from_status": "reconciling",
+            "reason": "Post-execution reconciliation failed: Created pull request did not satisfy current-run validation policy after read-back",
+            "to_status": "in_review"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-04-04T12:00:00Z",
+          "updated_at": "2026-04-11T16:04:28.927511Z"
+        },
+        "title": "Reconcile missing pull request"
+      },
+      "unresolved_conditions": []
+    },
+    "result": {
+      "accepted_completion": false,
+      "action": "review_required",
+      "enforcement_result": {
+        "action": "review_required",
+        "error": "Created pull request did not satisfy current-run validation policy after read-back",
+        "evidence_result": null,
+        "failure_classification": {
+          "category": "review_required",
+          "failure_type": "review_required",
+          "reason": "Created pull request did not satisfy current-run validation policy after read-back",
+          "recoverable": false,
+          "retryable": false,
+          "source": "evaluation",
+          "terminal": false
+        },
+        "reasons": [
+          "Created pull request did not satisfy current-run validation policy after read-back"
+        ],
+        "reconciliation_result": {
+          "blocking": true,
+          "mismatch_categories": [
+            "missing_required_artifact"
+          ],
+          "outcome": "review_required",
+          "reasons": [
+            "Created pull request did not satisfy current-run validation policy after read-back"
+          ],
+          "status": "review_required",
+          "task_id": "task-kno-183-scenario-c",
+          "terminal": false
+        },
+        "review_decision": null,
+        "review_request": {
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "requested_at": "2026-04-11T16:04:28.927511Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-183-scenario-c-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+          "task_id": "task-kno-183-scenario-c",
+          "trigger": "reconciliation"
+        },
+        "target_status": "in_review",
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "Harness can reconcile a missing PR after execution.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "required",
+              "required_artifact_types": [
+                "commit"
+              ],
+              "status": "satisfied",
+              "validated_artifact_ids": [
+                "artifact-commit-1"
+              ],
+              "validated_at": "2026-04-04T12:01:30Z",
+              "validation_method": "external_reconciliation",
+              "validator": {
+                "captured_by": "github-sync",
+                "source_id": "verification-existing-1",
+                "source_system": "harness",
+                "source_type": "verification"
+              }
+            },
+            "items": [
+              {
+                "branch": {
+                  "base_branch": "main",
+                  "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "name": "codex/e2e-test"
+                },
+                "captured_at": "2026-04-04T12:01:00Z",
+                "changed_files": [],
+                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "content_type": null,
+                "description": null,
+                "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "external_refs": [],
+                "id": "artifact-commit-1",
+                "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "metadata": {},
+                "provenance": {
+                  "captured_by": "github-sync",
+                  "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "source_system": "github",
+                  "source_type": "api"
+                },
+                "pull_request_number": null,
+                "repository": {
+                  "external_id": "repo-dryrun-1",
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                },
+                "review_state": null,
+                "title": null,
+                "type": "commit",
+                "verification_status": "verified"
+              }
+            ]
+          },
+          "assigned_executor": {
+            "assignment_reason": "Runtime coverage for reconciliation.",
+            "executor_id": "executor-1",
+            "executor_type": "codex"
+          },
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": {
+              "issue_id": "lin-1",
+              "issue_key": "HAR-1",
+              "project": null,
+              "provenance": {
+                "linked_at": "2026-04-11T16:04:28.921111Z",
+                "linked_by": "reevaluation",
+                "source": "completion_claim.external_facts"
+              },
+              "reasons": [],
+              "record_found": true,
+              "state": "completed",
+              "task_reference": null,
+              "workflow": {
+                "state_type": "completed",
+                "workflow_id": "workflow-completed",
+                "workflow_name": "completed"
+              }
+            }
+          },
+          "dependencies": [],
+          "description": "Exercise post-execution PR reconciliation.",
+          "id": "task-kno-183-scenario-c",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Exercise post-execution PR reconciliation."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-183-c",
+                  "metadata": {
+                    "attempt_id": "claim-kno-183-c:attempt"
+                  },
+                  "reason": "Execution completed successfully.",
+                  "reported_at": "2026-04-04T12:02:00Z",
+                  "reported_by": "codex"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "execution_log",
+                      "location": "stub://attempts/log",
+                      "reference_id": "claim-kno-183-c:attempt:log"
+                    }
+                  ],
+                  "attempt_id": "claim-kno-183-c:attempt",
+                  "completion_claim_id": "claim-kno-183-c",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "external_facts.expected_code_context",
+                              "external_facts.github_facts.branch"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit": [
+                          {
+                            "sources": [
+                              "external_facts.github_facts.branch",
+                              "external_facts.github_facts.commit"
+                            ],
+                            "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                          }
+                        ],
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "repository": [
+                          {
+                            "sources": [
+                              "external_facts.expected_code_context",
+                              "external_facts.github_facts.repository"
+                            ],
+                            "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                          }
+                        ],
+                        "used_task_artifact_fallback": false
+                      },
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [],
+                      "retryable": false,
+                      "rule_failures": [],
+                      "status": "valid",
+                      "validated_at": "2026-04-11T16:04:28.921225Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "run-claim-kno-183-c"
+                  },
+                  "recorded_at": "2026-04-04T12:02:05Z",
+                  "reevaluation": {},
+                  "reported_by": "codex",
+                  "status": "completed"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "req-task-kno-183-scenario-c",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": "missing_pr_after_execution",
+            "attempts": [
+              {
+                "attempt_id": "reconciliation-attempt-1",
+                "completed_at": "2026-04-11T16:04:28.925470Z",
+                "details": {
+                  "base_branch": "main",
+                  "branch_exists": true,
+                  "branch_head_commit_sha": null,
+                  "branch_name": "codex/e2e-test",
+                  "commit_exists": true,
+                  "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                  "context_resolution": {
+                    "conflicts": [],
+                    "selected_source": "merged",
+                    "sources": {
+                      "artifacts": {
+                        "base_branch": "main",
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      },
+                      "external_facts": {
+                        "base_branch": "main",
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      }
+                    }
+                  },
+                  "created_pull_request": true,
+                  "created_pull_request_revalidated": false,
+                  "error": "Created pull request did not satisfy current-run validation policy after read-back",
+                  "error_disposition": "review_required",
+                  "final_decision": {
+                    "reason": "persisted_pull_request_failed_validation",
+                    "result": "created_pull_request_revalidation_failed"
+                  },
+                  "policy": {
+                    "allow_closed_pr_match": false,
+                    "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
+                    "allow_open_pr_match": true,
+                    "escalate_on_ambiguous_match": true,
+                    "require_exact_branch_match": true,
+                    "require_head_sha_match": true,
+                    "require_run_linkage_for_commit_association": true,
+                    "require_run_linkage_for_multiple_attempts": true,
+                    "require_task_linkage": false
+                  },
+                  "pull_request_candidates": [
+                    {
+                      "base_branch": "main",
+                      "head": {
+                        "branch": "codex/e2e-test",
+                        "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                      },
+                      "lookup_sources": [
+                        "created_response"
+                      ],
+                      "merged": false,
+                      "number": 633,
+                      "repository": {
+                        "name": "HARNESS-DRYRUN",
+                        "owner": "KnoxAnalytics"
+                      },
+                      "review_state": null,
+                      "state": "open",
+                      "title": "Reconcile missing pull request (task-kno-183-scenario-c)",
+                      "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/633",
+                      "validation": {
+                        "accepted": true,
+                        "matched_by": [
+                          "head_sha_match",
+                          "task_linkage",
+                          "attempt_linkage",
+                          "completion_claim_linkage"
+                        ],
+                        "reasons": [],
+                        "signals": {
+                          "branch_match": true,
+                          "commit_association_match": false,
+                          "head_sha_match": true,
+                          "linkage_policy": {
+                            "reasons": [],
+                            "require_run_linkage": false
+                          },
+                          "repository_match": true,
+                          "run_linkage": {
+                            "attempt_id_present": true,
+                            "branch_name_present": true,
+                            "commit_sha_present": true,
+                            "completion_claim_id_present": true,
+                            "current_run": {
+                              "attempt_count": 1,
+                              "attempt_id": "claim-kno-183-c:attempt",
+                              "branch_name": "codex/e2e-test",
+                              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                              "completion_claim_id": "claim-kno-183-c",
+                              "multiple_attempts": false,
+                              "task_id": "task-kno-183-scenario-c",
+                              "task_title": "Reconcile missing pull request"
+                            },
+                            "linked": true,
+                            "markers": {
+                              "harness-attempt-id": "claim-kno-183-c:attempt",
+                              "harness-branch": "codex/e2e-test",
+                              "harness-commit-sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                              "harness-completion-claim-id": "claim-kno-183-c",
+                              "harness-task-id": "task-kno-183-scenario-c"
+                            },
+                            "task_id_marker_present": true
+                          },
+                          "state": "open",
+                          "state_acceptable": true,
+                          "task_linkage": {
+                            "linked": true,
+                            "task_id_present": true,
+                            "task_title_present": true
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "base_branch": "main",
+                      "head": {
+                        "branch": "codex/e2e-test",
+                        "sha": "1111111111111111111111111111111111111111"
+                      },
+                      "lookup_sources": [
+                        "created_persisted"
+                      ],
+                      "merged": false,
+                      "number": 633,
+                      "repository": {
+                        "name": "HARNESS-DRYRUN",
+                        "owner": "KnoxAnalytics"
+                      },
+                      "review_state": null,
+                      "state": "open",
+                      "title": "Reconcile missing pull request",
+                      "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/633",
+                      "validation": {
+                        "accepted": false,
+                        "matched_by": [
+                          "task_linkage"
+                        ],
+                        "reasons": [
+                          "head_sha_mismatch"
+                        ],
+                        "signals": {
+                          "branch_match": true,
+                          "commit_association_match": false,
+                          "head_sha_match": false,
+                          "linkage_policy": {
+                            "reasons": [],
+                            "require_run_linkage": false
+                          },
+                          "repository_match": true,
+                          "run_linkage": {
+                            "attempt_id_present": false,
+                            "branch_name_present": false,
+                            "commit_sha_present": false,
+                            "completion_claim_id_present": false,
+                            "current_run": {
+                              "attempt_count": 1,
+                              "attempt_id": "claim-kno-183-c:attempt",
+                              "branch_name": "codex/e2e-test",
+                              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                              "completion_claim_id": "claim-kno-183-c",
+                              "multiple_attempts": false,
+                              "task_id": "task-kno-183-scenario-c",
+                              "task_title": "Reconcile missing pull request"
+                            },
+                            "linked": false,
+                            "markers": {},
+                            "task_id_marker_present": false
+                          },
+                          "state": "open",
+                          "state_acceptable": true,
+                          "task_linkage": {
+                            "linked": true,
+                            "task_id_present": false,
+                            "task_title_present": true
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "pull_request_lookup": {
+                    "ambiguous": false,
+                    "candidate_count": 2,
+                    "found": false,
+                    "number": null,
+                    "searched_by_branch": true,
+                    "searched_by_commit": true,
+                    "source": null,
+                    "url": null,
+                    "valid_candidate_count": 0
+                  },
+                  "repository": {
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  }
+                },
+                "failure_type": "missing_pr_after_execution",
+                "handler_key": "missing_pr_after_execution",
+                "started_at": "2026-04-11T16:04:28.925303Z",
+                "status": "failed"
+              }
+            ],
+            "failed_at": "2026-04-11T16:04:28.925470Z",
+            "last_attempt_id": "reconciliation-attempt-1",
+            "last_error": "Created pull request did not satisfy current-run validation policy after read-back",
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "failed"
+          },
+          "required_capabilities": [],
+          "status": "in_review",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.923324Z",
+              "changed_by": "reconciliation",
+              "from_status": "executing",
+              "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+              "to_status": "reconciling"
+            },
+            {
+              "changed_at": "2026-04-11T16:04:28.927511Z",
+              "changed_by": "reconciliation",
+              "from_status": "reconciling",
+              "reason": "Post-execution reconciliation failed: Created pull request did not satisfy current-run validation policy after read-back",
+              "to_status": "in_review"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-04-04T12:00:00Z",
+            "updated_at": "2026-04-11T16:04:28.927511Z"
+          },
+          "title": "Reconcile missing pull request"
+        },
+        "transition_result": null,
+        "verification_result": null
+      },
+      "error": "Created pull request did not satisfy current-run validation policy after read-back",
+      "failure_classification": {
+        "category": "review_required",
+        "failure_type": "review_required",
+        "reason": "Created pull request did not satisfy current-run validation policy after read-back",
+        "recoverable": false,
+        "retryable": false,
+        "source": "evaluation",
+        "terminal": false
+      },
+      "invalid_input": false,
+      "reasons": [
+        "Created pull request did not satisfy current-run validation policy after read-back"
+      ],
+      "requires_review": true,
+      "target_status": "in_review",
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "Harness can reconcile a missing PR after execution.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "required",
+            "required_artifact_types": [
+              "commit"
+            ],
+            "status": "satisfied",
+            "validated_artifact_ids": [
+              "artifact-commit-1"
+            ],
+            "validated_at": "2026-04-04T12:01:30Z",
+            "validation_method": "external_reconciliation",
+            "validator": {
+              "captured_by": "github-sync",
+              "source_id": "verification-existing-1",
+              "source_system": "harness",
+              "source_type": "verification"
+            }
+          },
+          "items": [
+            {
+              "branch": {
+                "base_branch": "main",
+                "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "name": "codex/e2e-test"
+              },
+              "captured_at": "2026-04-04T12:01:00Z",
+              "changed_files": [],
+              "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "content_type": null,
+              "description": null,
+              "external_id": "commit-8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "external_refs": [],
+              "id": "artifact-commit-1",
+              "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+              "metadata": {},
+              "provenance": {
+                "captured_by": "github-sync",
+                "source_id": "commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "source_system": "github",
+                "source_type": "api"
+              },
+              "pull_request_number": null,
+              "repository": {
+                "external_id": "repo-dryrun-1",
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              },
+              "review_state": null,
+              "title": null,
+              "type": "commit",
+              "verification_status": "verified"
+            }
+          ]
+        },
+        "assigned_executor": {
+          "assignment_reason": "Runtime coverage for reconciliation.",
+          "executor_id": "executor-1",
+          "executor_type": "codex"
+        },
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": {
+            "issue_id": "lin-1",
+            "issue_key": "HAR-1",
+            "project": null,
+            "provenance": {
+              "linked_at": "2026-04-11T16:04:28.921111Z",
+              "linked_by": "reevaluation",
+              "source": "completion_claim.external_facts"
+            },
+            "reasons": [],
+            "record_found": true,
+            "state": "completed",
+            "task_reference": null,
+            "workflow": {
+              "state_type": "completed",
+              "workflow_id": "workflow-completed",
+              "workflow_name": "completed"
+            }
+          }
+        },
+        "dependencies": [],
+        "description": "Exercise post-execution PR reconciliation.",
+        "id": "task-kno-183-scenario-c",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Exercise post-execution PR reconciliation."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-183-c",
+                "metadata": {
+                  "attempt_id": "claim-kno-183-c:attempt"
+                },
+                "reason": "Execution completed successfully.",
+                "reported_at": "2026-04-04T12:02:00Z",
+                "reported_by": "codex"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [
+                  {
+                    "artifact_type": "execution_log",
+                    "location": "stub://attempts/log",
+                    "reference_id": "claim-kno-183-c:attempt:log"
+                  }
+                ],
+                "attempt_id": "claim-kno-183-c:attempt",
+                "completion_claim_id": "claim-kno-183-c",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "branch": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context",
+                            "external_facts.github_facts.branch"
+                          ],
+                          "value": "codex/e2e-test"
+                        }
+                      ],
+                      "commit": [
+                        {
+                          "sources": [
+                            "external_facts.github_facts.branch",
+                            "external_facts.github_facts.commit"
+                          ],
+                          "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                        }
+                      ],
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "repository": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context",
+                            "external_facts.github_facts.repository"
+                          ],
+                          "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                        }
+                      ],
+                      "used_task_artifact_fallback": false
+                    },
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [],
+                    "retryable": false,
+                    "rule_failures": [],
+                    "status": "valid",
+                    "validated_at": "2026-04-11T16:04:28.921225Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "run-claim-kno-183-c"
+                },
+                "recorded_at": "2026-04-04T12:02:05Z",
+                "reevaluation": {},
+                "reported_by": "codex",
+                "status": "completed"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "req-task-kno-183-scenario-c",
+          "source_system": "openclaw",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": "missing_pr_after_execution",
+          "attempts": [
+            {
+              "attempt_id": "reconciliation-attempt-1",
+              "completed_at": "2026-04-11T16:04:28.925470Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": true,
+                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "merged",
+                  "sources": {
+                    "artifacts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    },
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_pull_request": true,
+                "created_pull_request_revalidated": false,
+                "error": "Created pull request did not satisfy current-run validation policy after read-back",
+                "error_disposition": "review_required",
+                "final_decision": {
+                  "reason": "persisted_pull_request_failed_validation",
+                  "result": "created_pull_request_revalidation_failed"
+                },
+                "policy": {
+                  "allow_closed_pr_match": false,
+                  "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
+                  "allow_open_pr_match": true,
+                  "escalate_on_ambiguous_match": true,
+                  "require_exact_branch_match": true,
+                  "require_head_sha_match": true,
+                  "require_run_linkage_for_commit_association": true,
+                  "require_run_linkage_for_multiple_attempts": true,
+                  "require_task_linkage": false
+                },
+                "pull_request_candidates": [
+                  {
+                    "base_branch": "main",
+                    "head": {
+                      "branch": "codex/e2e-test",
+                      "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+                    },
+                    "lookup_sources": [
+                      "created_response"
+                    ],
+                    "merged": false,
+                    "number": 633,
+                    "repository": {
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    },
+                    "review_state": null,
+                    "state": "open",
+                    "title": "Reconcile missing pull request (task-kno-183-scenario-c)",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/633",
+                    "validation": {
+                      "accepted": true,
+                      "matched_by": [
+                        "head_sha_match",
+                        "task_linkage",
+                        "attempt_linkage",
+                        "completion_claim_linkage"
+                      ],
+                      "reasons": [],
+                      "signals": {
+                        "branch_match": true,
+                        "commit_association_match": false,
+                        "head_sha_match": true,
+                        "linkage_policy": {
+                          "reasons": [],
+                          "require_run_linkage": false
+                        },
+                        "repository_match": true,
+                        "run_linkage": {
+                          "attempt_id_present": true,
+                          "branch_name_present": true,
+                          "commit_sha_present": true,
+                          "completion_claim_id_present": true,
+                          "current_run": {
+                            "attempt_count": 1,
+                            "attempt_id": "claim-kno-183-c:attempt",
+                            "branch_name": "codex/e2e-test",
+                            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "completion_claim_id": "claim-kno-183-c",
+                            "multiple_attempts": false,
+                            "task_id": "task-kno-183-scenario-c",
+                            "task_title": "Reconcile missing pull request"
+                          },
+                          "linked": true,
+                          "markers": {
+                            "harness-attempt-id": "claim-kno-183-c:attempt",
+                            "harness-branch": "codex/e2e-test",
+                            "harness-commit-sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "harness-completion-claim-id": "claim-kno-183-c",
+                            "harness-task-id": "task-kno-183-scenario-c"
+                          },
+                          "task_id_marker_present": true
+                        },
+                        "state": "open",
+                        "state_acceptable": true,
+                        "task_linkage": {
+                          "linked": true,
+                          "task_id_present": true,
+                          "task_title_present": true
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "base_branch": "main",
+                    "head": {
+                      "branch": "codex/e2e-test",
+                      "sha": "1111111111111111111111111111111111111111"
+                    },
+                    "lookup_sources": [
+                      "created_persisted"
+                    ],
+                    "merged": false,
+                    "number": 633,
+                    "repository": {
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    },
+                    "review_state": null,
+                    "state": "open",
+                    "title": "Reconcile missing pull request",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/633",
+                    "validation": {
+                      "accepted": false,
+                      "matched_by": [
+                        "task_linkage"
+                      ],
+                      "reasons": [
+                        "head_sha_mismatch"
+                      ],
+                      "signals": {
+                        "branch_match": true,
+                        "commit_association_match": false,
+                        "head_sha_match": false,
+                        "linkage_policy": {
+                          "reasons": [],
+                          "require_run_linkage": false
+                        },
+                        "repository_match": true,
+                        "run_linkage": {
+                          "attempt_id_present": false,
+                          "branch_name_present": false,
+                          "commit_sha_present": false,
+                          "completion_claim_id_present": false,
+                          "current_run": {
+                            "attempt_count": 1,
+                            "attempt_id": "claim-kno-183-c:attempt",
+                            "branch_name": "codex/e2e-test",
+                            "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                            "completion_claim_id": "claim-kno-183-c",
+                            "multiple_attempts": false,
+                            "task_id": "task-kno-183-scenario-c",
+                            "task_title": "Reconcile missing pull request"
+                          },
+                          "linked": false,
+                          "markers": {},
+                          "task_id_marker_present": false
+                        },
+                        "state": "open",
+                        "state_acceptable": true,
+                        "task_linkage": {
+                          "linked": true,
+                          "task_id_present": false,
+                          "task_title_present": true
+                        }
+                      }
+                    }
+                  }
+                ],
+                "pull_request_lookup": {
+                  "ambiguous": false,
+                  "candidate_count": 2,
+                  "found": false,
+                  "number": null,
+                  "searched_by_branch": true,
+                  "searched_by_commit": true,
+                  "source": null,
+                  "url": null,
+                  "valid_candidate_count": 0
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_pr_after_execution",
+              "handler_key": "missing_pr_after_execution",
+              "started_at": "2026-04-11T16:04:28.925303Z",
+              "status": "failed"
+            }
+          ],
+          "failed_at": "2026-04-11T16:04:28.925470Z",
+          "last_attempt_id": "reconciliation-attempt-1",
+          "last_error": "Created pull request did not satisfy current-run validation policy after read-back",
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "failed"
+        },
+        "required_capabilities": [],
+        "status": "in_review",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.923324Z",
+            "changed_by": "reconciliation",
+            "from_status": "executing",
+            "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+            "to_status": "reconciling"
+          },
+          {
+            "changed_at": "2026-04-11T16:04:28.927511Z",
+            "changed_by": "reconciliation",
+            "from_status": "reconciling",
+            "reason": "Post-execution reconciliation failed: Created pull request did not satisfy current-run validation policy after read-back",
+            "to_status": "in_review"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-04-04T12:00:00Z",
+          "updated_at": "2026-04-11T16:04:28.927511Z"
+        },
+        "title": "Reconcile missing pull request"
+      }
+    },
+    "task_id": "task-kno-183-scenario-c"
+  },
   "invalid_input": false,
   "reasons": [
     "Created pull request did not satisfy current-run validation policy after read-back"
   ],
   "reconciliation_attempt": {
     "attempt_id": "reconciliation-attempt-1",
-    "completed_at": "2026-04-06T13:58:02.243501Z",
+    "completed_at": "2026-04-11T16:04:28.925470Z",
     "details": {
       "base_branch": "main",
       "branch_exists": true,
+      "branch_head_commit_sha": null,
       "branch_name": "codex/e2e-test",
       "commit_exists": true,
       "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
       "context_resolution": {
         "conflicts": [],
-        "selected_source": "external_facts",
+        "selected_source": "merged",
         "sources": {
           "artifacts": {
             "base_branch": "main",
@@ -48,6 +2145,7 @@
       "policy": {
         "allow_closed_pr_match": false,
         "allow_commit_association_match": true,
+        "allow_non_head_commit_association_match": false,
         "allow_open_pr_match": true,
         "escalate_on_ambiguous_match": true,
         "require_exact_branch_match": true,
@@ -214,10 +2312,35 @@
     },
     "failure_type": "missing_pr_after_execution",
     "handler_key": "missing_pr_after_execution",
-    "started_at": "2026-04-06T13:58:02.243026Z",
+    "started_at": "2026-04-11T16:04:28.925303Z",
     "status": "failed"
   },
   "requires_review": true,
+  "review_request": {
+    "allowed_outcomes": [
+      "accept_completion",
+      "keep_blocked",
+      "mark_failed",
+      "authorize_redispatch"
+    ],
+    "metadata": {
+      "reconciliation_attempt_id": "reconciliation-attempt-1",
+      "reconciliation_failure_type": "missing_pr_after_execution"
+    },
+    "presented_sections": [
+      "task_state",
+      "execution",
+      "evidence",
+      "reconciliation"
+    ],
+    "prior_review_ids": [],
+    "requested_at": "2026-04-11T16:04:28.927511Z",
+    "requested_by": "reconciliation",
+    "review_request_id": "review-request-task-kno-183-scenario-c-reconciliation-1",
+    "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+    "task_id": "task-kno-183-scenario-c",
+    "trigger": "reconciliation"
+  },
   "target_status": "in_review",
   "task_envelope": {
     "acceptance_criteria": [
@@ -297,7 +2420,7 @@
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:02.214163Z",
+          "linked_at": "2026-04-11T16:04:28.921111Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -366,6 +2489,8 @@
                       "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                     }
                   ],
+                  "commit_resolution_pending": false,
+                  "has_valid_current_run_pull_request_artifact": false,
                   "repository": [
                     {
                       "sources": [
@@ -378,16 +2503,23 @@
                   "used_task_artifact_fallback": false
                 },
                 "policy": {
+                  "allow_commit_resolution_via_reconciliation": true,
+                  "allow_missing_commit_artifact_with_verified_pull_request": true,
                   "allow_missing_pull_request": true,
+                  "reject_closed_or_historical_pull_request": true,
+                  "reject_non_numeric_pull_request_url": true,
+                  "reject_reserved_shared_branch": true,
                   "require_commit": true,
                   "require_exact_branch": true,
                   "require_repository": true,
                   "task_artifact_fallback_requires_single_attempt": true
                 },
+                "pull_request_observations": [],
                 "reasons": [],
                 "retryable": false,
+                "rule_failures": [],
                 "status": "valid",
-                "validated_at": "2026-04-06T13:58:02.214283Z",
+                "validated_at": "2026-04-11T16:04:28.921225Z",
                 "validated_by": "execution_validation"
               },
               "executor_run_id": "run-claim-kno-183-c"
@@ -431,16 +2563,17 @@
       "attempts": [
         {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T13:58:02.243501Z",
+          "completed_at": "2026-04-11T16:04:28.925470Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
+            "branch_head_commit_sha": null,
             "branch_name": "codex/e2e-test",
             "commit_exists": true,
             "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
             "context_resolution": {
               "conflicts": [],
-              "selected_source": "external_facts",
+              "selected_source": "merged",
               "sources": {
                 "artifacts": {
                   "base_branch": "main",
@@ -471,6 +2604,7 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -637,11 +2771,11 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T13:58:02.243026Z",
+          "started_at": "2026-04-11T16:04:28.925303Z",
           "status": "failed"
         }
       ],
-      "failed_at": "2026-04-06T13:58:02.243501Z",
+      "failed_at": "2026-04-11T16:04:28.925470Z",
       "last_attempt_id": "reconciliation-attempt-1",
       "last_error": "Created pull request did not satisfy current-run validation policy after read-back",
       "last_pr_url": null,
@@ -652,14 +2786,14 @@
     "status": "in_review",
     "status_history": [
       {
-        "changed_at": "2026-04-06T13:58:02.228915Z",
+        "changed_at": "2026-04-11T16:04:28.923324Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T13:58:02.256624Z",
+        "changed_at": "2026-04-11T16:04:28.927511Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
         "reason": "Post-execution reconciliation failed: Created pull request did not satisfy current-run validation policy after read-back",
@@ -669,7 +2803,7 @@
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T13:58:02.256624Z"
+      "updated_at": "2026-04-11T16:04:28.927511Z"
     },
     "title": "Reconcile missing pull request"
   }

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-c-read-model-final.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-c-read-model-final.json
@@ -1,17 +1,14 @@
 {
   "task": {
-    "assigned_executor": {
-      "assignment_reason": "Runtime coverage for reconciliation.",
-      "executor_id": "executor-1",
-      "executor_type": "codex"
-    },
+    "assigned_executor": null,
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:02.214163Z",
+          "linked_at": "2026-04-11T16:04:28.921111Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -29,11 +26,18 @@
     "current_status": "in_review",
     "description": "Exercise post-execution PR reconciliation.",
     "evaluation_summary": {
-      "count": 0,
-      "history": [],
-      "latest_action": null,
-      "latest_recorded_at": null,
-      "latest_target_status": null
+      "count": 1,
+      "history": [
+        {
+          "action": "review_required",
+          "evaluation_id": "6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+          "recorded_at": "2026-04-11T16:04:28.929710Z",
+          "target_status": "in_review"
+        }
+      ],
+      "latest_action": "review_required",
+      "latest_recorded_at": "2026-04-11T16:04:28.929710Z",
+      "latest_target_status": "in_review"
     },
     "evidence_summary": {
       "artifact_count": 1,
@@ -65,9 +69,9 @@
     },
     "execution_summary": {
       "attempt_count": 1,
-      "failure_state": "clear",
+      "failure_state": "review_required",
       "invalid_attempt_count": 0,
-      "last_failure_type": "none",
+      "last_failure_type": "review_required",
       "latest_artifact_references": [
         {
           "artifact_type": "execution_log",
@@ -106,6 +110,8 @@
                   "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                 }
               ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -118,16 +124,23 @@
               "used_task_artifact_fallback": false
             },
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T13:58:02.214283Z",
+            "validated_at": "2026-04-11T16:04:28.921225Z",
             "validated_by": "execution_validation"
           },
           "executor_run_id": "run-claim-kno-183-c"
@@ -157,6 +170,8 @@
               "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
             }
           ],
+          "commit_resolution_pending": false,
+          "has_valid_current_run_pull_request_artifact": false,
           "repository": [
             {
               "sources": [
@@ -169,42 +184,52 @@
           "used_task_artifact_fallback": false
         },
         "policy": {
+          "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
           "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
           "require_commit": true,
           "require_exact_branch": true,
           "require_repository": true,
           "task_artifact_fallback_requires_single_attempt": true
         },
+        "pull_request_observations": [],
         "reasons": [],
         "retryable": false,
+        "rule_failures": [],
         "status": "valid",
-        "validated_at": "2026-04-06T13:58:02.214283Z",
+        "validated_at": "2026-04-11T16:04:28.921225Z",
         "validated_by": "execution_validation"
       },
       "latest_dispatch_origin": null,
       "latest_status": "completed",
       "retry_count": 0,
       "retry_eligible": false,
-      "total_attempts": 0
+      "total_attempts": 1
     },
     "extensions": {},
     "failure_summary": {
-      "failure_source": "none",
-      "failure_type": "none",
+      "evaluation_id": "6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+      "failure_reason": "Created pull request did not satisfy current-run validation policy after read-back",
+      "failure_source": "evaluation",
+      "failure_type": "review_required",
+      "recorded_at": "2026-04-11T16:04:28.929710Z",
       "recoverable": false,
-      "state": "clear",
+      "state": "review_required",
       "terminal": false
     },
     "lifecycle_history": [
       {
-        "changed_at": "2026-04-06T13:58:02.228915Z",
+        "changed_at": "2026-04-11T16:04:28.923324Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T13:58:02.256624Z",
+        "changed_at": "2026-04-11T16:04:28.927511Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
         "reason": "Post-execution reconciliation failed: Created pull request did not satisfy current-run validation policy after read-back",
@@ -220,7 +245,19 @@
       "source_system": "openclaw",
       "source_type": "ingress_request"
     },
-    "reconciliation_summary": null,
+    "reconciliation_summary": {
+      "blocking": true,
+      "mismatch_categories": [
+        "missing_required_artifact"
+      ],
+      "outcome": "review_required",
+      "reasons": [
+        "Created pull request did not satisfy current-run validation policy after read-back"
+      ],
+      "status": "review_required",
+      "task_id": "task-kno-183-scenario-c",
+      "terminal": false
+    },
     "relationships": {
       "child_task_ids": [],
       "dependencies": [],
@@ -230,10 +267,62 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
-      "latest_request": null,
-      "request_count": 0,
-      "requests": [],
-      "status": "none"
+      "latest_effective_decision": null,
+      "latest_request": {
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "requested_at": "2026-04-11T16:04:28.927511Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-183-scenario-c-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+        "task_id": "task-kno-183-scenario-c",
+        "trigger": "reconciliation"
+      },
+      "request_count": 1,
+      "requests": [
+        {
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "requested_at": "2026-04-11T16:04:28.927511Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-183-scenario-c-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+          "task_id": "task-kno-183-scenario-c",
+          "trigger": "reconciliation"
+        }
+      ],
+      "resolved_decision_count": 0,
+      "status": "requested"
     },
     "task_id": "task-kno-183-scenario-c",
     "timeline": [
@@ -284,18 +373,6 @@
       },
       {
         "details": {
-          "artifact_type": "execution_log",
-          "location": "stub://attempts/log",
-          "reference_id": "claim-kno-183-c:attempt:log"
-        },
-        "event_id": "task-kno-183-scenario-c:execution_artifact:claim-kno-183-c:attempt:claim-kno-183-c:attempt:log",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-04T12:02:05Z",
-        "source": "codex",
-        "summary": "Execution artifact attached: execution_log"
-      },
-      {
-        "details": {
           "artifact_references": [
             {
               "artifact_type": "execution_log",
@@ -324,6 +401,8 @@
                   "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
                 }
               ],
+              "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -336,16 +415,23 @@
               "used_task_artifact_fallback": false
             },
             "policy": {
+              "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T13:58:02.214283Z",
+            "validated_at": "2026-04-11T16:04:28.921225Z",
             "validated_by": "execution_validation"
           },
           "completion_claim_id": "claim-kno-183-c",
@@ -360,11 +446,23 @@
       },
       {
         "details": {
+          "artifact_type": "execution_log",
+          "location": "stub://attempts/log",
+          "reference_id": "claim-kno-183-c:attempt:log"
+        },
+        "event_id": "task-kno-183-scenario-c:execution_artifact:claim-kno-183-c:attempt:claim-kno-183-c:attempt:log",
+        "event_type": "execution_artifact_attached",
+        "occurred_at": "2026-04-04T12:02:05Z",
+        "source": "codex",
+        "summary": "Execution artifact attached: execution_log"
+      },
+      {
+        "details": {
           "issue_id": "lin-1",
           "issue_key": "HAR-1",
           "project": null,
           "provenance": {
-            "linked_at": "2026-04-06T13:58:02.214163Z",
+            "linked_at": "2026-04-11T16:04:28.921111Z",
             "linked_by": "reevaluation",
             "source": "completion_claim.external_facts"
           },
@@ -380,13 +478,13 @@
         },
         "event_id": "task-kno-183-scenario-c:linear_linkage",
         "event_type": "linear_linkage_recorded",
-        "occurred_at": "2026-04-06T13:58:02.214163Z",
+        "occurred_at": "2026-04-11T16:04:28.921111Z",
         "source": "reevaluation",
         "summary": "Linear linkage recorded"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T13:58:02.228915Z",
+          "changed_at": "2026-04-11T16:04:28.923324Z",
           "changed_by": "reconciliation",
           "from_status": "executing",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -394,23 +492,24 @@
         },
         "event_id": "task-kno-183-scenario-c:status:0",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T13:58:02.228915Z",
+        "occurred_at": "2026-04-11T16:04:28.923324Z",
         "source": "reconciliation",
         "summary": "Status changed executing -> reconciling"
       },
       {
         "details": {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T13:58:02.243501Z",
+          "completed_at": "2026-04-11T16:04:28.925470Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
+            "branch_head_commit_sha": null,
             "branch_name": "codex/e2e-test",
             "commit_exists": true,
             "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
             "context_resolution": {
               "conflicts": [],
-              "selected_source": "external_facts",
+              "selected_source": "merged",
               "sources": {
                 "artifacts": {
                   "base_branch": "main",
@@ -441,6 +540,7 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -607,18 +707,51 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T13:58:02.243026Z",
+          "started_at": "2026-04-11T16:04:28.925303Z",
           "status": "failed"
         },
         "event_id": "task-kno-183-scenario-c:reconciliation:reconciliation-attempt-1",
         "event_type": "reconciliation_attempt_recorded",
-        "occurred_at": "2026-04-06T13:58:02.243501Z",
+        "occurred_at": "2026-04-11T16:04:28.925470Z",
         "source": "reconciliation",
         "summary": "Reconciliation attempt: missing_pr_after_execution"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T13:58:02.256624Z",
+          "allowed_outcomes": [
+            "accept_completion",
+            "keep_blocked",
+            "mark_failed",
+            "authorize_redispatch"
+          ],
+          "metadata": {
+            "reconciliation_attempt_id": "reconciliation-attempt-1",
+            "reconciliation_failure_type": "missing_pr_after_execution"
+          },
+          "presented_sections": [
+            "task_state",
+            "execution",
+            "evidence",
+            "reconciliation"
+          ],
+          "prior_review_ids": [],
+          "reason": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+          "requested_at": "2026-04-11T16:04:28.927511Z",
+          "requested_by": "reconciliation",
+          "review_request_id": "review-request-task-kno-183-scenario-c-reconciliation-1",
+          "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+          "task_id": "task-kno-183-scenario-c",
+          "trigger": "reconciliation"
+        },
+        "event_id": "task-kno-183-scenario-c:review-request:review-request-task-kno-183-scenario-c-reconciliation-1",
+        "event_type": "review_requested",
+        "occurred_at": "2026-04-11T16:04:28.927511Z",
+        "source": "reconciliation",
+        "summary": "Manual review requested"
+      },
+      {
+        "details": {
+          "changed_at": "2026-04-11T16:04:28.927511Z",
           "changed_by": "reconciliation",
           "from_status": "reconciling",
           "reason": "Post-execution reconciliation failed: Created pull request did not satisfy current-run validation policy after read-back",
@@ -626,15 +759,61 @@
         },
         "event_id": "task-kno-183-scenario-c:status:1",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T13:58:02.256624Z",
+        "occurred_at": "2026-04-11T16:04:28.927511Z",
         "source": "reconciliation",
         "summary": "Status changed reconciling -> in_review"
+      },
+      {
+        "details": {
+          "accepted_completion": false,
+          "action": "review_required",
+          "evaluation_id": "6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+          "reasons": [
+            "Created pull request did not satisfy current-run validation policy after read-back"
+          ],
+          "reconciliation_result": {
+            "blocking": true,
+            "mismatch_categories": [
+              "missing_required_artifact"
+            ],
+            "outcome": "review_required",
+            "reasons": [
+              "Created pull request did not satisfy current-run validation policy after read-back"
+            ],
+            "status": "review_required",
+            "task_id": "task-kno-183-scenario-c",
+            "terminal": false
+          },
+          "requires_review": true,
+          "target_status": "in_review",
+          "verification_result": null
+        },
+        "event_id": "task-kno-183-scenario-c:evaluation:6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+        "event_type": "evaluation_recorded",
+        "occurred_at": "2026-04-11T16:04:28.929710Z",
+        "source": "harness",
+        "summary": "Evaluation recorded: review_required"
+      },
+      {
+        "details": {
+          "failure_reason": "Created pull request did not satisfy current-run validation policy after read-back",
+          "failure_recorded": true,
+          "failure_source": "evaluation",
+          "failure_type": "review_required",
+          "recoverable": false,
+          "terminal": false
+        },
+        "event_id": "task-kno-183-scenario-c:failure:6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+        "event_type": "failure_recorded",
+        "occurred_at": "2026-04-11T16:04:28.929710Z",
+        "source": "evaluation",
+        "summary": "Failure recorded: review_required"
       }
     ],
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T13:58:02.256624Z"
+      "updated_at": "2026-04-11T16:04:28.927511Z"
     },
     "title": "Reconcile missing pull request",
     "verification_summary": null

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-c-read-model-initial.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-c-read-model-initial.json
@@ -5,6 +5,7 @@
       "executor_id": "executor-1",
       "executor_type": "codex"
     },
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": null
     },
@@ -87,9 +88,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-183-scenario-c",

--- a/docs/demo/kno-183-pr-create-readback-validation/scenario-c-timeline-final.json
+++ b/docs/demo/kno-183-pr-create-readback-validation/scenario-c-timeline-final.json
@@ -1,6 +1,6 @@
 {
   "current_status": "in_review",
-  "event_count": 8,
+  "event_count": 11,
   "task_id": "task-kno-183-scenario-c",
   "timeline": [
     {
@@ -50,18 +50,6 @@
     },
     {
       "details": {
-        "artifact_type": "execution_log",
-        "location": "stub://attempts/log",
-        "reference_id": "claim-kno-183-c:attempt:log"
-      },
-      "event_id": "task-kno-183-scenario-c:execution_artifact:claim-kno-183-c:attempt:claim-kno-183-c:attempt:log",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-04T12:02:05Z",
-      "source": "codex",
-      "summary": "Execution artifact attached: execution_log"
-    },
-    {
-      "details": {
         "artifact_references": [
           {
             "artifact_type": "execution_log",
@@ -90,6 +78,8 @@
                 "value": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
               }
             ],
+            "commit_resolution_pending": false,
+            "has_valid_current_run_pull_request_artifact": false,
             "repository": [
               {
                 "sources": [
@@ -102,16 +92,23 @@
             "used_task_artifact_fallback": false
           },
           "policy": {
+            "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [],
           "retryable": false,
+          "rule_failures": [],
           "status": "valid",
-          "validated_at": "2026-04-06T13:58:02.214283Z",
+          "validated_at": "2026-04-11T16:04:28.921225Z",
           "validated_by": "execution_validation"
         },
         "completion_claim_id": "claim-kno-183-c",
@@ -126,11 +123,23 @@
     },
     {
       "details": {
+        "artifact_type": "execution_log",
+        "location": "stub://attempts/log",
+        "reference_id": "claim-kno-183-c:attempt:log"
+      },
+      "event_id": "task-kno-183-scenario-c:execution_artifact:claim-kno-183-c:attempt:claim-kno-183-c:attempt:log",
+      "event_type": "execution_artifact_attached",
+      "occurred_at": "2026-04-04T12:02:05Z",
+      "source": "codex",
+      "summary": "Execution artifact attached: execution_log"
+    },
+    {
+      "details": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T13:58:02.214163Z",
+          "linked_at": "2026-04-11T16:04:28.921111Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -146,13 +155,13 @@
       },
       "event_id": "task-kno-183-scenario-c:linear_linkage",
       "event_type": "linear_linkage_recorded",
-      "occurred_at": "2026-04-06T13:58:02.214163Z",
+      "occurred_at": "2026-04-11T16:04:28.921111Z",
       "source": "reevaluation",
       "summary": "Linear linkage recorded"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T13:58:02.228915Z",
+        "changed_at": "2026-04-11T16:04:28.923324Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -160,23 +169,24 @@
       },
       "event_id": "task-kno-183-scenario-c:status:0",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T13:58:02.228915Z",
+      "occurred_at": "2026-04-11T16:04:28.923324Z",
       "source": "reconciliation",
       "summary": "Status changed executing -> reconciling"
     },
     {
       "details": {
         "attempt_id": "reconciliation-attempt-1",
-        "completed_at": "2026-04-06T13:58:02.243501Z",
+        "completed_at": "2026-04-11T16:04:28.925470Z",
         "details": {
           "base_branch": "main",
           "branch_exists": true,
+          "branch_head_commit_sha": null,
           "branch_name": "codex/e2e-test",
           "commit_exists": true,
           "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
           "context_resolution": {
             "conflicts": [],
-            "selected_source": "external_facts",
+            "selected_source": "merged",
             "sources": {
               "artifacts": {
                 "base_branch": "main",
@@ -207,6 +217,7 @@
           "policy": {
             "allow_closed_pr_match": false,
             "allow_commit_association_match": true,
+            "allow_non_head_commit_association_match": false,
             "allow_open_pr_match": true,
             "escalate_on_ambiguous_match": true,
             "require_exact_branch_match": true,
@@ -373,18 +384,51 @@
         },
         "failure_type": "missing_pr_after_execution",
         "handler_key": "missing_pr_after_execution",
-        "started_at": "2026-04-06T13:58:02.243026Z",
+        "started_at": "2026-04-11T16:04:28.925303Z",
         "status": "failed"
       },
       "event_id": "task-kno-183-scenario-c:reconciliation:reconciliation-attempt-1",
       "event_type": "reconciliation_attempt_recorded",
-      "occurred_at": "2026-04-06T13:58:02.243501Z",
+      "occurred_at": "2026-04-11T16:04:28.925470Z",
       "source": "reconciliation",
       "summary": "Reconciliation attempt: missing_pr_after_execution"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T13:58:02.256624Z",
+        "allowed_outcomes": [
+          "accept_completion",
+          "keep_blocked",
+          "mark_failed",
+          "authorize_redispatch"
+        ],
+        "metadata": {
+          "reconciliation_attempt_id": "reconciliation-attempt-1",
+          "reconciliation_failure_type": "missing_pr_after_execution"
+        },
+        "presented_sections": [
+          "task_state",
+          "execution",
+          "evidence",
+          "reconciliation"
+        ],
+        "prior_review_ids": [],
+        "reason": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+        "requested_at": "2026-04-11T16:04:28.927511Z",
+        "requested_by": "reconciliation",
+        "review_request_id": "review-request-task-kno-183-scenario-c-reconciliation-1",
+        "summary": "Manual review is required because post-execution reconciliation could not prove the reported external state: Created pull request did not satisfy current-run validation policy after read-back",
+        "task_id": "task-kno-183-scenario-c",
+        "trigger": "reconciliation"
+      },
+      "event_id": "task-kno-183-scenario-c:review-request:review-request-task-kno-183-scenario-c-reconciliation-1",
+      "event_type": "review_requested",
+      "occurred_at": "2026-04-11T16:04:28.927511Z",
+      "source": "reconciliation",
+      "summary": "Manual review requested"
+    },
+    {
+      "details": {
+        "changed_at": "2026-04-11T16:04:28.927511Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
         "reason": "Post-execution reconciliation failed: Created pull request did not satisfy current-run validation policy after read-back",
@@ -392,9 +436,55 @@
       },
       "event_id": "task-kno-183-scenario-c:status:1",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T13:58:02.256624Z",
+      "occurred_at": "2026-04-11T16:04:28.927511Z",
       "source": "reconciliation",
       "summary": "Status changed reconciling -> in_review"
+    },
+    {
+      "details": {
+        "accepted_completion": false,
+        "action": "review_required",
+        "evaluation_id": "6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+        "reasons": [
+          "Created pull request did not satisfy current-run validation policy after read-back"
+        ],
+        "reconciliation_result": {
+          "blocking": true,
+          "mismatch_categories": [
+            "missing_required_artifact"
+          ],
+          "outcome": "review_required",
+          "reasons": [
+            "Created pull request did not satisfy current-run validation policy after read-back"
+          ],
+          "status": "review_required",
+          "task_id": "task-kno-183-scenario-c",
+          "terminal": false
+        },
+        "requires_review": true,
+        "target_status": "in_review",
+        "verification_result": null
+      },
+      "event_id": "task-kno-183-scenario-c:evaluation:6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+      "event_type": "evaluation_recorded",
+      "occurred_at": "2026-04-11T16:04:28.929710Z",
+      "source": "harness",
+      "summary": "Evaluation recorded: review_required"
+    },
+    {
+      "details": {
+        "failure_reason": "Created pull request did not satisfy current-run validation policy after read-back",
+        "failure_recorded": true,
+        "failure_source": "evaluation",
+        "failure_type": "review_required",
+        "recoverable": false,
+        "terminal": false
+      },
+      "event_id": "task-kno-183-scenario-c:failure:6db13384-1c82-4a7e-b66c-f60ff7cb9c50",
+      "event_type": "failure_recorded",
+      "occurred_at": "2026-04-11T16:04:28.929710Z",
+      "source": "evaluation",
+      "summary": "Failure recorded: review_required"
     }
   ]
 }

--- a/docs/demo/kno-184-missing-commit-recovery-validation/README.md
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/README.md
@@ -2,13 +2,13 @@
 
 ## Scope
 
-This proof validates the `main` branch behavior merged from PR #166 for the specific boundary where a completion claim is missing commit SHA.
+This proof validates the current `main` branch behavior for the boundary where a completion claim is missing commit SHA.
 
 Validation target:
 
 1. Missing commit SHA + trustworthy repo/branch can recover commit SHA from branch head.
-2. Missing commit SHA + trustworthy repo/branch but unresolved branch head escalates safely.
-3. Missing commit SHA + weak execution identity remains blocked by `invalid_execution_attempt`.
+2. Missing commit SHA + trustworthy repo/branch but unresolved branch head fails terminally instead of pretending success.
+3. Missing commit SHA + weak execution identity remains blocked from acceptance and fails with a terminal contract violation.
 
 ## Execution mode
 
@@ -28,8 +28,8 @@ Validation target:
 ### Scenario A — Missing commit SHA recoverable from trusted branch head
 
 - Construction: a branch-only reconciliation-eligible task is submitted with commit context removed from the claim, while gateway branch-head lookup returns a SHA.
-- Expected: no `invalid_execution_attempt`; reconciliation resolves commit from branch head and proceeds normally.
-- Actual: claim action is `transition_applied`; reconciliation attempt is `resolved`; `details.branch_head_commit_sha` and `details.commit_sha` are both populated from branch-head recovery path.
+- Expected: no `invalid_execution_attempt`; reconciliation resolves commit from branch head, attaches the recovered commit artifact, and keeps the task blocked until PR proof is also reconciled.
+- Actual: claim action is `transition_applied`; reconciliation attempt is `resolved`; `details.commit_sha` is populated from branch-head recovery path; task status remains `blocked`.
 - Result: **matched expectation**.
 
 Evidence:
@@ -42,8 +42,8 @@ Evidence:
 ### Scenario B — Missing commit SHA cannot be resolved from branch head
 
 - Construction: same as Scenario A, but gateway branch-head lookup returns `null`.
-- Expected: no `invalid_execution_attempt`; recovery is attempted and fails; reconciliation escalates instead of pretending success.
-- Actual: claim action is `reconciliation_failed`; task is `in_review`; reconciliation details record unresolved branch-head commit and explicit error.
+- Expected: no `invalid_execution_attempt`; recovery is attempted and fails; reconciliation ends in a terminal failure instead of leaving ambiguous success.
+- Actual: claim action is `reconciliation_terminal_failed`; task is `failed`; reconciliation details record unresolved branch-head commit and explicit error.
 - Result: **matched expectation**.
 
 Evidence:
@@ -56,8 +56,8 @@ Evidence:
 ### Scenario C — Missing commit SHA with untrustworthy repo/branch identity
 
 - Construction: an executing task without trusted repo/branch evidence receives a successful claim attempt that includes no repo/branch/commit execution identity.
-- Expected: blocked by `invalid_execution_attempt`; commit recovery must not backdoor through weak identity.
-- Actual: action is `invalid_execution_attempt_failed`; validation reasons explicitly include missing repository, branch, and commit identity.
+- Expected: acceptance remains blocked; commit recovery must not backdoor through weak identity.
+- Actual: action is `contract_violation_failed`; the failure classification records a terminal contract violation due to missing branch identity for the current run.
 - Result: **matched expectation**.
 
 Evidence:
@@ -71,7 +71,7 @@ Evidence:
 
 `validated`
 
-All three scenarios matched expected behavior, including preservation of the `invalid_execution_attempt` boundary while allowing governed branch-head commit recovery only when repository and branch identity are trustworthy.
+All three scenarios matched expected behavior, including governed commit recovery only when repository and branch identity are trustworthy and honest terminal failure when recovery or attribution is insufficient.
 
 ## Completion artifact status
 

--- a/docs/demo/kno-184-missing-commit-recovery-validation/generate_proof_bundle.py
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/generate_proof_bundle.py
@@ -62,7 +62,7 @@ def _scenario_a() -> dict:
         "not_invalid_execution_attempt": "invalid_execution_attempt" not in claim_response,
         "action_transition_applied": claim_response.get("action") == "transition_applied",
         "attempt_resolved": attempt.get("status") == "resolved",
-        "branch_head_recovered": attempt.get("details", {}).get("branch_head_commit_sha") == resolved_sha,
+        "task_blocked_pending_pr_recovery": claim_response.get("task_envelope", {}).get("status") == "blocked",
         "commit_sha_recovered": attempt.get("details", {}).get("commit_sha") == resolved_sha,
         "read_model_http_200": read_initial_status == 200 and read_final_status == 200,
         "timeline_http_200": timeline_initial_status == 200 and timeline_final_status == 200,
@@ -77,6 +77,7 @@ def _scenario_a() -> dict:
             "recovery_attempted": True,
             "recovery_succeeds": True,
             "result": "transition_applied",
+            "task_status": "blocked",
         },
         "actual": {
             "claim_status": claim_status,
@@ -124,8 +125,8 @@ def _scenario_b() -> dict:
     checks = {
         "claim_http_200": claim_status == 200,
         "not_invalid_execution_attempt": "invalid_execution_attempt" not in claim_response,
-        "action_reconciliation_failed": claim_response.get("action") == "reconciliation_failed",
-        "task_in_review": claim_response.get("task_envelope", {}).get("status") == "in_review",
+        "action_reconciliation_terminal_failed": claim_response.get("action") == "reconciliation_terminal_failed",
+        "task_failed": claim_response.get("task_envelope", {}).get("status") == "failed",
         "recovery_attempted": "branch head" in str(attempt.get("details", {}).get("error", "")).lower(),
         "branch_head_unresolved": attempt.get("details", {}).get("branch_head_commit_sha") is None,
         "read_model_http_200": read_initial_status == 200 and read_final_status == 200,
@@ -140,7 +141,8 @@ def _scenario_b() -> dict:
             "invalid_execution_attempt": False,
             "recovery_attempted": True,
             "recovery_succeeds": False,
-            "result": "reconciliation_failed",
+            "result": "reconciliation_terminal_failed",
+            "task_status": "failed",
         },
         "actual": {
             "claim_status": claim_status,
@@ -227,12 +229,20 @@ def _scenario_c() -> dict:
     validation = claim_response.get("invalid_execution_attempt", {}).get("validation", {})
     checks = {
         "claim_http_200": claim_status == 200,
-        "invalid_execution_attempt_present": bool(claim_response.get("invalid_execution_attempt")),
-        "failure_type_invalid_execution_attempt": validation.get("failure_type") == "invalid_execution_attempt",
-        "missing_commit_reason_present": any("missing commit" in reason.lower() for reason in validation.get("reasons", [])),
-        "missing_repository_reason_present": any(
-            "missing repository" in reason.lower() for reason in validation.get("reasons", [])
-        ),
+        "action_contract_violation_failed": claim_response.get("action") == "contract_violation_failed",
+        "task_failed": claim_response.get("task_envelope", {}).get("status") == "failed",
+        "failure_type_contract_violation": claim_response.get("evaluation_record", {})
+        .get("result", {})
+        .get("failure_classification", {})
+        .get("failure_type")
+        == "contract_violation",
+        "missing_branch_reason_present": "missing branch identity"
+        in str(
+            claim_response.get("evaluation_record", {})
+            .get("result", {})
+            .get("failure_classification", {})
+            .get("reason", "")
+        ).lower(),
         "read_model_http_200": read_initial_status == 200 and read_final_status == 200,
         "timeline_http_200": timeline_initial_status == 200 and timeline_final_status == 200,
     }
@@ -242,9 +252,10 @@ def _scenario_c() -> dict:
         "description": "Missing commit SHA with untrustworthy repository/branch identity",
         "construction": "Created an executing task with no trusted repo/branch artifacts; submitted a successful execution attempt without repository, branch, or commit identity.",
         "expected": {
-            "invalid_execution_attempt": True,
+            "invalid_execution_attempt": False,
             "recovery_attempted": False,
-            "result": "blocked_by_invalid_execution_attempt",
+            "result": "contract_violation_failed",
+            "task_status": "failed",
         },
         "actual": {
             "claim_status": claim_status,

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-a-completion-claim-response.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-a-completion-claim-response.json
@@ -11,6 +11,12 @@
           "artifact_type": "pull_request",
           "is_valid": true,
           "issues": []
+        },
+        {
+          "artifact_id": "artifact-commit-aaaaaaaaaaaa",
+          "artifact_type": "commit",
+          "is_valid": true,
+          "issues": []
         }
       ],
       "is_sufficient": false,
@@ -73,7 +79,7 @@
               "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
               "name": "codex/e2e-test"
             },
-            "captured_at": "2026-04-06T15:28:46.057449Z",
+            "captured_at": "2026-04-11T16:04:28.892169Z",
             "changed_files": [],
             "commit_sha": null,
             "content_type": null,
@@ -103,6 +109,43 @@
             "title": "Reconcile missing pull request PR",
             "type": "pull_request",
             "verification_status": "verified"
+          },
+          {
+            "branch": {
+              "base_branch": "main",
+              "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "name": "codex/e2e-test"
+            },
+            "captured_at": "2026-04-11T16:04:28.892832Z",
+            "changed_files": [],
+            "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "content_type": null,
+            "description": "Attached by Harness reconciliation after execution completed without a commit artifact.",
+            "external_id": "commit-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "external_refs": [],
+            "id": "artifact-commit-aaaaaaaaaaaa",
+            "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "metadata": {
+              "attached_by": "missing_commit_after_execution",
+              "linked_pull_request_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409"
+            },
+            "provenance": {
+              "captured_by": "reconciliation_handler",
+              "source_id": "commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "source_system": "github",
+              "source_type": "api"
+            },
+            "pull_request_number": 409,
+            "repository": {
+              "external_id": null,
+              "host": "github.com",
+              "name": "HARNESS-DRYRUN",
+              "owner": "KnoxAnalytics"
+            },
+            "review_state": null,
+            "title": null,
+            "type": "commit",
+            "verification_status": "verified"
           }
         ]
       },
@@ -119,7 +162,7 @@
           "issue_key": "HAR-1",
           "project": null,
           "provenance": {
-            "linked_at": "2026-04-06T15:28:46.018784Z",
+            "linked_at": "2026-04-11T16:04:28.887919Z",
             "linked_by": "reevaluation",
             "source": "completion_claim.external_facts"
           },
@@ -179,6 +222,7 @@
                       }
                     ],
                     "commit_resolution_pending": true,
+                    "has_valid_current_run_pull_request_artifact": false,
                     "repository": [
                       {
                         "sources": [
@@ -191,16 +235,22 @@
                   },
                   "policy": {
                     "allow_commit_resolution_via_reconciliation": true,
+                    "allow_missing_commit_artifact_with_verified_pull_request": true,
                     "allow_missing_pull_request": true,
+                    "reject_closed_or_historical_pull_request": true,
+                    "reject_non_numeric_pull_request_url": true,
+                    "reject_reserved_shared_branch": true,
                     "require_commit": true,
                     "require_exact_branch": true,
                     "require_repository": true,
                     "task_artifact_fallback_requires_single_attempt": true
                   },
+                  "pull_request_observations": [],
                   "reasons": [],
                   "retryable": false,
+                  "rule_failures": [],
                   "status": "valid",
-                  "validated_at": "2026-04-06T15:28:46.019121Z",
+                  "validated_at": "2026-04-11T16:04:28.888059Z",
                   "validated_by": "execution_validation"
                 },
                 "executor_run_id": "run-claim-kno-184-scenario-a"
@@ -244,7 +294,7 @@
         "attempts": [
           {
             "attempt_id": "reconciliation-attempt-1",
-            "completed_at": "2026-04-06T15:28:46.057449Z",
+            "completed_at": "2026-04-11T16:04:28.892169Z",
             "details": {
               "base_branch": "main",
               "branch_exists": true,
@@ -277,6 +327,7 @@
               "policy": {
                 "allow_closed_pr_match": false,
                 "allow_commit_association_match": true,
+                "allow_non_head_commit_association_match": false,
                 "allow_open_pr_match": true,
                 "escalate_on_ambiguous_match": true,
                 "require_exact_branch_match": true,
@@ -450,29 +501,86 @@
             },
             "failure_type": "missing_pr_after_execution",
             "handler_key": "missing_pr_after_execution",
-            "started_at": "2026-04-06T15:28:46.056736Z",
+            "started_at": "2026-04-11T16:04:28.891828Z",
+            "status": "resolved"
+          },
+          {
+            "attempt_id": "reconciliation-attempt-2",
+            "completed_at": "2026-04-11T16:04:28.892832Z",
+            "details": {
+              "base_branch": "main",
+              "branch_exists": true,
+              "branch_head_commit_sha": null,
+              "branch_name": "codex/e2e-test",
+              "commit_exists": true,
+              "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "context_resolution": {
+                "conflicts": [],
+                "selected_source": "merged",
+                "sources": {
+                  "artifacts": {
+                    "base_branch": "main",
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
+                  },
+                  "external_facts": {
+                    "base_branch": "main",
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
+                  }
+                }
+              },
+              "created_commit_artifact": true,
+              "error": null,
+              "error_disposition": null,
+              "final_decision": {
+                "reason": "verified_pull_request_proof_and_commit_resolved",
+                "result": "attached_commit_artifact"
+              },
+              "pull_request_proof": {
+                "artifact_id": "artifact-pr-409",
+                "found": true,
+                "number": 409,
+                "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+                "verification_status": "verified"
+              },
+              "repository": {
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              }
+            },
+            "failure_type": "missing_commit_after_execution",
+            "handler_key": "missing_commit_after_execution",
+            "started_at": "2026-04-11T16:04:28.892832Z",
             "status": "resolved"
           }
         ],
         "failed_at": null,
-        "last_attempt_id": "reconciliation-attempt-1",
+        "last_attempt_id": "reconciliation-attempt-2",
         "last_error": null,
         "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
-        "resolved_at": "2026-04-06T15:28:46.057449Z",
+        "resolved_at": "2026-04-11T16:04:28.892832Z",
         "status": "resolved"
       },
       "required_capabilities": [],
       "status": "blocked",
       "status_history": [
         {
-          "changed_at": "2026-04-06T15:28:46.040922Z",
+          "changed_at": "2026-04-11T16:04:28.890047Z",
           "changed_by": "reconciliation",
           "from_status": "executing",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
           "to_status": "reconciling"
         },
         {
-          "changed_at": "2026-04-06T15:28:46.174320Z",
+          "changed_at": "2026-04-11T16:04:28.907020Z",
           "changed_by": "verification",
           "from_status": "reconciling",
           "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -482,17 +590,17 @@
       "timestamps": {
         "completed_at": null,
         "created_at": "2026-04-04T12:00:00Z",
-        "updated_at": "2026-04-06T15:28:46.174320Z"
+        "updated_at": "2026-04-11T16:04:28.907020Z"
       },
       "title": "Reconcile missing pull request"
     },
     "transition_result": {
       "actor": "verification",
-      "changed_at": "2026-04-06T15:28:46.174320Z",
+      "changed_at": "2026-04-11T16:04:28.907020Z",
       "from_status": "reconciling",
       "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
       "status_history_entry": {
-        "changed_at": "2026-04-06T15:28:46.174320Z",
+        "changed_at": "2026-04-11T16:04:28.907020Z",
         "changed_by": "verification",
         "from_status": "reconciling",
         "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -524,7 +632,7 @@
                 "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "name": "codex/e2e-test"
               },
-              "captured_at": "2026-04-06T15:28:46.057449Z",
+              "captured_at": "2026-04-11T16:04:28.892169Z",
               "changed_files": [],
               "commit_sha": null,
               "content_type": null,
@@ -554,6 +662,43 @@
               "title": "Reconcile missing pull request PR",
               "type": "pull_request",
               "verification_status": "verified"
+            },
+            {
+              "branch": {
+                "base_branch": "main",
+                "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "name": "codex/e2e-test"
+              },
+              "captured_at": "2026-04-11T16:04:28.892832Z",
+              "changed_files": [],
+              "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "content_type": null,
+              "description": "Attached by Harness reconciliation after execution completed without a commit artifact.",
+              "external_id": "commit-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "external_refs": [],
+              "id": "artifact-commit-aaaaaaaaaaaa",
+              "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "metadata": {
+                "attached_by": "missing_commit_after_execution",
+                "linked_pull_request_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409"
+              },
+              "provenance": {
+                "captured_by": "reconciliation_handler",
+                "source_id": "commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "source_system": "github",
+                "source_type": "api"
+              },
+              "pull_request_number": 409,
+              "repository": {
+                "external_id": null,
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              },
+              "review_state": null,
+              "title": null,
+              "type": "commit",
+              "verification_status": "verified"
             }
           ]
         },
@@ -570,7 +715,7 @@
             "issue_key": "HAR-1",
             "project": null,
             "provenance": {
-              "linked_at": "2026-04-06T15:28:46.018784Z",
+              "linked_at": "2026-04-11T16:04:28.887919Z",
               "linked_by": "reevaluation",
               "source": "completion_claim.external_facts"
             },
@@ -630,6 +775,7 @@
                         }
                       ],
                       "commit_resolution_pending": true,
+                      "has_valid_current_run_pull_request_artifact": false,
                       "repository": [
                         {
                           "sources": [
@@ -642,16 +788,22 @@
                     },
                     "policy": {
                       "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
                       "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
                       "require_commit": true,
                       "require_exact_branch": true,
                       "require_repository": true,
                       "task_artifact_fallback_requires_single_attempt": true
                     },
+                    "pull_request_observations": [],
                     "reasons": [],
                     "retryable": false,
+                    "rule_failures": [],
                     "status": "valid",
-                    "validated_at": "2026-04-06T15:28:46.019121Z",
+                    "validated_at": "2026-04-11T16:04:28.888059Z",
                     "validated_by": "execution_validation"
                   },
                   "executor_run_id": "run-claim-kno-184-scenario-a"
@@ -695,7 +847,7 @@
           "attempts": [
             {
               "attempt_id": "reconciliation-attempt-1",
-              "completed_at": "2026-04-06T15:28:46.057449Z",
+              "completed_at": "2026-04-11T16:04:28.892169Z",
               "details": {
                 "base_branch": "main",
                 "branch_exists": true,
@@ -728,6 +880,7 @@
                 "policy": {
                   "allow_closed_pr_match": false,
                   "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
                   "allow_open_pr_match": true,
                   "escalate_on_ambiguous_match": true,
                   "require_exact_branch_match": true,
@@ -901,29 +1054,86 @@
               },
               "failure_type": "missing_pr_after_execution",
               "handler_key": "missing_pr_after_execution",
-              "started_at": "2026-04-06T15:28:46.056736Z",
+              "started_at": "2026-04-11T16:04:28.891828Z",
+              "status": "resolved"
+            },
+            {
+              "attempt_id": "reconciliation-attempt-2",
+              "completed_at": "2026-04-11T16:04:28.892832Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": true,
+                "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "merged",
+                  "sources": {
+                    "artifacts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    },
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_commit_artifact": true,
+                "error": null,
+                "error_disposition": null,
+                "final_decision": {
+                  "reason": "verified_pull_request_proof_and_commit_resolved",
+                  "result": "attached_commit_artifact"
+                },
+                "pull_request_proof": {
+                  "artifact_id": "artifact-pr-409",
+                  "found": true,
+                  "number": 409,
+                  "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+                  "verification_status": "verified"
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_commit_after_execution",
+              "handler_key": "missing_commit_after_execution",
+              "started_at": "2026-04-11T16:04:28.892832Z",
               "status": "resolved"
             }
           ],
           "failed_at": null,
-          "last_attempt_id": "reconciliation-attempt-1",
+          "last_attempt_id": "reconciliation-attempt-2",
           "last_error": null,
           "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
-          "resolved_at": "2026-04-06T15:28:46.057449Z",
+          "resolved_at": "2026-04-11T16:04:28.892832Z",
           "status": "resolved"
         },
         "required_capabilities": [],
         "status": "blocked",
         "status_history": [
           {
-            "changed_at": "2026-04-06T15:28:46.040922Z",
+            "changed_at": "2026-04-11T16:04:28.890047Z",
             "changed_by": "reconciliation",
             "from_status": "executing",
             "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
             "to_status": "reconciling"
           },
           {
-            "changed_at": "2026-04-06T15:28:46.174320Z",
+            "changed_at": "2026-04-11T16:04:28.907020Z",
             "changed_by": "verification",
             "from_status": "reconciling",
             "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -933,13 +1143,20 @@
         "timestamps": {
           "completed_at": null,
           "created_at": "2026-04-04T12:00:00Z",
-          "updated_at": "2026-04-06T15:28:46.174320Z"
+          "updated_at": "2026-04-11T16:04:28.907020Z"
         },
         "title": "Reconcile missing pull request"
       },
       "to_status": "blocked"
     },
     "verification_result": {
+      "acceptance_criteria_assessment": {
+        "automatic_completion_safe": true,
+        "concrete_required_criteria_count": 1,
+        "flagged_criteria": [],
+        "reasons": [],
+        "required_criteria_count": 1
+      },
       "accepted_completion": false,
       "claimed_completion": true,
       "evidence_is_sufficient": false,
@@ -969,8 +1186,8 @@
   },
   "error": null,
   "evaluation_record": {
-    "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
-    "recorded_at": "2026-04-06T15:28:46.202979Z",
+    "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
+    "recorded_at": "2026-04-11T16:04:28.912294Z",
     "request": {
       "acceptance_criteria_satisfied": true,
       "claimed_completion": true,
@@ -982,7 +1199,35 @@
           "repository_name": "HARNESS-DRYRUN",
           "repository_owner": "KnoxAnalytics"
         },
-        "github_facts": null,
+        "github_facts": {
+          "artifact_found": true,
+          "artifact_refs": [
+            {
+              "artifact_type": "commit",
+              "external_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "url": null
+            }
+          ],
+          "branch": {
+            "base_branch": "main",
+            "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "codex/e2e-test"
+          },
+          "changed_files": null,
+          "commit": {
+            "message_summary": null,
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "url": null
+          },
+          "pull_request": null,
+          "reasons": [],
+          "repository": {
+            "external_id": null,
+            "host": "github.com",
+            "name": "HARNESS-DRYRUN",
+            "owner": "KnoxAnalytics"
+          }
+        },
         "linear_facts": {
           "issue_id": "lin-1",
           "issue_key": "HAR-1",
@@ -1036,7 +1281,7 @@
                 "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "name": "codex/e2e-test"
               },
-              "captured_at": "2026-04-06T15:28:46.057449Z",
+              "captured_at": "2026-04-11T16:04:28.892169Z",
               "changed_files": [],
               "commit_sha": null,
               "content_type": null,
@@ -1066,6 +1311,43 @@
               "title": "Reconcile missing pull request PR",
               "type": "pull_request",
               "verification_status": "verified"
+            },
+            {
+              "branch": {
+                "base_branch": "main",
+                "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "name": "codex/e2e-test"
+              },
+              "captured_at": "2026-04-11T16:04:28.892832Z",
+              "changed_files": [],
+              "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "content_type": null,
+              "description": "Attached by Harness reconciliation after execution completed without a commit artifact.",
+              "external_id": "commit-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "external_refs": [],
+              "id": "artifact-commit-aaaaaaaaaaaa",
+              "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "metadata": {
+                "attached_by": "missing_commit_after_execution",
+                "linked_pull_request_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409"
+              },
+              "provenance": {
+                "captured_by": "reconciliation_handler",
+                "source_id": "commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "source_system": "github",
+                "source_type": "api"
+              },
+              "pull_request_number": 409,
+              "repository": {
+                "external_id": null,
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              },
+              "review_state": null,
+              "title": null,
+              "type": "commit",
+              "verification_status": "verified"
             }
           ]
         },
@@ -1082,7 +1364,7 @@
             "issue_key": "HAR-1",
             "project": null,
             "provenance": {
-              "linked_at": "2026-04-06T15:28:46.018784Z",
+              "linked_at": "2026-04-11T16:04:28.887919Z",
               "linked_by": "reevaluation",
               "source": "completion_claim.external_facts"
             },
@@ -1142,6 +1424,7 @@
                         }
                       ],
                       "commit_resolution_pending": true,
+                      "has_valid_current_run_pull_request_artifact": false,
                       "repository": [
                         {
                           "sources": [
@@ -1154,16 +1437,22 @@
                     },
                     "policy": {
                       "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
                       "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
                       "require_commit": true,
                       "require_exact_branch": true,
                       "require_repository": true,
                       "task_artifact_fallback_requires_single_attempt": true
                     },
+                    "pull_request_observations": [],
                     "reasons": [],
                     "retryable": false,
+                    "rule_failures": [],
                     "status": "valid",
-                    "validated_at": "2026-04-06T15:28:46.019121Z",
+                    "validated_at": "2026-04-11T16:04:28.888059Z",
                     "validated_by": "execution_validation"
                   },
                   "executor_run_id": "run-claim-kno-184-scenario-a"
@@ -1207,7 +1496,7 @@
           "attempts": [
             {
               "attempt_id": "reconciliation-attempt-1",
-              "completed_at": "2026-04-06T15:28:46.057449Z",
+              "completed_at": "2026-04-11T16:04:28.892169Z",
               "details": {
                 "base_branch": "main",
                 "branch_exists": true,
@@ -1240,6 +1529,7 @@
                 "policy": {
                   "allow_closed_pr_match": false,
                   "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
                   "allow_open_pr_match": true,
                   "escalate_on_ambiguous_match": true,
                   "require_exact_branch_match": true,
@@ -1413,22 +1703,79 @@
               },
               "failure_type": "missing_pr_after_execution",
               "handler_key": "missing_pr_after_execution",
-              "started_at": "2026-04-06T15:28:46.056736Z",
+              "started_at": "2026-04-11T16:04:28.891828Z",
+              "status": "resolved"
+            },
+            {
+              "attempt_id": "reconciliation-attempt-2",
+              "completed_at": "2026-04-11T16:04:28.892832Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": true,
+                "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "merged",
+                  "sources": {
+                    "artifacts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    },
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_commit_artifact": true,
+                "error": null,
+                "error_disposition": null,
+                "final_decision": {
+                  "reason": "verified_pull_request_proof_and_commit_resolved",
+                  "result": "attached_commit_artifact"
+                },
+                "pull_request_proof": {
+                  "artifact_id": "artifact-pr-409",
+                  "found": true,
+                  "number": 409,
+                  "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+                  "verification_status": "verified"
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_commit_after_execution",
+              "handler_key": "missing_commit_after_execution",
+              "started_at": "2026-04-11T16:04:28.892832Z",
               "status": "resolved"
             }
           ],
           "failed_at": null,
-          "last_attempt_id": "reconciliation-attempt-1",
+          "last_attempt_id": "reconciliation-attempt-2",
           "last_error": null,
           "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
-          "resolved_at": "2026-04-06T15:28:46.057449Z",
+          "resolved_at": "2026-04-11T16:04:28.892832Z",
           "status": "resolved"
         },
         "required_capabilities": [],
         "status": "reconciling",
         "status_history": [
           {
-            "changed_at": "2026-04-06T15:28:46.040922Z",
+            "changed_at": "2026-04-11T16:04:28.890047Z",
             "changed_by": "reconciliation",
             "from_status": "executing",
             "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -1438,7 +1785,7 @@
         "timestamps": {
           "completed_at": null,
           "created_at": "2026-04-04T12:00:00Z",
-          "updated_at": "2026-04-06T15:28:46.057449Z"
+          "updated_at": "2026-04-11T16:04:28.892832Z"
         },
         "title": "Reconcile missing pull request"
       },
@@ -1455,6 +1802,12 @@
             {
               "artifact_id": "artifact-pr-409",
               "artifact_type": "pull_request",
+              "is_valid": true,
+              "issues": []
+            },
+            {
+              "artifact_id": "artifact-commit-aaaaaaaaaaaa",
+              "artifact_type": "commit",
               "is_valid": true,
               "issues": []
             }
@@ -1519,7 +1872,7 @@
                   "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                   "name": "codex/e2e-test"
                 },
-                "captured_at": "2026-04-06T15:28:46.057449Z",
+                "captured_at": "2026-04-11T16:04:28.892169Z",
                 "changed_files": [],
                 "commit_sha": null,
                 "content_type": null,
@@ -1549,6 +1902,43 @@
                 "title": "Reconcile missing pull request PR",
                 "type": "pull_request",
                 "verification_status": "verified"
+              },
+              {
+                "branch": {
+                  "base_branch": "main",
+                  "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "name": "codex/e2e-test"
+                },
+                "captured_at": "2026-04-11T16:04:28.892832Z",
+                "changed_files": [],
+                "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "content_type": null,
+                "description": "Attached by Harness reconciliation after execution completed without a commit artifact.",
+                "external_id": "commit-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "external_refs": [],
+                "id": "artifact-commit-aaaaaaaaaaaa",
+                "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "metadata": {
+                  "attached_by": "missing_commit_after_execution",
+                  "linked_pull_request_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409"
+                },
+                "provenance": {
+                  "captured_by": "reconciliation_handler",
+                  "source_id": "commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "source_system": "github",
+                  "source_type": "api"
+                },
+                "pull_request_number": 409,
+                "repository": {
+                  "external_id": null,
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                },
+                "review_state": null,
+                "title": null,
+                "type": "commit",
+                "verification_status": "verified"
               }
             ]
           },
@@ -1565,7 +1955,7 @@
               "issue_key": "HAR-1",
               "project": null,
               "provenance": {
-                "linked_at": "2026-04-06T15:28:46.018784Z",
+                "linked_at": "2026-04-11T16:04:28.887919Z",
                 "linked_by": "reevaluation",
                 "source": "completion_claim.external_facts"
               },
@@ -1625,6 +2015,7 @@
                           }
                         ],
                         "commit_resolution_pending": true,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "repository": [
                           {
                             "sources": [
@@ -1637,16 +2028,22 @@
                       },
                       "policy": {
                         "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [],
                       "retryable": false,
+                      "rule_failures": [],
                       "status": "valid",
-                      "validated_at": "2026-04-06T15:28:46.019121Z",
+                      "validated_at": "2026-04-11T16:04:28.888059Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "run-claim-kno-184-scenario-a"
@@ -1690,7 +2087,7 @@
             "attempts": [
               {
                 "attempt_id": "reconciliation-attempt-1",
-                "completed_at": "2026-04-06T15:28:46.057449Z",
+                "completed_at": "2026-04-11T16:04:28.892169Z",
                 "details": {
                   "base_branch": "main",
                   "branch_exists": true,
@@ -1723,6 +2120,7 @@
                   "policy": {
                     "allow_closed_pr_match": false,
                     "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
                     "allow_open_pr_match": true,
                     "escalate_on_ambiguous_match": true,
                     "require_exact_branch_match": true,
@@ -1896,29 +2294,86 @@
                 },
                 "failure_type": "missing_pr_after_execution",
                 "handler_key": "missing_pr_after_execution",
-                "started_at": "2026-04-06T15:28:46.056736Z",
+                "started_at": "2026-04-11T16:04:28.891828Z",
+                "status": "resolved"
+              },
+              {
+                "attempt_id": "reconciliation-attempt-2",
+                "completed_at": "2026-04-11T16:04:28.892832Z",
+                "details": {
+                  "base_branch": "main",
+                  "branch_exists": true,
+                  "branch_head_commit_sha": null,
+                  "branch_name": "codex/e2e-test",
+                  "commit_exists": true,
+                  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "context_resolution": {
+                    "conflicts": [],
+                    "selected_source": "merged",
+                    "sources": {
+                      "artifacts": {
+                        "base_branch": "main",
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      },
+                      "external_facts": {
+                        "base_branch": "main",
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      }
+                    }
+                  },
+                  "created_commit_artifact": true,
+                  "error": null,
+                  "error_disposition": null,
+                  "final_decision": {
+                    "reason": "verified_pull_request_proof_and_commit_resolved",
+                    "result": "attached_commit_artifact"
+                  },
+                  "pull_request_proof": {
+                    "artifact_id": "artifact-pr-409",
+                    "found": true,
+                    "number": 409,
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+                    "verification_status": "verified"
+                  },
+                  "repository": {
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  }
+                },
+                "failure_type": "missing_commit_after_execution",
+                "handler_key": "missing_commit_after_execution",
+                "started_at": "2026-04-11T16:04:28.892832Z",
                 "status": "resolved"
               }
             ],
             "failed_at": null,
-            "last_attempt_id": "reconciliation-attempt-1",
+            "last_attempt_id": "reconciliation-attempt-2",
             "last_error": null,
             "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
-            "resolved_at": "2026-04-06T15:28:46.057449Z",
+            "resolved_at": "2026-04-11T16:04:28.892832Z",
             "status": "resolved"
           },
           "required_capabilities": [],
           "status": "blocked",
           "status_history": [
             {
-              "changed_at": "2026-04-06T15:28:46.040922Z",
+              "changed_at": "2026-04-11T16:04:28.890047Z",
               "changed_by": "reconciliation",
               "from_status": "executing",
               "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
               "to_status": "reconciling"
             },
             {
-              "changed_at": "2026-04-06T15:28:46.174320Z",
+              "changed_at": "2026-04-11T16:04:28.907020Z",
               "changed_by": "verification",
               "from_status": "reconciling",
               "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -1928,17 +2383,17 @@
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-04-04T12:00:00Z",
-            "updated_at": "2026-04-06T15:28:46.174320Z"
+            "updated_at": "2026-04-11T16:04:28.907020Z"
           },
           "title": "Reconcile missing pull request"
         },
         "transition_result": {
           "actor": "verification",
-          "changed_at": "2026-04-06T15:28:46.174320Z",
+          "changed_at": "2026-04-11T16:04:28.907020Z",
           "from_status": "reconciling",
           "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
           "status_history_entry": {
-            "changed_at": "2026-04-06T15:28:46.174320Z",
+            "changed_at": "2026-04-11T16:04:28.907020Z",
             "changed_by": "verification",
             "from_status": "reconciling",
             "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -1970,7 +2425,7 @@
                     "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                     "name": "codex/e2e-test"
                   },
-                  "captured_at": "2026-04-06T15:28:46.057449Z",
+                  "captured_at": "2026-04-11T16:04:28.892169Z",
                   "changed_files": [],
                   "commit_sha": null,
                   "content_type": null,
@@ -2000,6 +2455,43 @@
                   "title": "Reconcile missing pull request PR",
                   "type": "pull_request",
                   "verification_status": "verified"
+                },
+                {
+                  "branch": {
+                    "base_branch": "main",
+                    "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "name": "codex/e2e-test"
+                  },
+                  "captured_at": "2026-04-11T16:04:28.892832Z",
+                  "changed_files": [],
+                  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "content_type": null,
+                  "description": "Attached by Harness reconciliation after execution completed without a commit artifact.",
+                  "external_id": "commit-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "external_refs": [],
+                  "id": "artifact-commit-aaaaaaaaaaaa",
+                  "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "metadata": {
+                    "attached_by": "missing_commit_after_execution",
+                    "linked_pull_request_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409"
+                  },
+                  "provenance": {
+                    "captured_by": "reconciliation_handler",
+                    "source_id": "commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "source_system": "github",
+                    "source_type": "api"
+                  },
+                  "pull_request_number": 409,
+                  "repository": {
+                    "external_id": null,
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  },
+                  "review_state": null,
+                  "title": null,
+                  "type": "commit",
+                  "verification_status": "verified"
                 }
               ]
             },
@@ -2016,7 +2508,7 @@
                 "issue_key": "HAR-1",
                 "project": null,
                 "provenance": {
-                  "linked_at": "2026-04-06T15:28:46.018784Z",
+                  "linked_at": "2026-04-11T16:04:28.887919Z",
                   "linked_by": "reevaluation",
                   "source": "completion_claim.external_facts"
                 },
@@ -2076,6 +2568,7 @@
                             }
                           ],
                           "commit_resolution_pending": true,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "repository": [
                             {
                               "sources": [
@@ -2088,16 +2581,22 @@
                         },
                         "policy": {
                           "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [],
                         "retryable": false,
+                        "rule_failures": [],
                         "status": "valid",
-                        "validated_at": "2026-04-06T15:28:46.019121Z",
+                        "validated_at": "2026-04-11T16:04:28.888059Z",
                         "validated_by": "execution_validation"
                       },
                       "executor_run_id": "run-claim-kno-184-scenario-a"
@@ -2141,7 +2640,7 @@
               "attempts": [
                 {
                   "attempt_id": "reconciliation-attempt-1",
-                  "completed_at": "2026-04-06T15:28:46.057449Z",
+                  "completed_at": "2026-04-11T16:04:28.892169Z",
                   "details": {
                     "base_branch": "main",
                     "branch_exists": true,
@@ -2174,6 +2673,7 @@
                     "policy": {
                       "allow_closed_pr_match": false,
                       "allow_commit_association_match": true,
+                      "allow_non_head_commit_association_match": false,
                       "allow_open_pr_match": true,
                       "escalate_on_ambiguous_match": true,
                       "require_exact_branch_match": true,
@@ -2347,29 +2847,86 @@
                   },
                   "failure_type": "missing_pr_after_execution",
                   "handler_key": "missing_pr_after_execution",
-                  "started_at": "2026-04-06T15:28:46.056736Z",
+                  "started_at": "2026-04-11T16:04:28.891828Z",
+                  "status": "resolved"
+                },
+                {
+                  "attempt_id": "reconciliation-attempt-2",
+                  "completed_at": "2026-04-11T16:04:28.892832Z",
+                  "details": {
+                    "base_branch": "main",
+                    "branch_exists": true,
+                    "branch_head_commit_sha": null,
+                    "branch_name": "codex/e2e-test",
+                    "commit_exists": true,
+                    "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "context_resolution": {
+                      "conflicts": [],
+                      "selected_source": "merged",
+                      "sources": {
+                        "artifacts": {
+                          "base_branch": "main",
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                          "repository_host": "github.com",
+                          "repository_name": "HARNESS-DRYRUN",
+                          "repository_owner": "KnoxAnalytics"
+                        },
+                        "external_facts": {
+                          "base_branch": "main",
+                          "branch_name": "codex/e2e-test",
+                          "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                          "repository_host": "github.com",
+                          "repository_name": "HARNESS-DRYRUN",
+                          "repository_owner": "KnoxAnalytics"
+                        }
+                      }
+                    },
+                    "created_commit_artifact": true,
+                    "error": null,
+                    "error_disposition": null,
+                    "final_decision": {
+                      "reason": "verified_pull_request_proof_and_commit_resolved",
+                      "result": "attached_commit_artifact"
+                    },
+                    "pull_request_proof": {
+                      "artifact_id": "artifact-pr-409",
+                      "found": true,
+                      "number": 409,
+                      "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+                      "verification_status": "verified"
+                    },
+                    "repository": {
+                      "host": "github.com",
+                      "name": "HARNESS-DRYRUN",
+                      "owner": "KnoxAnalytics"
+                    }
+                  },
+                  "failure_type": "missing_commit_after_execution",
+                  "handler_key": "missing_commit_after_execution",
+                  "started_at": "2026-04-11T16:04:28.892832Z",
                   "status": "resolved"
                 }
               ],
               "failed_at": null,
-              "last_attempt_id": "reconciliation-attempt-1",
+              "last_attempt_id": "reconciliation-attempt-2",
               "last_error": null,
               "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
-              "resolved_at": "2026-04-06T15:28:46.057449Z",
+              "resolved_at": "2026-04-11T16:04:28.892832Z",
               "status": "resolved"
             },
             "required_capabilities": [],
             "status": "blocked",
             "status_history": [
               {
-                "changed_at": "2026-04-06T15:28:46.040922Z",
+                "changed_at": "2026-04-11T16:04:28.890047Z",
                 "changed_by": "reconciliation",
                 "from_status": "executing",
                 "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
                 "to_status": "reconciling"
               },
               {
-                "changed_at": "2026-04-06T15:28:46.174320Z",
+                "changed_at": "2026-04-11T16:04:28.907020Z",
                 "changed_by": "verification",
                 "from_status": "reconciling",
                 "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -2379,13 +2936,20 @@
             "timestamps": {
               "completed_at": null,
               "created_at": "2026-04-04T12:00:00Z",
-              "updated_at": "2026-04-06T15:28:46.174320Z"
+              "updated_at": "2026-04-11T16:04:28.907020Z"
             },
             "title": "Reconcile missing pull request"
           },
           "to_status": "blocked"
         },
         "verification_result": {
+          "acceptance_criteria_assessment": {
+            "automatic_completion_safe": true,
+            "concrete_required_criteria_count": 1,
+            "flagged_criteria": [],
+            "reasons": [],
+            "required_criteria_count": 1
+          },
           "accepted_completion": false,
           "claimed_completion": true,
           "evidence_is_sufficient": false,
@@ -2455,7 +3019,7 @@
                 "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "name": "codex/e2e-test"
               },
-              "captured_at": "2026-04-06T15:28:46.057449Z",
+              "captured_at": "2026-04-11T16:04:28.892169Z",
               "changed_files": [],
               "commit_sha": null,
               "content_type": null,
@@ -2485,6 +3049,43 @@
               "title": "Reconcile missing pull request PR",
               "type": "pull_request",
               "verification_status": "verified"
+            },
+            {
+              "branch": {
+                "base_branch": "main",
+                "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "name": "codex/e2e-test"
+              },
+              "captured_at": "2026-04-11T16:04:28.892832Z",
+              "changed_files": [],
+              "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "content_type": null,
+              "description": "Attached by Harness reconciliation after execution completed without a commit artifact.",
+              "external_id": "commit-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "external_refs": [],
+              "id": "artifact-commit-aaaaaaaaaaaa",
+              "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "metadata": {
+                "attached_by": "missing_commit_after_execution",
+                "linked_pull_request_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409"
+              },
+              "provenance": {
+                "captured_by": "reconciliation_handler",
+                "source_id": "commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "source_system": "github",
+                "source_type": "api"
+              },
+              "pull_request_number": 409,
+              "repository": {
+                "external_id": null,
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              },
+              "review_state": null,
+              "title": null,
+              "type": "commit",
+              "verification_status": "verified"
             }
           ]
         },
@@ -2501,7 +3102,7 @@
             "issue_key": "HAR-1",
             "project": null,
             "provenance": {
-              "linked_at": "2026-04-06T15:28:46.018784Z",
+              "linked_at": "2026-04-11T16:04:28.887919Z",
               "linked_by": "reevaluation",
               "source": "completion_claim.external_facts"
             },
@@ -2561,6 +3162,7 @@
                         }
                       ],
                       "commit_resolution_pending": true,
+                      "has_valid_current_run_pull_request_artifact": false,
                       "repository": [
                         {
                           "sources": [
@@ -2573,16 +3175,22 @@
                     },
                     "policy": {
                       "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
                       "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
                       "require_commit": true,
                       "require_exact_branch": true,
                       "require_repository": true,
                       "task_artifact_fallback_requires_single_attempt": true
                     },
+                    "pull_request_observations": [],
                     "reasons": [],
                     "retryable": false,
+                    "rule_failures": [],
                     "status": "valid",
-                    "validated_at": "2026-04-06T15:28:46.019121Z",
+                    "validated_at": "2026-04-11T16:04:28.888059Z",
                     "validated_by": "execution_validation"
                   },
                   "executor_run_id": "run-claim-kno-184-scenario-a"
@@ -2626,7 +3234,7 @@
           "attempts": [
             {
               "attempt_id": "reconciliation-attempt-1",
-              "completed_at": "2026-04-06T15:28:46.057449Z",
+              "completed_at": "2026-04-11T16:04:28.892169Z",
               "details": {
                 "base_branch": "main",
                 "branch_exists": true,
@@ -2659,6 +3267,7 @@
                 "policy": {
                   "allow_closed_pr_match": false,
                   "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
                   "allow_open_pr_match": true,
                   "escalate_on_ambiguous_match": true,
                   "require_exact_branch_match": true,
@@ -2832,29 +3441,86 @@
               },
               "failure_type": "missing_pr_after_execution",
               "handler_key": "missing_pr_after_execution",
-              "started_at": "2026-04-06T15:28:46.056736Z",
+              "started_at": "2026-04-11T16:04:28.891828Z",
+              "status": "resolved"
+            },
+            {
+              "attempt_id": "reconciliation-attempt-2",
+              "completed_at": "2026-04-11T16:04:28.892832Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": true,
+                "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "merged",
+                  "sources": {
+                    "artifacts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    },
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_commit_artifact": true,
+                "error": null,
+                "error_disposition": null,
+                "final_decision": {
+                  "reason": "verified_pull_request_proof_and_commit_resolved",
+                  "result": "attached_commit_artifact"
+                },
+                "pull_request_proof": {
+                  "artifact_id": "artifact-pr-409",
+                  "found": true,
+                  "number": 409,
+                  "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+                  "verification_status": "verified"
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_commit_after_execution",
+              "handler_key": "missing_commit_after_execution",
+              "started_at": "2026-04-11T16:04:28.892832Z",
               "status": "resolved"
             }
           ],
           "failed_at": null,
-          "last_attempt_id": "reconciliation-attempt-1",
+          "last_attempt_id": "reconciliation-attempt-2",
           "last_error": null,
           "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
-          "resolved_at": "2026-04-06T15:28:46.057449Z",
+          "resolved_at": "2026-04-11T16:04:28.892832Z",
           "status": "resolved"
         },
         "required_capabilities": [],
         "status": "blocked",
         "status_history": [
           {
-            "changed_at": "2026-04-06T15:28:46.040922Z",
+            "changed_at": "2026-04-11T16:04:28.890047Z",
             "changed_by": "reconciliation",
             "from_status": "executing",
             "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
             "to_status": "reconciling"
           },
           {
-            "changed_at": "2026-04-06T15:28:46.174320Z",
+            "changed_at": "2026-04-11T16:04:28.907020Z",
             "changed_by": "verification",
             "from_status": "reconciling",
             "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -2864,7 +3530,7 @@
         "timestamps": {
           "completed_at": null,
           "created_at": "2026-04-04T12:00:00Z",
-          "updated_at": "2026-04-06T15:28:46.174320Z"
+          "updated_at": "2026-04-11T16:04:28.907020Z"
         },
         "title": "Reconcile missing pull request"
       }
@@ -2912,7 +3578,7 @@
             "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "name": "codex/e2e-test"
           },
-          "captured_at": "2026-04-06T15:28:46.057449Z",
+          "captured_at": "2026-04-11T16:04:28.892169Z",
           "changed_files": [],
           "commit_sha": null,
           "content_type": null,
@@ -2942,6 +3608,43 @@
           "title": "Reconcile missing pull request PR",
           "type": "pull_request",
           "verification_status": "verified"
+        },
+        {
+          "branch": {
+            "base_branch": "main",
+            "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "codex/e2e-test"
+          },
+          "captured_at": "2026-04-11T16:04:28.892832Z",
+          "changed_files": [],
+          "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "content_type": null,
+          "description": "Attached by Harness reconciliation after execution completed without a commit artifact.",
+          "external_id": "commit-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "external_refs": [],
+          "id": "artifact-commit-aaaaaaaaaaaa",
+          "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "metadata": {
+            "attached_by": "missing_commit_after_execution",
+            "linked_pull_request_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409"
+          },
+          "provenance": {
+            "captured_by": "reconciliation_handler",
+            "source_id": "commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source_system": "github",
+            "source_type": "api"
+          },
+          "pull_request_number": 409,
+          "repository": {
+            "external_id": null,
+            "host": "github.com",
+            "name": "HARNESS-DRYRUN",
+            "owner": "KnoxAnalytics"
+          },
+          "review_state": null,
+          "title": null,
+          "type": "commit",
+          "verification_status": "verified"
         }
       ]
     },
@@ -2958,7 +3661,7 @@
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T15:28:46.018784Z",
+          "linked_at": "2026-04-11T16:04:28.887919Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -3018,6 +3721,7 @@
                     }
                   ],
                   "commit_resolution_pending": true,
+                  "has_valid_current_run_pull_request_artifact": false,
                   "repository": [
                     {
                       "sources": [
@@ -3030,16 +3734,22 @@
                 },
                 "policy": {
                   "allow_commit_resolution_via_reconciliation": true,
+                  "allow_missing_commit_artifact_with_verified_pull_request": true,
                   "allow_missing_pull_request": true,
+                  "reject_closed_or_historical_pull_request": true,
+                  "reject_non_numeric_pull_request_url": true,
+                  "reject_reserved_shared_branch": true,
                   "require_commit": true,
                   "require_exact_branch": true,
                   "require_repository": true,
                   "task_artifact_fallback_requires_single_attempt": true
                 },
+                "pull_request_observations": [],
                 "reasons": [],
                 "retryable": false,
+                "rule_failures": [],
                 "status": "valid",
-                "validated_at": "2026-04-06T15:28:46.019121Z",
+                "validated_at": "2026-04-11T16:04:28.888059Z",
                 "validated_by": "execution_validation"
               },
               "executor_run_id": "run-claim-kno-184-scenario-a"
@@ -3047,8 +3757,8 @@
             "recorded_at": "2026-04-04T12:02:05Z",
             "reevaluation": {
               "action": "transition_applied",
-              "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
-              "linked_at": "2026-04-06T15:28:46.202979Z"
+              "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
+              "linked_at": "2026-04-11T16:04:28.912294Z"
             },
             "reported_by": "codex",
             "status": "completed"
@@ -3087,7 +3797,7 @@
       "attempts": [
         {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T15:28:46.057449Z",
+          "completed_at": "2026-04-11T16:04:28.892169Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
@@ -3120,6 +3830,7 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -3293,29 +4004,86 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T15:28:46.056736Z",
+          "started_at": "2026-04-11T16:04:28.891828Z",
+          "status": "resolved"
+        },
+        {
+          "attempt_id": "reconciliation-attempt-2",
+          "completed_at": "2026-04-11T16:04:28.892832Z",
+          "details": {
+            "base_branch": "main",
+            "branch_exists": true,
+            "branch_head_commit_sha": null,
+            "branch_name": "codex/e2e-test",
+            "commit_exists": true,
+            "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "context_resolution": {
+              "conflicts": [],
+              "selected_source": "merged",
+              "sources": {
+                "artifacts": {
+                  "base_branch": "main",
+                  "branch_name": "codex/e2e-test",
+                  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "repository_host": "github.com",
+                  "repository_name": "HARNESS-DRYRUN",
+                  "repository_owner": "KnoxAnalytics"
+                },
+                "external_facts": {
+                  "base_branch": "main",
+                  "branch_name": "codex/e2e-test",
+                  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "repository_host": "github.com",
+                  "repository_name": "HARNESS-DRYRUN",
+                  "repository_owner": "KnoxAnalytics"
+                }
+              }
+            },
+            "created_commit_artifact": true,
+            "error": null,
+            "error_disposition": null,
+            "final_decision": {
+              "reason": "verified_pull_request_proof_and_commit_resolved",
+              "result": "attached_commit_artifact"
+            },
+            "pull_request_proof": {
+              "artifact_id": "artifact-pr-409",
+              "found": true,
+              "number": 409,
+              "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+              "verification_status": "verified"
+            },
+            "repository": {
+              "host": "github.com",
+              "name": "HARNESS-DRYRUN",
+              "owner": "KnoxAnalytics"
+            }
+          },
+          "failure_type": "missing_commit_after_execution",
+          "handler_key": "missing_commit_after_execution",
+          "started_at": "2026-04-11T16:04:28.892832Z",
           "status": "resolved"
         }
       ],
       "failed_at": null,
-      "last_attempt_id": "reconciliation-attempt-1",
+      "last_attempt_id": "reconciliation-attempt-2",
       "last_error": null,
       "last_pr_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
-      "resolved_at": "2026-04-06T15:28:46.057449Z",
+      "resolved_at": "2026-04-11T16:04:28.892832Z",
       "status": "resolved"
     },
     "required_capabilities": [],
     "status": "blocked",
     "status_history": [
       {
-        "changed_at": "2026-04-06T15:28:46.040922Z",
+        "changed_at": "2026-04-11T16:04:28.890047Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T15:28:46.174320Z",
+        "changed_at": "2026-04-11T16:04:28.907020Z",
         "changed_by": "verification",
         "from_status": "reconciling",
         "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -3325,7 +4093,7 @@
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T15:28:46.219533Z"
+      "updated_at": "2026-04-11T16:04:28.914605Z"
     },
     "title": "Reconcile missing pull request"
   }

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-a-read-model-final.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-a-read-model-final.json
@@ -5,13 +5,14 @@
       "executor_id": "executor-1",
       "executor_type": "codex"
     },
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T15:28:46.018784Z",
+          "linked_at": "2026-04-11T16:04:28.887919Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -33,18 +34,19 @@
       "history": [
         {
           "action": "transition_applied",
-          "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
-          "recorded_at": "2026-04-06T15:28:46.202979Z",
+          "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
+          "recorded_at": "2026-04-11T16:04:28.912294Z",
           "target_status": "blocked"
         }
       ],
       "latest_action": "transition_applied",
-      "latest_recorded_at": "2026-04-06T15:28:46.202979Z",
+      "latest_recorded_at": "2026-04-11T16:04:28.912294Z",
       "latest_target_status": "blocked"
     },
     "evidence_summary": {
-      "artifact_count": 1,
+      "artifact_count": 2,
       "artifact_type_counts": {
+        "commit": 1,
         "pull_request": 1
       },
       "completion_evidence": {
@@ -58,12 +60,12 @@
       },
       "validated_artifact_count": 0,
       "verification_status_counts": {
-        "verified": 1
+        "verified": 2
       }
     },
     "execution_summary": {
       "attempt_count": 1,
-      "failure_state": "retryable",
+      "failure_state": "failed",
       "invalid_attempt_count": 0,
       "last_failure_type": "evidence_insufficient",
       "latest_artifact_references": [
@@ -95,6 +97,7 @@
                 }
               ],
               "commit_resolution_pending": true,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -107,16 +110,22 @@
             },
             "policy": {
               "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T15:28:46.019121Z",
+            "validated_at": "2026-04-11T16:04:28.888059Z",
             "validated_by": "execution_validation"
           },
           "executor_run_id": "run-claim-kno-184-scenario-a"
@@ -124,8 +133,8 @@
         "recorded_at": "2026-04-04T12:02:05Z",
         "reevaluation": {
           "action": "transition_applied",
-          "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
-          "linked_at": "2026-04-06T15:28:46.202979Z"
+          "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
+          "linked_at": "2026-04-11T16:04:28.912294Z"
         },
         "reported_by": "codex",
         "status": "completed"
@@ -141,6 +150,7 @@
             }
           ],
           "commit_resolution_pending": true,
+          "has_valid_current_run_pull_request_artifact": false,
           "repository": [
             {
               "sources": [
@@ -153,16 +163,22 @@
         },
         "policy": {
           "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
           "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
           "require_commit": true,
           "require_exact_branch": true,
           "require_repository": true,
           "task_artifact_fallback_requires_single_attempt": true
         },
+        "pull_request_observations": [],
         "reasons": [],
         "retryable": false,
+        "rule_failures": [],
         "status": "valid",
-        "validated_at": "2026-04-06T15:28:46.019121Z",
+        "validated_at": "2026-04-11T16:04:28.888059Z",
         "validated_by": "execution_validation"
       },
       "latest_dispatch_origin": null,
@@ -173,25 +189,25 @@
     },
     "extensions": {},
     "failure_summary": {
-      "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
+      "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
       "failure_reason": "Completion evidence policy is not_applicable and does not authorize completion",
       "failure_source": "evaluation",
       "failure_type": "evidence_insufficient",
-      "recorded_at": "2026-04-06T15:28:46.202979Z",
+      "recorded_at": "2026-04-11T16:04:28.912294Z",
       "recoverable": false,
       "state": "failed",
       "terminal": false
     },
     "lifecycle_history": [
       {
-        "changed_at": "2026-04-06T15:28:46.040922Z",
+        "changed_at": "2026-04-11T16:04:28.890047Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T15:28:46.174320Z",
+        "changed_at": "2026-04-11T16:04:28.907020Z",
         "changed_by": "verification",
         "from_status": "reconciling",
         "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -228,9 +244,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-184-scenario-a",
@@ -256,18 +274,6 @@
       },
       {
         "details": {
-          "artifact_type": "execution_log",
-          "location": "stub://attempts/log",
-          "reference_id": "claim-kno-184-scenario-a:attempt:log"
-        },
-        "event_id": "task-kno-184-scenario-a:execution_artifact:claim-kno-184-scenario-a:attempt:claim-kno-184-scenario-a:attempt:log",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-04T12:02:05Z",
-        "source": "codex",
-        "summary": "Execution artifact attached: execution_log"
-      },
-      {
-        "details": {
           "artifact_references": [
             {
               "artifact_type": "execution_log",
@@ -287,6 +293,7 @@
                 }
               ],
               "commit_resolution_pending": true,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -299,23 +306,29 @@
             },
             "policy": {
               "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T15:28:46.019121Z",
+            "validated_at": "2026-04-11T16:04:28.888059Z",
             "validated_by": "execution_validation"
           },
           "completion_claim_id": "claim-kno-184-scenario-a",
           "reevaluation": {
             "action": "transition_applied",
-            "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
-            "linked_at": "2026-04-06T15:28:46.202979Z"
+            "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
+            "linked_at": "2026-04-11T16:04:28.912294Z"
           },
           "status": "completed"
         },
@@ -327,11 +340,23 @@
       },
       {
         "details": {
+          "artifact_type": "execution_log",
+          "location": "stub://attempts/log",
+          "reference_id": "claim-kno-184-scenario-a:attempt:log"
+        },
+        "event_id": "task-kno-184-scenario-a:execution_artifact:claim-kno-184-scenario-a:attempt:claim-kno-184-scenario-a:attempt:log",
+        "event_type": "execution_artifact_attached",
+        "occurred_at": "2026-04-04T12:02:05Z",
+        "source": "codex",
+        "summary": "Execution artifact attached: execution_log"
+      },
+      {
+        "details": {
           "issue_id": "lin-1",
           "issue_key": "HAR-1",
           "project": null,
           "provenance": {
-            "linked_at": "2026-04-06T15:28:46.018784Z",
+            "linked_at": "2026-04-11T16:04:28.887919Z",
             "linked_by": "reevaluation",
             "source": "completion_claim.external_facts"
           },
@@ -347,13 +372,13 @@
         },
         "event_id": "task-kno-184-scenario-a:linear_linkage",
         "event_type": "linear_linkage_recorded",
-        "occurred_at": "2026-04-06T15:28:46.018784Z",
+        "occurred_at": "2026-04-11T16:04:28.887919Z",
         "source": "reevaluation",
         "summary": "Linear linkage recorded"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T15:28:46.040922Z",
+          "changed_at": "2026-04-11T16:04:28.890047Z",
           "changed_by": "reconciliation",
           "from_status": "executing",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -361,7 +386,7 @@
         },
         "event_id": "task-kno-184-scenario-a:status:0",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T15:28:46.040922Z",
+        "occurred_at": "2026-04-11T16:04:28.890047Z",
         "source": "reconciliation",
         "summary": "Status changed executing -> reconciling"
       },
@@ -387,14 +412,14 @@
         },
         "event_id": "task-kno-184-scenario-a:artifact:artifact-pr-409",
         "event_type": "artifact_captured",
-        "occurred_at": "2026-04-06T15:28:46.057449Z",
+        "occurred_at": "2026-04-11T16:04:28.892169Z",
         "source": "github",
         "summary": "Artifact captured: pull_request"
       },
       {
         "details": {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T15:28:46.057449Z",
+          "completed_at": "2026-04-11T16:04:28.892169Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
@@ -427,6 +452,7 @@
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -600,18 +626,108 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T15:28:46.056736Z",
+          "started_at": "2026-04-11T16:04:28.891828Z",
           "status": "resolved"
         },
         "event_id": "task-kno-184-scenario-a:reconciliation:reconciliation-attempt-1",
         "event_type": "reconciliation_attempt_recorded",
-        "occurred_at": "2026-04-06T15:28:46.057449Z",
+        "occurred_at": "2026-04-11T16:04:28.892169Z",
         "source": "reconciliation",
         "summary": "Reconciliation attempt: missing_pr_after_execution"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T15:28:46.174320Z",
+          "artifact_id": "artifact-commit-aaaaaaaaaaaa",
+          "branch": {
+            "base_branch": "main",
+            "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "codex/e2e-test"
+          },
+          "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "pull_request_number": 409,
+          "repository": {
+            "external_id": null,
+            "host": "github.com",
+            "name": "HARNESS-DRYRUN",
+            "owner": "KnoxAnalytics"
+          },
+          "title": null,
+          "type": "commit",
+          "verification_status": "verified"
+        },
+        "event_id": "task-kno-184-scenario-a:artifact:artifact-commit-aaaaaaaaaaaa",
+        "event_type": "artifact_captured",
+        "occurred_at": "2026-04-11T16:04:28.892832Z",
+        "source": "github",
+        "summary": "Artifact captured: commit"
+      },
+      {
+        "details": {
+          "attempt_id": "reconciliation-attempt-2",
+          "completed_at": "2026-04-11T16:04:28.892832Z",
+          "details": {
+            "base_branch": "main",
+            "branch_exists": true,
+            "branch_head_commit_sha": null,
+            "branch_name": "codex/e2e-test",
+            "commit_exists": true,
+            "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "context_resolution": {
+              "conflicts": [],
+              "selected_source": "merged",
+              "sources": {
+                "artifacts": {
+                  "base_branch": "main",
+                  "branch_name": "codex/e2e-test",
+                  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "repository_host": "github.com",
+                  "repository_name": "HARNESS-DRYRUN",
+                  "repository_owner": "KnoxAnalytics"
+                },
+                "external_facts": {
+                  "base_branch": "main",
+                  "branch_name": "codex/e2e-test",
+                  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "repository_host": "github.com",
+                  "repository_name": "HARNESS-DRYRUN",
+                  "repository_owner": "KnoxAnalytics"
+                }
+              }
+            },
+            "created_commit_artifact": true,
+            "error": null,
+            "error_disposition": null,
+            "final_decision": {
+              "reason": "verified_pull_request_proof_and_commit_resolved",
+              "result": "attached_commit_artifact"
+            },
+            "pull_request_proof": {
+              "artifact_id": "artifact-pr-409",
+              "found": true,
+              "number": 409,
+              "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+              "verification_status": "verified"
+            },
+            "repository": {
+              "host": "github.com",
+              "name": "HARNESS-DRYRUN",
+              "owner": "KnoxAnalytics"
+            }
+          },
+          "failure_type": "missing_commit_after_execution",
+          "handler_key": "missing_commit_after_execution",
+          "started_at": "2026-04-11T16:04:28.892832Z",
+          "status": "resolved"
+        },
+        "event_id": "task-kno-184-scenario-a:reconciliation:reconciliation-attempt-2",
+        "event_type": "reconciliation_attempt_recorded",
+        "occurred_at": "2026-04-11T16:04:28.892832Z",
+        "source": "reconciliation",
+        "summary": "Reconciliation attempt: missing_commit_after_execution"
+      },
+      {
+        "details": {
+          "changed_at": "2026-04-11T16:04:28.907020Z",
           "changed_by": "verification",
           "from_status": "reconciling",
           "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -619,7 +735,7 @@
         },
         "event_id": "task-kno-184-scenario-a:status:1",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T15:28:46.174320Z",
+        "occurred_at": "2026-04-11T16:04:28.907020Z",
         "source": "verification",
         "summary": "Status changed reconciling -> blocked"
       },
@@ -627,7 +743,7 @@
         "details": {
           "accepted_completion": false,
           "action": "transition_applied",
-          "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
+          "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
           "reasons": [
             "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion"
           ],
@@ -646,6 +762,13 @@
           "requires_review": false,
           "target_status": "blocked",
           "verification_result": {
+            "acceptance_criteria_assessment": {
+              "automatic_completion_safe": true,
+              "concrete_required_criteria_count": 1,
+              "flagged_criteria": [],
+              "reasons": [],
+              "required_criteria_count": 1
+            },
             "accepted_completion": false,
             "claimed_completion": true,
             "evidence_is_sufficient": false,
@@ -673,9 +796,9 @@
             "verification_passed": false
           }
         },
-        "event_id": "task-kno-184-scenario-a:evaluation:f622a7e4-ef17-4cf4-a217-03b8916e525d",
+        "event_id": "task-kno-184-scenario-a:evaluation:3781f4af-60ec-47a5-bfbd-adb484bf5d96",
         "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-06T15:28:46.202979Z",
+        "occurred_at": "2026-04-11T16:04:28.912294Z",
         "source": "harness",
         "summary": "Evaluation recorded: transition_applied"
       },
@@ -688,9 +811,9 @@
           "recoverable": false,
           "terminal": false
         },
-        "event_id": "task-kno-184-scenario-a:failure:f622a7e4-ef17-4cf4-a217-03b8916e525d",
+        "event_id": "task-kno-184-scenario-a:failure:3781f4af-60ec-47a5-bfbd-adb484bf5d96",
         "event_type": "failure_recorded",
-        "occurred_at": "2026-04-06T15:28:46.202979Z",
+        "occurred_at": "2026-04-11T16:04:28.912294Z",
         "source": "evaluation",
         "summary": "Failure recorded: evidence_insufficient"
       }
@@ -698,10 +821,17 @@
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T15:28:46.219533Z"
+      "updated_at": "2026-04-11T16:04:28.914605Z"
     },
     "title": "Reconcile missing pull request",
     "verification_summary": {
+      "acceptance_criteria_assessment": {
+        "automatic_completion_safe": true,
+        "concrete_required_criteria_count": 1,
+        "flagged_criteria": [],
+        "reasons": [],
+        "required_criteria_count": 1
+      },
       "accepted_completion": false,
       "claimed_completion": true,
       "evidence_is_sufficient": false,

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-a-read-model-initial.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-a-read-model-initial.json
@@ -5,6 +5,7 @@
       "executor_id": "executor-1",
       "executor_type": "codex"
     },
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": null
     },
@@ -74,9 +75,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-184-scenario-a",

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-a-timeline-final.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-a-timeline-final.json
@@ -1,6 +1,6 @@
 {
   "current_status": "blocked",
-  "event_count": 10,
+  "event_count": 12,
   "task_id": "task-kno-184-scenario-a",
   "timeline": [
     {
@@ -24,18 +24,6 @@
     },
     {
       "details": {
-        "artifact_type": "execution_log",
-        "location": "stub://attempts/log",
-        "reference_id": "claim-kno-184-scenario-a:attempt:log"
-      },
-      "event_id": "task-kno-184-scenario-a:execution_artifact:claim-kno-184-scenario-a:attempt:claim-kno-184-scenario-a:attempt:log",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-04T12:02:05Z",
-      "source": "codex",
-      "summary": "Execution artifact attached: execution_log"
-    },
-    {
-      "details": {
         "artifact_references": [
           {
             "artifact_type": "execution_log",
@@ -55,6 +43,7 @@
               }
             ],
             "commit_resolution_pending": true,
+            "has_valid_current_run_pull_request_artifact": false,
             "repository": [
               {
                 "sources": [
@@ -67,23 +56,29 @@
           },
           "policy": {
             "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [],
           "retryable": false,
+          "rule_failures": [],
           "status": "valid",
-          "validated_at": "2026-04-06T15:28:46.019121Z",
+          "validated_at": "2026-04-11T16:04:28.888059Z",
           "validated_by": "execution_validation"
         },
         "completion_claim_id": "claim-kno-184-scenario-a",
         "reevaluation": {
           "action": "transition_applied",
-          "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
-          "linked_at": "2026-04-06T15:28:46.202979Z"
+          "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
+          "linked_at": "2026-04-11T16:04:28.912294Z"
         },
         "status": "completed"
       },
@@ -95,11 +90,23 @@
     },
     {
       "details": {
+        "artifact_type": "execution_log",
+        "location": "stub://attempts/log",
+        "reference_id": "claim-kno-184-scenario-a:attempt:log"
+      },
+      "event_id": "task-kno-184-scenario-a:execution_artifact:claim-kno-184-scenario-a:attempt:claim-kno-184-scenario-a:attempt:log",
+      "event_type": "execution_artifact_attached",
+      "occurred_at": "2026-04-04T12:02:05Z",
+      "source": "codex",
+      "summary": "Execution artifact attached: execution_log"
+    },
+    {
+      "details": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T15:28:46.018784Z",
+          "linked_at": "2026-04-11T16:04:28.887919Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -115,13 +122,13 @@
       },
       "event_id": "task-kno-184-scenario-a:linear_linkage",
       "event_type": "linear_linkage_recorded",
-      "occurred_at": "2026-04-06T15:28:46.018784Z",
+      "occurred_at": "2026-04-11T16:04:28.887919Z",
       "source": "reevaluation",
       "summary": "Linear linkage recorded"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T15:28:46.040922Z",
+        "changed_at": "2026-04-11T16:04:28.890047Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -129,7 +136,7 @@
       },
       "event_id": "task-kno-184-scenario-a:status:0",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T15:28:46.040922Z",
+      "occurred_at": "2026-04-11T16:04:28.890047Z",
       "source": "reconciliation",
       "summary": "Status changed executing -> reconciling"
     },
@@ -155,14 +162,14 @@
       },
       "event_id": "task-kno-184-scenario-a:artifact:artifact-pr-409",
       "event_type": "artifact_captured",
-      "occurred_at": "2026-04-06T15:28:46.057449Z",
+      "occurred_at": "2026-04-11T16:04:28.892169Z",
       "source": "github",
       "summary": "Artifact captured: pull_request"
     },
     {
       "details": {
         "attempt_id": "reconciliation-attempt-1",
-        "completed_at": "2026-04-06T15:28:46.057449Z",
+        "completed_at": "2026-04-11T16:04:28.892169Z",
         "details": {
           "base_branch": "main",
           "branch_exists": true,
@@ -195,6 +202,7 @@
           "policy": {
             "allow_closed_pr_match": false,
             "allow_commit_association_match": true,
+            "allow_non_head_commit_association_match": false,
             "allow_open_pr_match": true,
             "escalate_on_ambiguous_match": true,
             "require_exact_branch_match": true,
@@ -368,18 +376,108 @@
         },
         "failure_type": "missing_pr_after_execution",
         "handler_key": "missing_pr_after_execution",
-        "started_at": "2026-04-06T15:28:46.056736Z",
+        "started_at": "2026-04-11T16:04:28.891828Z",
         "status": "resolved"
       },
       "event_id": "task-kno-184-scenario-a:reconciliation:reconciliation-attempt-1",
       "event_type": "reconciliation_attempt_recorded",
-      "occurred_at": "2026-04-06T15:28:46.057449Z",
+      "occurred_at": "2026-04-11T16:04:28.892169Z",
       "source": "reconciliation",
       "summary": "Reconciliation attempt: missing_pr_after_execution"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T15:28:46.174320Z",
+        "artifact_id": "artifact-commit-aaaaaaaaaaaa",
+        "branch": {
+          "base_branch": "main",
+          "head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "name": "codex/e2e-test"
+        },
+        "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "pull_request_number": 409,
+        "repository": {
+          "external_id": null,
+          "host": "github.com",
+          "name": "HARNESS-DRYRUN",
+          "owner": "KnoxAnalytics"
+        },
+        "title": null,
+        "type": "commit",
+        "verification_status": "verified"
+      },
+      "event_id": "task-kno-184-scenario-a:artifact:artifact-commit-aaaaaaaaaaaa",
+      "event_type": "artifact_captured",
+      "occurred_at": "2026-04-11T16:04:28.892832Z",
+      "source": "github",
+      "summary": "Artifact captured: commit"
+    },
+    {
+      "details": {
+        "attempt_id": "reconciliation-attempt-2",
+        "completed_at": "2026-04-11T16:04:28.892832Z",
+        "details": {
+          "base_branch": "main",
+          "branch_exists": true,
+          "branch_head_commit_sha": null,
+          "branch_name": "codex/e2e-test",
+          "commit_exists": true,
+          "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "context_resolution": {
+            "conflicts": [],
+            "selected_source": "merged",
+            "sources": {
+              "artifacts": {
+                "base_branch": "main",
+                "branch_name": "codex/e2e-test",
+                "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "repository_host": "github.com",
+                "repository_name": "HARNESS-DRYRUN",
+                "repository_owner": "KnoxAnalytics"
+              },
+              "external_facts": {
+                "base_branch": "main",
+                "branch_name": "codex/e2e-test",
+                "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "repository_host": "github.com",
+                "repository_name": "HARNESS-DRYRUN",
+                "repository_owner": "KnoxAnalytics"
+              }
+            }
+          },
+          "created_commit_artifact": true,
+          "error": null,
+          "error_disposition": null,
+          "final_decision": {
+            "reason": "verified_pull_request_proof_and_commit_resolved",
+            "result": "attached_commit_artifact"
+          },
+          "pull_request_proof": {
+            "artifact_id": "artifact-pr-409",
+            "found": true,
+            "number": 409,
+            "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/409",
+            "verification_status": "verified"
+          },
+          "repository": {
+            "host": "github.com",
+            "name": "HARNESS-DRYRUN",
+            "owner": "KnoxAnalytics"
+          }
+        },
+        "failure_type": "missing_commit_after_execution",
+        "handler_key": "missing_commit_after_execution",
+        "started_at": "2026-04-11T16:04:28.892832Z",
+        "status": "resolved"
+      },
+      "event_id": "task-kno-184-scenario-a:reconciliation:reconciliation-attempt-2",
+      "event_type": "reconciliation_attempt_recorded",
+      "occurred_at": "2026-04-11T16:04:28.892832Z",
+      "source": "reconciliation",
+      "summary": "Reconciliation attempt: missing_commit_after_execution"
+    },
+    {
+      "details": {
+        "changed_at": "2026-04-11T16:04:28.907020Z",
         "changed_by": "verification",
         "from_status": "reconciling",
         "reason": "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion",
@@ -387,7 +485,7 @@
       },
       "event_id": "task-kno-184-scenario-a:status:1",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T15:28:46.174320Z",
+      "occurred_at": "2026-04-11T16:04:28.907020Z",
       "source": "verification",
       "summary": "Status changed reconciling -> blocked"
     },
@@ -395,7 +493,7 @@
       "details": {
         "accepted_completion": false,
         "action": "transition_applied",
-        "evaluation_id": "f622a7e4-ef17-4cf4-a217-03b8916e525d",
+        "evaluation_id": "3781f4af-60ec-47a5-bfbd-adb484bf5d96",
         "reasons": [
           "Verification evaluated task 'task-kno-184-scenario-a' against canonical completion policy; Executor-reported success was treated as advisory input only; Completion evidence policy is not_applicable and does not authorize completion"
         ],
@@ -414,6 +512,13 @@
         "requires_review": false,
         "target_status": "blocked",
         "verification_result": {
+          "acceptance_criteria_assessment": {
+            "automatic_completion_safe": true,
+            "concrete_required_criteria_count": 1,
+            "flagged_criteria": [],
+            "reasons": [],
+            "required_criteria_count": 1
+          },
           "accepted_completion": false,
           "claimed_completion": true,
           "evidence_is_sufficient": false,
@@ -441,9 +546,9 @@
           "verification_passed": false
         }
       },
-      "event_id": "task-kno-184-scenario-a:evaluation:f622a7e4-ef17-4cf4-a217-03b8916e525d",
+      "event_id": "task-kno-184-scenario-a:evaluation:3781f4af-60ec-47a5-bfbd-adb484bf5d96",
       "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-06T15:28:46.202979Z",
+      "occurred_at": "2026-04-11T16:04:28.912294Z",
       "source": "harness",
       "summary": "Evaluation recorded: transition_applied"
     },
@@ -456,9 +561,9 @@
         "recoverable": false,
         "terminal": false
       },
-      "event_id": "task-kno-184-scenario-a:failure:f622a7e4-ef17-4cf4-a217-03b8916e525d",
+      "event_id": "task-kno-184-scenario-a:failure:3781f4af-60ec-47a5-bfbd-adb484bf5d96",
       "event_type": "failure_recorded",
-      "occurred_at": "2026-04-06T15:28:46.202979Z",
+      "occurred_at": "2026-04-11T16:04:28.912294Z",
       "source": "evaluation",
       "summary": "Failure recorded: evidence_insufficient"
     }

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-b-completion-claim-response.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-b-completion-claim-response.json
@@ -1,14 +1,1190 @@
 {
   "accepted_completion": false,
-  "action": "reconciliation_failed",
+  "action": "reconciliation_terminal_failed",
+  "enforcement_result": {
+    "action": "transition_applied",
+    "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+    "evidence_result": null,
+    "failure_classification": {
+      "category": "reconciliation_mismatch",
+      "failure_type": "reconciliation_mismatch",
+      "reason": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+      "recoverable": false,
+      "retryable": false,
+      "source": "evaluation",
+      "terminal": true
+    },
+    "reasons": [
+      "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+    ],
+    "reconciliation_result": {
+      "blocking": true,
+      "mismatch_categories": [
+        "missing_required_artifact"
+      ],
+      "outcome": "terminal_invalid",
+      "reasons": [
+        "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+      ],
+      "status": "mismatch",
+      "task_id": "task-kno-184-scenario-b",
+      "terminal": true
+    },
+    "review_decision": null,
+    "review_request": null,
+    "target_status": "failed",
+    "task_envelope": {
+      "acceptance_criteria": [
+        {
+          "description": "Harness can reconcile a missing PR after execution.",
+          "id": "ac-1",
+          "required": true
+        }
+      ],
+      "artifacts": {
+        "completion_evidence": {
+          "notes": null,
+          "policy": "not_applicable",
+          "required_artifact_types": [],
+          "status": "not_applicable",
+          "validated_artifact_ids": [],
+          "validated_at": null,
+          "validation_method": "none",
+          "validator": null
+        },
+        "items": []
+      },
+      "assigned_executor": null,
+      "child_task_ids": [],
+      "constraints": [],
+      "coordination": {
+        "linear": {
+          "issue_id": "lin-1",
+          "issue_key": "HAR-1",
+          "project": null,
+          "provenance": {
+            "linked_at": "2026-04-11T16:04:28.921821Z",
+            "linked_by": "reevaluation",
+            "source": "completion_claim.external_facts"
+          },
+          "reasons": [],
+          "record_found": true,
+          "state": "completed",
+          "task_reference": null,
+          "workflow": {
+            "state_type": "completed",
+            "workflow_id": "workflow-completed",
+            "workflow_name": "completed"
+          }
+        }
+      },
+      "dependencies": [],
+      "description": "Exercise post-execution PR reconciliation.",
+      "id": "task-kno-184-scenario-b",
+      "objective": {
+        "deliverable_type": "unspecified",
+        "success_signal": "Task satisfies declared acceptance criteria.",
+        "summary": "Exercise post-execution PR reconciliation."
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {
+          "advisory_completion_claims": [
+            {
+              "claim_id": "claim-kno-184-scenario-b",
+              "metadata": {
+                "attempt_id": "claim-kno-184-scenario-b:attempt"
+              },
+              "reason": "Execution completed successfully.",
+              "reported_at": "2026-04-04T12:02:00Z",
+              "reported_by": "codex"
+            }
+          ],
+          "execution_attempts": [
+            {
+              "artifact_references": [
+                {
+                  "artifact_type": "execution_log",
+                  "location": "stub://attempts/log",
+                  "reference_id": "claim-kno-184-scenario-b:attempt:log"
+                }
+              ],
+              "attempt_id": "claim-kno-184-scenario-b:attempt",
+              "completion_claim_id": "claim-kno-184-scenario-b",
+              "metadata": {
+                "attempt_validation": {
+                  "context_observations": {
+                    "branch": [
+                      {
+                        "sources": [
+                          "external_facts.expected_code_context"
+                        ],
+                        "value": "codex/e2e-test"
+                      }
+                    ],
+                    "commit_resolution_pending": true,
+                    "has_valid_current_run_pull_request_artifact": false,
+                    "repository": [
+                      {
+                        "sources": [
+                          "external_facts.expected_code_context"
+                        ],
+                        "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                      }
+                    ],
+                    "used_task_artifact_fallback": false
+                  },
+                  "policy": {
+                    "allow_commit_resolution_via_reconciliation": true,
+                    "allow_missing_commit_artifact_with_verified_pull_request": true,
+                    "allow_missing_pull_request": true,
+                    "reject_closed_or_historical_pull_request": true,
+                    "reject_non_numeric_pull_request_url": true,
+                    "reject_reserved_shared_branch": true,
+                    "require_commit": true,
+                    "require_exact_branch": true,
+                    "require_repository": true,
+                    "task_artifact_fallback_requires_single_attempt": true
+                  },
+                  "pull_request_observations": [],
+                  "reasons": [],
+                  "retryable": false,
+                  "rule_failures": [],
+                  "status": "valid",
+                  "validated_at": "2026-04-11T16:04:28.921907Z",
+                  "validated_by": "execution_validation"
+                },
+                "executor_run_id": "run-claim-kno-184-scenario-b"
+              },
+              "recorded_at": "2026-04-04T12:02:05Z",
+              "reevaluation": {},
+              "reported_by": "codex",
+              "status": "completed"
+            }
+          ],
+          "schema_required_deferred_fields": [
+            "parent_task_id",
+            "child_task_ids",
+            "dependencies",
+            "assigned_executor",
+            "required_capabilities",
+            "priority",
+            "artifacts.items",
+            "artifacts.completion_evidence",
+            "observability"
+          ]
+        },
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "origin": {
+        "ingress_id": null,
+        "ingress_name": null,
+        "requested_by": null,
+        "source_id": "req-task-kno-184-scenario-b",
+        "source_system": "openclaw",
+        "source_type": "ingress_request"
+      },
+      "parent_task_id": null,
+      "priority": "normal",
+      "reconciliation": {
+        "active_failure_type": "missing_pr_after_execution",
+        "attempts": [
+          {
+            "attempt_id": "reconciliation-attempt-1",
+            "completed_at": "2026-04-11T16:04:28.925488Z",
+            "details": {
+              "base_branch": "main",
+              "branch_exists": true,
+              "branch_head_commit_sha": null,
+              "branch_name": "codex/e2e-test",
+              "commit_exists": null,
+              "commit_sha": "",
+              "context_resolution": {
+                "conflicts": [],
+                "selected_source": "external_facts",
+                "sources": {
+                  "external_facts": {
+                    "base_branch": "main",
+                    "branch_name": "codex/e2e-test",
+                    "commit_sha": "",
+                    "repository_host": "github.com",
+                    "repository_name": "HARNESS-DRYRUN",
+                    "repository_owner": "KnoxAnalytics"
+                  }
+                }
+              },
+              "created_pull_request": false,
+              "created_pull_request_revalidated": false,
+              "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+              "error_disposition": "terminal_failed",
+              "final_decision": {
+                "reason": "objective_execution_contradiction",
+                "result": "terminal_failed"
+              },
+              "policy": {
+                "allow_closed_pr_match": false,
+                "allow_commit_association_match": true,
+                "allow_non_head_commit_association_match": false,
+                "allow_open_pr_match": true,
+                "escalate_on_ambiguous_match": true,
+                "require_exact_branch_match": true,
+                "require_head_sha_match": true,
+                "require_run_linkage_for_commit_association": true,
+                "require_run_linkage_for_multiple_attempts": true,
+                "require_task_linkage": false
+              },
+              "pull_request_candidates": [],
+              "pull_request_lookup": {
+                "ambiguous": false,
+                "candidate_count": 0,
+                "found": false,
+                "number": null,
+                "searched_by_branch": false,
+                "searched_by_commit": false,
+                "source": null,
+                "url": null,
+                "valid_candidate_count": 0
+              },
+              "repository": {
+                "host": "github.com",
+                "name": "HARNESS-DRYRUN",
+                "owner": "KnoxAnalytics"
+              }
+            },
+            "failure_type": "missing_pr_after_execution",
+            "handler_key": "missing_pr_after_execution",
+            "started_at": "2026-04-11T16:04:28.925384Z",
+            "status": "failed"
+          }
+        ],
+        "failed_at": "2026-04-11T16:04:28.925488Z",
+        "last_attempt_id": "reconciliation-attempt-1",
+        "last_error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+        "last_pr_url": null,
+        "resolved_at": null,
+        "status": "failed"
+      },
+      "required_capabilities": [],
+      "status": "failed",
+      "status_history": [
+        {
+          "changed_at": "2026-04-11T16:04:28.923694Z",
+          "changed_by": "reconciliation",
+          "from_status": "executing",
+          "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+          "to_status": "reconciling"
+        },
+        {
+          "changed_at": "2026-04-11T16:04:28.927227Z",
+          "changed_by": "reconciliation",
+          "from_status": "reconciling",
+          "reason": "Post-execution reconciliation established a terminal execution failure: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+          "to_status": "failed"
+        }
+      ],
+      "timestamps": {
+        "completed_at": null,
+        "created_at": "2026-04-04T12:00:00Z",
+        "updated_at": "2026-04-11T16:04:28.927227Z"
+      },
+      "title": "Reconcile missing pull request"
+    },
+    "transition_result": null,
+    "verification_result": null
+  },
   "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+  "evaluation_record": {
+    "evaluation_id": "149c4438-b885-41d6-80b8-803cd85d88f3",
+    "recorded_at": "2026-04-11T16:04:28.929118Z",
+    "request": {
+      "acceptance_criteria_satisfied": true,
+      "claimed_completion": true,
+      "external_facts": {
+        "expected_code_context": {
+          "base_branch": "main",
+          "branch_name": "codex/e2e-test",
+          "repository_host": "github.com",
+          "repository_name": "HARNESS-DRYRUN",
+          "repository_owner": "KnoxAnalytics"
+        },
+        "github_facts": null,
+        "linear_facts": {
+          "issue_id": "lin-1",
+          "issue_key": "HAR-1",
+          "project": null,
+          "reasons": [],
+          "record_found": true,
+          "state": "completed",
+          "task_reference": null,
+          "workflow": {
+            "state_type": "completed",
+            "workflow_id": "workflow-completed",
+            "workflow_name": "completed"
+          }
+        }
+      },
+      "retry_context": null,
+      "review_decision": null,
+      "review_is_active": false,
+      "review_reasons": [],
+      "review_request": null,
+      "runtime_facts": {
+        "attempt_count": 1,
+        "executor_reported_failure": false,
+        "executor_reported_success": true,
+        "latest_attempt_outcome": "completed",
+        "terminal_failure": false
+      },
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "Harness can reconcile a missing PR after execution.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "not_applicable",
+            "required_artifact_types": [],
+            "status": "not_applicable",
+            "validated_artifact_ids": [],
+            "validated_at": null,
+            "validation_method": "none",
+            "validator": null
+          },
+          "items": []
+        },
+        "assigned_executor": null,
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": {
+            "issue_id": "lin-1",
+            "issue_key": "HAR-1",
+            "project": null,
+            "provenance": {
+              "linked_at": "2026-04-11T16:04:28.921821Z",
+              "linked_by": "reevaluation",
+              "source": "completion_claim.external_facts"
+            },
+            "reasons": [],
+            "record_found": true,
+            "state": "completed",
+            "task_reference": null,
+            "workflow": {
+              "state_type": "completed",
+              "workflow_id": "workflow-completed",
+              "workflow_name": "completed"
+            }
+          }
+        },
+        "dependencies": [],
+        "description": "Exercise post-execution PR reconciliation.",
+        "id": "task-kno-184-scenario-b",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Exercise post-execution PR reconciliation."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-184-scenario-b",
+                "metadata": {
+                  "attempt_id": "claim-kno-184-scenario-b:attempt"
+                },
+                "reason": "Execution completed successfully.",
+                "reported_at": "2026-04-04T12:02:00Z",
+                "reported_by": "codex"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [
+                  {
+                    "artifact_type": "execution_log",
+                    "location": "stub://attempts/log",
+                    "reference_id": "claim-kno-184-scenario-b:attempt:log"
+                  }
+                ],
+                "attempt_id": "claim-kno-184-scenario-b:attempt",
+                "completion_claim_id": "claim-kno-184-scenario-b",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "branch": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context"
+                          ],
+                          "value": "codex/e2e-test"
+                        }
+                      ],
+                      "commit_resolution_pending": true,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "repository": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context"
+                          ],
+                          "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                        }
+                      ],
+                      "used_task_artifact_fallback": false
+                    },
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [],
+                    "retryable": false,
+                    "rule_failures": [],
+                    "status": "valid",
+                    "validated_at": "2026-04-11T16:04:28.921907Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "run-claim-kno-184-scenario-b"
+                },
+                "recorded_at": "2026-04-04T12:02:05Z",
+                "reevaluation": {},
+                "reported_by": "codex",
+                "status": "completed"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "req-task-kno-184-scenario-b",
+          "source_system": "openclaw",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": "missing_pr_after_execution",
+          "attempts": [
+            {
+              "attempt_id": "reconciliation-attempt-1",
+              "completed_at": "2026-04-11T16:04:28.925488Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": null,
+                "commit_sha": "",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "external_facts",
+                  "sources": {
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_pull_request": false,
+                "created_pull_request_revalidated": false,
+                "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+                "error_disposition": "terminal_failed",
+                "final_decision": {
+                  "reason": "objective_execution_contradiction",
+                  "result": "terminal_failed"
+                },
+                "policy": {
+                  "allow_closed_pr_match": false,
+                  "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
+                  "allow_open_pr_match": true,
+                  "escalate_on_ambiguous_match": true,
+                  "require_exact_branch_match": true,
+                  "require_head_sha_match": true,
+                  "require_run_linkage_for_commit_association": true,
+                  "require_run_linkage_for_multiple_attempts": true,
+                  "require_task_linkage": false
+                },
+                "pull_request_candidates": [],
+                "pull_request_lookup": {
+                  "ambiguous": false,
+                  "candidate_count": 0,
+                  "found": false,
+                  "number": null,
+                  "searched_by_branch": false,
+                  "searched_by_commit": false,
+                  "source": null,
+                  "url": null,
+                  "valid_candidate_count": 0
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_pr_after_execution",
+              "handler_key": "missing_pr_after_execution",
+              "started_at": "2026-04-11T16:04:28.925384Z",
+              "status": "failed"
+            }
+          ],
+          "failed_at": "2026-04-11T16:04:28.925488Z",
+          "last_attempt_id": "reconciliation-attempt-1",
+          "last_error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "failed"
+        },
+        "required_capabilities": [],
+        "status": "failed",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.923694Z",
+            "changed_by": "reconciliation",
+            "from_status": "executing",
+            "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+            "to_status": "reconciling"
+          },
+          {
+            "changed_at": "2026-04-11T16:04:28.927227Z",
+            "changed_by": "reconciliation",
+            "from_status": "reconciling",
+            "reason": "Post-execution reconciliation established a terminal execution failure: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+            "to_status": "failed"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-04-04T12:00:00Z",
+          "updated_at": "2026-04-11T16:04:28.927227Z"
+        },
+        "title": "Reconcile missing pull request"
+      },
+      "unresolved_conditions": []
+    },
+    "result": {
+      "accepted_completion": false,
+      "action": "transition_applied",
+      "enforcement_result": {
+        "action": "transition_applied",
+        "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+        "evidence_result": null,
+        "failure_classification": {
+          "category": "reconciliation_mismatch",
+          "failure_type": "reconciliation_mismatch",
+          "reason": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+          "recoverable": false,
+          "retryable": false,
+          "source": "evaluation",
+          "terminal": true
+        },
+        "reasons": [
+          "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+        ],
+        "reconciliation_result": {
+          "blocking": true,
+          "mismatch_categories": [
+            "missing_required_artifact"
+          ],
+          "outcome": "terminal_invalid",
+          "reasons": [
+            "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+          ],
+          "status": "mismatch",
+          "task_id": "task-kno-184-scenario-b",
+          "terminal": true
+        },
+        "review_decision": null,
+        "review_request": null,
+        "target_status": "failed",
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "Harness can reconcile a missing PR after execution.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "not_applicable",
+              "required_artifact_types": [],
+              "status": "not_applicable",
+              "validated_artifact_ids": [],
+              "validated_at": null,
+              "validation_method": "none",
+              "validator": null
+            },
+            "items": []
+          },
+          "assigned_executor": null,
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": {
+              "issue_id": "lin-1",
+              "issue_key": "HAR-1",
+              "project": null,
+              "provenance": {
+                "linked_at": "2026-04-11T16:04:28.921821Z",
+                "linked_by": "reevaluation",
+                "source": "completion_claim.external_facts"
+              },
+              "reasons": [],
+              "record_found": true,
+              "state": "completed",
+              "task_reference": null,
+              "workflow": {
+                "state_type": "completed",
+                "workflow_id": "workflow-completed",
+                "workflow_name": "completed"
+              }
+            }
+          },
+          "dependencies": [],
+          "description": "Exercise post-execution PR reconciliation.",
+          "id": "task-kno-184-scenario-b",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Exercise post-execution PR reconciliation."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-184-scenario-b",
+                  "metadata": {
+                    "attempt_id": "claim-kno-184-scenario-b:attempt"
+                  },
+                  "reason": "Execution completed successfully.",
+                  "reported_at": "2026-04-04T12:02:00Z",
+                  "reported_by": "codex"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [
+                    {
+                      "artifact_type": "execution_log",
+                      "location": "stub://attempts/log",
+                      "reference_id": "claim-kno-184-scenario-b:attempt:log"
+                    }
+                  ],
+                  "attempt_id": "claim-kno-184-scenario-b:attempt",
+                  "completion_claim_id": "claim-kno-184-scenario-b",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "branch": [
+                          {
+                            "sources": [
+                              "external_facts.expected_code_context"
+                            ],
+                            "value": "codex/e2e-test"
+                          }
+                        ],
+                        "commit_resolution_pending": true,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "repository": [
+                          {
+                            "sources": [
+                              "external_facts.expected_code_context"
+                            ],
+                            "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                          }
+                        ],
+                        "used_task_artifact_fallback": false
+                      },
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [],
+                      "retryable": false,
+                      "rule_failures": [],
+                      "status": "valid",
+                      "validated_at": "2026-04-11T16:04:28.921907Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "run-claim-kno-184-scenario-b"
+                  },
+                  "recorded_at": "2026-04-04T12:02:05Z",
+                  "reevaluation": {},
+                  "reported_by": "codex",
+                  "status": "completed"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "req-task-kno-184-scenario-b",
+            "source_system": "openclaw",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": "missing_pr_after_execution",
+            "attempts": [
+              {
+                "attempt_id": "reconciliation-attempt-1",
+                "completed_at": "2026-04-11T16:04:28.925488Z",
+                "details": {
+                  "base_branch": "main",
+                  "branch_exists": true,
+                  "branch_head_commit_sha": null,
+                  "branch_name": "codex/e2e-test",
+                  "commit_exists": null,
+                  "commit_sha": "",
+                  "context_resolution": {
+                    "conflicts": [],
+                    "selected_source": "external_facts",
+                    "sources": {
+                      "external_facts": {
+                        "base_branch": "main",
+                        "branch_name": "codex/e2e-test",
+                        "commit_sha": "",
+                        "repository_host": "github.com",
+                        "repository_name": "HARNESS-DRYRUN",
+                        "repository_owner": "KnoxAnalytics"
+                      }
+                    }
+                  },
+                  "created_pull_request": false,
+                  "created_pull_request_revalidated": false,
+                  "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+                  "error_disposition": "terminal_failed",
+                  "final_decision": {
+                    "reason": "objective_execution_contradiction",
+                    "result": "terminal_failed"
+                  },
+                  "policy": {
+                    "allow_closed_pr_match": false,
+                    "allow_commit_association_match": true,
+                    "allow_non_head_commit_association_match": false,
+                    "allow_open_pr_match": true,
+                    "escalate_on_ambiguous_match": true,
+                    "require_exact_branch_match": true,
+                    "require_head_sha_match": true,
+                    "require_run_linkage_for_commit_association": true,
+                    "require_run_linkage_for_multiple_attempts": true,
+                    "require_task_linkage": false
+                  },
+                  "pull_request_candidates": [],
+                  "pull_request_lookup": {
+                    "ambiguous": false,
+                    "candidate_count": 0,
+                    "found": false,
+                    "number": null,
+                    "searched_by_branch": false,
+                    "searched_by_commit": false,
+                    "source": null,
+                    "url": null,
+                    "valid_candidate_count": 0
+                  },
+                  "repository": {
+                    "host": "github.com",
+                    "name": "HARNESS-DRYRUN",
+                    "owner": "KnoxAnalytics"
+                  }
+                },
+                "failure_type": "missing_pr_after_execution",
+                "handler_key": "missing_pr_after_execution",
+                "started_at": "2026-04-11T16:04:28.925384Z",
+                "status": "failed"
+              }
+            ],
+            "failed_at": "2026-04-11T16:04:28.925488Z",
+            "last_attempt_id": "reconciliation-attempt-1",
+            "last_error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "failed"
+          },
+          "required_capabilities": [],
+          "status": "failed",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.923694Z",
+              "changed_by": "reconciliation",
+              "from_status": "executing",
+              "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+              "to_status": "reconciling"
+            },
+            {
+              "changed_at": "2026-04-11T16:04:28.927227Z",
+              "changed_by": "reconciliation",
+              "from_status": "reconciling",
+              "reason": "Post-execution reconciliation established a terminal execution failure: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+              "to_status": "failed"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-04-04T12:00:00Z",
+            "updated_at": "2026-04-11T16:04:28.927227Z"
+          },
+          "title": "Reconcile missing pull request"
+        },
+        "transition_result": null,
+        "verification_result": null
+      },
+      "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+      "failure_classification": {
+        "category": "reconciliation_mismatch",
+        "failure_type": "reconciliation_mismatch",
+        "reason": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+        "recoverable": false,
+        "retryable": false,
+        "source": "evaluation",
+        "terminal": true
+      },
+      "invalid_input": false,
+      "reasons": [
+        "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+      ],
+      "requires_review": false,
+      "target_status": "failed",
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "Harness can reconcile a missing PR after execution.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "not_applicable",
+            "required_artifact_types": [],
+            "status": "not_applicable",
+            "validated_artifact_ids": [],
+            "validated_at": null,
+            "validation_method": "none",
+            "validator": null
+          },
+          "items": []
+        },
+        "assigned_executor": null,
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": {
+            "issue_id": "lin-1",
+            "issue_key": "HAR-1",
+            "project": null,
+            "provenance": {
+              "linked_at": "2026-04-11T16:04:28.921821Z",
+              "linked_by": "reevaluation",
+              "source": "completion_claim.external_facts"
+            },
+            "reasons": [],
+            "record_found": true,
+            "state": "completed",
+            "task_reference": null,
+            "workflow": {
+              "state_type": "completed",
+              "workflow_id": "workflow-completed",
+              "workflow_name": "completed"
+            }
+          }
+        },
+        "dependencies": [],
+        "description": "Exercise post-execution PR reconciliation.",
+        "id": "task-kno-184-scenario-b",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Exercise post-execution PR reconciliation."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-184-scenario-b",
+                "metadata": {
+                  "attempt_id": "claim-kno-184-scenario-b:attempt"
+                },
+                "reason": "Execution completed successfully.",
+                "reported_at": "2026-04-04T12:02:00Z",
+                "reported_by": "codex"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [
+                  {
+                    "artifact_type": "execution_log",
+                    "location": "stub://attempts/log",
+                    "reference_id": "claim-kno-184-scenario-b:attempt:log"
+                  }
+                ],
+                "attempt_id": "claim-kno-184-scenario-b:attempt",
+                "completion_claim_id": "claim-kno-184-scenario-b",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "branch": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context"
+                          ],
+                          "value": "codex/e2e-test"
+                        }
+                      ],
+                      "commit_resolution_pending": true,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "repository": [
+                        {
+                          "sources": [
+                            "external_facts.expected_code_context"
+                          ],
+                          "value": "github.com/KnoxAnalytics/HARNESS-DRYRUN"
+                        }
+                      ],
+                      "used_task_artifact_fallback": false
+                    },
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [],
+                    "retryable": false,
+                    "rule_failures": [],
+                    "status": "valid",
+                    "validated_at": "2026-04-11T16:04:28.921907Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "run-claim-kno-184-scenario-b"
+                },
+                "recorded_at": "2026-04-04T12:02:05Z",
+                "reevaluation": {},
+                "reported_by": "codex",
+                "status": "completed"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "req-task-kno-184-scenario-b",
+          "source_system": "openclaw",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": "missing_pr_after_execution",
+          "attempts": [
+            {
+              "attempt_id": "reconciliation-attempt-1",
+              "completed_at": "2026-04-11T16:04:28.925488Z",
+              "details": {
+                "base_branch": "main",
+                "branch_exists": true,
+                "branch_head_commit_sha": null,
+                "branch_name": "codex/e2e-test",
+                "commit_exists": null,
+                "commit_sha": "",
+                "context_resolution": {
+                  "conflicts": [],
+                  "selected_source": "external_facts",
+                  "sources": {
+                    "external_facts": {
+                      "base_branch": "main",
+                      "branch_name": "codex/e2e-test",
+                      "commit_sha": "",
+                      "repository_host": "github.com",
+                      "repository_name": "HARNESS-DRYRUN",
+                      "repository_owner": "KnoxAnalytics"
+                    }
+                  }
+                },
+                "created_pull_request": false,
+                "created_pull_request_revalidated": false,
+                "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+                "error_disposition": "terminal_failed",
+                "final_decision": {
+                  "reason": "objective_execution_contradiction",
+                  "result": "terminal_failed"
+                },
+                "policy": {
+                  "allow_closed_pr_match": false,
+                  "allow_commit_association_match": true,
+                  "allow_non_head_commit_association_match": false,
+                  "allow_open_pr_match": true,
+                  "escalate_on_ambiguous_match": true,
+                  "require_exact_branch_match": true,
+                  "require_head_sha_match": true,
+                  "require_run_linkage_for_commit_association": true,
+                  "require_run_linkage_for_multiple_attempts": true,
+                  "require_task_linkage": false
+                },
+                "pull_request_candidates": [],
+                "pull_request_lookup": {
+                  "ambiguous": false,
+                  "candidate_count": 0,
+                  "found": false,
+                  "number": null,
+                  "searched_by_branch": false,
+                  "searched_by_commit": false,
+                  "source": null,
+                  "url": null,
+                  "valid_candidate_count": 0
+                },
+                "repository": {
+                  "host": "github.com",
+                  "name": "HARNESS-DRYRUN",
+                  "owner": "KnoxAnalytics"
+                }
+              },
+              "failure_type": "missing_pr_after_execution",
+              "handler_key": "missing_pr_after_execution",
+              "started_at": "2026-04-11T16:04:28.925384Z",
+              "status": "failed"
+            }
+          ],
+          "failed_at": "2026-04-11T16:04:28.925488Z",
+          "last_attempt_id": "reconciliation-attempt-1",
+          "last_error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "failed"
+        },
+        "required_capabilities": [],
+        "status": "failed",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.923694Z",
+            "changed_by": "reconciliation",
+            "from_status": "executing",
+            "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
+            "to_status": "reconciling"
+          },
+          {
+            "changed_at": "2026-04-11T16:04:28.927227Z",
+            "changed_by": "reconciliation",
+            "from_status": "reconciling",
+            "reason": "Post-execution reconciliation established a terminal execution failure: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+            "to_status": "failed"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-04-04T12:00:00Z",
+          "updated_at": "2026-04-11T16:04:28.927227Z"
+        },
+        "title": "Reconcile missing pull request"
+      }
+    },
+    "task_id": "task-kno-184-scenario-b"
+  },
   "invalid_input": false,
   "reasons": [
     "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
   ],
   "reconciliation_attempt": {
     "attempt_id": "reconciliation-attempt-1",
-    "completed_at": "2026-04-06T15:28:46.292582Z",
+    "completed_at": "2026-04-11T16:04:28.925488Z",
     "details": {
       "base_branch": "main",
       "branch_exists": true,
@@ -33,14 +1209,15 @@
       "created_pull_request": false,
       "created_pull_request_revalidated": false,
       "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
-      "error_disposition": "review_required",
+      "error_disposition": "terminal_failed",
       "final_decision": {
-        "reason": "reconciliation_runtime_error",
-        "result": "review_required_failure"
+        "reason": "objective_execution_contradiction",
+        "result": "terminal_failed"
       },
       "policy": {
         "allow_closed_pr_match": false,
         "allow_commit_association_match": true,
+        "allow_non_head_commit_association_match": false,
         "allow_open_pr_match": true,
         "escalate_on_ambiguous_match": true,
         "require_exact_branch_match": true,
@@ -69,11 +1246,11 @@
     },
     "failure_type": "missing_pr_after_execution",
     "handler_key": "missing_pr_after_execution",
-    "started_at": "2026-04-06T15:28:46.292165Z",
+    "started_at": "2026-04-11T16:04:28.925384Z",
     "status": "failed"
   },
-  "requires_review": true,
-  "target_status": "in_review",
+  "requires_review": false,
+  "target_status": "failed",
   "task_envelope": {
     "acceptance_criteria": [
       {
@@ -95,11 +1272,7 @@
       },
       "items": []
     },
-    "assigned_executor": {
-      "assignment_reason": "Runtime coverage for reconciliation.",
-      "executor_id": "executor-1",
-      "executor_type": "codex"
-    },
+    "assigned_executor": null,
     "child_task_ids": [],
     "constraints": [],
     "coordination": {
@@ -108,7 +1281,7 @@
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T15:28:46.259877Z",
+          "linked_at": "2026-04-11T16:04:28.921821Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -168,6 +1341,7 @@
                     }
                   ],
                   "commit_resolution_pending": true,
+                  "has_valid_current_run_pull_request_artifact": false,
                   "repository": [
                     {
                       "sources": [
@@ -180,16 +1354,22 @@
                 },
                 "policy": {
                   "allow_commit_resolution_via_reconciliation": true,
+                  "allow_missing_commit_artifact_with_verified_pull_request": true,
                   "allow_missing_pull_request": true,
+                  "reject_closed_or_historical_pull_request": true,
+                  "reject_non_numeric_pull_request_url": true,
+                  "reject_reserved_shared_branch": true,
                   "require_commit": true,
                   "require_exact_branch": true,
                   "require_repository": true,
                   "task_artifact_fallback_requires_single_attempt": true
                 },
+                "pull_request_observations": [],
                 "reasons": [],
                 "retryable": false,
+                "rule_failures": [],
                 "status": "valid",
-                "validated_at": "2026-04-06T15:28:46.260117Z",
+                "validated_at": "2026-04-11T16:04:28.921907Z",
                 "validated_by": "execution_validation"
               },
               "executor_run_id": "run-claim-kno-184-scenario-b"
@@ -233,7 +1413,7 @@
       "attempts": [
         {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T15:28:46.292582Z",
+          "completed_at": "2026-04-11T16:04:28.925488Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
@@ -258,14 +1438,15 @@
             "created_pull_request": false,
             "created_pull_request_revalidated": false,
             "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
-            "error_disposition": "review_required",
+            "error_disposition": "terminal_failed",
             "final_decision": {
-              "reason": "reconciliation_runtime_error",
-              "result": "review_required_failure"
+              "reason": "objective_execution_contradiction",
+              "result": "terminal_failed"
             },
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -294,11 +1475,11 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T15:28:46.292165Z",
+          "started_at": "2026-04-11T16:04:28.925384Z",
           "status": "failed"
         }
       ],
-      "failed_at": "2026-04-06T15:28:46.292582Z",
+      "failed_at": "2026-04-11T16:04:28.925488Z",
       "last_attempt_id": "reconciliation-attempt-1",
       "last_error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
       "last_pr_url": null,
@@ -306,27 +1487,27 @@
       "status": "failed"
     },
     "required_capabilities": [],
-    "status": "in_review",
+    "status": "failed",
     "status_history": [
       {
-        "changed_at": "2026-04-06T15:28:46.276202Z",
+        "changed_at": "2026-04-11T16:04:28.923694Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T15:28:46.309322Z",
+        "changed_at": "2026-04-11T16:04:28.927227Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
-        "reason": "Post-execution reconciliation failed: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
-        "to_status": "in_review"
+        "reason": "Post-execution reconciliation established a terminal execution failure: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+        "to_status": "failed"
       }
     ],
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T15:28:46.309322Z"
+      "updated_at": "2026-04-11T16:04:28.927227Z"
     },
     "title": "Reconcile missing pull request"
   }

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-b-read-model-final.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-b-read-model-final.json
@@ -1,17 +1,14 @@
 {
   "task": {
-    "assigned_executor": {
-      "assignment_reason": "Runtime coverage for reconciliation.",
-      "executor_id": "executor-1",
-      "executor_type": "codex"
-    },
+    "assigned_executor": null,
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T15:28:46.259877Z",
+          "linked_at": "2026-04-11T16:04:28.921821Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -26,14 +23,21 @@
         }
       }
     },
-    "current_status": "in_review",
+    "current_status": "failed",
     "description": "Exercise post-execution PR reconciliation.",
     "evaluation_summary": {
-      "count": 0,
-      "history": [],
-      "latest_action": null,
-      "latest_recorded_at": null,
-      "latest_target_status": null
+      "count": 1,
+      "history": [
+        {
+          "action": "transition_applied",
+          "evaluation_id": "149c4438-b885-41d6-80b8-803cd85d88f3",
+          "recorded_at": "2026-04-11T16:04:28.929118Z",
+          "target_status": "failed"
+        }
+      ],
+      "latest_action": "transition_applied",
+      "latest_recorded_at": "2026-04-11T16:04:28.929118Z",
+      "latest_target_status": "failed"
     },
     "evidence_summary": {
       "artifact_count": 0,
@@ -52,9 +56,9 @@
     },
     "execution_summary": {
       "attempt_count": 1,
-      "failure_state": "clear",
+      "failure_state": "terminal",
       "invalid_attempt_count": 0,
-      "last_failure_type": "none",
+      "last_failure_type": "reconciliation_mismatch",
       "latest_artifact_references": [
         {
           "artifact_type": "execution_log",
@@ -84,6 +88,7 @@
                 }
               ],
               "commit_resolution_pending": true,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -96,16 +101,22 @@
             },
             "policy": {
               "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T15:28:46.260117Z",
+            "validated_at": "2026-04-11T16:04:28.921907Z",
             "validated_by": "execution_validation"
           },
           "executor_run_id": "run-claim-kno-184-scenario-b"
@@ -126,6 +137,7 @@
             }
           ],
           "commit_resolution_pending": true,
+          "has_valid_current_run_pull_request_artifact": false,
           "repository": [
             {
               "sources": [
@@ -138,46 +150,55 @@
         },
         "policy": {
           "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
           "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
           "require_commit": true,
           "require_exact_branch": true,
           "require_repository": true,
           "task_artifact_fallback_requires_single_attempt": true
         },
+        "pull_request_observations": [],
         "reasons": [],
         "retryable": false,
+        "rule_failures": [],
         "status": "valid",
-        "validated_at": "2026-04-06T15:28:46.260117Z",
+        "validated_at": "2026-04-11T16:04:28.921907Z",
         "validated_by": "execution_validation"
       },
       "latest_dispatch_origin": null,
       "latest_status": "completed",
       "retry_count": 0,
       "retry_eligible": false,
-      "total_attempts": 0
+      "total_attempts": 1
     },
     "extensions": {},
     "failure_summary": {
-      "failure_source": "none",
-      "failure_type": "none",
+      "evaluation_id": "149c4438-b885-41d6-80b8-803cd85d88f3",
+      "failure_reason": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+      "failure_source": "evaluation",
+      "failure_type": "reconciliation_mismatch",
+      "recorded_at": "2026-04-11T16:04:28.929118Z",
       "recoverable": false,
-      "state": "clear",
-      "terminal": false
+      "state": "terminal",
+      "terminal": true
     },
     "lifecycle_history": [
       {
-        "changed_at": "2026-04-06T15:28:46.276202Z",
+        "changed_at": "2026-04-11T16:04:28.923694Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
         "to_status": "reconciling"
       },
       {
-        "changed_at": "2026-04-06T15:28:46.309322Z",
+        "changed_at": "2026-04-11T16:04:28.927227Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
-        "reason": "Post-execution reconciliation failed: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
-        "to_status": "in_review"
+        "reason": "Post-execution reconciliation established a terminal execution failure: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+        "to_status": "failed"
       }
     ],
     "objective_summary": "Exercise post-execution PR reconciliation.",
@@ -189,7 +210,19 @@
       "source_system": "openclaw",
       "source_type": "ingress_request"
     },
-    "reconciliation_summary": null,
+    "reconciliation_summary": {
+      "blocking": true,
+      "mismatch_categories": [
+        "missing_required_artifact"
+      ],
+      "outcome": "terminal_invalid",
+      "reasons": [
+        "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+      ],
+      "status": "mismatch",
+      "task_id": "task-kno-184-scenario-b",
+      "terminal": true
+    },
     "relationships": {
       "child_task_ids": [],
       "dependencies": [],
@@ -199,9 +232,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-184-scenario-b",
@@ -216,7 +251,7 @@
             "source_system": "openclaw",
             "source_type": "ingress_request"
           },
-          "status": "in_review",
+          "status": "failed",
           "title": "Reconcile missing pull request"
         },
         "event_id": "task-kno-184-scenario-b:created",
@@ -224,18 +259,6 @@
         "occurred_at": "2026-04-04T12:00:00Z",
         "source": "openclaw",
         "summary": "Task created"
-      },
-      {
-        "details": {
-          "artifact_type": "execution_log",
-          "location": "stub://attempts/log",
-          "reference_id": "claim-kno-184-scenario-b:attempt:log"
-        },
-        "event_id": "task-kno-184-scenario-b:execution_artifact:claim-kno-184-scenario-b:attempt:claim-kno-184-scenario-b:attempt:log",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-04T12:02:05Z",
-        "source": "codex",
-        "summary": "Execution artifact attached: execution_log"
       },
       {
         "details": {
@@ -258,6 +281,7 @@
                 }
               ],
               "commit_resolution_pending": true,
+              "has_valid_current_run_pull_request_artifact": false,
               "repository": [
                 {
                   "sources": [
@@ -270,16 +294,22 @@
             },
             "policy": {
               "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [],
             "retryable": false,
+            "rule_failures": [],
             "status": "valid",
-            "validated_at": "2026-04-06T15:28:46.260117Z",
+            "validated_at": "2026-04-11T16:04:28.921907Z",
             "validated_by": "execution_validation"
           },
           "completion_claim_id": "claim-kno-184-scenario-b",
@@ -294,11 +324,23 @@
       },
       {
         "details": {
+          "artifact_type": "execution_log",
+          "location": "stub://attempts/log",
+          "reference_id": "claim-kno-184-scenario-b:attempt:log"
+        },
+        "event_id": "task-kno-184-scenario-b:execution_artifact:claim-kno-184-scenario-b:attempt:claim-kno-184-scenario-b:attempt:log",
+        "event_type": "execution_artifact_attached",
+        "occurred_at": "2026-04-04T12:02:05Z",
+        "source": "codex",
+        "summary": "Execution artifact attached: execution_log"
+      },
+      {
+        "details": {
           "issue_id": "lin-1",
           "issue_key": "HAR-1",
           "project": null,
           "provenance": {
-            "linked_at": "2026-04-06T15:28:46.259877Z",
+            "linked_at": "2026-04-11T16:04:28.921821Z",
             "linked_by": "reevaluation",
             "source": "completion_claim.external_facts"
           },
@@ -314,13 +356,13 @@
         },
         "event_id": "task-kno-184-scenario-b:linear_linkage",
         "event_type": "linear_linkage_recorded",
-        "occurred_at": "2026-04-06T15:28:46.259877Z",
+        "occurred_at": "2026-04-11T16:04:28.921821Z",
         "source": "reevaluation",
         "summary": "Linear linkage recorded"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T15:28:46.276202Z",
+          "changed_at": "2026-04-11T16:04:28.923694Z",
           "changed_by": "reconciliation",
           "from_status": "executing",
           "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -328,14 +370,14 @@
         },
         "event_id": "task-kno-184-scenario-b:status:0",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T15:28:46.276202Z",
+        "occurred_at": "2026-04-11T16:04:28.923694Z",
         "source": "reconciliation",
         "summary": "Status changed executing -> reconciling"
       },
       {
         "details": {
           "attempt_id": "reconciliation-attempt-1",
-          "completed_at": "2026-04-06T15:28:46.292582Z",
+          "completed_at": "2026-04-11T16:04:28.925488Z",
           "details": {
             "base_branch": "main",
             "branch_exists": true,
@@ -360,14 +402,15 @@
             "created_pull_request": false,
             "created_pull_request_revalidated": false,
             "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
-            "error_disposition": "review_required",
+            "error_disposition": "terminal_failed",
             "final_decision": {
-              "reason": "reconciliation_runtime_error",
-              "result": "review_required_failure"
+              "reason": "objective_execution_contradiction",
+              "result": "terminal_failed"
             },
             "policy": {
               "allow_closed_pr_match": false,
               "allow_commit_association_match": true,
+              "allow_non_head_commit_association_match": false,
               "allow_open_pr_match": true,
               "escalate_on_ambiguous_match": true,
               "require_exact_branch_match": true,
@@ -396,34 +439,80 @@
           },
           "failure_type": "missing_pr_after_execution",
           "handler_key": "missing_pr_after_execution",
-          "started_at": "2026-04-06T15:28:46.292165Z",
+          "started_at": "2026-04-11T16:04:28.925384Z",
           "status": "failed"
         },
         "event_id": "task-kno-184-scenario-b:reconciliation:reconciliation-attempt-1",
         "event_type": "reconciliation_attempt_recorded",
-        "occurred_at": "2026-04-06T15:28:46.292582Z",
+        "occurred_at": "2026-04-11T16:04:28.925488Z",
         "source": "reconciliation",
         "summary": "Reconciliation attempt: missing_pr_after_execution"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T15:28:46.309322Z",
+          "changed_at": "2026-04-11T16:04:28.927227Z",
           "changed_by": "reconciliation",
           "from_status": "reconciling",
-          "reason": "Post-execution reconciliation failed: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
-          "to_status": "in_review"
+          "reason": "Post-execution reconciliation established a terminal execution failure: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+          "to_status": "failed"
         },
         "event_id": "task-kno-184-scenario-b:status:1",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T15:28:46.309322Z",
+        "occurred_at": "2026-04-11T16:04:28.927227Z",
         "source": "reconciliation",
-        "summary": "Status changed reconciling -> in_review"
+        "summary": "Status changed reconciling -> failed"
+      },
+      {
+        "details": {
+          "accepted_completion": false,
+          "action": "transition_applied",
+          "evaluation_id": "149c4438-b885-41d6-80b8-803cd85d88f3",
+          "reasons": [
+            "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+          ],
+          "reconciliation_result": {
+            "blocking": true,
+            "mismatch_categories": [
+              "missing_required_artifact"
+            ],
+            "outcome": "terminal_invalid",
+            "reasons": [
+              "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+            ],
+            "status": "mismatch",
+            "task_id": "task-kno-184-scenario-b",
+            "terminal": true
+          },
+          "requires_review": false,
+          "target_status": "failed",
+          "verification_result": null
+        },
+        "event_id": "task-kno-184-scenario-b:evaluation:149c4438-b885-41d6-80b8-803cd85d88f3",
+        "event_type": "evaluation_recorded",
+        "occurred_at": "2026-04-11T16:04:28.929118Z",
+        "source": "harness",
+        "summary": "Evaluation recorded: transition_applied"
+      },
+      {
+        "details": {
+          "failure_reason": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+          "failure_recorded": true,
+          "failure_source": "evaluation",
+          "failure_type": "reconciliation_mismatch",
+          "recoverable": false,
+          "terminal": true
+        },
+        "event_id": "task-kno-184-scenario-b:failure:149c4438-b885-41d6-80b8-803cd85d88f3",
+        "event_type": "failure_recorded",
+        "occurred_at": "2026-04-11T16:04:28.929118Z",
+        "source": "evaluation",
+        "summary": "Failure recorded: reconciliation_mismatch"
       }
     ],
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-04T12:00:00Z",
-      "updated_at": "2026-04-06T15:28:46.309322Z"
+      "updated_at": "2026-04-11T16:04:28.927227Z"
     },
     "title": "Reconcile missing pull request",
     "verification_summary": null

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-b-read-model-initial.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-b-read-model-initial.json
@@ -5,6 +5,7 @@
       "executor_id": "executor-1",
       "executor_type": "codex"
     },
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": null
     },
@@ -74,9 +75,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-184-scenario-b",

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-b-timeline-final.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-b-timeline-final.json
@@ -1,6 +1,6 @@
 {
-  "current_status": "in_review",
-  "event_count": 7,
+  "current_status": "failed",
+  "event_count": 9,
   "task_id": "task-kno-184-scenario-b",
   "timeline": [
     {
@@ -13,7 +13,7 @@
           "source_system": "openclaw",
           "source_type": "ingress_request"
         },
-        "status": "in_review",
+        "status": "failed",
         "title": "Reconcile missing pull request"
       },
       "event_id": "task-kno-184-scenario-b:created",
@@ -21,18 +21,6 @@
       "occurred_at": "2026-04-04T12:00:00Z",
       "source": "openclaw",
       "summary": "Task created"
-    },
-    {
-      "details": {
-        "artifact_type": "execution_log",
-        "location": "stub://attempts/log",
-        "reference_id": "claim-kno-184-scenario-b:attempt:log"
-      },
-      "event_id": "task-kno-184-scenario-b:execution_artifact:claim-kno-184-scenario-b:attempt:claim-kno-184-scenario-b:attempt:log",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-04T12:02:05Z",
-      "source": "codex",
-      "summary": "Execution artifact attached: execution_log"
     },
     {
       "details": {
@@ -55,6 +43,7 @@
               }
             ],
             "commit_resolution_pending": true,
+            "has_valid_current_run_pull_request_artifact": false,
             "repository": [
               {
                 "sources": [
@@ -67,16 +56,22 @@
           },
           "policy": {
             "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [],
           "retryable": false,
+          "rule_failures": [],
           "status": "valid",
-          "validated_at": "2026-04-06T15:28:46.260117Z",
+          "validated_at": "2026-04-11T16:04:28.921907Z",
           "validated_by": "execution_validation"
         },
         "completion_claim_id": "claim-kno-184-scenario-b",
@@ -91,11 +86,23 @@
     },
     {
       "details": {
+        "artifact_type": "execution_log",
+        "location": "stub://attempts/log",
+        "reference_id": "claim-kno-184-scenario-b:attempt:log"
+      },
+      "event_id": "task-kno-184-scenario-b:execution_artifact:claim-kno-184-scenario-b:attempt:claim-kno-184-scenario-b:attempt:log",
+      "event_type": "execution_artifact_attached",
+      "occurred_at": "2026-04-04T12:02:05Z",
+      "source": "codex",
+      "summary": "Execution artifact attached: execution_log"
+    },
+    {
+      "details": {
         "issue_id": "lin-1",
         "issue_key": "HAR-1",
         "project": null,
         "provenance": {
-          "linked_at": "2026-04-06T15:28:46.259877Z",
+          "linked_at": "2026-04-11T16:04:28.921821Z",
           "linked_by": "reevaluation",
           "source": "completion_claim.external_facts"
         },
@@ -111,13 +118,13 @@
       },
       "event_id": "task-kno-184-scenario-b:linear_linkage",
       "event_type": "linear_linkage_recorded",
-      "occurred_at": "2026-04-06T15:28:46.259877Z",
+      "occurred_at": "2026-04-11T16:04:28.921821Z",
       "source": "reevaluation",
       "summary": "Linear linkage recorded"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T15:28:46.276202Z",
+        "changed_at": "2026-04-11T16:04:28.923694Z",
         "changed_by": "reconciliation",
         "from_status": "executing",
         "reason": "Execution completed without a pull request artifact; invoking reconciliation handler.",
@@ -125,14 +132,14 @@
       },
       "event_id": "task-kno-184-scenario-b:status:0",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T15:28:46.276202Z",
+      "occurred_at": "2026-04-11T16:04:28.923694Z",
       "source": "reconciliation",
       "summary": "Status changed executing -> reconciling"
     },
     {
       "details": {
         "attempt_id": "reconciliation-attempt-1",
-        "completed_at": "2026-04-06T15:28:46.292582Z",
+        "completed_at": "2026-04-11T16:04:28.925488Z",
         "details": {
           "base_branch": "main",
           "branch_exists": true,
@@ -157,14 +164,15 @@
           "created_pull_request": false,
           "created_pull_request_revalidated": false,
           "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
-          "error_disposition": "review_required",
+          "error_disposition": "terminal_failed",
           "final_decision": {
-            "reason": "reconciliation_runtime_error",
-            "result": "review_required_failure"
+            "reason": "objective_execution_contradiction",
+            "result": "terminal_failed"
           },
           "policy": {
             "allow_closed_pr_match": false,
             "allow_commit_association_match": true,
+            "allow_non_head_commit_association_match": false,
             "allow_open_pr_match": true,
             "escalate_on_ambiguous_match": true,
             "require_exact_branch_match": true,
@@ -193,28 +201,74 @@
         },
         "failure_type": "missing_pr_after_execution",
         "handler_key": "missing_pr_after_execution",
-        "started_at": "2026-04-06T15:28:46.292165Z",
+        "started_at": "2026-04-11T16:04:28.925384Z",
         "status": "failed"
       },
       "event_id": "task-kno-184-scenario-b:reconciliation:reconciliation-attempt-1",
       "event_type": "reconciliation_attempt_recorded",
-      "occurred_at": "2026-04-06T15:28:46.292582Z",
+      "occurred_at": "2026-04-11T16:04:28.925488Z",
       "source": "reconciliation",
       "summary": "Reconciliation attempt: missing_pr_after_execution"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T15:28:46.309322Z",
+        "changed_at": "2026-04-11T16:04:28.927227Z",
         "changed_by": "reconciliation",
         "from_status": "reconciling",
-        "reason": "Post-execution reconciliation failed: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
-        "to_status": "in_review"
+        "reason": "Post-execution reconciliation established a terminal execution failure: Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+        "to_status": "failed"
       },
       "event_id": "task-kno-184-scenario-b:status:1",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T15:28:46.309322Z",
+      "occurred_at": "2026-04-11T16:04:28.927227Z",
       "source": "reconciliation",
-      "summary": "Status changed reconciling -> in_review"
+      "summary": "Status changed reconciling -> failed"
+    },
+    {
+      "details": {
+        "accepted_completion": false,
+        "action": "transition_applied",
+        "evaluation_id": "149c4438-b885-41d6-80b8-803cd85d88f3",
+        "reasons": [
+          "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+        ],
+        "reconciliation_result": {
+          "blocking": true,
+          "mismatch_categories": [
+            "missing_required_artifact"
+          ],
+          "outcome": "terminal_invalid",
+          "reasons": [
+            "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head"
+          ],
+          "status": "mismatch",
+          "task_id": "task-kno-184-scenario-b",
+          "terminal": true
+        },
+        "requires_review": false,
+        "target_status": "failed",
+        "verification_result": null
+      },
+      "event_id": "task-kno-184-scenario-b:evaluation:149c4438-b885-41d6-80b8-803cd85d88f3",
+      "event_type": "evaluation_recorded",
+      "occurred_at": "2026-04-11T16:04:28.929118Z",
+      "source": "harness",
+      "summary": "Evaluation recorded: transition_applied"
+    },
+    {
+      "details": {
+        "failure_reason": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
+        "failure_recorded": true,
+        "failure_source": "evaluation",
+        "failure_type": "reconciliation_mismatch",
+        "recoverable": false,
+        "terminal": true
+      },
+      "event_id": "task-kno-184-scenario-b:failure:149c4438-b885-41d6-80b8-803cd85d88f3",
+      "event_type": "failure_recorded",
+      "occurred_at": "2026-04-11T16:04:28.929118Z",
+      "source": "evaluation",
+      "summary": "Failure recorded: reconciliation_mismatch"
     }
   ]
 }

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-c-completion-claim-response.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-c-completion-claim-response.json
@@ -1,294 +1,26 @@
 {
   "accepted_completion": false,
-  "action": "invalid_execution_attempt_failed",
-  "dispatch": {
-    "attempt_id": "attempt-2",
-    "attempt_status": "completed",
-    "dispatch_id": "dispatch:task-kno-184-scenario-c:2",
-    "executor": "codex",
-    "task_id": "task-kno-184-scenario-c"
-  },
-  "error": "Successful execution attempt is missing repository identity for the current run.",
-  "evaluation_record": {
-    "evaluation_id": "4331a2a9-241f-4407-889d-0d7f5910ec84",
-    "recorded_at": "2026-04-06T15:28:46.422509Z",
-    "request": {
-      "acceptance_criteria_satisfied": false,
-      "claimed_completion": true,
-      "external_facts": null,
-      "retry_context": null,
-      "review_decision": null,
-      "review_is_active": false,
-      "review_reasons": [],
-      "review_request": null,
-      "runtime_facts": {
-        "attempt_count": 2,
-        "executor_reported_failure": false,
-        "executor_reported_success": true,
-        "latest_attempt_outcome": "completed",
-        "terminal_failure": false
-      },
-      "task_envelope": {
-        "acceptance_criteria": [
-          {
-            "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
-            "id": "ac-1",
-            "required": true
-          }
-        ],
-        "artifacts": {
-          "completion_evidence": {
-            "notes": null,
-            "policy": "deferred",
-            "required_artifact_types": [],
-            "status": "deferred",
-            "validated_artifact_ids": [],
-            "validated_at": null,
-            "validation_method": "deferred",
-            "validator": null
-          },
-          "items": []
-        },
-        "assigned_executor": {
-          "assignment_reason": "Validate invalid execution attempt boundary.",
-          "executor_id": "executor-kno-184-scenario-c",
-          "executor_type": "codex"
-        },
-        "child_task_ids": [],
-        "constraints": [],
-        "coordination": {
-          "linear": null
-        },
-        "dependencies": [],
-        "description": "Validate invalid execution attempt boundary remains enforced.",
-        "id": "task-kno-184-scenario-c",
-        "objective": {
-          "deliverable_type": "unspecified",
-          "success_signal": "Task satisfies declared acceptance criteria.",
-          "summary": "Validate invalid execution attempt boundary remains enforced."
-        },
-        "observability": {
-          "errors": [],
-          "execution_metadata": {
-            "advisory_completion_claims": [
-              {
-                "claim_id": "claim-kno-184-scenario-c",
-                "metadata": {},
-                "reason": "executor reported completion",
-                "reported_at": "2026-04-06T00:01:00Z",
-                "reported_by": "codex"
-              },
-              {
-                "claim_id": "attempt-2:claim",
-                "metadata": {
-                  "advisory_only": true,
-                  "attempt_id": "attempt-2",
-                  "dispatch_mode": "automatic",
-                  "execution_parameters": {
-                    "prior_invalid_attempt_id": null
-                  }
-                },
-                "reason": "Successful execution attempt is missing repository identity for the current run.",
-                "reported_at": "2026-04-06T15:28:46.348574Z",
-                "reported_by": "codex"
-              }
-            ],
-            "execution_attempts": [
-              {
-                "artifact_references": [],
-                "attempt_id": "attempt-kno-184-scenario-c",
-                "completion_claim_id": "claim-kno-184-scenario-c",
-                "metadata": {
-                  "attempt_validation": {
-                    "context_observations": {
-                      "commit_resolution_pending": false,
-                      "used_task_artifact_fallback": false
-                    },
-                    "failure_type": "invalid_execution_attempt",
-                    "policy": {
-                      "allow_commit_resolution_via_reconciliation": true,
-                      "allow_missing_pull_request": true,
-                      "require_commit": true,
-                      "require_exact_branch": true,
-                      "require_repository": true,
-                      "task_artifact_fallback_requires_single_attempt": true
-                    },
-                    "reasons": [
-                      "Successful execution attempt is missing repository identity for the current run.",
-                      "Successful execution attempt is missing branch identity for the current run.",
-                      "Successful execution attempt is missing commit SHA for the current run."
-                    ],
-                    "retryable": true,
-                    "status": "invalid",
-                    "validated_at": "2026-04-06T15:28:46.343141Z",
-                    "validated_by": "execution_validation"
-                  },
-                  "executor_run_id": "run-kno-184-scenario-c"
-                },
-                "recorded_at": "2026-04-06T00:01:01Z",
-                "reevaluation": {},
-                "reported_by": "codex",
-                "status": "succeeded"
-              },
-              {
-                "artifact_references": [
-                  {
-                    "artifact_type": "execution_log",
-                    "commit_sha": null,
-                    "external_id": null,
-                    "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-                    "metadata": {
-                      "advisory": true
-                    },
-                    "reference_id": "attempt-2:log"
-                  }
-                ],
-                "attempt_id": "attempt-2",
-                "completion_claim_id": "attempt-2:claim",
-                "metadata": {
-                  "attempt_validation": {
-                    "context_observations": {
-                      "commit_resolution_pending": false,
-                      "used_task_artifact_fallback": false
-                    },
-                    "failure_type": "invalid_execution_attempt",
-                    "policy": {
-                      "allow_commit_resolution_via_reconciliation": true,
-                      "allow_missing_pull_request": true,
-                      "require_commit": true,
-                      "require_exact_branch": true,
-                      "require_repository": true,
-                      "task_artifact_fallback_requires_single_attempt": true
-                    },
-                    "reasons": [
-                      "Successful execution attempt is missing repository identity for the current run.",
-                      "Successful execution attempt is missing branch identity for the current run.",
-                      "Successful execution attempt is missing commit SHA for the current run."
-                    ],
-                    "retryable": true,
-                    "status": "invalid",
-                    "validated_at": "2026-04-06T15:28:46.349648Z",
-                    "validated_by": "execution_validation"
-                  },
-                  "dispatch_at": "2026-04-06T15:28:46.348588Z",
-                  "dispatch_id": "dispatch:task-kno-184-scenario-c:2",
-                  "dispatch_mode": "automatic",
-                  "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "dispatch_trigger": "invalid_execution_attempt_retry",
-                  "execution_events": [
-                    {
-                      "event_id": "attempt-2:started",
-                      "event_type": "execution_started",
-                      "metadata": {
-                        "adapter": "stub-executor",
-                        "mode": "stub"
-                      },
-                      "occurred_at": "2026-04-06T15:28:46.348407Z",
-                      "source_system": "stub-executor"
-                    },
-                    {
-                      "event_id": "attempt-2:completed",
-                      "event_type": "execution_succeeded",
-                      "metadata": {
-                        "adapter": "stub-executor",
-                        "executor_run_id": "stub-run-attempt-2"
-                      },
-                      "occurred_at": "2026-04-06T15:28:46.348422Z",
-                      "source_system": "stub-executor"
-                    }
-                  ],
-                  "execution_parameters": {
-                    "prior_invalid_attempt_id": null
-                  },
-                  "executor": "codex"
-                },
-                "recorded_at": "2026-04-06T15:28:46.348583Z",
-                "reevaluation": {},
-                "reported_by": "codex",
-                "status": "completed"
-              }
-            ],
-            "schema_required_deferred_fields": [
-              "parent_task_id",
-              "child_task_ids",
-              "dependencies",
-              "assigned_executor",
-              "required_capabilities",
-              "priority",
-              "artifacts.items",
-              "artifacts.completion_evidence",
-              "observability"
-            ]
-          },
-          "retries": {
-            "attempt_count": 0,
-            "last_retry_at": null,
-            "max_attempts": 0
-          }
-        },
-        "origin": {
-          "ingress_id": null,
-          "ingress_name": null,
-          "requested_by": null,
-          "source_id": "KNO-184",
-          "source_system": "linear",
-          "source_type": "ingress_request"
-        },
-        "parent_task_id": null,
-        "priority": "normal",
-        "reconciliation": {
-          "active_failure_type": null,
-          "attempts": [],
-          "failed_at": null,
-          "last_attempt_id": null,
-          "last_error": null,
-          "last_pr_url": null,
-          "resolved_at": null,
-          "status": "not_required"
-        },
-        "required_capabilities": [],
-        "status": "failed",
-        "status_history": [
-          {
-            "changed_at": "2026-04-06T15:28:46.389386Z",
-            "changed_by": "verification",
-            "from_status": "executing",
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
-            "to_status": "failed"
-          }
-        ],
-        "timestamps": {
-          "completed_at": null,
-          "created_at": "2026-04-06T00:00:00Z",
-          "updated_at": "2026-04-06T15:28:46.389386Z"
-        },
-        "title": "KNO-184 scenario C validation"
-      },
-      "unresolved_conditions": []
-    },
-    "result": {
-      "accepted_completion": false,
-      "action": "transition_applied",
-      "enforcement_result": {
-        "action": "transition_applied",
-        "error": "Successful execution attempt is missing repository identity for the current run.",
-        "evidence_result": null,
-        "failure_classification": {
-          "category": "invalid_execution_attempt",
-          "failure_type": "invalid_execution_attempt",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
-          "recoverable": false,
-          "retryable": false,
-          "source": "executor",
-          "terminal": true
-        },
-        "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
-        ],
-        "reconciliation_result": null,
+  "action": "contract_violation_failed",
+  "contract_violation": {
+    "failure_evaluation_record": {
+      "evaluation_id": "6ca68aac-1160-4cef-82e9-4cca94a995c8",
+      "recorded_at": "2026-04-11T16:04:28.936965Z",
+      "request": {
+        "acceptance_criteria_satisfied": false,
+        "claimed_completion": true,
+        "external_facts": null,
+        "retry_context": null,
         "review_decision": null,
+        "review_is_active": false,
+        "review_reasons": [],
         "review_request": null,
-        "target_status": "failed",
+        "runtime_facts": {
+          "attempt_count": 1,
+          "executor_reported_failure": false,
+          "executor_reported_success": true,
+          "latest_attempt_outcome": null,
+          "terminal_failure": false
+        },
         "task_envelope": {
           "acceptance_criteria": [
             {
@@ -310,11 +42,7 @@
             },
             "items": []
           },
-          "assigned_executor": {
-            "assignment_reason": "Validate invalid execution attempt boundary.",
-            "executor_id": "executor-kno-184-scenario-c",
-            "executor_type": "codex"
-          },
+          "assigned_executor": null,
           "child_task_ids": [],
           "constraints": [],
           "coordination": {
@@ -338,20 +66,6 @@
                   "reason": "executor reported completion",
                   "reported_at": "2026-04-06T00:01:00Z",
                   "reported_by": "codex"
-                },
-                {
-                  "claim_id": "attempt-2:claim",
-                  "metadata": {
-                    "advisory_only": true,
-                    "attempt_id": "attempt-2",
-                    "dispatch_mode": "automatic",
-                    "execution_parameters": {
-                      "prior_invalid_attempt_id": null
-                    }
-                  },
-                  "reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "reported_at": "2026-04-06T15:28:46.348574Z",
-                  "reported_by": "codex"
                 }
               ],
               "execution_attempts": [
@@ -363,25 +77,35 @@
                     "attempt_validation": {
                       "context_observations": {
                         "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
-                      "failure_type": "invalid_execution_attempt",
+                      "failure_type": "contract_violation",
                       "policy": {
                         "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
+                        "Successful execution attempt is missing branch identity for the current run."
                       ],
-                      "retryable": true,
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
                       "status": "invalid",
-                      "validated_at": "2026-04-06T15:28:46.343141Z",
+                      "validated_at": "2026-04-11T16:04:28.933135Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "run-kno-184-scenario-c"
@@ -390,83 +114,6 @@
                   "reevaluation": {},
                   "reported_by": "codex",
                   "status": "succeeded"
-                },
-                {
-                  "artifact_references": [
-                    {
-                      "artifact_type": "execution_log",
-                      "commit_sha": null,
-                      "external_id": null,
-                      "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-                      "metadata": {
-                        "advisory": true
-                      },
-                      "reference_id": "attempt-2:log"
-                    }
-                  ],
-                  "attempt_id": "attempt-2",
-                  "completion_claim_id": "attempt-2:claim",
-                  "metadata": {
-                    "attempt_validation": {
-                      "context_observations": {
-                        "commit_resolution_pending": false,
-                        "used_task_artifact_fallback": false
-                      },
-                      "failure_type": "invalid_execution_attempt",
-                      "policy": {
-                        "allow_commit_resolution_via_reconciliation": true,
-                        "allow_missing_pull_request": true,
-                        "require_commit": true,
-                        "require_exact_branch": true,
-                        "require_repository": true,
-                        "task_artifact_fallback_requires_single_attempt": true
-                      },
-                      "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
-                      ],
-                      "retryable": true,
-                      "status": "invalid",
-                      "validated_at": "2026-04-06T15:28:46.349648Z",
-                      "validated_by": "execution_validation"
-                    },
-                    "dispatch_at": "2026-04-06T15:28:46.348588Z",
-                    "dispatch_id": "dispatch:task-kno-184-scenario-c:2",
-                    "dispatch_mode": "automatic",
-                    "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-                    "dispatch_trigger": "invalid_execution_attempt_retry",
-                    "execution_events": [
-                      {
-                        "event_id": "attempt-2:started",
-                        "event_type": "execution_started",
-                        "metadata": {
-                          "adapter": "stub-executor",
-                          "mode": "stub"
-                        },
-                        "occurred_at": "2026-04-06T15:28:46.348407Z",
-                        "source_system": "stub-executor"
-                      },
-                      {
-                        "event_id": "attempt-2:completed",
-                        "event_type": "execution_succeeded",
-                        "metadata": {
-                          "adapter": "stub-executor",
-                          "executor_run_id": "stub-run-attempt-2"
-                        },
-                        "occurred_at": "2026-04-06T15:28:46.348422Z",
-                        "source_system": "stub-executor"
-                      }
-                    ],
-                    "execution_parameters": {
-                      "prior_invalid_attempt_id": null
-                    },
-                    "executor": "codex"
-                  },
-                  "recorded_at": "2026-04-06T15:28:46.348583Z",
-                  "reevaluation": {},
-                  "reported_by": "codex",
-                  "status": "completed"
                 }
               ],
               "schema_required_deferred_fields": [
@@ -511,294 +158,377 @@
           "status": "failed",
           "status_history": [
             {
-              "changed_at": "2026-04-06T15:28:46.389386Z",
+              "changed_at": "2026-04-11T16:04:28.935026Z",
               "changed_by": "verification",
               "from_status": "executing",
-              "reason": "Successful execution attempt is missing repository identity for the current run.",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
               "to_status": "failed"
             }
           ],
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-04-06T00:00:00Z",
-            "updated_at": "2026-04-06T15:28:46.389386Z"
+            "updated_at": "2026-04-11T16:04:28.935026Z"
           },
           "title": "KNO-184 scenario C validation"
         },
-        "transition_result": null,
-        "verification_result": null
+        "unresolved_conditions": []
       },
-      "error": "Successful execution attempt is missing repository identity for the current run.",
-      "failure_classification": {
-        "category": "invalid_execution_attempt",
-        "failure_type": "invalid_execution_attempt",
-        "reason": "Successful execution attempt is missing repository identity for the current run.",
-        "recoverable": false,
-        "retryable": false,
-        "source": "executor",
-        "terminal": true
-      },
-      "invalid_input": false,
-      "reasons": [
-        "Successful execution attempt is missing repository identity for the current run."
-      ],
-      "requires_review": false,
-      "target_status": "failed",
-      "task_envelope": {
-        "acceptance_criteria": [
-          {
-            "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
-            "id": "ac-1",
-            "required": true
-          }
-        ],
-        "artifacts": {
-          "completion_evidence": {
-            "notes": null,
-            "policy": "deferred",
-            "required_artifact_types": [],
-            "status": "deferred",
-            "validated_artifact_ids": [],
-            "validated_at": null,
-            "validation_method": "deferred",
-            "validator": null
+      "result": {
+        "accepted_completion": false,
+        "action": "transition_applied",
+        "enforcement_result": {
+          "action": "transition_applied",
+          "error": "Successful execution attempt is missing branch identity for the current run.",
+          "evidence_result": null,
+          "failure_classification": {
+            "category": "contract_violation",
+            "failure_type": "contract_violation",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
+            "recoverable": false,
+            "retryable": false,
+            "source": "executor",
+            "terminal": true
           },
-          "items": []
-        },
-        "assigned_executor": {
-          "assignment_reason": "Validate invalid execution attempt boundary.",
-          "executor_id": "executor-kno-184-scenario-c",
-          "executor_type": "codex"
-        },
-        "child_task_ids": [],
-        "constraints": [],
-        "coordination": {
-          "linear": null
-        },
-        "dependencies": [],
-        "description": "Validate invalid execution attempt boundary remains enforced.",
-        "id": "task-kno-184-scenario-c",
-        "objective": {
-          "deliverable_type": "unspecified",
-          "success_signal": "Task satisfies declared acceptance criteria.",
-          "summary": "Validate invalid execution attempt boundary remains enforced."
-        },
-        "observability": {
-          "errors": [],
-          "execution_metadata": {
-            "advisory_completion_claims": [
+          "reasons": [
+            "Successful execution attempt is missing branch identity for the current run."
+          ],
+          "reconciliation_result": null,
+          "review_decision": null,
+          "review_request": null,
+          "target_status": "failed",
+          "task_envelope": {
+            "acceptance_criteria": [
               {
-                "claim_id": "claim-kno-184-scenario-c",
-                "metadata": {},
-                "reason": "executor reported completion",
-                "reported_at": "2026-04-06T00:01:00Z",
-                "reported_by": "codex"
-              },
-              {
-                "claim_id": "attempt-2:claim",
-                "metadata": {
-                  "advisory_only": true,
-                  "attempt_id": "attempt-2",
-                  "dispatch_mode": "automatic",
-                  "execution_parameters": {
-                    "prior_invalid_attempt_id": null
-                  }
-                },
-                "reason": "Successful execution attempt is missing repository identity for the current run.",
-                "reported_at": "2026-04-06T15:28:46.348574Z",
-                "reported_by": "codex"
+                "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
+                "id": "ac-1",
+                "required": true
               }
             ],
-            "execution_attempts": [
-              {
-                "artifact_references": [],
-                "attempt_id": "attempt-kno-184-scenario-c",
-                "completion_claim_id": "claim-kno-184-scenario-c",
-                "metadata": {
-                  "attempt_validation": {
-                    "context_observations": {
-                      "commit_resolution_pending": false,
-                      "used_task_artifact_fallback": false
-                    },
-                    "failure_type": "invalid_execution_attempt",
-                    "policy": {
-                      "allow_commit_resolution_via_reconciliation": true,
-                      "allow_missing_pull_request": true,
-                      "require_commit": true,
-                      "require_exact_branch": true,
-                      "require_repository": true,
-                      "task_artifact_fallback_requires_single_attempt": true
-                    },
-                    "reasons": [
-                      "Successful execution attempt is missing repository identity for the current run.",
-                      "Successful execution attempt is missing branch identity for the current run.",
-                      "Successful execution attempt is missing commit SHA for the current run."
-                    ],
-                    "retryable": true,
-                    "status": "invalid",
-                    "validated_at": "2026-04-06T15:28:46.343141Z",
-                    "validated_by": "execution_validation"
-                  },
-                  "executor_run_id": "run-kno-184-scenario-c"
-                },
-                "recorded_at": "2026-04-06T00:01:01Z",
-                "reevaluation": {},
-                "reported_by": "codex",
-                "status": "succeeded"
+            "artifacts": {
+              "completion_evidence": {
+                "notes": null,
+                "policy": "deferred",
+                "required_artifact_types": [],
+                "status": "deferred",
+                "validated_artifact_ids": [],
+                "validated_at": null,
+                "validation_method": "deferred",
+                "validator": null
               },
-              {
-                "artifact_references": [
+              "items": []
+            },
+            "assigned_executor": null,
+            "child_task_ids": [],
+            "constraints": [],
+            "coordination": {
+              "linear": null
+            },
+            "dependencies": [],
+            "description": "Validate invalid execution attempt boundary remains enforced.",
+            "id": "task-kno-184-scenario-c",
+            "objective": {
+              "deliverable_type": "unspecified",
+              "success_signal": "Task satisfies declared acceptance criteria.",
+              "summary": "Validate invalid execution attempt boundary remains enforced."
+            },
+            "observability": {
+              "errors": [],
+              "execution_metadata": {
+                "advisory_completion_claims": [
                   {
-                    "artifact_type": "execution_log",
-                    "commit_sha": null,
-                    "external_id": null,
-                    "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-                    "metadata": {
-                      "advisory": true
-                    },
-                    "reference_id": "attempt-2:log"
+                    "claim_id": "claim-kno-184-scenario-c",
+                    "metadata": {},
+                    "reason": "executor reported completion",
+                    "reported_at": "2026-04-06T00:01:00Z",
+                    "reported_by": "codex"
                   }
                 ],
-                "attempt_id": "attempt-2",
-                "completion_claim_id": "attempt-2:claim",
-                "metadata": {
-                  "attempt_validation": {
-                    "context_observations": {
-                      "commit_resolution_pending": false,
-                      "used_task_artifact_fallback": false
-                    },
-                    "failure_type": "invalid_execution_attempt",
-                    "policy": {
-                      "allow_commit_resolution_via_reconciliation": true,
-                      "allow_missing_pull_request": true,
-                      "require_commit": true,
-                      "require_exact_branch": true,
-                      "require_repository": true,
-                      "task_artifact_fallback_requires_single_attempt": true
-                    },
-                    "reasons": [
-                      "Successful execution attempt is missing repository identity for the current run.",
-                      "Successful execution attempt is missing branch identity for the current run.",
-                      "Successful execution attempt is missing commit SHA for the current run."
-                    ],
-                    "retryable": true,
-                    "status": "invalid",
-                    "validated_at": "2026-04-06T15:28:46.349648Z",
-                    "validated_by": "execution_validation"
-                  },
-                  "dispatch_at": "2026-04-06T15:28:46.348588Z",
-                  "dispatch_id": "dispatch:task-kno-184-scenario-c:2",
-                  "dispatch_mode": "automatic",
-                  "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "dispatch_trigger": "invalid_execution_attempt_retry",
-                  "execution_events": [
-                    {
-                      "event_id": "attempt-2:started",
-                      "event_type": "execution_started",
-                      "metadata": {
-                        "adapter": "stub-executor",
-                        "mode": "stub"
+                "execution_attempts": [
+                  {
+                    "artifact_references": [],
+                    "attempt_id": "attempt-kno-184-scenario-c",
+                    "completion_claim_id": "claim-kno-184-scenario-c",
+                    "metadata": {
+                      "attempt_validation": {
+                        "context_observations": {
+                          "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
+                          "used_task_artifact_fallback": false
+                        },
+                        "failure_type": "contract_violation",
+                        "policy": {
+                          "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
+                          "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
+                          "require_commit": true,
+                          "require_exact_branch": true,
+                          "require_repository": true,
+                          "task_artifact_fallback_requires_single_attempt": true
+                        },
+                        "pull_request_observations": [],
+                        "reasons": [
+                          "Successful execution attempt is missing branch identity for the current run."
+                        ],
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
+                        "status": "invalid",
+                        "validated_at": "2026-04-11T16:04:28.933135Z",
+                        "validated_by": "execution_validation"
                       },
-                      "occurred_at": "2026-04-06T15:28:46.348407Z",
-                      "source_system": "stub-executor"
+                      "executor_run_id": "run-kno-184-scenario-c"
                     },
-                    {
-                      "event_id": "attempt-2:completed",
-                      "event_type": "execution_succeeded",
-                      "metadata": {
-                        "adapter": "stub-executor",
-                        "executor_run_id": "stub-run-attempt-2"
-                      },
-                      "occurred_at": "2026-04-06T15:28:46.348422Z",
-                      "source_system": "stub-executor"
-                    }
-                  ],
-                  "execution_parameters": {
-                    "prior_invalid_attempt_id": null
-                  },
-                  "executor": "codex"
-                },
-                "recorded_at": "2026-04-06T15:28:46.348583Z",
-                "reevaluation": {},
-                "reported_by": "codex",
-                "status": "completed"
+                    "recorded_at": "2026-04-06T00:01:01Z",
+                    "reevaluation": {},
+                    "reported_by": "codex",
+                    "status": "succeeded"
+                  }
+                ],
+                "schema_required_deferred_fields": [
+                  "parent_task_id",
+                  "child_task_ids",
+                  "dependencies",
+                  "assigned_executor",
+                  "required_capabilities",
+                  "priority",
+                  "artifacts.items",
+                  "artifacts.completion_evidence",
+                  "observability"
+                ]
+              },
+              "retries": {
+                "attempt_count": 0,
+                "last_retry_at": null,
+                "max_attempts": 0
+              }
+            },
+            "origin": {
+              "ingress_id": null,
+              "ingress_name": null,
+              "requested_by": null,
+              "source_id": "KNO-184",
+              "source_system": "linear",
+              "source_type": "ingress_request"
+            },
+            "parent_task_id": null,
+            "priority": "normal",
+            "reconciliation": {
+              "active_failure_type": null,
+              "attempts": [],
+              "failed_at": null,
+              "last_attempt_id": null,
+              "last_error": null,
+              "last_pr_url": null,
+              "resolved_at": null,
+              "status": "not_required"
+            },
+            "required_capabilities": [],
+            "status": "failed",
+            "status_history": [
+              {
+                "changed_at": "2026-04-11T16:04:28.935026Z",
+                "changed_by": "verification",
+                "from_status": "executing",
+                "reason": "Successful execution attempt is missing branch identity for the current run.",
+                "to_status": "failed"
               }
             ],
-            "schema_required_deferred_fields": [
-              "parent_task_id",
-              "child_task_ids",
-              "dependencies",
-              "assigned_executor",
-              "required_capabilities",
-              "priority",
-              "artifacts.items",
-              "artifacts.completion_evidence",
-              "observability"
-            ]
+            "timestamps": {
+              "completed_at": null,
+              "created_at": "2026-04-06T00:00:00Z",
+              "updated_at": "2026-04-11T16:04:28.935026Z"
+            },
+            "title": "KNO-184 scenario C validation"
           },
-          "retries": {
-            "attempt_count": 0,
-            "last_retry_at": null,
-            "max_attempts": 0
-          }
+          "transition_result": null,
+          "verification_result": null
         },
-        "origin": {
-          "ingress_id": null,
-          "ingress_name": null,
-          "requested_by": null,
-          "source_id": "KNO-184",
-          "source_system": "linear",
-          "source_type": "ingress_request"
+        "error": "Successful execution attempt is missing branch identity for the current run.",
+        "failure_classification": {
+          "category": "contract_violation",
+          "failure_type": "contract_violation",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
+          "recoverable": false,
+          "retryable": false,
+          "source": "executor",
+          "terminal": true
         },
-        "parent_task_id": null,
-        "priority": "normal",
-        "reconciliation": {
-          "active_failure_type": null,
-          "attempts": [],
-          "failed_at": null,
-          "last_attempt_id": null,
-          "last_error": null,
-          "last_pr_url": null,
-          "resolved_at": null,
-          "status": "not_required"
-        },
-        "required_capabilities": [],
-        "status": "failed",
-        "status_history": [
-          {
-            "changed_at": "2026-04-06T15:28:46.389386Z",
-            "changed_by": "verification",
-            "from_status": "executing",
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
-            "to_status": "failed"
-          }
+        "invalid_input": false,
+        "reasons": [
+          "Successful execution attempt is missing branch identity for the current run."
         ],
-        "timestamps": {
-          "completed_at": null,
-          "created_at": "2026-04-06T00:00:00Z",
-          "updated_at": "2026-04-06T15:28:46.389386Z"
-        },
-        "title": "KNO-184 scenario C validation"
-      }
+        "requires_review": false,
+        "target_status": "failed",
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "deferred",
+              "required_artifact_types": [],
+              "status": "deferred",
+              "validated_artifact_ids": [],
+              "validated_at": null,
+              "validation_method": "deferred",
+              "validator": null
+            },
+            "items": []
+          },
+          "assigned_executor": null,
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": null
+          },
+          "dependencies": [],
+          "description": "Validate invalid execution attempt boundary remains enforced.",
+          "id": "task-kno-184-scenario-c",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Validate invalid execution attempt boundary remains enforced."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-184-scenario-c",
+                  "metadata": {},
+                  "reason": "executor reported completion",
+                  "reported_at": "2026-04-06T00:01:00Z",
+                  "reported_by": "codex"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [],
+                  "attempt_id": "attempt-kno-184-scenario-c",
+                  "completion_claim_id": "claim-kno-184-scenario-c",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "used_task_artifact_fallback": false
+                      },
+                      "failure_type": "contract_violation",
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [
+                        "Successful execution attempt is missing branch identity for the current run."
+                      ],
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
+                      "status": "invalid",
+                      "validated_at": "2026-04-11T16:04:28.933135Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "run-kno-184-scenario-c"
+                  },
+                  "recorded_at": "2026-04-06T00:01:01Z",
+                  "reevaluation": {},
+                  "reported_by": "codex",
+                  "status": "succeeded"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "KNO-184",
+            "source_system": "linear",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": null,
+            "attempts": [],
+            "failed_at": null,
+            "last_attempt_id": null,
+            "last_error": null,
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "not_required"
+          },
+          "required_capabilities": [],
+          "status": "failed",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.935026Z",
+              "changed_by": "verification",
+              "from_status": "executing",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
+              "to_status": "failed"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-04-06T00:00:00Z",
+            "updated_at": "2026-04-11T16:04:28.935026Z"
+          },
+          "title": "KNO-184 scenario C validation"
+        }
+      },
+      "task_id": "task-kno-184-scenario-c"
     },
-    "task_id": "task-kno-184-scenario-c"
-  },
-  "invalid_execution_attempt": {
-    "evaluation_record": {
-      "evaluation_id": "a69bc9e7-831c-426e-b788-28057dbdeb15",
-      "recorded_at": "2026-04-06T15:28:46.344300Z",
+    "initial_evaluation_record": {
+      "evaluation_id": "8a5f3d70-fd9c-4eb5-a82c-4d62a30d6fee",
+      "recorded_at": "2026-04-11T16:04:28.933276Z",
       "request": {
         "acceptance_criteria_satisfied": false,
         "claimed_completion": true,
         "external_facts": null,
-        "retry_context": {
-          "attempt_number": 1,
-          "is_final_attempt": true,
-          "max_retries": 1,
-          "scheduled_at": "2026-04-06T15:28:46.344064Z",
-          "triggered_by_category": "invalid_execution_attempt",
-          "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-        },
+        "retry_context": null,
         "review_decision": null,
         "review_is_active": false,
         "review_reasons": [],
@@ -870,25 +600,35 @@
                     "attempt_validation": {
                       "context_observations": {
                         "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
-                      "failure_type": "invalid_execution_attempt",
+                      "failure_type": "contract_violation",
                       "policy": {
                         "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
+                        "Successful execution attempt is missing branch identity for the current run."
                       ],
-                      "retryable": true,
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
                       "status": "invalid",
-                      "validated_at": "2026-04-06T15:28:46.343141Z",
+                      "validated_at": "2026-04-11T16:04:28.933135Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "run-kno-184-scenario-c"
@@ -943,7 +683,7 @@
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-04-06T00:00:00Z",
-            "updated_at": "2026-04-06T15:28:46.343333Z"
+            "updated_at": "2026-04-11T16:04:28.933250Z"
           },
           "title": "KNO-184 scenario C validation"
         },
@@ -954,19 +694,19 @@
         "action": "no_op",
         "enforcement_result": {
           "action": "no_op",
-          "error": "Successful execution attempt is missing repository identity for the current run.",
+          "error": "Successful execution attempt is missing branch identity for the current run.",
           "evidence_result": null,
           "failure_classification": {
-            "category": "invalid_execution_attempt",
-            "failure_type": "invalid_execution_attempt",
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
-            "recoverable": true,
-            "retryable": true,
+            "category": "contract_violation",
+            "failure_type": "contract_violation",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
+            "recoverable": false,
+            "retryable": false,
             "source": "executor",
-            "terminal": false
+            "terminal": true
           },
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
           "reconciliation_result": null,
           "review_decision": null,
@@ -1032,25 +772,35 @@
                       "attempt_validation": {
                         "context_observations": {
                           "commit_resolution_pending": false,
+                          "has_valid_current_run_pull_request_artifact": false,
                           "used_task_artifact_fallback": false
                         },
-                        "failure_type": "invalid_execution_attempt",
+                        "failure_type": "contract_violation",
                         "policy": {
                           "allow_commit_resolution_via_reconciliation": true,
+                          "allow_missing_commit_artifact_with_verified_pull_request": true,
                           "allow_missing_pull_request": true,
+                          "reject_closed_or_historical_pull_request": true,
+                          "reject_non_numeric_pull_request_url": true,
+                          "reject_reserved_shared_branch": true,
                           "require_commit": true,
                           "require_exact_branch": true,
                           "require_repository": true,
                           "task_artifact_fallback_requires_single_attempt": true
                         },
+                        "pull_request_observations": [],
                         "reasons": [
-                          "Successful execution attempt is missing repository identity for the current run.",
-                          "Successful execution attempt is missing branch identity for the current run.",
-                          "Successful execution attempt is missing commit SHA for the current run."
+                          "Successful execution attempt is missing branch identity for the current run."
                         ],
-                        "retryable": true,
+                        "retryable": false,
+                        "rule_failures": [
+                          {
+                            "message": "Successful execution attempt is missing branch identity for the current run.",
+                            "rule": "missing_branch_identity"
+                          }
+                        ],
                         "status": "invalid",
-                        "validated_at": "2026-04-06T15:28:46.343141Z",
+                        "validated_at": "2026-04-11T16:04:28.933135Z",
                         "validated_by": "execution_validation"
                       },
                       "executor_run_id": "run-kno-184-scenario-c"
@@ -1105,26 +855,26 @@
             "timestamps": {
               "completed_at": null,
               "created_at": "2026-04-06T00:00:00Z",
-              "updated_at": "2026-04-06T15:28:46.343333Z"
+              "updated_at": "2026-04-11T16:04:28.933250Z"
             },
             "title": "KNO-184 scenario C validation"
           },
           "transition_result": null,
           "verification_result": null
         },
-        "error": "Successful execution attempt is missing repository identity for the current run.",
+        "error": "Successful execution attempt is missing branch identity for the current run.",
         "failure_classification": {
-          "category": "invalid_execution_attempt",
-          "failure_type": "invalid_execution_attempt",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
-          "recoverable": true,
-          "retryable": true,
+          "category": "contract_violation",
+          "failure_type": "contract_violation",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
+          "recoverable": false,
+          "retryable": false,
           "source": "executor",
-          "terminal": false
+          "terminal": true
         },
         "invalid_input": false,
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
         "requires_review": false,
         "target_status": null,
@@ -1188,25 +938,35 @@
                     "attempt_validation": {
                       "context_observations": {
                         "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
                         "used_task_artifact_fallback": false
                       },
-                      "failure_type": "invalid_execution_attempt",
+                      "failure_type": "contract_violation",
                       "policy": {
                         "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
                         "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
                         "require_commit": true,
                         "require_exact_branch": true,
                         "require_repository": true,
                         "task_artifact_fallback_requires_single_attempt": true
                       },
+                      "pull_request_observations": [],
                       "reasons": [
-                        "Successful execution attempt is missing repository identity for the current run.",
-                        "Successful execution attempt is missing branch identity for the current run.",
-                        "Successful execution attempt is missing commit SHA for the current run."
+                        "Successful execution attempt is missing branch identity for the current run."
                       ],
-                      "retryable": true,
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
                       "status": "invalid",
-                      "validated_at": "2026-04-06T15:28:46.343141Z",
+                      "validated_at": "2026-04-11T16:04:28.933135Z",
                       "validated_by": "execution_validation"
                     },
                     "executor_run_id": "run-kno-184-scenario-c"
@@ -1261,52 +1021,574 @@
           "timestamps": {
             "completed_at": null,
             "created_at": "2026-04-06T00:00:00Z",
-            "updated_at": "2026-04-06T15:28:46.343333Z"
+            "updated_at": "2026-04-11T16:04:28.933250Z"
           },
           "title": "KNO-184 scenario C validation"
         }
       },
       "task_id": "task-kno-184-scenario-c"
     },
-    "retry_context": {
-      "attempt_number": 1,
-      "is_final_attempt": true,
-      "max_retries": 1,
-      "scheduled_at": "2026-04-06T15:28:46.344064Z",
-      "triggered_by_category": "invalid_execution_attempt",
-      "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-    },
-    "status": "retry_scheduled",
+    "invalid_attempt_count": 0,
+    "retry_budget": 1,
+    "status": "failed",
     "validation": {
       "context_observations": {
         "commit_resolution_pending": false,
+        "has_valid_current_run_pull_request_artifact": false,
         "used_task_artifact_fallback": false
       },
-      "failure_type": "invalid_execution_attempt",
+      "failure_type": "contract_violation",
       "policy": {
         "allow_commit_resolution_via_reconciliation": true,
+        "allow_missing_commit_artifact_with_verified_pull_request": true,
         "allow_missing_pull_request": true,
+        "reject_closed_or_historical_pull_request": true,
+        "reject_non_numeric_pull_request_url": true,
+        "reject_reserved_shared_branch": true,
         "require_commit": true,
         "require_exact_branch": true,
         "require_repository": true,
         "task_artifact_fallback_requires_single_attempt": true
       },
+      "pull_request_observations": [],
       "reasons": [
-        "Successful execution attempt is missing repository identity for the current run.",
-        "Successful execution attempt is missing branch identity for the current run.",
-        "Successful execution attempt is missing commit SHA for the current run."
+        "Successful execution attempt is missing branch identity for the current run."
       ],
-      "retryable": true,
+      "retryable": false,
+      "rule_failures": [
+        {
+          "message": "Successful execution attempt is missing branch identity for the current run.",
+          "rule": "missing_branch_identity"
+        }
+      ],
       "status": "invalid",
-      "validated_at": "2026-04-06T15:28:46.343141Z",
+      "validated_at": "2026-04-11T16:04:28.933135Z",
       "validated_by": "execution_validation"
     }
   },
+  "error": "Successful execution attempt is missing branch identity for the current run.",
+  "evaluation_record": {
+    "evaluation_id": "6ca68aac-1160-4cef-82e9-4cca94a995c8",
+    "recorded_at": "2026-04-11T16:04:28.936965Z",
+    "request": {
+      "acceptance_criteria_satisfied": false,
+      "claimed_completion": true,
+      "external_facts": null,
+      "retry_context": null,
+      "review_decision": null,
+      "review_is_active": false,
+      "review_reasons": [],
+      "review_request": null,
+      "runtime_facts": {
+        "attempt_count": 1,
+        "executor_reported_failure": false,
+        "executor_reported_success": true,
+        "latest_attempt_outcome": null,
+        "terminal_failure": false
+      },
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "deferred",
+            "required_artifact_types": [],
+            "status": "deferred",
+            "validated_artifact_ids": [],
+            "validated_at": null,
+            "validation_method": "deferred",
+            "validator": null
+          },
+          "items": []
+        },
+        "assigned_executor": null,
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": null
+        },
+        "dependencies": [],
+        "description": "Validate invalid execution attempt boundary remains enforced.",
+        "id": "task-kno-184-scenario-c",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Validate invalid execution attempt boundary remains enforced."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-184-scenario-c",
+                "metadata": {},
+                "reason": "executor reported completion",
+                "reported_at": "2026-04-06T00:01:00Z",
+                "reported_by": "codex"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [],
+                "attempt_id": "attempt-kno-184-scenario-c",
+                "completion_claim_id": "claim-kno-184-scenario-c",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "used_task_artifact_fallback": false
+                    },
+                    "failure_type": "contract_violation",
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [
+                      "Successful execution attempt is missing branch identity for the current run."
+                    ],
+                    "retryable": false,
+                    "rule_failures": [
+                      {
+                        "message": "Successful execution attempt is missing branch identity for the current run.",
+                        "rule": "missing_branch_identity"
+                      }
+                    ],
+                    "status": "invalid",
+                    "validated_at": "2026-04-11T16:04:28.933135Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "run-kno-184-scenario-c"
+                },
+                "recorded_at": "2026-04-06T00:01:01Z",
+                "reevaluation": {},
+                "reported_by": "codex",
+                "status": "succeeded"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "KNO-184",
+          "source_system": "linear",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": null,
+          "attempts": [],
+          "failed_at": null,
+          "last_attempt_id": null,
+          "last_error": null,
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "not_required"
+        },
+        "required_capabilities": [],
+        "status": "failed",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.935026Z",
+            "changed_by": "verification",
+            "from_status": "executing",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
+            "to_status": "failed"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-04-06T00:00:00Z",
+          "updated_at": "2026-04-11T16:04:28.935026Z"
+        },
+        "title": "KNO-184 scenario C validation"
+      },
+      "unresolved_conditions": []
+    },
+    "result": {
+      "accepted_completion": false,
+      "action": "transition_applied",
+      "enforcement_result": {
+        "action": "transition_applied",
+        "error": "Successful execution attempt is missing branch identity for the current run.",
+        "evidence_result": null,
+        "failure_classification": {
+          "category": "contract_violation",
+          "failure_type": "contract_violation",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
+          "recoverable": false,
+          "retryable": false,
+          "source": "executor",
+          "terminal": true
+        },
+        "reasons": [
+          "Successful execution attempt is missing branch identity for the current run."
+        ],
+        "reconciliation_result": null,
+        "review_decision": null,
+        "review_request": null,
+        "target_status": "failed",
+        "task_envelope": {
+          "acceptance_criteria": [
+            {
+              "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
+              "id": "ac-1",
+              "required": true
+            }
+          ],
+          "artifacts": {
+            "completion_evidence": {
+              "notes": null,
+              "policy": "deferred",
+              "required_artifact_types": [],
+              "status": "deferred",
+              "validated_artifact_ids": [],
+              "validated_at": null,
+              "validation_method": "deferred",
+              "validator": null
+            },
+            "items": []
+          },
+          "assigned_executor": null,
+          "child_task_ids": [],
+          "constraints": [],
+          "coordination": {
+            "linear": null
+          },
+          "dependencies": [],
+          "description": "Validate invalid execution attempt boundary remains enforced.",
+          "id": "task-kno-184-scenario-c",
+          "objective": {
+            "deliverable_type": "unspecified",
+            "success_signal": "Task satisfies declared acceptance criteria.",
+            "summary": "Validate invalid execution attempt boundary remains enforced."
+          },
+          "observability": {
+            "errors": [],
+            "execution_metadata": {
+              "advisory_completion_claims": [
+                {
+                  "claim_id": "claim-kno-184-scenario-c",
+                  "metadata": {},
+                  "reason": "executor reported completion",
+                  "reported_at": "2026-04-06T00:01:00Z",
+                  "reported_by": "codex"
+                }
+              ],
+              "execution_attempts": [
+                {
+                  "artifact_references": [],
+                  "attempt_id": "attempt-kno-184-scenario-c",
+                  "completion_claim_id": "claim-kno-184-scenario-c",
+                  "metadata": {
+                    "attempt_validation": {
+                      "context_observations": {
+                        "commit_resolution_pending": false,
+                        "has_valid_current_run_pull_request_artifact": false,
+                        "used_task_artifact_fallback": false
+                      },
+                      "failure_type": "contract_violation",
+                      "policy": {
+                        "allow_commit_resolution_via_reconciliation": true,
+                        "allow_missing_commit_artifact_with_verified_pull_request": true,
+                        "allow_missing_pull_request": true,
+                        "reject_closed_or_historical_pull_request": true,
+                        "reject_non_numeric_pull_request_url": true,
+                        "reject_reserved_shared_branch": true,
+                        "require_commit": true,
+                        "require_exact_branch": true,
+                        "require_repository": true,
+                        "task_artifact_fallback_requires_single_attempt": true
+                      },
+                      "pull_request_observations": [],
+                      "reasons": [
+                        "Successful execution attempt is missing branch identity for the current run."
+                      ],
+                      "retryable": false,
+                      "rule_failures": [
+                        {
+                          "message": "Successful execution attempt is missing branch identity for the current run.",
+                          "rule": "missing_branch_identity"
+                        }
+                      ],
+                      "status": "invalid",
+                      "validated_at": "2026-04-11T16:04:28.933135Z",
+                      "validated_by": "execution_validation"
+                    },
+                    "executor_run_id": "run-kno-184-scenario-c"
+                  },
+                  "recorded_at": "2026-04-06T00:01:01Z",
+                  "reevaluation": {},
+                  "reported_by": "codex",
+                  "status": "succeeded"
+                }
+              ],
+              "schema_required_deferred_fields": [
+                "parent_task_id",
+                "child_task_ids",
+                "dependencies",
+                "assigned_executor",
+                "required_capabilities",
+                "priority",
+                "artifacts.items",
+                "artifacts.completion_evidence",
+                "observability"
+              ]
+            },
+            "retries": {
+              "attempt_count": 0,
+              "last_retry_at": null,
+              "max_attempts": 0
+            }
+          },
+          "origin": {
+            "ingress_id": null,
+            "ingress_name": null,
+            "requested_by": null,
+            "source_id": "KNO-184",
+            "source_system": "linear",
+            "source_type": "ingress_request"
+          },
+          "parent_task_id": null,
+          "priority": "normal",
+          "reconciliation": {
+            "active_failure_type": null,
+            "attempts": [],
+            "failed_at": null,
+            "last_attempt_id": null,
+            "last_error": null,
+            "last_pr_url": null,
+            "resolved_at": null,
+            "status": "not_required"
+          },
+          "required_capabilities": [],
+          "status": "failed",
+          "status_history": [
+            {
+              "changed_at": "2026-04-11T16:04:28.935026Z",
+              "changed_by": "verification",
+              "from_status": "executing",
+              "reason": "Successful execution attempt is missing branch identity for the current run.",
+              "to_status": "failed"
+            }
+          ],
+          "timestamps": {
+            "completed_at": null,
+            "created_at": "2026-04-06T00:00:00Z",
+            "updated_at": "2026-04-11T16:04:28.935026Z"
+          },
+          "title": "KNO-184 scenario C validation"
+        },
+        "transition_result": null,
+        "verification_result": null
+      },
+      "error": "Successful execution attempt is missing branch identity for the current run.",
+      "failure_classification": {
+        "category": "contract_violation",
+        "failure_type": "contract_violation",
+        "reason": "Successful execution attempt is missing branch identity for the current run.",
+        "recoverable": false,
+        "retryable": false,
+        "source": "executor",
+        "terminal": true
+      },
+      "invalid_input": false,
+      "reasons": [
+        "Successful execution attempt is missing branch identity for the current run."
+      ],
+      "requires_review": false,
+      "target_status": "failed",
+      "task_envelope": {
+        "acceptance_criteria": [
+          {
+            "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
+            "id": "ac-1",
+            "required": true
+          }
+        ],
+        "artifacts": {
+          "completion_evidence": {
+            "notes": null,
+            "policy": "deferred",
+            "required_artifact_types": [],
+            "status": "deferred",
+            "validated_artifact_ids": [],
+            "validated_at": null,
+            "validation_method": "deferred",
+            "validator": null
+          },
+          "items": []
+        },
+        "assigned_executor": null,
+        "child_task_ids": [],
+        "constraints": [],
+        "coordination": {
+          "linear": null
+        },
+        "dependencies": [],
+        "description": "Validate invalid execution attempt boundary remains enforced.",
+        "id": "task-kno-184-scenario-c",
+        "objective": {
+          "deliverable_type": "unspecified",
+          "success_signal": "Task satisfies declared acceptance criteria.",
+          "summary": "Validate invalid execution attempt boundary remains enforced."
+        },
+        "observability": {
+          "errors": [],
+          "execution_metadata": {
+            "advisory_completion_claims": [
+              {
+                "claim_id": "claim-kno-184-scenario-c",
+                "metadata": {},
+                "reason": "executor reported completion",
+                "reported_at": "2026-04-06T00:01:00Z",
+                "reported_by": "codex"
+              }
+            ],
+            "execution_attempts": [
+              {
+                "artifact_references": [],
+                "attempt_id": "attempt-kno-184-scenario-c",
+                "completion_claim_id": "claim-kno-184-scenario-c",
+                "metadata": {
+                  "attempt_validation": {
+                    "context_observations": {
+                      "commit_resolution_pending": false,
+                      "has_valid_current_run_pull_request_artifact": false,
+                      "used_task_artifact_fallback": false
+                    },
+                    "failure_type": "contract_violation",
+                    "policy": {
+                      "allow_commit_resolution_via_reconciliation": true,
+                      "allow_missing_commit_artifact_with_verified_pull_request": true,
+                      "allow_missing_pull_request": true,
+                      "reject_closed_or_historical_pull_request": true,
+                      "reject_non_numeric_pull_request_url": true,
+                      "reject_reserved_shared_branch": true,
+                      "require_commit": true,
+                      "require_exact_branch": true,
+                      "require_repository": true,
+                      "task_artifact_fallback_requires_single_attempt": true
+                    },
+                    "pull_request_observations": [],
+                    "reasons": [
+                      "Successful execution attempt is missing branch identity for the current run."
+                    ],
+                    "retryable": false,
+                    "rule_failures": [
+                      {
+                        "message": "Successful execution attempt is missing branch identity for the current run.",
+                        "rule": "missing_branch_identity"
+                      }
+                    ],
+                    "status": "invalid",
+                    "validated_at": "2026-04-11T16:04:28.933135Z",
+                    "validated_by": "execution_validation"
+                  },
+                  "executor_run_id": "run-kno-184-scenario-c"
+                },
+                "recorded_at": "2026-04-06T00:01:01Z",
+                "reevaluation": {},
+                "reported_by": "codex",
+                "status": "succeeded"
+              }
+            ],
+            "schema_required_deferred_fields": [
+              "parent_task_id",
+              "child_task_ids",
+              "dependencies",
+              "assigned_executor",
+              "required_capabilities",
+              "priority",
+              "artifacts.items",
+              "artifacts.completion_evidence",
+              "observability"
+            ]
+          },
+          "retries": {
+            "attempt_count": 0,
+            "last_retry_at": null,
+            "max_attempts": 0
+          }
+        },
+        "origin": {
+          "ingress_id": null,
+          "ingress_name": null,
+          "requested_by": null,
+          "source_id": "KNO-184",
+          "source_system": "linear",
+          "source_type": "ingress_request"
+        },
+        "parent_task_id": null,
+        "priority": "normal",
+        "reconciliation": {
+          "active_failure_type": null,
+          "attempts": [],
+          "failed_at": null,
+          "last_attempt_id": null,
+          "last_error": null,
+          "last_pr_url": null,
+          "resolved_at": null,
+          "status": "not_required"
+        },
+        "required_capabilities": [],
+        "status": "failed",
+        "status_history": [
+          {
+            "changed_at": "2026-04-11T16:04:28.935026Z",
+            "changed_by": "verification",
+            "from_status": "executing",
+            "reason": "Successful execution attempt is missing branch identity for the current run.",
+            "to_status": "failed"
+          }
+        ],
+        "timestamps": {
+          "completed_at": null,
+          "created_at": "2026-04-06T00:00:00Z",
+          "updated_at": "2026-04-11T16:04:28.935026Z"
+        },
+        "title": "KNO-184 scenario C validation"
+      }
+    },
+    "task_id": "task-kno-184-scenario-c"
+  },
   "invalid_input": false,
   "reasons": [
-    "Successful execution attempt is missing repository identity for the current run.",
-    "Successful execution attempt is missing branch identity for the current run.",
-    "Successful execution attempt is missing commit SHA for the current run."
+    "Successful execution attempt is missing branch identity for the current run."
   ],
   "requires_review": false,
   "target_status": "failed",
@@ -1331,11 +1613,7 @@
       },
       "items": []
     },
-    "assigned_executor": {
-      "assignment_reason": "Validate invalid execution attempt boundary.",
-      "executor_id": "executor-kno-184-scenario-c",
-      "executor_type": "codex"
-    },
+    "assigned_executor": null,
     "child_task_ids": [],
     "constraints": [],
     "coordination": {
@@ -1359,20 +1637,6 @@
             "reason": "executor reported completion",
             "reported_at": "2026-04-06T00:01:00Z",
             "reported_by": "codex"
-          },
-          {
-            "claim_id": "attempt-2:claim",
-            "metadata": {
-              "advisory_only": true,
-              "attempt_id": "attempt-2",
-              "dispatch_mode": "automatic",
-              "execution_parameters": {
-                "prior_invalid_attempt_id": null
-              }
-            },
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
-            "reported_at": "2026-04-06T15:28:46.348574Z",
-            "reported_by": "codex"
           }
         ],
         "execution_attempts": [
@@ -1384,25 +1648,35 @@
               "attempt_validation": {
                 "context_observations": {
                   "commit_resolution_pending": false,
+                  "has_valid_current_run_pull_request_artifact": false,
                   "used_task_artifact_fallback": false
                 },
-                "failure_type": "invalid_execution_attempt",
+                "failure_type": "contract_violation",
                 "policy": {
                   "allow_commit_resolution_via_reconciliation": true,
+                  "allow_missing_commit_artifact_with_verified_pull_request": true,
                   "allow_missing_pull_request": true,
+                  "reject_closed_or_historical_pull_request": true,
+                  "reject_non_numeric_pull_request_url": true,
+                  "reject_reserved_shared_branch": true,
                   "require_commit": true,
                   "require_exact_branch": true,
                   "require_repository": true,
                   "task_artifact_fallback_requires_single_attempt": true
                 },
+                "pull_request_observations": [],
                 "reasons": [
-                  "Successful execution attempt is missing repository identity for the current run.",
-                  "Successful execution attempt is missing branch identity for the current run.",
-                  "Successful execution attempt is missing commit SHA for the current run."
+                  "Successful execution attempt is missing branch identity for the current run."
                 ],
-                "retryable": true,
+                "retryable": false,
+                "rule_failures": [
+                  {
+                    "message": "Successful execution attempt is missing branch identity for the current run.",
+                    "rule": "missing_branch_identity"
+                  }
+                ],
                 "status": "invalid",
-                "validated_at": "2026-04-06T15:28:46.343141Z",
+                "validated_at": "2026-04-11T16:04:28.933135Z",
                 "validated_by": "execution_validation"
               },
               "executor_run_id": "run-kno-184-scenario-c"
@@ -1411,83 +1685,6 @@
             "reevaluation": {},
             "reported_by": "codex",
             "status": "succeeded"
-          },
-          {
-            "artifact_references": [
-              {
-                "artifact_type": "execution_log",
-                "commit_sha": null,
-                "external_id": null,
-                "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-                "metadata": {
-                  "advisory": true
-                },
-                "reference_id": "attempt-2:log"
-              }
-            ],
-            "attempt_id": "attempt-2",
-            "completion_claim_id": "attempt-2:claim",
-            "metadata": {
-              "attempt_validation": {
-                "context_observations": {
-                  "commit_resolution_pending": false,
-                  "used_task_artifact_fallback": false
-                },
-                "failure_type": "invalid_execution_attempt",
-                "policy": {
-                  "allow_commit_resolution_via_reconciliation": true,
-                  "allow_missing_pull_request": true,
-                  "require_commit": true,
-                  "require_exact_branch": true,
-                  "require_repository": true,
-                  "task_artifact_fallback_requires_single_attempt": true
-                },
-                "reasons": [
-                  "Successful execution attempt is missing repository identity for the current run.",
-                  "Successful execution attempt is missing branch identity for the current run.",
-                  "Successful execution attempt is missing commit SHA for the current run."
-                ],
-                "retryable": true,
-                "status": "invalid",
-                "validated_at": "2026-04-06T15:28:46.349648Z",
-                "validated_by": "execution_validation"
-              },
-              "dispatch_at": "2026-04-06T15:28:46.348588Z",
-              "dispatch_id": "dispatch:task-kno-184-scenario-c:2",
-              "dispatch_mode": "automatic",
-              "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-              "dispatch_trigger": "invalid_execution_attempt_retry",
-              "execution_events": [
-                {
-                  "event_id": "attempt-2:started",
-                  "event_type": "execution_started",
-                  "metadata": {
-                    "adapter": "stub-executor",
-                    "mode": "stub"
-                  },
-                  "occurred_at": "2026-04-06T15:28:46.348407Z",
-                  "source_system": "stub-executor"
-                },
-                {
-                  "event_id": "attempt-2:completed",
-                  "event_type": "execution_succeeded",
-                  "metadata": {
-                    "adapter": "stub-executor",
-                    "executor_run_id": "stub-run-attempt-2"
-                  },
-                  "occurred_at": "2026-04-06T15:28:46.348422Z",
-                  "source_system": "stub-executor"
-                }
-              ],
-              "execution_parameters": {
-                "prior_invalid_attempt_id": null
-              },
-              "executor": "codex"
-            },
-            "recorded_at": "2026-04-06T15:28:46.348583Z",
-            "reevaluation": {},
-            "reported_by": "codex",
-            "status": "completed"
           }
         ],
         "schema_required_deferred_fields": [
@@ -1532,17 +1729,17 @@
     "status": "failed",
     "status_history": [
       {
-        "changed_at": "2026-04-06T15:28:46.389386Z",
+        "changed_at": "2026-04-11T16:04:28.935026Z",
         "changed_by": "verification",
         "from_status": "executing",
-        "reason": "Successful execution attempt is missing repository identity for the current run.",
+        "reason": "Successful execution attempt is missing branch identity for the current run.",
         "to_status": "failed"
       }
     ],
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-06T00:00:00Z",
-      "updated_at": "2026-04-06T15:28:46.389386Z"
+      "updated_at": "2026-04-11T16:04:28.935026Z"
     },
     "title": "KNO-184 scenario C validation"
   }

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-c-read-model-final.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-c-read-model-final.json
@@ -1,39 +1,30 @@
 {
   "task": {
-    "assigned_executor": {
-      "assignment_reason": "Validate invalid execution attempt boundary.",
-      "executor_id": "executor-kno-184-scenario-c",
-      "executor_type": "codex"
-    },
+    "assigned_executor": null,
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": null
     },
     "current_status": "failed",
     "description": "Validate invalid execution attempt boundary remains enforced.",
     "evaluation_summary": {
-      "count": 3,
+      "count": 2,
       "history": [
         {
           "action": "no_op",
-          "evaluation_id": "a69bc9e7-831c-426e-b788-28057dbdeb15",
-          "recorded_at": "2026-04-06T15:28:46.344300Z",
-          "target_status": null
-        },
-        {
-          "action": "no_op",
-          "evaluation_id": "8b6bcab3-3de1-4c40-9063-1c3e176e1cbd",
-          "recorded_at": "2026-04-06T15:28:46.351263Z",
+          "evaluation_id": "8a5f3d70-fd9c-4eb5-a82c-4d62a30d6fee",
+          "recorded_at": "2026-04-11T16:04:28.933276Z",
           "target_status": null
         },
         {
           "action": "transition_applied",
-          "evaluation_id": "4331a2a9-241f-4407-889d-0d7f5910ec84",
-          "recorded_at": "2026-04-06T15:28:46.422509Z",
+          "evaluation_id": "6ca68aac-1160-4cef-82e9-4cca94a995c8",
+          "recorded_at": "2026-04-11T16:04:28.936965Z",
           "target_status": "failed"
         }
       ],
       "latest_action": "transition_applied",
-      "latest_recorded_at": "2026-04-06T15:28:46.422509Z",
+      "latest_recorded_at": "2026-04-11T16:04:28.936965Z",
       "latest_target_status": "failed"
     },
     "evidence_summary": {
@@ -52,146 +43,114 @@
       "verification_status_counts": {}
     },
     "execution_summary": {
-      "attempt_count": 2,
+      "attempt_count": 1,
       "failure_state": "terminal",
-      "invalid_attempt_count": 2,
-      "last_failure_type": "invalid_execution_attempt",
-      "latest_artifact_references": [
-        {
-          "artifact_type": "execution_log",
-          "commit_sha": null,
-          "external_id": null,
-          "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-          "metadata": {
-            "advisory": true
-          },
-          "reference_id": "attempt-2:log"
-        }
-      ],
+      "invalid_attempt_count": 0,
+      "last_failure_type": "contract_violation",
+      "latest_artifact_references": [],
       "latest_attempt": {
-        "artifact_references": [
-          {
-            "artifact_type": "execution_log",
-            "commit_sha": null,
-            "external_id": null,
-            "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-            "metadata": {
-              "advisory": true
-            },
-            "reference_id": "attempt-2:log"
-          }
-        ],
-        "attempt_id": "attempt-2",
-        "completion_claim_id": "attempt-2:claim",
+        "artifact_references": [],
+        "attempt_id": "attempt-kno-184-scenario-c",
+        "completion_claim_id": "claim-kno-184-scenario-c",
         "metadata": {
           "attempt_validation": {
             "context_observations": {
               "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "used_task_artifact_fallback": false
             },
-            "failure_type": "invalid_execution_attempt",
+            "failure_type": "contract_violation",
             "policy": {
               "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [
-              "Successful execution attempt is missing repository identity for the current run.",
-              "Successful execution attempt is missing branch identity for the current run.",
-              "Successful execution attempt is missing commit SHA for the current run."
+              "Successful execution attempt is missing branch identity for the current run."
             ],
-            "retryable": true,
+            "retryable": false,
+            "rule_failures": [
+              {
+                "message": "Successful execution attempt is missing branch identity for the current run.",
+                "rule": "missing_branch_identity"
+              }
+            ],
             "status": "invalid",
-            "validated_at": "2026-04-06T15:28:46.349648Z",
+            "validated_at": "2026-04-11T16:04:28.933135Z",
             "validated_by": "execution_validation"
           },
-          "dispatch_at": "2026-04-06T15:28:46.348588Z",
-          "dispatch_id": "dispatch:task-kno-184-scenario-c:2",
-          "dispatch_mode": "automatic",
-          "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-          "dispatch_trigger": "invalid_execution_attempt_retry",
-          "execution_events": [
-            {
-              "event_id": "attempt-2:started",
-              "event_type": "execution_started",
-              "metadata": {
-                "adapter": "stub-executor",
-                "mode": "stub"
-              },
-              "occurred_at": "2026-04-06T15:28:46.348407Z",
-              "source_system": "stub-executor"
-            },
-            {
-              "event_id": "attempt-2:completed",
-              "event_type": "execution_succeeded",
-              "metadata": {
-                "adapter": "stub-executor",
-                "executor_run_id": "stub-run-attempt-2"
-              },
-              "occurred_at": "2026-04-06T15:28:46.348422Z",
-              "source_system": "stub-executor"
-            }
-          ],
-          "execution_parameters": {
-            "prior_invalid_attempt_id": null
-          },
-          "executor": "codex"
+          "executor_run_id": "run-kno-184-scenario-c"
         },
-        "recorded_at": "2026-04-06T15:28:46.348583Z",
+        "recorded_at": "2026-04-06T00:01:01Z",
         "reevaluation": {},
         "reported_by": "codex",
-        "status": "completed"
+        "status": "succeeded"
       },
       "latest_attempt_validation": {
         "context_observations": {
           "commit_resolution_pending": false,
+          "has_valid_current_run_pull_request_artifact": false,
           "used_task_artifact_fallback": false
         },
-        "failure_type": "invalid_execution_attempt",
+        "failure_type": "contract_violation",
         "policy": {
           "allow_commit_resolution_via_reconciliation": true,
+          "allow_missing_commit_artifact_with_verified_pull_request": true,
           "allow_missing_pull_request": true,
+          "reject_closed_or_historical_pull_request": true,
+          "reject_non_numeric_pull_request_url": true,
+          "reject_reserved_shared_branch": true,
           "require_commit": true,
           "require_exact_branch": true,
           "require_repository": true,
           "task_artifact_fallback_requires_single_attempt": true
         },
+        "pull_request_observations": [],
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run.",
-          "Successful execution attempt is missing branch identity for the current run.",
-          "Successful execution attempt is missing commit SHA for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
-        "retryable": true,
+        "retryable": false,
+        "rule_failures": [
+          {
+            "message": "Successful execution attempt is missing branch identity for the current run.",
+            "rule": "missing_branch_identity"
+          }
+        ],
         "status": "invalid",
-        "validated_at": "2026-04-06T15:28:46.349648Z",
+        "validated_at": "2026-04-11T16:04:28.933135Z",
         "validated_by": "execution_validation"
       },
-      "latest_dispatch_origin": "automatic",
-      "latest_status": "completed",
-      "retry_count": 1,
+      "latest_dispatch_origin": null,
+      "latest_status": "succeeded",
+      "retry_count": 0,
       "retry_eligible": false,
-      "total_attempts": 3
+      "total_attempts": 2
     },
     "extensions": {},
     "failure_summary": {
-      "evaluation_id": "4331a2a9-241f-4407-889d-0d7f5910ec84",
-      "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
+      "evaluation_id": "6ca68aac-1160-4cef-82e9-4cca94a995c8",
+      "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
       "failure_source": "executor",
-      "failure_type": "invalid_execution_attempt",
-      "recorded_at": "2026-04-06T15:28:46.422509Z",
+      "failure_type": "contract_violation",
+      "recorded_at": "2026-04-11T16:04:28.936965Z",
       "recoverable": false,
-      "state": "failed",
+      "state": "terminal",
       "terminal": true
     },
     "lifecycle_history": [
       {
-        "changed_at": "2026-04-06T15:28:46.389386Z",
+        "changed_at": "2026-04-11T16:04:28.935026Z",
         "changed_by": "verification",
         "from_status": "executing",
-        "reason": "Successful execution attempt is missing repository identity for the current run.",
+        "reason": "Successful execution attempt is missing branch identity for the current run.",
         "to_status": "failed"
       }
     ],
@@ -214,9 +173,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-184-scenario-c",
@@ -247,25 +208,35 @@
           "attempt_validation": {
             "context_observations": {
               "commit_resolution_pending": false,
+              "has_valid_current_run_pull_request_artifact": false,
               "used_task_artifact_fallback": false
             },
-            "failure_type": "invalid_execution_attempt",
+            "failure_type": "contract_violation",
             "policy": {
               "allow_commit_resolution_via_reconciliation": true,
+              "allow_missing_commit_artifact_with_verified_pull_request": true,
               "allow_missing_pull_request": true,
+              "reject_closed_or_historical_pull_request": true,
+              "reject_non_numeric_pull_request_url": true,
+              "reject_reserved_shared_branch": true,
               "require_commit": true,
               "require_exact_branch": true,
               "require_repository": true,
               "task_artifact_fallback_requires_single_attempt": true
             },
+            "pull_request_observations": [],
             "reasons": [
-              "Successful execution attempt is missing repository identity for the current run.",
-              "Successful execution attempt is missing branch identity for the current run.",
-              "Successful execution attempt is missing commit SHA for the current run."
+              "Successful execution attempt is missing branch identity for the current run."
             ],
-            "retryable": true,
+            "retryable": false,
+            "rule_failures": [
+              {
+                "message": "Successful execution attempt is missing branch identity for the current run.",
+                "rule": "missing_branch_identity"
+              }
+            ],
             "status": "invalid",
-            "validated_at": "2026-04-06T15:28:46.343141Z",
+            "validated_at": "2026-04-11T16:04:28.933135Z",
             "validated_by": "execution_validation"
           },
           "completion_claim_id": "claim-kno-184-scenario-c",
@@ -280,256 +251,49 @@
       },
       {
         "details": {
-          "attempt_number": 1,
-          "is_final_attempt": true,
-          "max_retries": 1,
-          "scheduled_at": "2026-04-06T15:28:46.344064Z",
-          "triggered_by_category": "invalid_execution_attempt",
-          "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-        },
-        "event_id": "task-kno-184-scenario-c:retry-scheduled:a69bc9e7-831c-426e-b788-28057dbdeb15",
-        "event_type": "retry_scheduled",
-        "occurred_at": "2026-04-06T15:28:46.344064Z",
-        "source": "harness",
-        "summary": "Retry scheduled: attempt 1"
-      },
-      {
-        "details": {
-          "attempt_number": 1,
-          "is_final_attempt": true,
-          "max_retries": 1,
-          "scheduled_at": "2026-04-06T15:28:46.344064Z",
-          "triggered_by_category": "invalid_execution_attempt",
-          "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-        },
-        "event_id": "task-kno-184-scenario-c:retry-started:a69bc9e7-831c-426e-b788-28057dbdeb15",
-        "event_type": "retry_attempt_started",
-        "occurred_at": "2026-04-06T15:28:46.344064Z",
-        "source": "harness",
-        "summary": "Retry attempt started: attempt 1"
-      },
-      {
-        "details": {
           "accepted_completion": false,
           "action": "no_op",
-          "evaluation_id": "a69bc9e7-831c-426e-b788-28057dbdeb15",
+          "evaluation_id": "8a5f3d70-fd9c-4eb5-a82c-4d62a30d6fee",
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
           "reconciliation_result": null,
           "requires_review": false,
           "target_status": null,
           "verification_result": null
         },
-        "event_id": "task-kno-184-scenario-c:evaluation:a69bc9e7-831c-426e-b788-28057dbdeb15",
+        "event_id": "task-kno-184-scenario-c:evaluation:8a5f3d70-fd9c-4eb5-a82c-4d62a30d6fee",
         "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-06T15:28:46.344300Z",
+        "occurred_at": "2026-04-11T16:04:28.933276Z",
         "source": "harness",
         "summary": "Evaluation recorded: no_op"
       },
       {
         "details": {
-          "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
+          "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
           "failure_recorded": true,
           "failure_source": "executor",
-          "failure_type": "invalid_execution_attempt",
-          "recoverable": true,
-          "terminal": false
-        },
-        "event_id": "task-kno-184-scenario-c:failure:a69bc9e7-831c-426e-b788-28057dbdeb15",
-        "event_type": "failure_recorded",
-        "occurred_at": "2026-04-06T15:28:46.344300Z",
-        "source": "executor",
-        "summary": "Failure recorded: invalid_execution_attempt"
-      },
-      {
-        "details": {
-          "action": "no_op",
-          "attempt_number": 1,
-          "failure_classification": {
-            "category": "invalid_execution_attempt",
-            "failure_type": "invalid_execution_attempt",
-            "reason": "Successful execution attempt is missing repository identity for the current run.",
-            "recoverable": true,
-            "retryable": true,
-            "source": "executor",
-            "terminal": false
-          },
-          "is_final_attempt": true,
-          "max_retries": 1,
-          "scheduled_at": "2026-04-06T15:28:46.344064Z",
-          "triggered_by_category": "invalid_execution_attempt",
-          "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-        },
-        "event_id": "task-kno-184-scenario-c:retry-completed:a69bc9e7-831c-426e-b788-28057dbdeb15",
-        "event_type": "retry_attempt_completed",
-        "occurred_at": "2026-04-06T15:28:46.344300Z",
-        "source": "harness",
-        "summary": "Retry attempt completed: attempt 1"
-      },
-      {
-        "details": {
-          "event_id": "attempt-2:started",
-          "event_type": "execution_started",
-          "metadata": {
-            "adapter": "stub-executor",
-            "mode": "stub"
-          },
-          "occurred_at": "2026-04-06T15:28:46.348407Z",
-          "source_system": "stub-executor"
-        },
-        "event_id": "task-kno-184-scenario-c:execution_event:attempt-2:0",
-        "event_type": "execution_event_recorded",
-        "occurred_at": "2026-04-06T15:28:46.348407Z",
-        "source": "codex",
-        "summary": "Execution event: execution_started"
-      },
-      {
-        "details": {
-          "event_id": "attempt-2:completed",
-          "event_type": "execution_succeeded",
-          "metadata": {
-            "adapter": "stub-executor",
-            "executor_run_id": "stub-run-attempt-2"
-          },
-          "occurred_at": "2026-04-06T15:28:46.348422Z",
-          "source_system": "stub-executor"
-        },
-        "event_id": "task-kno-184-scenario-c:execution_event:attempt-2:1",
-        "event_type": "execution_event_recorded",
-        "occurred_at": "2026-04-06T15:28:46.348422Z",
-        "source": "codex",
-        "summary": "Execution event: execution_succeeded"
-      },
-      {
-        "details": {
-          "artifact_type": "execution_log",
-          "commit_sha": null,
-          "external_id": null,
-          "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-          "metadata": {
-            "advisory": true
-          },
-          "reference_id": "attempt-2:log"
-        },
-        "event_id": "task-kno-184-scenario-c:execution_artifact:attempt-2:attempt-2:log",
-        "event_type": "execution_artifact_attached",
-        "occurred_at": "2026-04-06T15:28:46.348583Z",
-        "source": "codex",
-        "summary": "Execution artifact attached: execution_log"
-      },
-      {
-        "details": {
-          "artifact_references": [
-            {
-              "artifact_type": "execution_log",
-              "commit_sha": null,
-              "external_id": null,
-              "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-              "metadata": {
-                "advisory": true
-              },
-              "reference_id": "attempt-2:log"
-            }
-          ],
-          "attempt_id": "attempt-2",
-          "attempt_validation": {
-            "context_observations": {
-              "commit_resolution_pending": false,
-              "used_task_artifact_fallback": false
-            },
-            "failure_type": "invalid_execution_attempt",
-            "policy": {
-              "allow_commit_resolution_via_reconciliation": true,
-              "allow_missing_pull_request": true,
-              "require_commit": true,
-              "require_exact_branch": true,
-              "require_repository": true,
-              "task_artifact_fallback_requires_single_attempt": true
-            },
-            "reasons": [
-              "Successful execution attempt is missing repository identity for the current run.",
-              "Successful execution attempt is missing branch identity for the current run.",
-              "Successful execution attempt is missing commit SHA for the current run."
-            ],
-            "retryable": true,
-            "status": "invalid",
-            "validated_at": "2026-04-06T15:28:46.349648Z",
-            "validated_by": "execution_validation"
-          },
-          "completion_claim_id": "attempt-2:claim",
-          "reevaluation": {},
-          "status": "completed"
-        },
-        "event_id": "task-kno-184-scenario-c:execution_attempt:attempt-2",
-        "event_type": "execution_attempt_recorded",
-        "occurred_at": "2026-04-06T15:28:46.348583Z",
-        "source": "codex",
-        "summary": "Execution attempt recorded: attempt-2"
-      },
-      {
-        "details": {
-          "attempt_id": "attempt-2",
-          "dispatch_id": "dispatch:task-kno-184-scenario-c:2",
-          "dispatch_mode": "automatic",
-          "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-          "dispatch_trigger": "invalid_execution_attempt_retry",
-          "execution_parameters": {
-            "prior_invalid_attempt_id": null
-          },
-          "executor": "codex"
-        },
-        "event_id": "task-kno-184-scenario-c:dispatch:dispatch:task-kno-184-scenario-c:2",
-        "event_type": "task_dispatched",
-        "occurred_at": "2026-04-06T15:28:46.348588Z",
-        "source": "codex",
-        "summary": "Task dispatched: attempt-2"
-      },
-      {
-        "details": {
-          "accepted_completion": false,
-          "action": "no_op",
-          "evaluation_id": "8b6bcab3-3de1-4c40-9063-1c3e176e1cbd",
-          "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
-          ],
-          "reconciliation_result": null,
-          "requires_review": false,
-          "target_status": null,
-          "verification_result": null
-        },
-        "event_id": "task-kno-184-scenario-c:evaluation:8b6bcab3-3de1-4c40-9063-1c3e176e1cbd",
-        "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-06T15:28:46.351263Z",
-        "source": "harness",
-        "summary": "Evaluation recorded: no_op"
-      },
-      {
-        "details": {
-          "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-          "failure_recorded": true,
-          "failure_source": "executor",
-          "failure_type": "invalid_execution_attempt",
+          "failure_type": "contract_violation",
           "recoverable": false,
           "terminal": true
         },
-        "event_id": "task-kno-184-scenario-c:failure:8b6bcab3-3de1-4c40-9063-1c3e176e1cbd",
+        "event_id": "task-kno-184-scenario-c:failure:8a5f3d70-fd9c-4eb5-a82c-4d62a30d6fee",
         "event_type": "failure_recorded",
-        "occurred_at": "2026-04-06T15:28:46.351263Z",
+        "occurred_at": "2026-04-11T16:04:28.933276Z",
         "source": "executor",
-        "summary": "Failure recorded: invalid_execution_attempt"
+        "summary": "Failure recorded: contract_violation"
       },
       {
         "details": {
-          "changed_at": "2026-04-06T15:28:46.389386Z",
+          "changed_at": "2026-04-11T16:04:28.935026Z",
           "changed_by": "verification",
           "from_status": "executing",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
           "to_status": "failed"
         },
         "event_id": "task-kno-184-scenario-c:status:0",
         "event_type": "status_transition",
-        "occurred_at": "2026-04-06T15:28:46.389386Z",
+        "occurred_at": "2026-04-11T16:04:28.935026Z",
         "source": "verification",
         "summary": "Status changed executing -> failed"
       },
@@ -537,41 +301,41 @@
         "details": {
           "accepted_completion": false,
           "action": "transition_applied",
-          "evaluation_id": "4331a2a9-241f-4407-889d-0d7f5910ec84",
+          "evaluation_id": "6ca68aac-1160-4cef-82e9-4cca94a995c8",
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
           "reconciliation_result": null,
           "requires_review": false,
           "target_status": "failed",
           "verification_result": null
         },
-        "event_id": "task-kno-184-scenario-c:evaluation:4331a2a9-241f-4407-889d-0d7f5910ec84",
+        "event_id": "task-kno-184-scenario-c:evaluation:6ca68aac-1160-4cef-82e9-4cca94a995c8",
         "event_type": "evaluation_recorded",
-        "occurred_at": "2026-04-06T15:28:46.422509Z",
+        "occurred_at": "2026-04-11T16:04:28.936965Z",
         "source": "harness",
         "summary": "Evaluation recorded: transition_applied"
       },
       {
         "details": {
-          "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
+          "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
           "failure_recorded": true,
           "failure_source": "executor",
-          "failure_type": "invalid_execution_attempt",
+          "failure_type": "contract_violation",
           "recoverable": false,
           "terminal": true
         },
-        "event_id": "task-kno-184-scenario-c:failure:4331a2a9-241f-4407-889d-0d7f5910ec84",
+        "event_id": "task-kno-184-scenario-c:failure:6ca68aac-1160-4cef-82e9-4cca94a995c8",
         "event_type": "failure_recorded",
-        "occurred_at": "2026-04-06T15:28:46.422509Z",
+        "occurred_at": "2026-04-11T16:04:28.936965Z",
         "source": "executor",
-        "summary": "Failure recorded: invalid_execution_attempt"
+        "summary": "Failure recorded: contract_violation"
       }
     ],
     "timestamps": {
       "completed_at": null,
       "created_at": "2026-04-06T00:00:00Z",
-      "updated_at": "2026-04-06T15:28:46.389386Z"
+      "updated_at": "2026-04-11T16:04:28.935026Z"
     },
     "title": "KNO-184 scenario C validation",
     "verification_summary": null

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-c-read-model-initial.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-c-read-model-initial.json
@@ -5,6 +5,7 @@
       "executor_id": "executor-kno-184-scenario-c",
       "executor_type": "codex"
     },
+    "clarification_summary": null,
     "coordination_summary": {
       "linear": null
     },
@@ -74,9 +75,11 @@
       "decision_count": 0,
       "decisions": [],
       "latest_decision": null,
+      "latest_effective_decision": null,
       "latest_request": null,
       "request_count": 0,
       "requests": [],
+      "resolved_decision_count": 0,
       "status": "none"
     },
     "task_id": "task-kno-184-scenario-c",

--- a/docs/demo/kno-184-missing-commit-recovery-validation/scenario-c-timeline-final.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/scenario-c-timeline-final.json
@@ -1,6 +1,6 @@
 {
   "current_status": "failed",
-  "event_count": 17,
+  "event_count": 7,
   "task_id": "task-kno-184-scenario-c",
   "timeline": [
     {
@@ -29,25 +29,35 @@
         "attempt_validation": {
           "context_observations": {
             "commit_resolution_pending": false,
+            "has_valid_current_run_pull_request_artifact": false,
             "used_task_artifact_fallback": false
           },
-          "failure_type": "invalid_execution_attempt",
+          "failure_type": "contract_violation",
           "policy": {
             "allow_commit_resolution_via_reconciliation": true,
+            "allow_missing_commit_artifact_with_verified_pull_request": true,
             "allow_missing_pull_request": true,
+            "reject_closed_or_historical_pull_request": true,
+            "reject_non_numeric_pull_request_url": true,
+            "reject_reserved_shared_branch": true,
             "require_commit": true,
             "require_exact_branch": true,
             "require_repository": true,
             "task_artifact_fallback_requires_single_attempt": true
           },
+          "pull_request_observations": [],
           "reasons": [
-            "Successful execution attempt is missing repository identity for the current run.",
-            "Successful execution attempt is missing branch identity for the current run.",
-            "Successful execution attempt is missing commit SHA for the current run."
+            "Successful execution attempt is missing branch identity for the current run."
           ],
-          "retryable": true,
+          "retryable": false,
+          "rule_failures": [
+            {
+              "message": "Successful execution attempt is missing branch identity for the current run.",
+              "rule": "missing_branch_identity"
+            }
+          ],
           "status": "invalid",
-          "validated_at": "2026-04-06T15:28:46.343141Z",
+          "validated_at": "2026-04-11T16:04:28.933135Z",
           "validated_by": "execution_validation"
         },
         "completion_claim_id": "claim-kno-184-scenario-c",
@@ -62,256 +72,49 @@
     },
     {
       "details": {
-        "attempt_number": 1,
-        "is_final_attempt": true,
-        "max_retries": 1,
-        "scheduled_at": "2026-04-06T15:28:46.344064Z",
-        "triggered_by_category": "invalid_execution_attempt",
-        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-      },
-      "event_id": "task-kno-184-scenario-c:retry-scheduled:a69bc9e7-831c-426e-b788-28057dbdeb15",
-      "event_type": "retry_scheduled",
-      "occurred_at": "2026-04-06T15:28:46.344064Z",
-      "source": "harness",
-      "summary": "Retry scheduled: attempt 1"
-    },
-    {
-      "details": {
-        "attempt_number": 1,
-        "is_final_attempt": true,
-        "max_retries": 1,
-        "scheduled_at": "2026-04-06T15:28:46.344064Z",
-        "triggered_by_category": "invalid_execution_attempt",
-        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-      },
-      "event_id": "task-kno-184-scenario-c:retry-started:a69bc9e7-831c-426e-b788-28057dbdeb15",
-      "event_type": "retry_attempt_started",
-      "occurred_at": "2026-04-06T15:28:46.344064Z",
-      "source": "harness",
-      "summary": "Retry attempt started: attempt 1"
-    },
-    {
-      "details": {
         "accepted_completion": false,
         "action": "no_op",
-        "evaluation_id": "a69bc9e7-831c-426e-b788-28057dbdeb15",
+        "evaluation_id": "8a5f3d70-fd9c-4eb5-a82c-4d62a30d6fee",
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
         "reconciliation_result": null,
         "requires_review": false,
         "target_status": null,
         "verification_result": null
       },
-      "event_id": "task-kno-184-scenario-c:evaluation:a69bc9e7-831c-426e-b788-28057dbdeb15",
+      "event_id": "task-kno-184-scenario-c:evaluation:8a5f3d70-fd9c-4eb5-a82c-4d62a30d6fee",
       "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-06T15:28:46.344300Z",
+      "occurred_at": "2026-04-11T16:04:28.933276Z",
       "source": "harness",
       "summary": "Evaluation recorded: no_op"
     },
     {
       "details": {
-        "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
+        "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
         "failure_recorded": true,
         "failure_source": "executor",
-        "failure_type": "invalid_execution_attempt",
-        "recoverable": true,
-        "terminal": false
-      },
-      "event_id": "task-kno-184-scenario-c:failure:a69bc9e7-831c-426e-b788-28057dbdeb15",
-      "event_type": "failure_recorded",
-      "occurred_at": "2026-04-06T15:28:46.344300Z",
-      "source": "executor",
-      "summary": "Failure recorded: invalid_execution_attempt"
-    },
-    {
-      "details": {
-        "action": "no_op",
-        "attempt_number": 1,
-        "failure_classification": {
-          "category": "invalid_execution_attempt",
-          "failure_type": "invalid_execution_attempt",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
-          "recoverable": true,
-          "retryable": true,
-          "source": "executor",
-          "terminal": false
-        },
-        "is_final_attempt": true,
-        "max_retries": 1,
-        "scheduled_at": "2026-04-06T15:28:46.344064Z",
-        "triggered_by_category": "invalid_execution_attempt",
-        "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-      },
-      "event_id": "task-kno-184-scenario-c:retry-completed:a69bc9e7-831c-426e-b788-28057dbdeb15",
-      "event_type": "retry_attempt_completed",
-      "occurred_at": "2026-04-06T15:28:46.344300Z",
-      "source": "harness",
-      "summary": "Retry attempt completed: attempt 1"
-    },
-    {
-      "details": {
-        "event_id": "attempt-2:started",
-        "event_type": "execution_started",
-        "metadata": {
-          "adapter": "stub-executor",
-          "mode": "stub"
-        },
-        "occurred_at": "2026-04-06T15:28:46.348407Z",
-        "source_system": "stub-executor"
-      },
-      "event_id": "task-kno-184-scenario-c:execution_event:attempt-2:0",
-      "event_type": "execution_event_recorded",
-      "occurred_at": "2026-04-06T15:28:46.348407Z",
-      "source": "codex",
-      "summary": "Execution event: execution_started"
-    },
-    {
-      "details": {
-        "event_id": "attempt-2:completed",
-        "event_type": "execution_succeeded",
-        "metadata": {
-          "adapter": "stub-executor",
-          "executor_run_id": "stub-run-attempt-2"
-        },
-        "occurred_at": "2026-04-06T15:28:46.348422Z",
-        "source_system": "stub-executor"
-      },
-      "event_id": "task-kno-184-scenario-c:execution_event:attempt-2:1",
-      "event_type": "execution_event_recorded",
-      "occurred_at": "2026-04-06T15:28:46.348422Z",
-      "source": "codex",
-      "summary": "Execution event: execution_succeeded"
-    },
-    {
-      "details": {
-        "artifact_type": "execution_log",
-        "commit_sha": null,
-        "external_id": null,
-        "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-        "metadata": {
-          "advisory": true
-        },
-        "reference_id": "attempt-2:log"
-      },
-      "event_id": "task-kno-184-scenario-c:execution_artifact:attempt-2:attempt-2:log",
-      "event_type": "execution_artifact_attached",
-      "occurred_at": "2026-04-06T15:28:46.348583Z",
-      "source": "codex",
-      "summary": "Execution artifact attached: execution_log"
-    },
-    {
-      "details": {
-        "artifact_references": [
-          {
-            "artifact_type": "execution_log",
-            "commit_sha": null,
-            "external_id": null,
-            "location": "stub://executions/task-kno-184-scenario-c/attempt-2/log",
-            "metadata": {
-              "advisory": true
-            },
-            "reference_id": "attempt-2:log"
-          }
-        ],
-        "attempt_id": "attempt-2",
-        "attempt_validation": {
-          "context_observations": {
-            "commit_resolution_pending": false,
-            "used_task_artifact_fallback": false
-          },
-          "failure_type": "invalid_execution_attempt",
-          "policy": {
-            "allow_commit_resolution_via_reconciliation": true,
-            "allow_missing_pull_request": true,
-            "require_commit": true,
-            "require_exact_branch": true,
-            "require_repository": true,
-            "task_artifact_fallback_requires_single_attempt": true
-          },
-          "reasons": [
-            "Successful execution attempt is missing repository identity for the current run.",
-            "Successful execution attempt is missing branch identity for the current run.",
-            "Successful execution attempt is missing commit SHA for the current run."
-          ],
-          "retryable": true,
-          "status": "invalid",
-          "validated_at": "2026-04-06T15:28:46.349648Z",
-          "validated_by": "execution_validation"
-        },
-        "completion_claim_id": "attempt-2:claim",
-        "reevaluation": {},
-        "status": "completed"
-      },
-      "event_id": "task-kno-184-scenario-c:execution_attempt:attempt-2",
-      "event_type": "execution_attempt_recorded",
-      "occurred_at": "2026-04-06T15:28:46.348583Z",
-      "source": "codex",
-      "summary": "Execution attempt recorded: attempt-2"
-    },
-    {
-      "details": {
-        "attempt_id": "attempt-2",
-        "dispatch_id": "dispatch:task-kno-184-scenario-c:2",
-        "dispatch_mode": "automatic",
-        "dispatch_reason": "Successful execution attempt is missing repository identity for the current run.",
-        "dispatch_trigger": "invalid_execution_attempt_retry",
-        "execution_parameters": {
-          "prior_invalid_attempt_id": null
-        },
-        "executor": "codex"
-      },
-      "event_id": "task-kno-184-scenario-c:dispatch:dispatch:task-kno-184-scenario-c:2",
-      "event_type": "task_dispatched",
-      "occurred_at": "2026-04-06T15:28:46.348588Z",
-      "source": "codex",
-      "summary": "Task dispatched: attempt-2"
-    },
-    {
-      "details": {
-        "accepted_completion": false,
-        "action": "no_op",
-        "evaluation_id": "8b6bcab3-3de1-4c40-9063-1c3e176e1cbd",
-        "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
-        ],
-        "reconciliation_result": null,
-        "requires_review": false,
-        "target_status": null,
-        "verification_result": null
-      },
-      "event_id": "task-kno-184-scenario-c:evaluation:8b6bcab3-3de1-4c40-9063-1c3e176e1cbd",
-      "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-06T15:28:46.351263Z",
-      "source": "harness",
-      "summary": "Evaluation recorded: no_op"
-    },
-    {
-      "details": {
-        "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
-        "failure_recorded": true,
-        "failure_source": "executor",
-        "failure_type": "invalid_execution_attempt",
+        "failure_type": "contract_violation",
         "recoverable": false,
         "terminal": true
       },
-      "event_id": "task-kno-184-scenario-c:failure:8b6bcab3-3de1-4c40-9063-1c3e176e1cbd",
+      "event_id": "task-kno-184-scenario-c:failure:8a5f3d70-fd9c-4eb5-a82c-4d62a30d6fee",
       "event_type": "failure_recorded",
-      "occurred_at": "2026-04-06T15:28:46.351263Z",
+      "occurred_at": "2026-04-11T16:04:28.933276Z",
       "source": "executor",
-      "summary": "Failure recorded: invalid_execution_attempt"
+      "summary": "Failure recorded: contract_violation"
     },
     {
       "details": {
-        "changed_at": "2026-04-06T15:28:46.389386Z",
+        "changed_at": "2026-04-11T16:04:28.935026Z",
         "changed_by": "verification",
         "from_status": "executing",
-        "reason": "Successful execution attempt is missing repository identity for the current run.",
+        "reason": "Successful execution attempt is missing branch identity for the current run.",
         "to_status": "failed"
       },
       "event_id": "task-kno-184-scenario-c:status:0",
       "event_type": "status_transition",
-      "occurred_at": "2026-04-06T15:28:46.389386Z",
+      "occurred_at": "2026-04-11T16:04:28.935026Z",
       "source": "verification",
       "summary": "Status changed executing -> failed"
     },
@@ -319,35 +122,35 @@
       "details": {
         "accepted_completion": false,
         "action": "transition_applied",
-        "evaluation_id": "4331a2a9-241f-4407-889d-0d7f5910ec84",
+        "evaluation_id": "6ca68aac-1160-4cef-82e9-4cca94a995c8",
         "reasons": [
-          "Successful execution attempt is missing repository identity for the current run."
+          "Successful execution attempt is missing branch identity for the current run."
         ],
         "reconciliation_result": null,
         "requires_review": false,
         "target_status": "failed",
         "verification_result": null
       },
-      "event_id": "task-kno-184-scenario-c:evaluation:4331a2a9-241f-4407-889d-0d7f5910ec84",
+      "event_id": "task-kno-184-scenario-c:evaluation:6ca68aac-1160-4cef-82e9-4cca94a995c8",
       "event_type": "evaluation_recorded",
-      "occurred_at": "2026-04-06T15:28:46.422509Z",
+      "occurred_at": "2026-04-11T16:04:28.936965Z",
       "source": "harness",
       "summary": "Evaluation recorded: transition_applied"
     },
     {
       "details": {
-        "failure_reason": "Successful execution attempt is missing repository identity for the current run.",
+        "failure_reason": "Successful execution attempt is missing branch identity for the current run.",
         "failure_recorded": true,
         "failure_source": "executor",
-        "failure_type": "invalid_execution_attempt",
+        "failure_type": "contract_violation",
         "recoverable": false,
         "terminal": true
       },
-      "event_id": "task-kno-184-scenario-c:failure:4331a2a9-241f-4407-889d-0d7f5910ec84",
+      "event_id": "task-kno-184-scenario-c:failure:6ca68aac-1160-4cef-82e9-4cca94a995c8",
       "event_type": "failure_recorded",
-      "occurred_at": "2026-04-06T15:28:46.422509Z",
+      "occurred_at": "2026-04-11T16:04:28.936965Z",
       "source": "executor",
-      "summary": "Failure recorded: invalid_execution_attempt"
+      "summary": "Failure recorded: contract_violation"
     }
   ]
 }

--- a/docs/demo/kno-184-missing-commit-recovery-validation/summary.json
+++ b/docs/demo/kno-184-missing-commit-recovery-validation/summary.json
@@ -10,11 +10,11 @@
     {
       "actual": {
         "action": "transition_applied",
-        "branch_head_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "branch_head_commit_sha": null,
         "claim_status": 200,
         "final_decision": {
-          "reason": "no_valid_existing_candidate",
-          "result": "created_new"
+          "reason": "verified_pull_request_proof_and_commit_resolved",
+          "result": "attached_commit_artifact"
         },
         "invalid_execution_attempt_present": false,
         "resolved_commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -23,11 +23,11 @@
       "checks": {
         "action_transition_applied": true,
         "attempt_resolved": true,
-        "branch_head_recovered": true,
         "claim_http_200": true,
         "commit_sha_recovered": true,
         "not_invalid_execution_attempt": true,
         "read_model_http_200": true,
+        "task_blocked_pending_pr_recovery": true,
         "timeline_http_200": true
       },
       "construction": "Branch-only reconciliation task with commit context removed from completion claim; fake GitHub gateway returns branch head SHA.",
@@ -36,28 +36,29 @@
         "invalid_execution_attempt": false,
         "recovery_attempted": true,
         "recovery_succeeds": true,
-        "result": "transition_applied"
+        "result": "transition_applied",
+        "task_status": "blocked"
       },
       "matched_expectation": true,
       "scenario": "A"
     },
     {
       "actual": {
-        "action": "reconciliation_failed",
+        "action": "reconciliation_terminal_failed",
         "branch_head_commit_sha": null,
         "claim_status": 200,
         "error": "Commit SHA is required for missing_pr_after_execution reconciliation and could not be resolved from the branch head",
         "invalid_execution_attempt_present": false,
-        "task_status": "in_review"
+        "task_status": "failed"
       },
       "checks": {
-        "action_reconciliation_failed": true,
+        "action_reconciliation_terminal_failed": true,
         "branch_head_unresolved": true,
         "claim_http_200": true,
         "not_invalid_execution_attempt": true,
         "read_model_http_200": true,
         "recovery_attempted": true,
-        "task_in_review": true,
+        "task_failed": true,
         "timeline_http_200": true
       },
       "construction": "Branch-only reconciliation task with commit context removed from completion claim; fake GitHub gateway returns no branch head SHA.",
@@ -66,560 +67,44 @@
         "invalid_execution_attempt": false,
         "recovery_attempted": true,
         "recovery_succeeds": false,
-        "result": "reconciliation_failed"
+        "result": "reconciliation_terminal_failed",
+        "task_status": "failed"
       },
       "matched_expectation": true,
       "scenario": "B"
     },
     {
       "actual": {
-        "action": "invalid_execution_attempt_failed",
+        "action": "contract_violation_failed",
         "claim_status": 200,
         "failure_classification": {
-          "category": "invalid_execution_attempt",
-          "failure_type": "invalid_execution_attempt",
-          "reason": "Successful execution attempt is missing repository identity for the current run.",
+          "category": "contract_violation",
+          "failure_type": "contract_violation",
+          "reason": "Successful execution attempt is missing branch identity for the current run.",
           "recoverable": false,
           "retryable": false,
           "source": "executor",
           "terminal": true
         },
-        "invalid_execution_attempt": {
-          "evaluation_record": {
-            "evaluation_id": "a69bc9e7-831c-426e-b788-28057dbdeb15",
-            "recorded_at": "2026-04-06T15:28:46.344300Z",
-            "request": {
-              "acceptance_criteria_satisfied": false,
-              "claimed_completion": true,
-              "external_facts": null,
-              "retry_context": {
-                "attempt_number": 1,
-                "is_final_attempt": true,
-                "max_retries": 1,
-                "scheduled_at": "2026-04-06T15:28:46.344064Z",
-                "triggered_by_category": "invalid_execution_attempt",
-                "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-              },
-              "review_decision": null,
-              "review_is_active": false,
-              "review_reasons": [],
-              "review_request": null,
-              "runtime_facts": {
-                "attempt_count": 1,
-                "executor_reported_failure": false,
-                "executor_reported_success": true,
-                "latest_attempt_outcome": null,
-                "terminal_failure": false
-              },
-              "task_envelope": {
-                "acceptance_criteria": [
-                  {
-                    "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
-                    "id": "ac-1",
-                    "required": true
-                  }
-                ],
-                "artifacts": {
-                  "completion_evidence": {
-                    "notes": null,
-                    "policy": "deferred",
-                    "required_artifact_types": [],
-                    "status": "deferred",
-                    "validated_artifact_ids": [],
-                    "validated_at": null,
-                    "validation_method": "deferred",
-                    "validator": null
-                  },
-                  "items": []
-                },
-                "assigned_executor": {
-                  "assignment_reason": "Validate invalid execution attempt boundary.",
-                  "executor_id": "executor-kno-184-scenario-c",
-                  "executor_type": "codex"
-                },
-                "child_task_ids": [],
-                "constraints": [],
-                "coordination": {
-                  "linear": null
-                },
-                "dependencies": [],
-                "description": "Validate invalid execution attempt boundary remains enforced.",
-                "id": "task-kno-184-scenario-c",
-                "objective": {
-                  "deliverable_type": "unspecified",
-                  "success_signal": "Task satisfies declared acceptance criteria.",
-                  "summary": "Validate invalid execution attempt boundary remains enforced."
-                },
-                "observability": {
-                  "errors": [],
-                  "execution_metadata": {
-                    "advisory_completion_claims": [
-                      {
-                        "claim_id": "claim-kno-184-scenario-c",
-                        "metadata": {},
-                        "reason": "executor reported completion",
-                        "reported_at": "2026-04-06T00:01:00Z",
-                        "reported_by": "codex"
-                      }
-                    ],
-                    "execution_attempts": [
-                      {
-                        "artifact_references": [],
-                        "attempt_id": "attempt-kno-184-scenario-c",
-                        "completion_claim_id": "claim-kno-184-scenario-c",
-                        "metadata": {
-                          "attempt_validation": {
-                            "context_observations": {
-                              "commit_resolution_pending": false,
-                              "used_task_artifact_fallback": false
-                            },
-                            "failure_type": "invalid_execution_attempt",
-                            "policy": {
-                              "allow_commit_resolution_via_reconciliation": true,
-                              "allow_missing_pull_request": true,
-                              "require_commit": true,
-                              "require_exact_branch": true,
-                              "require_repository": true,
-                              "task_artifact_fallback_requires_single_attempt": true
-                            },
-                            "reasons": [
-                              "Successful execution attempt is missing repository identity for the current run.",
-                              "Successful execution attempt is missing branch identity for the current run.",
-                              "Successful execution attempt is missing commit SHA for the current run."
-                            ],
-                            "retryable": true,
-                            "status": "invalid",
-                            "validated_at": "2026-04-06T15:28:46.343141Z",
-                            "validated_by": "execution_validation"
-                          },
-                          "executor_run_id": "run-kno-184-scenario-c"
-                        },
-                        "recorded_at": "2026-04-06T00:01:01Z",
-                        "reevaluation": {},
-                        "reported_by": "codex",
-                        "status": "succeeded"
-                      }
-                    ],
-                    "schema_required_deferred_fields": [
-                      "parent_task_id",
-                      "child_task_ids",
-                      "dependencies",
-                      "assigned_executor",
-                      "required_capabilities",
-                      "priority",
-                      "artifacts.items",
-                      "artifacts.completion_evidence",
-                      "observability"
-                    ]
-                  },
-                  "retries": {
-                    "attempt_count": 0,
-                    "last_retry_at": null,
-                    "max_attempts": 0
-                  }
-                },
-                "origin": {
-                  "ingress_id": null,
-                  "ingress_name": null,
-                  "requested_by": null,
-                  "source_id": "KNO-184",
-                  "source_system": "linear",
-                  "source_type": "ingress_request"
-                },
-                "parent_task_id": null,
-                "priority": "normal",
-                "reconciliation": {
-                  "active_failure_type": null,
-                  "attempts": [],
-                  "failed_at": null,
-                  "last_attempt_id": null,
-                  "last_error": null,
-                  "last_pr_url": null,
-                  "resolved_at": null,
-                  "status": "not_required"
-                },
-                "required_capabilities": [],
-                "status": "executing",
-                "status_history": [],
-                "timestamps": {
-                  "completed_at": null,
-                  "created_at": "2026-04-06T00:00:00Z",
-                  "updated_at": "2026-04-06T15:28:46.343333Z"
-                },
-                "title": "KNO-184 scenario C validation"
-              },
-              "unresolved_conditions": []
-            },
-            "result": {
-              "accepted_completion": false,
-              "action": "no_op",
-              "enforcement_result": {
-                "action": "no_op",
-                "error": "Successful execution attempt is missing repository identity for the current run.",
-                "evidence_result": null,
-                "failure_classification": {
-                  "category": "invalid_execution_attempt",
-                  "failure_type": "invalid_execution_attempt",
-                  "reason": "Successful execution attempt is missing repository identity for the current run.",
-                  "recoverable": true,
-                  "retryable": true,
-                  "source": "executor",
-                  "terminal": false
-                },
-                "reasons": [
-                  "Successful execution attempt is missing repository identity for the current run."
-                ],
-                "reconciliation_result": null,
-                "review_decision": null,
-                "review_request": null,
-                "target_status": null,
-                "task_envelope": {
-                  "acceptance_criteria": [
-                    {
-                      "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
-                      "id": "ac-1",
-                      "required": true
-                    }
-                  ],
-                  "artifacts": {
-                    "completion_evidence": {
-                      "notes": null,
-                      "policy": "deferred",
-                      "required_artifact_types": [],
-                      "status": "deferred",
-                      "validated_artifact_ids": [],
-                      "validated_at": null,
-                      "validation_method": "deferred",
-                      "validator": null
-                    },
-                    "items": []
-                  },
-                  "assigned_executor": {
-                    "assignment_reason": "Validate invalid execution attempt boundary.",
-                    "executor_id": "executor-kno-184-scenario-c",
-                    "executor_type": "codex"
-                  },
-                  "child_task_ids": [],
-                  "constraints": [],
-                  "coordination": {
-                    "linear": null
-                  },
-                  "dependencies": [],
-                  "description": "Validate invalid execution attempt boundary remains enforced.",
-                  "id": "task-kno-184-scenario-c",
-                  "objective": {
-                    "deliverable_type": "unspecified",
-                    "success_signal": "Task satisfies declared acceptance criteria.",
-                    "summary": "Validate invalid execution attempt boundary remains enforced."
-                  },
-                  "observability": {
-                    "errors": [],
-                    "execution_metadata": {
-                      "advisory_completion_claims": [
-                        {
-                          "claim_id": "claim-kno-184-scenario-c",
-                          "metadata": {},
-                          "reason": "executor reported completion",
-                          "reported_at": "2026-04-06T00:01:00Z",
-                          "reported_by": "codex"
-                        }
-                      ],
-                      "execution_attempts": [
-                        {
-                          "artifact_references": [],
-                          "attempt_id": "attempt-kno-184-scenario-c",
-                          "completion_claim_id": "claim-kno-184-scenario-c",
-                          "metadata": {
-                            "attempt_validation": {
-                              "context_observations": {
-                                "commit_resolution_pending": false,
-                                "used_task_artifact_fallback": false
-                              },
-                              "failure_type": "invalid_execution_attempt",
-                              "policy": {
-                                "allow_commit_resolution_via_reconciliation": true,
-                                "allow_missing_pull_request": true,
-                                "require_commit": true,
-                                "require_exact_branch": true,
-                                "require_repository": true,
-                                "task_artifact_fallback_requires_single_attempt": true
-                              },
-                              "reasons": [
-                                "Successful execution attempt is missing repository identity for the current run.",
-                                "Successful execution attempt is missing branch identity for the current run.",
-                                "Successful execution attempt is missing commit SHA for the current run."
-                              ],
-                              "retryable": true,
-                              "status": "invalid",
-                              "validated_at": "2026-04-06T15:28:46.343141Z",
-                              "validated_by": "execution_validation"
-                            },
-                            "executor_run_id": "run-kno-184-scenario-c"
-                          },
-                          "recorded_at": "2026-04-06T00:01:01Z",
-                          "reevaluation": {},
-                          "reported_by": "codex",
-                          "status": "succeeded"
-                        }
-                      ],
-                      "schema_required_deferred_fields": [
-                        "parent_task_id",
-                        "child_task_ids",
-                        "dependencies",
-                        "assigned_executor",
-                        "required_capabilities",
-                        "priority",
-                        "artifacts.items",
-                        "artifacts.completion_evidence",
-                        "observability"
-                      ]
-                    },
-                    "retries": {
-                      "attempt_count": 0,
-                      "last_retry_at": null,
-                      "max_attempts": 0
-                    }
-                  },
-                  "origin": {
-                    "ingress_id": null,
-                    "ingress_name": null,
-                    "requested_by": null,
-                    "source_id": "KNO-184",
-                    "source_system": "linear",
-                    "source_type": "ingress_request"
-                  },
-                  "parent_task_id": null,
-                  "priority": "normal",
-                  "reconciliation": {
-                    "active_failure_type": null,
-                    "attempts": [],
-                    "failed_at": null,
-                    "last_attempt_id": null,
-                    "last_error": null,
-                    "last_pr_url": null,
-                    "resolved_at": null,
-                    "status": "not_required"
-                  },
-                  "required_capabilities": [],
-                  "status": "executing",
-                  "status_history": [],
-                  "timestamps": {
-                    "completed_at": null,
-                    "created_at": "2026-04-06T00:00:00Z",
-                    "updated_at": "2026-04-06T15:28:46.343333Z"
-                  },
-                  "title": "KNO-184 scenario C validation"
-                },
-                "transition_result": null,
-                "verification_result": null
-              },
-              "error": "Successful execution attempt is missing repository identity for the current run.",
-              "failure_classification": {
-                "category": "invalid_execution_attempt",
-                "failure_type": "invalid_execution_attempt",
-                "reason": "Successful execution attempt is missing repository identity for the current run.",
-                "recoverable": true,
-                "retryable": true,
-                "source": "executor",
-                "terminal": false
-              },
-              "invalid_input": false,
-              "reasons": [
-                "Successful execution attempt is missing repository identity for the current run."
-              ],
-              "requires_review": false,
-              "target_status": null,
-              "task_envelope": {
-                "acceptance_criteria": [
-                  {
-                    "description": "invalid_execution_attempt remains enforced when execution identity is weak.",
-                    "id": "ac-1",
-                    "required": true
-                  }
-                ],
-                "artifacts": {
-                  "completion_evidence": {
-                    "notes": null,
-                    "policy": "deferred",
-                    "required_artifact_types": [],
-                    "status": "deferred",
-                    "validated_artifact_ids": [],
-                    "validated_at": null,
-                    "validation_method": "deferred",
-                    "validator": null
-                  },
-                  "items": []
-                },
-                "assigned_executor": {
-                  "assignment_reason": "Validate invalid execution attempt boundary.",
-                  "executor_id": "executor-kno-184-scenario-c",
-                  "executor_type": "codex"
-                },
-                "child_task_ids": [],
-                "constraints": [],
-                "coordination": {
-                  "linear": null
-                },
-                "dependencies": [],
-                "description": "Validate invalid execution attempt boundary remains enforced.",
-                "id": "task-kno-184-scenario-c",
-                "objective": {
-                  "deliverable_type": "unspecified",
-                  "success_signal": "Task satisfies declared acceptance criteria.",
-                  "summary": "Validate invalid execution attempt boundary remains enforced."
-                },
-                "observability": {
-                  "errors": [],
-                  "execution_metadata": {
-                    "advisory_completion_claims": [
-                      {
-                        "claim_id": "claim-kno-184-scenario-c",
-                        "metadata": {},
-                        "reason": "executor reported completion",
-                        "reported_at": "2026-04-06T00:01:00Z",
-                        "reported_by": "codex"
-                      }
-                    ],
-                    "execution_attempts": [
-                      {
-                        "artifact_references": [],
-                        "attempt_id": "attempt-kno-184-scenario-c",
-                        "completion_claim_id": "claim-kno-184-scenario-c",
-                        "metadata": {
-                          "attempt_validation": {
-                            "context_observations": {
-                              "commit_resolution_pending": false,
-                              "used_task_artifact_fallback": false
-                            },
-                            "failure_type": "invalid_execution_attempt",
-                            "policy": {
-                              "allow_commit_resolution_via_reconciliation": true,
-                              "allow_missing_pull_request": true,
-                              "require_commit": true,
-                              "require_exact_branch": true,
-                              "require_repository": true,
-                              "task_artifact_fallback_requires_single_attempt": true
-                            },
-                            "reasons": [
-                              "Successful execution attempt is missing repository identity for the current run.",
-                              "Successful execution attempt is missing branch identity for the current run.",
-                              "Successful execution attempt is missing commit SHA for the current run."
-                            ],
-                            "retryable": true,
-                            "status": "invalid",
-                            "validated_at": "2026-04-06T15:28:46.343141Z",
-                            "validated_by": "execution_validation"
-                          },
-                          "executor_run_id": "run-kno-184-scenario-c"
-                        },
-                        "recorded_at": "2026-04-06T00:01:01Z",
-                        "reevaluation": {},
-                        "reported_by": "codex",
-                        "status": "succeeded"
-                      }
-                    ],
-                    "schema_required_deferred_fields": [
-                      "parent_task_id",
-                      "child_task_ids",
-                      "dependencies",
-                      "assigned_executor",
-                      "required_capabilities",
-                      "priority",
-                      "artifacts.items",
-                      "artifacts.completion_evidence",
-                      "observability"
-                    ]
-                  },
-                  "retries": {
-                    "attempt_count": 0,
-                    "last_retry_at": null,
-                    "max_attempts": 0
-                  }
-                },
-                "origin": {
-                  "ingress_id": null,
-                  "ingress_name": null,
-                  "requested_by": null,
-                  "source_id": "KNO-184",
-                  "source_system": "linear",
-                  "source_type": "ingress_request"
-                },
-                "parent_task_id": null,
-                "priority": "normal",
-                "reconciliation": {
-                  "active_failure_type": null,
-                  "attempts": [],
-                  "failed_at": null,
-                  "last_attempt_id": null,
-                  "last_error": null,
-                  "last_pr_url": null,
-                  "resolved_at": null,
-                  "status": "not_required"
-                },
-                "required_capabilities": [],
-                "status": "executing",
-                "status_history": [],
-                "timestamps": {
-                  "completed_at": null,
-                  "created_at": "2026-04-06T00:00:00Z",
-                  "updated_at": "2026-04-06T15:28:46.343333Z"
-                },
-                "title": "KNO-184 scenario C validation"
-              }
-            },
-            "task_id": "task-kno-184-scenario-c"
-          },
-          "retry_context": {
-            "attempt_number": 1,
-            "is_final_attempt": true,
-            "max_retries": 1,
-            "scheduled_at": "2026-04-06T15:28:46.344064Z",
-            "triggered_by_category": "invalid_execution_attempt",
-            "triggered_by_reason": "Successful execution attempt is missing repository identity for the current run."
-          },
-          "status": "retry_scheduled",
-          "validation": {
-            "context_observations": {
-              "commit_resolution_pending": false,
-              "used_task_artifact_fallback": false
-            },
-            "failure_type": "invalid_execution_attempt",
-            "policy": {
-              "allow_commit_resolution_via_reconciliation": true,
-              "allow_missing_pull_request": true,
-              "require_commit": true,
-              "require_exact_branch": true,
-              "require_repository": true,
-              "task_artifact_fallback_requires_single_attempt": true
-            },
-            "reasons": [
-              "Successful execution attempt is missing repository identity for the current run.",
-              "Successful execution attempt is missing branch identity for the current run.",
-              "Successful execution attempt is missing commit SHA for the current run."
-            ],
-            "retryable": true,
-            "status": "invalid",
-            "validated_at": "2026-04-06T15:28:46.343141Z",
-            "validated_by": "execution_validation"
-          }
-        },
+        "invalid_execution_attempt": null,
         "task_status": "failed"
       },
       "checks": {
+        "action_contract_violation_failed": true,
         "claim_http_200": true,
-        "failure_type_invalid_execution_attempt": true,
-        "invalid_execution_attempt_present": true,
-        "missing_commit_reason_present": true,
-        "missing_repository_reason_present": true,
+        "failure_type_contract_violation": true,
+        "missing_branch_reason_present": true,
         "read_model_http_200": true,
+        "task_failed": true,
         "timeline_http_200": true
       },
       "construction": "Created an executing task with no trusted repo/branch artifacts; submitted a successful execution attempt without repository, branch, or commit identity.",
       "description": "Missing commit SHA with untrustworthy repository/branch identity",
       "expected": {
-        "invalid_execution_attempt": true,
+        "invalid_execution_attempt": false,
         "recovery_attempted": false,
-        "result": "blocked_by_invalid_execution_attempt"
+        "result": "contract_violation_failed",
+        "task_status": "failed"
       },
       "matched_expectation": true,
       "scenario": "C"

--- a/tests/test_demo_proof_bundles.py
+++ b/tests/test_demo_proof_bundles.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+class DemoProofBundleTests(unittest.TestCase):
+    def test_in_review_read_model_fixtures_hide_stale_assignment_and_show_active_review(self) -> None:
+        read_model_paths = sorted(Path("docs/demo").glob("**/*read-model-final.json"))
+        self.assertTrue(read_model_paths)
+
+        failures: list[str] = []
+        for path in read_model_paths:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            task = payload.get("task") or {}
+            if task.get("current_status") != "in_review":
+                continue
+
+            review_status = ((task.get("review_summary") or {}).get("status")) or "none"
+            assigned_executor = task.get("assigned_executor")
+
+            if review_status != "requested":
+                failures.append(f"{path}: expected review_summary.status=requested, found {review_status!r}")
+            if assigned_executor is not None:
+                failures.append(f"{path}: expected assigned_executor to be null while review gate is active")
+
+        self.assertFalse(failures, "\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
Refresh the demo proof bundles so the committed operator-facing artifacts match current Harness semantics instead of stale snapshots.

This PR:
- adds a real generator for `kno-181-invalid-execution-attempt-gate`
- regenerates the affected `kno-181`, `kno-183`, and `kno-184` proof bundles from current code
- adds a regression test that enforces the read-model invariant for active review gates in committed demo fixtures
- updates the proof docs where the current `main` behavior has evolved

## Why it changed
Harness cannot claim accountability if its own proof bundles drift away from the control-plane truth.

The concrete drift here was that one committed `in_review` read-model fixture still exposed a stale `assigned_executor` and no active review gate, even though the merged read-model semantics now hide stale assignments while a review gate is active.

## Impact
Operators and reviewers can trust the committed demo/proof artifacts again, and future drift in these bundles will be caught by test coverage instead of silently accumulating.

## Validation
- `python3 -m unittest tests.test_demo_proof_bundles`
- `python3 -m unittest discover -s tests`
