### PR TITLE
feat: add openclaw supervision queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It does not trust agent-reported completion on its own. It accepts or blocks lif
 Harness is not a PM tool, an agent runtime, or a chatbot UI.
 OpenClaw ingress is also intentionally narrow. It can submit task intent, provenance, and planning-ready work into Harness, but it cannot declare `executing` or `completed`, inject executor runtime telemetry, or claim completion on initial handoff. If OpenClaw wants to hand work off as `planned`, it must provide explicit planning-grade objective fields plus a concrete `plan_summary`, and it cannot declare unresolved conditions at the same time. If OpenClaw also supplies parent/dependency/capability structure, that structure must be canonical and non-self-referential before Harness will persist it. If unresolved ambiguity still exists, Harness now converts that upstream signal into canonical clarification and blocks the task instead of letting vague work look ready. Execution and completion truth must still come back through executor/reporting paths that Harness can verify.
 
+On the inspection side, Harness now also exposes a canonical supervision queue at `GET /supervision/queue`. That queue is a read-only projection for OpenClaw-style supervisors: it surfaces tasks that currently need attention because they are in review, blocked on clarification, retryable, carrying invalid execution proof, or stale. It does not authorize actions on its own and it does not replace canonical reevaluation, dispatch, or completion-claim paths.
+
 The same boundary now applies to manual and Linear ingress. Those adapters may submit task intent, coordination metadata, and clarification blockers, but they cannot claim completion, assert acceptance, inject runtime facts, or attach repository execution artifacts such as PRs, commits, branches, or changed-file proofs on initial handoff.
 
 That same boundary now applies to the canonical `POST /tasks` and one-shot new-task `POST /evaluate` paths as well. A brand-new task may carry intent, planning state, support artifacts, and clarification blockers, but it may not arrive already carrying execution truth. If a caller tries to create a new task with claimed completion, runtime facts, prevalidated completion evidence, execution attempts, advisory completion claims, reconciliation history, assignment truth, or runtime/terminal lifecycle truth, Harness rejects the request as invalid input instead of storing a polluted task snapshot. Even when initial support artifacts are allowed, Harness strips any caller-submitted `verification_status=verified` before persisting the task so new work cannot begin with pre-certified artifact truth.
@@ -149,6 +151,7 @@ See:
   - `GET /tasks/<task_id>/evaluations`
   - `GET /tasks/<task_id>/read-model`
   - `GET /tasks/<task_id>/timeline`
+  - `GET /supervision/queue`
 - Canonical mutation surfaces:
 - `POST /tasks`
 - `POST /tasks/<task_id>/reevaluate`
@@ -208,6 +211,7 @@ Backend inspection routes:
 - `GET /tasks`: dashboard list surface.
 - `GET /tasks/<task_id>/read-model`: canonical detail surface for current task truth.
 - `GET /tasks/<task_id>/timeline`: canonical audit timeline.
+- `GET /supervision/queue`: canonical autonomous-supervision triage surface.
 
 For triage surfaces, `review_required` stays distinct from terminal failure. If a task is in `in_review`, the projected `failure_summary.state` and `execution_summary.failure_state` remain `review_required` rather than collapsing into `failed`.
 

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -12,6 +12,27 @@ This document is the source-of-truth API usage guide for execution agents and do
 
 For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritative mutation path.
 
+## Canonical Inspection Paths
+
+- `GET /tasks`: canonical task inventory and triage surface
+- `GET /tasks/<task_id>`: raw persisted task envelope
+- `GET /tasks/<task_id>/evaluations`: append-only evaluation history
+- `GET /tasks/<task_id>/read-model`: canonical current-truth projection for one task
+- `GET /tasks/<task_id>/timeline`: canonical ordered audit timeline for one task
+- `GET /supervision/queue`: canonical attention queue for autonomous supervisors such as OpenClaw
+
+`GET /supervision/queue` is projection-only. It does not create work, mutate task state, or authorize follow-up actions. It exists so an ingress-side supervisor can poll Harness for the tasks that currently need intervention without rebuilding policy client-side from raw task payloads.
+
+Queue entries are derived from canonical read-model and timeline truth and currently classify:
+
+- `review_required`
+- `clarification_required`
+- `invalid_execution_attempt`
+- `retryable_failure`
+- `stale_active_task`
+
+OpenClaw or another supervisor may use those entries to decide what to inspect next, but the actual task mutation still has to go back through canonical submission, dispatch, completion-claim, or reevaluation paths.
+
 `POST /tasks` is an intake/planning creation path, not a completion-reporting path. A brand-new task may include objective, planning, support artifacts, coordination metadata, and clarification blockers, but it must not arrive with claimed completion, acceptance assertions, runtime facts, validated completion evidence, execution attempts, advisory completion claims, reconciliation history, or runtime/terminal lifecycle state already attached.
 
 Fresh task creation also cannot inject assignment truth. Do not send `request.assigned_executor`, and do not try to create a new task directly in `assigned`. Executor assignment belongs to dispatcher-owned flows after Harness has accepted and persisted the task.

--- a/docs/integrations/overview.md
+++ b/docs/integrations/overview.md
@@ -47,6 +47,12 @@ The existing spike demonstrated:
 
 Harness now includes an OpenClaw-shaped ingress endpoint (`POST /ingress/openclaw`) backed by a thin adapter that normalizes request content into canonical submission payloads.
 
+Harness also now exposes a canonical supervision polling surface for ingress-side autonomy:
+
+- `GET /supervision/queue`
+
+That queue is a read-only projection over canonical Harness truth. It is intended for OpenClaw-style supervisors that need to know which tasks currently require attention because they are review-gated, clarification-blocked, retryable, showing invalid execution proof, or stale.
+
 Relevant code and docs:
 
 - [modules/connectors/openclaw_harness_spike.py](../../modules/connectors/openclaw_harness_spike.py)
