### PR TITLE
Order latest completion claims by reported timestamp

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -1811,7 +1811,16 @@ def _latest_advisory_completion_claim(task_envelope: dict[str, Any]) -> dict[str
     ) or []
     if not isinstance(claims, list):
         return None
-    return next((claim for claim in reversed(claims) if isinstance(claim, dict)), None)
+    dict_claims = [claim for claim in claims if isinstance(claim, dict)]
+    if not dict_claims:
+        return None
+    return max(
+        dict_claims,
+        key=lambda claim: (
+            _parse_iso_timestamp(str(claim.get("reported_at") or "")),
+            str(claim.get("claim_id") or ""),
+        ),
+    )
 
 
 def _advisory_completion_claim_by_id(task_envelope: dict[str, Any], claim_id: str | None) -> dict[str, Any] | None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,15 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from modules.adapters.executor_adapter import ExecutorDispatchOutput, StubExecutorAdapter
-from modules.api import HarnessApiService, _latest_execution_attempt, build_parser, evaluate_http_payload, run_server
+from modules.api import (
+    HarnessApiService,
+    _execution_attempt_for_completion_claim,
+    _latest_advisory_completion_claim,
+    _latest_execution_attempt,
+    build_parser,
+    evaluate_http_payload,
+    run_server,
+)
 from modules.contracts.execution_advisory import (
     AdvisoryCompletionClaim,
     ArtifactReference,
@@ -86,6 +94,72 @@ class LatestExecutionAttemptTests(unittest.TestCase):
         }
 
         attempt = _latest_execution_attempt(task)
+
+        self.assertIsNotNone(attempt)
+        self.assertEqual(attempt["attempt_id"], "attempt-newer")
+
+
+class LatestAdvisoryCompletionClaimTests(unittest.TestCase):
+    def test_latest_advisory_completion_claim_uses_newest_reported_at_when_out_of_order(self) -> None:
+        task = {
+            "observability": {
+                "execution_metadata": {
+                    "advisory_completion_claims": [
+                        {
+                            "claim_id": "claim-newer",
+                            "reported_at": "2026-04-11T09:10:05Z",
+                            "metadata": {"attempt_id": "attempt-newer"},
+                        },
+                        {
+                            "claim_id": "claim-older",
+                            "reported_at": "2026-04-11T09:05:05Z",
+                            "metadata": {"attempt_id": "attempt-older"},
+                        },
+                    ]
+                }
+            }
+        }
+
+        claim = _latest_advisory_completion_claim(task)
+
+        self.assertIsNotNone(claim)
+        self.assertEqual(claim["claim_id"], "claim-newer")
+
+    def test_execution_attempt_for_completion_claim_uses_latest_claim_by_reported_at(self) -> None:
+        task = {
+            "observability": {
+                "execution_metadata": {
+                    "advisory_completion_claims": [
+                        {
+                            "claim_id": "claim-newer",
+                            "reported_at": "2026-04-11T09:10:05Z",
+                            "metadata": {"attempt_id": "attempt-newer"},
+                        },
+                        {
+                            "claim_id": "claim-older",
+                            "reported_at": "2026-04-11T09:05:05Z",
+                            "metadata": {"attempt_id": "attempt-older"},
+                        },
+                    ],
+                    "execution_attempts": [
+                        {
+                            "attempt_id": "attempt-newer",
+                            "completion_claim_id": "claim-newer",
+                            "recorded_at": "2026-04-11T09:10:05Z",
+                            "status": "completed",
+                        },
+                        {
+                            "attempt_id": "attempt-older",
+                            "completion_claim_id": "claim-older",
+                            "recorded_at": "2026-04-11T09:05:05Z",
+                            "status": "failed",
+                        },
+                    ],
+                }
+            }
+        }
+
+        attempt = _execution_attempt_for_completion_claim(task)
 
         self.assertIsNotNone(attempt)
         self.assertEqual(attempt["attempt_id"], "attempt-newer")


### PR DESCRIPTION
## Summary
- choose the latest advisory completion claim by `reported_at` instead of list position
- keep claim-to-attempt binding aligned with the newest canonical claim when claim order drifts
- add regressions covering out-of-order claim chronology and linked-attempt selection

## Validation
- python3 -m unittest tests.test_api.LatestAdvisoryCompletionClaimTests
- python3 -m unittest tests.test_api.LatestExecutionAttemptTests
- python3 -m unittest tests.e2e.test_control_plane_completion_replay_flows
- python3 -m unittest discover -s tests