### PR TITLE
Order reconciliation claims by reported timestamp

### DIFF
--- a/modules/reconciliation_runtime.py
+++ b/modules/reconciliation_runtime.py
@@ -730,7 +730,16 @@ def _current_completion_claim(task_envelope: TaskEnvelope) -> dict[str, Any] | N
     claims = execution_metadata.get("advisory_completion_claims") or []
     if not isinstance(claims, list):
         return None
-    return next((claim for claim in reversed(claims) if isinstance(claim, dict)), None)
+    valid_claims = [claim for claim in claims if isinstance(claim, dict)]
+    if not valid_claims:
+        return None
+    return max(
+        valid_claims,
+        key=lambda claim: (
+            _parse_iso_timestamp(str(claim.get("reported_at") or "")),
+            str(claim.get("claim_id") or ""),
+        ),
+    )
 
 
 def _parse_iso_timestamp(value: str | None):

--- a/tests/test_completion_claim_reconciliation.py
+++ b/tests/test_completion_claim_reconciliation.py
@@ -9,6 +9,8 @@ from modules.reconciliation_runtime import (
     ReconciliationFailureType,
     ReconciliationHandlerRegistry,
     RetryableReconciliationRuntimeError,
+    _current_completion_claim,
+    _current_execution_attempt,
     build_default_reconciliation_registry,
 )
 from modules.intake import create_task_envelope
@@ -513,6 +515,50 @@ class CompletionClaimReconciliationTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
+
+    def test_current_completion_claim_uses_newest_reported_at_when_claims_are_out_of_order(self) -> None:
+        task = _task_envelope(task_id="task-current-claim-order")
+        task = _record_execution_attempt(
+            task,
+            claim_id="claim-newer",
+            attempt_id="attempt-newer",
+            status="completed",
+            recorded_at="2026-04-11T09:10:05Z",
+        )
+        task = _record_execution_attempt(
+            task,
+            claim_id="claim-older",
+            attempt_id="attempt-older",
+            status="failed",
+            recorded_at="2026-04-11T09:05:05Z",
+        )
+
+        claim = _current_completion_claim(task)
+
+        self.assertIsNotNone(claim)
+        self.assertEqual(claim["claim_id"], "claim-newer")
+
+    def test_current_execution_attempt_uses_attempt_for_newest_claim_when_claims_are_out_of_order(self) -> None:
+        task = _task_envelope(task_id="task-current-attempt-order")
+        task = _record_execution_attempt(
+            task,
+            claim_id="claim-newer",
+            attempt_id="attempt-newer",
+            status="completed",
+            recorded_at="2026-04-11T09:10:05Z",
+        )
+        task = _record_execution_attempt(
+            task,
+            claim_id="claim-older",
+            attempt_id="attempt-older",
+            status="failed",
+            recorded_at="2026-04-11T09:05:05Z",
+        )
+
+        attempt = _current_execution_attempt(task)
+
+        self.assertIsNotNone(attempt)
+        self.assertEqual(attempt["attempt_id"], "attempt-newer")
 
     def test_submit_completion_claim_attaches_existing_open_pr_with_matching_branch_and_sha(self) -> None:
         gateway = _FakeGitHubGateway(


### PR DESCRIPTION
## Summary
- make reconciliation choose the current advisory completion claim by `reported_at` instead of append order
- keep current run linkage and attempt binding aligned with the newest canonical claim when claim order drifts
- add regressions covering out-of-order reconciliation claim and attempt selection

## Validation
- python3 -m unittest tests.test_completion_claim_reconciliation.CompletionClaimReconciliationTests.test_current_completion_claim_uses_newest_reported_at_when_claims_are_out_of_order tests.test_completion_claim_reconciliation.CompletionClaimReconciliationTests.test_current_execution_attempt_uses_attempt_for_newest_claim_when_claims_are_out_of_order
- python3 -m unittest tests.test_completion_claim_reconciliation.CompletionClaimReconciliationTests.test_submit_completion_claim_requires_run_linkage_when_multiple_attempts_exist tests.test_completion_claim_reconciliation.CompletionClaimReconciliationTests.test_submit_completion_claim_accepts_existing_candidate_with_matching_run_linkage_when_multiple_attempts_exist
- python3 -m unittest tests.e2e.test_control_plane_completion_replay_flows
- python3 -m unittest discover -s tests