### PR TITLE
feat: expose supervision state in openclaw spike

### DIFF
--- a/docs/integration/openclaw-harness-spike.md
+++ b/docs/integration/openclaw-harness-spike.md
@@ -44,6 +44,7 @@ The spike uses only:
 
 - `POST /tasks`
 - `POST /tasks/<task_id>/reevaluate`
+- `GET /supervision/queue`
 - `GET /tasks/<task_id>`
 - `GET /tasks/<task_id>/read-model`
 - `GET /tasks/<task_id>/timeline`
@@ -55,9 +56,10 @@ The built-in spike flow intentionally exercises a real control-plane change:
 
 1. OpenClaw-style client submits a task that claims completion
 2. Harness blocks the task because required evidence is still missing
-3. OpenClaw-style client submits reevaluation with the missing review-note artifact
-4. Harness accepts completion
-5. Client fetches read model, timeline, and evaluation history
+3. OpenClaw-style client reads the canonical supervision queue and sees the live clarification blocker
+4. OpenClaw-style client submits reevaluation with the missing review-note artifact
+5. Harness accepts completion
+6. Client fetches read model, timeline, evaluation history, and confirms the queue entry cleared
 
 ## What Was Learned
 
@@ -75,7 +77,7 @@ That builder now exists in [`modules/connectors/ingress_request_builder.py`](../
 Other observations:
 
 - duplicate task handling is clear: `POST /tasks` returns `409`, and reevaluation remains explicit
-- inspection endpoints are already sufficient for operator and dashboard visibility
+- inspection endpoints are already sufficient for operator, dashboard, and thin-supervisor visibility
 - no API redesign was required for this spike
 
 Since the spike was written, Harness added a dedicated OpenClaw ingress adapter endpoint (`POST /ingress/openclaw`) that still delegates into canonical submission semantics (`POST /tasks`) rather than introducing a separate control-plane contract.

--- a/modules/connectors/openclaw_harness_spike.py
+++ b/modules/connectors/openclaw_harness_spike.py
@@ -51,6 +51,12 @@ class OpenClawHarnessSpikeResult:
     read_model_status: int
     timeline_status: int
     evaluation_history_count: int
+    initial_supervision_queue_status: int
+    initial_supervision_attention_type: str | None
+    initial_supervision_suggested_action: str | None
+    final_supervision_queue_status: int
+    final_supervision_attention_type: str | None
+    final_supervision_suggested_action: str | None
 
 
 def build_task_submission_payload(
@@ -207,6 +213,9 @@ class OpenClawHarnessSpikeClient:
     def get_evaluation_history(self, task_id: str) -> tuple[int, dict[str, Any]]:
         return self._request_json("GET", f"/tasks/{task_id}/evaluations")
 
+    def get_supervision_queue(self) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", "/supervision/queue")
+
 
 def _demo_review_note_artifact() -> dict[str, Any]:
     return {
@@ -236,6 +245,18 @@ def _demo_review_note_artifact() -> dict[str, Any]:
             "note_kind": "manual_confirmation",
         },
     }
+
+
+def _find_supervision_entry(queue_payload: dict[str, Any], *, task_id: str) -> dict[str, Any] | None:
+    queue = queue_payload.get("queue") if isinstance(queue_payload.get("queue"), list) else []
+    return next(
+        (
+            item
+            for item in queue
+            if isinstance(item, dict) and str(item.get("task_id") or "") == task_id
+        ),
+        None,
+    )
 
 
 def run_openclaw_spike_flow(*, base_url: str, task_id: str = "task-openclaw-spike-1") -> OpenClawHarnessSpikeResult:
@@ -277,6 +298,10 @@ def run_openclaw_spike_flow(*, base_url: str, task_id: str = "task-openclaw-spik
     read_model_status, _ = client.get_task_read_model(task_id)
     if read_model_status >= 400:
         raise RuntimeError(f"OpenClaw spike read-model fetch failed for {task_id}")
+    initial_supervision_queue_status, initial_supervision_payload = client.get_supervision_queue()
+    if initial_supervision_queue_status >= 400:
+        raise RuntimeError(f"OpenClaw spike supervision queue fetch failed for {task_id}")
+    initial_supervision_entry = _find_supervision_entry(initial_supervision_payload, task_id=task_id)
 
     reevaluation_status, reevaluation_payload = client.reevaluate_task(
         task_id,
@@ -306,8 +331,10 @@ def run_openclaw_spike_flow(*, base_url: str, task_id: str = "task-openclaw-spik
 
     timeline_status, _ = client.get_task_timeline(task_id)
     history_status, history_payload = client.get_evaluation_history(task_id)
-    if timeline_status >= 400 or history_status >= 400:
+    final_supervision_queue_status, final_supervision_payload = client.get_supervision_queue()
+    if timeline_status >= 400 or history_status >= 400 or final_supervision_queue_status >= 400:
         raise RuntimeError(f"OpenClaw spike inspection failed for {task_id}")
+    final_supervision_entry = _find_supervision_entry(final_supervision_payload, task_id=task_id)
 
     return OpenClawHarnessSpikeResult(
         task_id=task_id,
@@ -320,6 +347,20 @@ def run_openclaw_spike_flow(*, base_url: str, task_id: str = "task-openclaw-spik
         read_model_status=read_model_status,
         timeline_status=timeline_status,
         evaluation_history_count=len(history_payload.get("evaluations", ())),
+        initial_supervision_queue_status=initial_supervision_queue_status,
+        initial_supervision_attention_type=(
+            initial_supervision_entry.get("attention_type") if isinstance(initial_supervision_entry, dict) else None
+        ),
+        initial_supervision_suggested_action=(
+            initial_supervision_entry.get("suggested_action") if isinstance(initial_supervision_entry, dict) else None
+        ),
+        final_supervision_queue_status=final_supervision_queue_status,
+        final_supervision_attention_type=(
+            final_supervision_entry.get("attention_type") if isinstance(final_supervision_entry, dict) else None
+        ),
+        final_supervision_suggested_action=(
+            final_supervision_entry.get("suggested_action") if isinstance(final_supervision_entry, dict) else None
+        ),
     )
 
 
@@ -349,6 +390,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"read_model: {result.read_model_status}")
         print(f"timeline: {result.timeline_status}")
         print(f"evaluation_history_count: {result.evaluation_history_count}")
+        print(
+            "initial_supervision: "
+            f"{result.initial_supervision_queue_status} "
+            f"({result.initial_supervision_attention_type}, {result.initial_supervision_suggested_action})"
+        )
+        print(
+            "final_supervision: "
+            f"{result.final_supervision_queue_status} "
+            f"({result.final_supervision_attention_type}, {result.final_supervision_suggested_action})"
+        )
 
     return 0
 

--- a/tests/connectors/test_openclaw_harness_spike.py
+++ b/tests/connectors/test_openclaw_harness_spike.py
@@ -72,6 +72,7 @@ class OpenClawHarnessSpikeTests(unittest.TestCase):
         read_model_status, read_model_payload = self.client.get_task_read_model(task_id)
         timeline_status, timeline_payload = self.client.get_task_timeline(task_id)
         history_status, history_payload = self.client.get_evaluation_history(task_id)
+        queue_status, queue_payload = self.client.get_supervision_queue()
 
         self.assertEqual(task_status, 200)
         self.assertEqual(task_payload["task"]["id"], task_id)
@@ -81,6 +82,8 @@ class OpenClawHarnessSpikeTests(unittest.TestCase):
         self.assertGreaterEqual(timeline_payload["event_count"], 1)
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history_payload["evaluations"]), 1)
+        self.assertEqual(queue_status, 200)
+        self.assertNotIn(task_id, {item["task_id"] for item in queue_payload["queue"]})
 
     def test_representative_spike_flow_moves_blocked_to_completed(self) -> None:
         result = run_openclaw_spike_flow(base_url=self.base_url, task_id="task-openclaw-flow-1")
@@ -92,6 +95,12 @@ class OpenClawHarnessSpikeTests(unittest.TestCase):
         self.assertEqual(result.read_model_status, 200)
         self.assertEqual(result.timeline_status, 200)
         self.assertEqual(result.evaluation_history_count, 2)
+        self.assertEqual(result.initial_supervision_queue_status, 200)
+        self.assertEqual(result.initial_supervision_attention_type, "clarification_required")
+        self.assertEqual(result.initial_supervision_suggested_action, "collect_clarification")
+        self.assertEqual(result.final_supervision_queue_status, 200)
+        self.assertIsNone(result.final_supervision_attention_type)
+        self.assertIsNone(result.final_supervision_suggested_action)
 
     def test_duplicate_task_id_behavior_matches_canonical_submission_policy(self) -> None:
         self.client.submit_task(intent=self._intent(task_id="task-openclaw-duplicate-1"), context=self._context())


### PR DESCRIPTION
## Summary
- teach the OpenClaw spike client to fetch `GET /supervision/queue`
- include initial and final supervision state in the representative spike result
- document and test that the spike sees a live clarification blocker before reevaluation and a cleared queue state afterward

## Verification
- python3 -m unittest tests.connectors.test_openclaw_harness_spike
- python3 -m unittest tests.test_api.HarnessHttpApiTests.test_api_exposes_supervision_queue_endpoint tests.test_simulator
- python3 -m unittest discover -s tests