@@ -59,6 +65,7 @@ Relevant code and docs:
 Real today:
 
 - canonical API submission and reevaluation
+- canonical supervision queue for autonomous polling
 - normalized fact models
 - Linear-shaped ingress adapter
 - OpenClaw-shaped ingress adapter
@@ -68,6 +75,6 @@ Not live today:
 
 - live GitHub polling or webhook orchestration
 - live Linear issue creation or sync loops
-- full OpenClaw runtime/plugin lifecycle integration
+- full OpenClaw runtime/plugin lifecycle integration or autonomous loop execution
 
 That split is intentional. Harness should remain a standalone control-plane service, not become tightly coupled to any single ingress or executor runtime.

--- a/docs/superpowers/plans/2026-04-11-openclaw-autonomy-supervisor-mvp.md
+++ b/docs/superpowers/plans/2026-04-11-openclaw-autonomy-supervisor-mvp.md
@@ -1,0 +1,351 @@
+# OpenClaw Autonomy Supervisor MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a canonical supervision queue that OpenClaw can poll to identify stale, blocked, review-gated, retryable, or invalid-proof tasks without rebuilding policy client-side.
+
+**Architecture:** Add a new read-only supervision service that projects queue entries from existing read-models and timelines, then expose it via a new `GET /supervision/queue` endpoint. Reuse existing review, clarification, execution, and failure summaries so the queue remains a thin projection over canonical Harness truth.
+
+**Tech Stack:** Python 3, existing `modules.api` HTTP server, existing `modules.read_model` surfaces, `unittest`
+
+---
+
+### Task 1: Add failing supervision service tests
+
+**Files:**
+- Create: `tests/test_supervision.py`
+- Test: `tests/test_supervision.py`
+
+- [ ] **Step 1: Write failing tests for queue classification**
+
+```python
+import unittest
+from copy import deepcopy
+
+from modules.api import HarnessApiService
+from modules.store import FileBackedHarnessStore
+from modules.supervision import HarnessSupervisionService
+from tests.test_api import _completion_claim_payload, _execution_attempt_payload, _manual_happy_path_overlay_payload
+
+
+class HarnessSupervisionServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.store = FileBackedHarnessStore(".tmp/test-supervision-store")
+        self.api = HarnessApiService(store=self.store)
+        self.service = HarnessSupervisionService(store=self.store, now_provider=lambda: "2026-04-12T12:00:00Z")
+
+    def test_queue_surfaces_review_required_tasks(self) -> None:
+        payload = {"request": deepcopy(_manual_happy_path_overlay_payload()["request"]["task_envelope"])}
+        status, created = self.api.submit(payload)
+        self.assertEqual(status, 200)
+
+        # Replace with a real review-required creation path during implementation.
+        queue = self.service.list_attention_queue()
+
+        self.assertEqual(queue[0]["attention_type"], "review_required")
+
+    def test_queue_surfaces_invalid_execution_attempt_tasks(self) -> None:
+        payload = {"request": deepcopy(_manual_happy_path_overlay_payload()["request"]["task_envelope"])}
+        status, created = self.api.submit(payload)
+        self.assertEqual(status, 200)
+
+        queue = self.service.list_attention_queue()
+
+        self.assertEqual(queue[0]["attention_type"], "invalid_execution_attempt")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m unittest tests.test_supervision`
+Expected: FAIL with `ModuleNotFoundError` or missing supervision service/test behavior.
+
+- [ ] **Step 3: Replace placeholder setup in the tests with real canonical task scenarios**
+
+```python
+# Use existing API helpers and canonical flows to create:
+# - a review-required task
+# - a clarification-required task
+# - a retryable blocked task
+# - an invalid execution attempt task
+# - a stale assigned task with old timestamps
+```
+
+- [ ] **Step 4: Re-run the tests and confirm they still fail for missing implementation**
+
+Run: `python3 -m unittest tests.test_supervision`
+Expected: FAIL because `HarnessSupervisionService` and/or queue behavior are not implemented yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_supervision.py
+git commit -m "test: add supervision queue regressions"
+```
+
+### Task 2: Implement the supervision service
+
+**Files:**
+- Create: `modules/supervision.py`
+- Modify: `modules/__init__.py`
+- Test: `tests/test_supervision.py`
+
+- [ ] **Step 1: Add the new service with queue-entry builders**
+
+```python
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from modules.read_model import HarnessReadModelService
+from modules.store import HarnessStore, build_harness_store
+
+
+def _parse_iso_timestamp(value: str | None) -> datetime:
+    if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class SupervisionQueueEntry:
+    task_id: str
+    title: str
+    current_status: str
+    attention_type: str
+    suggested_action: str
+    reason: str
+    last_activity_at: str | None
+    stale: bool
+    review_status: str
+    clarification_status: str
+    failure_state: str
+    retry_eligible: bool
+
+
+class HarnessSupervisionService:
+    def __init__(
+        self,
+        *,
+        store: HarnessStore | None = None,
+        now_provider: Callable[[], str] | None = None,
+    ) -> None:
+        self.read_model_service = HarnessReadModelService(store=store or build_harness_store())
+        self._now_provider = now_provider
+```
+
+- [ ] **Step 2: Implement attention classification priority**
+
+```python
+    def _classify_attention(self, task: dict[str, Any]) -> tuple[str, str, str] | None:
+        review_status = str((task.get("review_summary") or {}).get("status") or "none")
+        clarification_status = str((task.get("clarification_summary") or {}).get("status") or "none")
+        execution_summary = task.get("execution_summary") or {}
+        failure_state = str((task.get("failure_summary") or {}).get("state") or "clear")
+        latest_validation = (execution_summary.get("latest_attempt_validation") or {}) if isinstance(execution_summary, dict) else {}
+
+        if str(task.get("current_status") or "") == "in_review" or review_status == "requested":
+            return ("review_required", "resolve_review_gate", "Task has an active manual review gate.")
+        if clarification_status == "required":
+            return ("clarification_required", "collect_clarification", "Task is blocked on explicit clarification.")
+        if latest_validation.get("failure_type") == "invalid_execution_attempt":
+            return ("invalid_execution_attempt", "request_fresh_proof_or_rework", "Latest execution attempt failed the proof contract.")
+        if bool(execution_summary.get("retry_eligible")) or failure_state == "retryable":
+            return ("retryable_failure", "retry_or_redispatch", "Task is in a retryable failure state.")
+        return None
+```
+
+- [ ] **Step 3: Implement last-activity and staleness logic**
+
+```python
+    def _last_activity_at(self, task: dict[str, Any]) -> str | None:
+        timeline = task.get("timeline") or []
+        events = [event for event in timeline if isinstance(event, dict)]
+        if not events:
+            return None
+        latest = max(events, key=lambda event: (_parse_iso_timestamp(str(event.get("occurred_at") or "")), str(event.get("event_id") or "")))
+        occurred_at = latest.get("occurred_at")
+        return str(occurred_at) if occurred_at is not None else None
+```
+
+- [ ] **Step 4: Implement queue assembly**
+
+```python
+    def list_attention_queue(self) -> list[dict[str, Any]]:
+        tasks = [asdict(item) for item in self.read_model_service.list_task_read_models()]
+        queue: list[dict[str, Any]] = []
+        for task in tasks:
+            classification = self._classify_attention(task)
+            if classification is None:
+                continue
+            attention_type, suggested_action, reason = classification
+            queue.append(
+                asdict(
+                    SupervisionQueueEntry(
+                        task_id=str(task["task_id"]),
+                        title=str(task["title"]),
+                        current_status=str(task["current_status"]),
+                        attention_type=attention_type,
+                        suggested_action=suggested_action,
+                        reason=reason,
+                        last_activity_at=self._last_activity_at(task),
+                        stale=False,
+                        review_status=str((task.get("review_summary") or {}).get("status") or "none"),
+                        clarification_status=str((task.get("clarification_summary") or {}).get("status") or "none"),
+                        failure_state=str((task.get("failure_summary") or {}).get("state") or "clear"),
+                        retry_eligible=bool((task.get("execution_summary") or {}).get("retry_eligible")),
+                    )
+                )
+            )
+        return queue
+```
+
+- [ ] **Step 5: Run the tests and make them pass**
+
+Run: `python3 -m unittest tests.test_supervision`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add modules/supervision.py modules/__init__.py tests/test_supervision.py
+git commit -m "feat: add supervision queue service"
+```
+
+### Task 3: Expose the queue in the API
+
+**Files:**
+- Modify: `modules/api.py`
+- Test: `tests/test_api.py`
+
+- [ ] **Step 1: Write the failing API test**
+
+```python
+def test_api_exposes_supervision_queue_endpoint(self) -> None:
+    status, payload = self._get_json("/supervision/queue")
+
+    self.assertEqual(status, 200)
+    self.assertIn("generated_at", payload)
+    self.assertIn("queue", payload)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python3 -m unittest tests.test_api.HarnessApiHttpTests.test_api_exposes_supervision_queue_endpoint`
+Expected: FAIL with `404` or missing route.
+
+- [ ] **Step 3: Add service and route wiring**
+
+```python
+from modules.supervision import HarnessSupervisionService
+
+
+class HarnessApiService:
+    def __init__(...):
+        ...
+        self.supervision_service = HarnessSupervisionService(store=self.store)
+
+    def get_supervision_queue(self) -> tuple[int, dict[str, Any]]:
+        return HTTPStatus.OK, {
+            "generated_at": _iso_now(),
+            "queue": self.supervision_service.list_attention_queue(),
+        }
+```
+
+- [ ] **Step 4: Add the GET route**
+
+```python
+if path_components == ("supervision", "queue"):
+    status, payload = service.get_supervision_queue()
+    self._write_json(status, payload)
+    return
+```
+
+- [ ] **Step 5: Re-run the API test**
+
+Run: `python3 -m unittest tests.test_api.HarnessApiHttpTests.test_api_exposes_supervision_queue_endpoint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add modules/api.py tests/test_api.py
+git commit -m "feat: expose supervision queue endpoint"
+```
+
+### Task 4: Add end-to-end queue semantics coverage
+
+**Files:**
+- Modify: `tests/e2e/runtime_harness.py`
+- Create: `tests/e2e/test_control_plane_supervision_queue_flows.py`
+
+- [ ] **Step 1: Add a runtime helper for the queue endpoint**
+
+```python
+def supervision_queue(self) -> tuple[int, dict]:
+    return self.get_json("/supervision/queue")
+```
+
+- [ ] **Step 2: Write an end-to-end flow for review, clarification, retryable, and stale queue entries**
+
+```python
+def test_supervision_queue_surfaces_review_and_retry_attention(self) -> None:
+    review = self.create_evaluate_scenario(...)
+    retryable = self.create_evaluate_scenario(...)
+
+    status, payload = self.supervision_queue()
+
+    self.assertEqual(status, 200)
+    tasks = {item["task_id"]: item for item in payload["queue"]}
+    self.assertEqual(tasks[review.task_id]["attention_type"], "review_required")
+    self.assertEqual(tasks[retryable.task_id]["attention_type"], "retryable_failure")
+```
+
+- [ ] **Step 3: Run the targeted e2e test and make it pass**
+
+Run: `python3 -m unittest tests.e2e.test_control_plane_supervision_queue_flows`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/runtime_harness.py tests/e2e/test_control_plane_supervision_queue_flows.py
+git commit -m "test: cover supervision queue control-plane flows"
+```
+
+### Task 5: Update docs and run full verification
+
+**Files:**
+- Modify: `docs/api/agent-api-usage.md`
+- Modify: `docs/integrations/overview.md`
+- Modify: `docs/architecture/openclaw-executor-adapter.md`
+
+- [ ] **Step 1: Document the new canonical queue**
+
+```md
+- `GET /supervision/queue`: list tasks that currently need autonomous or operator attention.
+```
+
+- [ ] **Step 2: Document OpenClaw polling intent**
+
+```md
+OpenClaw should poll the supervision queue rather than infer stale or retryable states from raw task data.
+```
+
+- [ ] **Step 3: Run targeted verification**
+
+Run: `python3 -m unittest tests.test_supervision tests.test_api tests.e2e.test_control_plane_supervision_queue_flows`
+Expected: PASS
+
+- [ ] **Step 4: Run full backend verification**
+
+Run: `python3 -m unittest discover -s tests`
+Expected: PASS with all existing suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/api/agent-api-usage.md docs/integrations/overview.md docs/architecture/openclaw-executor-adapter.md
+git commit -m "docs: describe supervision queue for autonomy MVP"
+```

--- a/docs/superpowers/specs/2026-04-11-openclaw-autonomy-supervisor-design.md
+++ b/docs/superpowers/specs/2026-04-11-openclaw-autonomy-supervisor-design.md
@@ -1,0 +1,185 @@
+# OpenClaw Autonomy Supervisor MVP Design
+
+## Goal
+
+Make autonomous OpenClaw-supervised runs feasible without weakening Harness control-plane boundaries.
+
+OpenClaw remains the only human-facing ingress. Harness remains the canonical source of task truth, evidence enforcement, reconciliation, and lifecycle correctness. The MVP should let OpenClaw poll Harness for tasks that need attention because they are stale, blocked, review-gated, or showing invalid execution proof.
+
+## Problem
+
+Harness can already:
+
+- accept canonical tasks and ingress-shaped task submissions
+- dispatch work
+- validate completion claims
+- reconcile repository proof
+- expose canonical read-model and timeline surfaces
+
+Harness cannot yet:
+
+- provide a canonical supervision queue for OpenClaw
+- tell OpenClaw which tasks need intervention right now
+- distinguish between benign inactive tasks and stale active tasks
+- surface a bounded next action for retry, clarification, review, or stale investigation
+
+Without that queue, OpenClaw can create or observe tasks but cannot supervise them with canonical Harness truth. That makes autonomous runs fragile and forces orchestration logic back into ingress code.
+
+## Scope
+
+This MVP slice adds one new capability:
+
+- a canonical supervision queue that OpenClaw can poll
+
+The queue will project attention items from existing Harness truth using current read-model fields and timeline data.
+
+## Out Of Scope
+
+This slice does not add:
+
+- live OpenClaw webhooks or long-running subscription transport
+- live Linear polling
+- a production Codex Cloud executor adapter
+- automatic redispatch or mutation from the queue itself
+- a new dashboard mutation surface
+
+Those are follow-on autonomy slices.
+
+## Users
+
+- OpenClaw automation loop
+- operators validating whether Harness can supervise real work
+
+## Design Principles
+
+1. OpenClaw polls canonical Harness truth instead of rebuilding heuristics client-side.
+2. The queue is read-only. It recommends actions; it does not perform them.
+3. Attention reasons must map to existing control-plane truth, not worker claims.
+4. Staleness must be explicit and deterministic.
+5. Queue entries must be auditable back to task id, status, timeline, and summaries.
+
+## Proposed Surface
+
+Add a new read-only endpoint:
+
+- `GET /supervision/queue`
+
+Response shape:
+
+- `generated_at`
+- `queue`
+  - `task_id`
+  - `title`
+  - `current_status`
+  - `attention_type`
+  - `suggested_action`
+  - `reason`
+  - `last_activity_at`
+  - `stale`
+  - `review_status`
+  - `clarification_status`
+  - `failure_state`
+  - `retry_eligible`
+
+This is intentionally projection-only and uses existing canonical task/read-model data.
+
+## Attention Types
+
+The first slice should include these attention types:
+
+1. `review_required`
+- Trigger when the canonical review gate is active.
+- Source truth: `current_status == "in_review"` or `review_summary.status == "requested"`.
+- Suggested action: `resolve_review_gate`.
+
+2. `clarification_required`
+- Trigger when the task is blocked on missing information.
+- Source truth: `clarification_summary.status == "required"`.
+- Suggested action: `collect_clarification`.
+
+3. `retryable_failure`
+- Trigger when Harness has classified the current state as retryable.
+- Source truth: `execution_summary.retry_eligible == true` or `failure_summary.state == "retryable"`.
+- Suggested action: `retry_or_redispatch`.
+
+4. `invalid_execution_attempt`
+- Trigger when the latest execution attempt failed the executor-proof gate.
+- Source truth: `execution_summary.latest_attempt_validation.failure_type == "invalid_execution_attempt"`.
+- Suggested action: `request_fresh_proof_or_rework`.
+
+5. `stale_active_task`
+- Trigger when an active task has not had canonical activity within a configured threshold.
+- Active statuses for the first slice: `planned`, `dispatch_ready`, `assigned`, `blocked`.
+- Exclude tasks already covered by review or clarification attention.
+- Suggested action: `investigate_staleness`.
+
+## Staleness Model
+
+The queue should derive `last_activity_at` from the latest canonical timeline event timestamp when available. This keeps staleness tied to auditable state transitions, evaluation records, dispatches, clarification, and artifact capture rather than ad hoc task fields.
+
+Default thresholds for the MVP:
+
+- `planned`: 24 hours
+- `dispatch_ready`: 2 hours
+- `assigned`: 2 hours
+- `blocked`: 8 hours
+
+These values are control-plane defaults for unattended supervision tests, not product promises.
+
+## Implementation Units
+
+### `modules/supervision.py`
+
+New read-model style service responsible for:
+
+- building queue entries from `HarnessReadModelService.list_task_read_models()`
+- classifying attention type
+- computing `last_activity_at`
+- computing stale status against default thresholds
+
+### `modules/api.py`
+
+Add:
+
+- `HarnessApiService.get_supervision_queue()`
+- `GET /supervision/queue` route in `HarnessApiHandler.do_GET`
+
+### Tests
+
+Add new tests covering:
+
+- direct supervision service classification
+- API route behavior
+- interaction with existing review, clarification, retryable, and invalid execution states
+
+## Why This Slice First
+
+This is the smallest slice that makes autonomous supervision real:
+
+- OpenClaw gets a canonical queue of “what needs attention now”
+- Harness remains the source of truth for why
+- no mutation or executor integration is required to prove the supervision boundary
+
+It directly supports the next slices:
+
+- OpenClaw polling loop
+- bounded autonomous retry/rework
+- real executor integration
+
+## Risks
+
+1. Overlapping attention categories
+- Mitigation: strict priority ordering in the queue classifier.
+
+2. False stale positives
+- Mitigation: use canonical timeline timestamps and conservative thresholds.
+
+3. OpenClaw re-implementing policy anyway
+- Mitigation: include `suggested_action` and `reason` so clients can remain thin.
+
+## Success Criteria
+
+1. A new canonical endpoint returns a queue of tasks that need autonomous or operator attention.
+2. The queue is derived entirely from canonical Harness truth.
+3. The queue covers review, clarification, retryable failure, invalid proof, and stale active work.
+4. The queue is fully test-covered and does not regress existing read-model semantics.

--- a/modules/api.py
+++ b/modules/api.py
@@ -68,6 +68,7 @@ from modules.reconciliation_runtime import (
     task_has_valid_current_run_commit_artifact,
     task_has_valid_current_run_pull_request_artifact,
 )
+from modules.supervision import HarnessSupervisionService
 from modules.store import (
     EvaluationRecord,
     HarnessStore,
@@ -2955,6 +2956,7 @@ class HarnessApiService:
     ) -> None:
         self.store = store or build_harness_store()
         self.read_model_service = HarnessReadModelService(store=self.store)
+        self.supervision_service = HarnessSupervisionService(store=self.store)
         self.reconciliation_registry = reconciliation_registry or build_default_reconciliation_registry()
 
     def _build_postgres_health_payload(self, store: PostgresHarnessStore) -> dict[str, Any]:
@@ -4136,6 +4138,12 @@ class HarnessApiService:
         tasks = self.read_model_service.list_task_read_models()
         return HTTPStatus.OK, {"tasks": [_to_jsonable(task) for task in tasks]}
 
+    def get_supervision_queue(self) -> tuple[int, dict[str, Any]]:
+        return HTTPStatus.OK, {
+            "generated_at": _iso_now(),
+            "queue": self.supervision_service.list_attention_queue(),
+        }
+
     def get_evaluation_history(self, task_id: str) -> tuple[int, dict[str, Any]]:
         try:
             self.store.get_task(task_id)
@@ -4202,6 +4210,11 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
 
         if path_components == ("tasks",):
             status, payload = service.list_tasks()
+            self._write_json(status, payload)
+            return
+
+        if path_components == ("supervision", "queue"):
+            status, payload = service.get_supervision_queue()
             self._write_json(status, payload)
             return
 

--- a/modules/supervision.py
+++ b/modules/supervision.py
@@ -1,0 +1,196 @@
+"""Canonical supervision queue for autonomous OpenClaw-style polling."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from modules.read_model import HarnessReadModelService
+from modules.store import HarnessStore, build_harness_store
+
+
+def _parse_iso_timestamp(value: str | None) -> datetime:
+    if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class SupervisionQueueEntry:
+    task_id: str
+    title: str
+    current_status: str
+    attention_type: str
+    suggested_action: str
+    reason: str
+    last_activity_at: str | None
+    stale: bool
+    review_status: str
+    clarification_status: str
+    failure_state: str
+    retry_eligible: bool
+
+
+class HarnessSupervisionService:
+    """Project canonical task truth into an attention queue for autonomous supervisors."""
+
+    def __init__(
+        self,
+        *,
+        store: HarnessStore | None = None,
+        now_provider: Callable[[], str] | None = None,
+        stale_after_seconds_by_status: dict[str, int] | None = None,
+    ) -> None:
+        resolved_store = store or build_harness_store()
+        self.read_model_service = HarnessReadModelService(store=resolved_store)
+        self._now_provider = now_provider or self._iso_now
+        self._stale_after_seconds_by_status = stale_after_seconds_by_status or {
+            "planned": 24 * 60 * 60,
+            "dispatch_ready": 2 * 60 * 60,
+            "assigned": 2 * 60 * 60,
+            "blocked": 8 * 60 * 60,
+        }
+
+    @staticmethod
+    def _iso_now() -> str:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def _last_activity_at(self, task: dict[str, Any]) -> str | None:
+        timeline = task.get("timeline")
+        events = [event for event in timeline if isinstance(event, dict)] if isinstance(timeline, list) else []
+        if events:
+            latest_event = max(
+                events,
+                key=lambda event: (
+                    _parse_iso_timestamp(str(event.get("occurred_at") or "")),
+                    str(event.get("event_id") or ""),
+                ),
+            )
+            occurred_at = latest_event.get("occurred_at")
+            if occurred_at is not None:
+                return str(occurred_at)
+
+        timestamps = task.get("timestamps") if isinstance(task.get("timestamps"), dict) else {}
+        updated_at = timestamps.get("updated_at")
+        if updated_at is not None:
+            return str(updated_at)
+        created_at = timestamps.get("created_at")
+        return str(created_at) if created_at is not None else None
+
+    def _is_stale(self, task: dict[str, Any], *, last_activity_at: str | None) -> bool:
+        current_status = str(task.get("current_status") or "")
+        threshold_seconds = self._stale_after_seconds_by_status.get(current_status)
+        if threshold_seconds is None:
+            return False
+        if not last_activity_at:
+            return False
+        return (_parse_iso_timestamp(self._now_provider()) - _parse_iso_timestamp(last_activity_at)).total_seconds() >= threshold_seconds
+
+    def _classify_attention(
+        self,
+        task: dict[str, Any],
+        *,
+        last_activity_at: str | None,
+    ) -> tuple[str, str, str, bool] | None:
+        current_status = str(task.get("current_status") or "")
+        review_summary = task.get("review_summary") if isinstance(task.get("review_summary"), dict) else {}
+        clarification_summary = (
+            task.get("clarification_summary") if isinstance(task.get("clarification_summary"), dict) else {}
+        )
+        failure_summary = task.get("failure_summary") if isinstance(task.get("failure_summary"), dict) else {}
+        execution_summary = task.get("execution_summary") if isinstance(task.get("execution_summary"), dict) else {}
+        latest_attempt_validation = (
+            execution_summary.get("latest_attempt_validation")
+            if isinstance(execution_summary.get("latest_attempt_validation"), dict)
+            else {}
+        )
+
+        if current_status == "in_review" or str(review_summary.get("status") or "none") == "requested":
+            return (
+                "review_required",
+                "resolve_review_gate",
+                "Task has an active manual review gate that blocks autonomous completion.",
+                False,
+            )
+        if str(clarification_summary.get("status") or "none") == "required":
+            return (
+                "clarification_required",
+                "collect_clarification",
+                "Task is blocked on explicit clarification and cannot proceed safely.",
+                False,
+            )
+        if str(latest_attempt_validation.get("status") or "") == "invalid":
+            return (
+                "invalid_execution_attempt",
+                "request_fresh_proof_or_rework",
+                "Latest execution attempt failed the current-run proof contract.",
+                False,
+            )
+        if bool(execution_summary.get("retry_eligible")) or str(failure_summary.get("state") or "") == "retryable":
+            return (
+                "retryable_failure",
+                "retry_or_redispatch",
+                "Task is in a retryable failure state and remains eligible for governed recovery.",
+                False,
+            )
+
+        stale = self._is_stale(task, last_activity_at=last_activity_at)
+        if stale:
+            return (
+                "stale_active_task",
+                "investigate_staleness",
+                "Task is active but has not produced recent canonical activity.",
+                True,
+            )
+        return None
+
+    def list_attention_queue(self) -> list[dict[str, Any]]:
+        priority = {
+            "review_required": 0,
+            "clarification_required": 1,
+            "invalid_execution_attempt": 2,
+            "retryable_failure": 3,
+            "stale_active_task": 4,
+        }
+        queue: list[dict[str, Any]] = []
+        for read_model in self.read_model_service.list_task_read_models():
+            task = asdict(read_model)
+            last_activity_at = self._last_activity_at(task)
+            attention = self._classify_attention(task, last_activity_at=last_activity_at)
+            if attention is None:
+                continue
+            attention_type, suggested_action, reason, stale = attention
+            queue.append(
+                asdict(
+                    SupervisionQueueEntry(
+                        task_id=str(task["task_id"]),
+                        title=str(task["title"]),
+                        current_status=str(task["current_status"]),
+                        attention_type=attention_type,
+                        suggested_action=suggested_action,
+                        reason=reason,
+                        last_activity_at=last_activity_at,
+                        stale=stale,
+                        review_status=str(((task.get("review_summary") or {}).get("status")) or "none"),
+                        clarification_status=str(((task.get("clarification_summary") or {}).get("status")) or "none"),
+                        failure_state=str(((task.get("failure_summary") or {}).get("state")) or "clear"),
+                        retry_eligible=bool(((task.get("execution_summary") or {}).get("retry_eligible"))),
+                    )
+                )
+            )
+
+        return sorted(
+            queue,
+            key=lambda item: (
+                priority.get(str(item.get("attention_type")), 99),
+                _parse_iso_timestamp(str(item.get("last_activity_at") or "")),
+                str(item.get("task_id") or ""),
+            ),
+        )
+
+
+__all__ = [
+    "HarnessSupervisionService",
+    "SupervisionQueueEntry",
+]

--- a/tests/e2e/runtime_harness.py
+++ b/tests/e2e/runtime_harness.py
@@ -150,6 +150,9 @@ class RuntimeApiTestCase(unittest.TestCase):
     def list_tasks(self) -> tuple[int, dict]:
         return self.get_json("/tasks")
 
+    def supervision_queue(self) -> tuple[int, dict]:
+        return self.get_json("/supervision/queue")
+
     def post_json(self, path: str, payload: dict) -> tuple[int, dict]:
         request = Request(
             self.base_url + path,

--- a/tests/e2e/test_control_plane_supervision_queue_flows.py
+++ b/tests/e2e/test_control_plane_supervision_queue_flows.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from modules.demo_cases import build_demo_request
+from tests.e2e.runtime_harness import RuntimeApiTestCase
+from tests.e2e.scenario_builders import build_review_decision_from_request, to_jsonable
+
+
+class ControlPlaneSupervisionQueueFlowTests(RuntimeApiTestCase):
+    def _queue_by_task_id(self, payload: dict) -> dict[str, dict]:
+        return {item["task_id"]: item for item in payload["queue"]}
+
+    def test_supervision_queue_surfaces_review_and_retry_attention(self) -> None:
+        review = self.create_evaluate_scenario({"request": to_jsonable(build_demo_request("review_required"))})
+
+        retry_payload = {"request": to_jsonable(build_demo_request("blocked_insufficient_evidence"))}
+        retry_payload["request"]["runtime_facts"] = {
+            "executor_reported_failure": True,
+            "attempt_count": 1,
+            "latest_attempt_outcome": "failed",
+        }
+        with patch.dict(os.environ, {"HARNESS_CLASSIFIED_RETRY_BUDGET": "2"}):
+            retryable = self.create_evaluate_scenario(retry_payload)
+
+        status, payload = self.supervision_queue()
+        queue = payload["queue"]
+        entries = self._queue_by_task_id(payload)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(queue[0]["task_id"], review.task_id)
+        self.assertEqual(entries[review.task_id]["attention_type"], "review_required")
+        self.assertEqual(entries[review.task_id]["suggested_action"], "resolve_review_gate")
+        self.assertFalse(entries[review.task_id]["stale"])
+        self.assertEqual(entries[retryable.task_id]["attention_type"], "retryable_failure")
+        self.assertEqual(entries[retryable.task_id]["suggested_action"], "retry_or_redispatch")
+        self.assertTrue(entries[retryable.task_id]["retry_eligible"])
+        self.assertEqual(entries[retryable.task_id]["failure_state"], "retryable")
+
+    def test_supervision_queue_clears_review_attention_after_manual_resolution(self) -> None:
+        review = self.create_evaluate_scenario({"request": to_jsonable(build_demo_request("review_required"))})
+
+        before_status, before_payload = self.supervision_queue()
+        self.assertEqual(before_status, 200)
+        self.assertEqual(self._queue_by_task_id(before_payload)[review.task_id]["attention_type"], "review_required")
+
+        resolved = review.reevaluate(
+            {
+                "request": {
+                    "review_decision": build_review_decision_from_request(
+                        review.created.response["enforcement_result"]["review_request"],
+                        outcome="accept_completion",
+                    )
+                }
+            }
+        )
+        after_status, after_payload = self.supervision_queue()
+
+        self.assertEqual(resolved.status, 200)
+        self.assertEqual(resolved.task["status"], "completed")
+        self.assertEqual(after_status, 200)
+        self.assertNotIn(review.task_id, self._queue_by_task_id(after_payload))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5649,6 +5649,19 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(read_status, 200)
         self.assertEqual(read_payload["task"]["extensions"]["openclaw"]["metadata"]["request_kind"], "openclaw")
 
+    def test_api_exposes_supervision_queue_endpoint(self) -> None:
+        create_status, create_payload = self._post_json("/evaluate", _request_payload("review_required"))
+
+        status, payload = self._get_json("/supervision/queue")
+
+        self.assertEqual(create_status, 200)
+        self.assertEqual(status, 200)
+        self.assertIn("generated_at", payload)
+        queue_by_task_id = {item["task_id"]: item for item in payload["queue"]}
+        queue_item = queue_by_task_id[create_payload["task_envelope"]["id"]]
+        self.assertEqual(queue_item["attention_type"], "review_required")
+        self.assertEqual(queue_item["suggested_action"], "resolve_review_gate")
+
     def test_api_openclaw_ingress_rejects_invalid_payload_without_persisting_state(self) -> None:
         payload = _openclaw_ingress_payload(task_id="task-openclaw-invalid-1")
         payload["context"] = "invalid"

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from copy import deepcopy
+from unittest.mock import patch
+
+from modules.api import HarnessApiService
+from modules.store import FileBackedHarnessStore
+from modules.supervision import HarnessSupervisionService
+from tests.test_api import (
+    _completion_claim_payload,
+    _execution_attempt_payload,
+    _manual_happy_path_overlay_payload,
+    _request_payload,
+)
+
+
+class HarnessSupervisionServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = FileBackedHarnessStore(self.temp_dir.name)
+        self.api = HarnessApiService(store=self.store)
+        self.service = HarnessSupervisionService(
+            store=self.store,
+            now_provider=lambda: "2026-04-12T12:00:00Z",
+            stale_after_seconds_by_status={
+                "planned": 24 * 60 * 60,
+                "dispatch_ready": 2 * 60 * 60,
+                "assigned": 2 * 60 * 60,
+                "blocked": 8 * 60 * 60,
+            },
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _queue_by_task_id(self) -> dict[str, dict]:
+        return {item["task_id"]: item for item in self.service.list_attention_queue()}
+
+    def test_queue_surfaces_review_and_clarification_attention(self) -> None:
+        review_status, review_response = self.api.evaluate(_request_payload("review_required"))
+        self.assertEqual(review_status, 200)
+
+        clarification_payload = _manual_happy_path_overlay_payload()
+        clarification_payload["request"]["task_envelope"]["id"] = "task-supervision-clarification-1"
+        clarification_payload["request"]["task_envelope"]["title"] = "Clarification queue coverage"
+        clarification_payload["request"]["task_envelope"]["description"] = "Queue should surface clarification blockers."
+        clarification_status, clarification_response = self.api.submit(
+            {
+                "request": {
+                    "task_envelope": deepcopy(clarification_payload["request"]["task_envelope"]),
+                    "task_status": "dispatch_ready",
+                    "unresolved_conditions": ["Need repository clarification before execution can begin."],
+                }
+            }
+        )
+        self.assertEqual(clarification_status, 200)
+
+        queue = self._queue_by_task_id()
+
+        review_item = queue[review_response["task_envelope"]["id"]]
+        self.assertEqual(review_item["attention_type"], "review_required")
+        self.assertEqual(review_item["suggested_action"], "resolve_review_gate")
+
+        clarification_item = queue[clarification_response["task_envelope"]["id"]]
+        self.assertEqual(clarification_item["attention_type"], "clarification_required")
+        self.assertEqual(clarification_item["suggested_action"], "collect_clarification")
+
+    def test_queue_surfaces_retryable_and_invalid_execution_attention(self) -> None:
+        retry_payload = _request_payload("blocked_insufficient_evidence")
+        retry_payload["request"]["runtime_facts"] = {
+            "executor_reported_failure": True,
+            "attempt_count": 1,
+            "latest_attempt_outcome": "failed",
+        }
+        with patch.dict(os.environ, {"HARNESS_CLASSIFIED_RETRY_BUDGET": "2"}):
+            retry_status, retry_response = self.api.evaluate(retry_payload)
+        self.assertEqual(retry_status, 200)
+
+        invalid_payload = _manual_happy_path_overlay_payload()
+        invalid_task = deepcopy(invalid_payload["request"]["task_envelope"])
+        invalid_task["id"] = "task-supervision-invalid-attempt-1"
+        invalid_task["title"] = "Invalid execution attempt queue coverage"
+        invalid_task["description"] = "Queue should surface invalid execution proof."
+        submit_status, submit_response = self.api.submit({"request": {"task_envelope": invalid_task}})
+        self.assertEqual(submit_status, 200)
+
+        task_id = submit_response["task_envelope"]["id"]
+        stored_task = deepcopy(self.store.get_task(task_id))
+        stored_task["status"] = "assigned"
+        stored_task["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-supervision-invalid-attempt-1",
+            "assignment_reason": "Exercise invalid execution attempt supervision.",
+        }
+        stored_task["timestamps"]["updated_at"] = "2026-04-01T10:03:00Z"
+        self.store.update_task(stored_task)
+
+        with patch.dict(os.environ, {"HARNESS_INVALID_EXECUTION_RETRY_BUDGET": "1"}):
+            invalid_status, invalid_response = self.api.submit_completion_claim(
+                task_id,
+                {
+                    "request": {
+                        **_completion_claim_payload(claim_id="claim-supervision-invalid-1"),
+                        **_execution_attempt_payload(attempt_id="attempt-supervision-invalid-1"),
+                        "runtime_facts": {"executor_reported_success": True, "attempt_count": 1},
+                    }
+                },
+            )
+        self.assertEqual(invalid_status, 200)
+
+        queue = self._queue_by_task_id()
+
+        retry_item = queue[retry_response["task_envelope"]["id"]]
+        self.assertEqual(retry_item["attention_type"], "retryable_failure")
+        self.assertEqual(retry_item["suggested_action"], "retry_or_redispatch")
+
+        invalid_item = queue[invalid_response["task_envelope"]["id"]]
+        self.assertEqual(invalid_item["attention_type"], "invalid_execution_attempt")
+        self.assertEqual(invalid_item["suggested_action"], "request_fresh_proof_or_rework")
+
+    def test_queue_surfaces_stale_active_tasks(self) -> None:
+        stale_payload = _manual_happy_path_overlay_payload()
+        stale_task = deepcopy(stale_payload["request"]["task_envelope"])
+        stale_task["id"] = "task-supervision-stale-assigned-1"
+        stale_task["title"] = "Stale assigned task"
+        stale_task["description"] = "Queue should surface stale active tasks."
+        stale_task["timestamps"]["created_at"] = "2026-04-01T08:00:00Z"
+        stale_task["timestamps"]["updated_at"] = "2026-04-01T08:00:00Z"
+
+        submit_status, submit_response = self.api.submit({"request": {"task_envelope": stale_task}})
+        self.assertEqual(submit_status, 200)
+
+        task_id = submit_response["task_envelope"]["id"]
+        stored_task = deepcopy(self.store.get_task(task_id))
+        stored_task["status"] = "assigned"
+        stored_task["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-supervision-stale-1",
+            "assignment_reason": "Exercise stale assignment supervision.",
+        }
+        stored_task["timestamps"]["updated_at"] = "2026-04-01T08:00:00Z"
+        self.store.update_task(stored_task)
+
+        queue = self._queue_by_task_id()
+
+        stale_item = queue[task_id]
+        self.assertEqual(stale_item["attention_type"], "stale_active_task")
+        self.assertEqual(stale_item["suggested_action"], "investigate_staleness")
+        self.assertTrue(stale_item["stale"])
+


### PR DESCRIPTION
## Summary
- add a canonical supervision queue service and `GET /supervision/queue` API surface
- cover the queue with unit, API, and e2e runtime tests
- document the queue as the read-only OpenClaw supervision surface for autonomous polling

## Verification
- python3 -m unittest tests.test_supervision
- python3 -m unittest tests.test_api.HarnessHttpApiTests.test_api_exposes_supervision_queue_endpoint
- python3 -m unittest tests.e2e.test_control_plane_supervision_queue_flows
- python3 -m unittest discover -s tests