### PR TITLE
feat: add openclaw supervision loop

### DIFF
--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -33,6 +33,12 @@ Queue entries are derived from canonical read-model and timeline truth and curre
 
 OpenClaw or another supervisor may use those entries to decide what to inspect next, but the actual task mutation still has to go back through canonical submission, dispatch, completion-claim, or reevaluation paths.
 
+The repository now includes a thin example supervisor loop in [`modules/connectors/openclaw_supervisor.py`](../../modules/connectors/openclaw_supervisor.py). That client does not mutate review, clarification, or proof decisions on its own. It only:
+
+- polls `GET /supervision/queue`
+- enriches queue entries with canonical inspection surfaces
+- optionally triggers `POST /tasks/<task_id>/dispatch` for bounded redispatch when the queue recommends `retry_or_redispatch` and the current canonical task state remains dispatchable
+
 `POST /tasks` is an intake/planning creation path, not a completion-reporting path. A brand-new task may include objective, planning, support artifacts, coordination metadata, and clarification blockers, but it must not arrive with claimed completion, acceptance assertions, runtime facts, validated completion evidence, execution attempts, advisory completion claims, reconciliation history, or runtime/terminal lifecycle state already attached.
 
 Fresh task creation also cannot inject assignment truth. Do not send `request.assigned_executor`, and do not try to create a new task directly in `assigned`. Executor assignment belongs to dispatcher-owned flows after Harness has accepted and persisted the task.

--- a/docs/integration/openclaw-harness-spike.md
+++ b/docs/integration/openclaw-harness-spike.md
@@ -88,6 +88,35 @@ Other observations:
 - no API redesign was required for this spike
 - the same thin client can now observe both clarification-driven and review-driven supervision states through the canonical queue
 
+## Thin Supervisor Loop
+
+The spike now also includes a thin OpenClaw-side supervisor client in [`modules/connectors/openclaw_supervisor.py`](../../modules/connectors/openclaw_supervisor.py).
+
+That loop does not invent new control-plane behavior. It:
+
+- polls `GET /supervision/queue`
+- enriches each attention item with `GET /tasks/<task_id>/read-model`
+- inspects `GET /tasks/<task_id>/timeline`
+- inspects `GET /tasks/<task_id>/evaluations`
+- turns the canonical `suggested_action` into an explicit next-step decision
+
+The loop remains intentionally narrow:
+
+- `review_required` stays a manual-review requirement
+- `clarification_required` stays a clarification collection requirement
+- `invalid_execution_attempt` stays a proof-or-rework requirement
+- `stale_active_task` stays an investigation requirement
+
+It currently performs one bounded autonomous follow-up:
+
+- if the queue surfaces `retryable_failure`, and the canonical task state is dispatchable, the loop may call `POST /tasks/<task_id>/dispatch` with an explicit `dispatch_trigger=openclaw_supervision_loop`
+
+That keeps OpenClaw thin while proving the next autonomy step:
+
+- OpenClaw can observe what needs attention
+- OpenClaw can inspect the canonical evidence behind that attention
+- OpenClaw can trigger a governed redispatch without bypassing Harness lifecycle enforcement
+
 Since the spike was written, Harness added a dedicated OpenClaw ingress adapter endpoint (`POST /ingress/openclaw`) that still delegates into canonical submission semantics (`POST /tasks`) rather than introducing a separate control-plane contract.
 
 That ingress endpoint is now explicitly constrained to intake/planning handoff. It accepts task intent, provenance, and other ingress-owned context, but it rejects executor runtime facts, completion claims, and execution/terminal lifecycle states. OpenClaw can describe the work; it cannot declare the work executed or complete through ingress.

--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -51,7 +51,14 @@ from .openclaw_harness_spike import (
     OpenClawHarnessSpikeResult,
     OpenClawSourceContext,
     OpenClawTaskIntent,
+    run_openclaw_review_gate_spike_flow,
     run_openclaw_spike_flow,
+)
+from .openclaw_supervisor import (
+    OpenClawHarnessSupervisor,
+    OpenClawSupervisionActionResult,
+    OpenClawSupervisionCycleResult,
+    OpenClawSupervisionDecision,
 )
 
 __all__ = [
@@ -71,11 +78,16 @@ __all__ = [
     "OpenClawHarnessSpikeClient",
     "OpenClawHarnessSpikeError",
     "OpenClawHarnessSpikeResult",
+    "OpenClawHarnessSupervisor",
     "OpenClawIngressInputError",
     "OpenClawSourceContext",
+    "OpenClawSupervisionActionResult",
+    "OpenClawSupervisionCycleResult",
+    "OpenClawSupervisionDecision",
     "OpenClawTaskIntent",
     "build_task_reevaluation_payload",
     "build_task_submission_payload",
+    "run_openclaw_review_gate_spike_flow",
     "run_openclaw_spike_flow",
     "translate_github_artifact_facts",
     "validate_github_artifact_references",

--- a/modules/connectors/openclaw_harness_spike.py
+++ b/modules/connectors/openclaw_harness_spike.py
@@ -217,6 +217,9 @@ class OpenClawHarnessSpikeClient:
     def get_supervision_queue(self) -> tuple[int, dict[str, Any]]:
         return self._request_json("GET", "/supervision/queue")
 
+    def dispatch_task(self, task_id: str, *, payload: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", f"/tasks/{task_id}/dispatch", payload or {})
+
 
 def _demo_review_note_artifact() -> dict[str, Any]:
     return {

--- a/modules/connectors/openclaw_supervisor.py
+++ b/modules/connectors/openclaw_supervisor.py
@@ -1,0 +1,202 @@
+"""Thin OpenClaw-side supervision loop over canonical Harness APIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .openclaw_harness_spike import OpenClawHarnessSpikeClient
+
+
+@dataclass(frozen=True)
+class OpenClawSupervisionDecision:
+    """One canonical attention item enriched with inspection context."""
+
+    task_id: str
+    title: str
+    current_status: str
+    attention_type: str
+    suggested_action: str
+    reason: str
+    stale: bool
+    last_activity_at: str | None
+    read_model_status: int
+    timeline_status: int
+    evaluation_history_count: int
+    timeline_event_count: int
+    can_autonomously_dispatch: bool
+    proposed_dispatch_payload: dict[str, Any] | None
+    read_model: dict[str, Any]
+    timeline: dict[str, Any]
+    evaluations: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class OpenClawSupervisionActionResult:
+    """Outcome of one supervisor decision during a cycle."""
+
+    task_id: str
+    attention_type: str
+    action_status: str
+    http_status: int | None
+    action: str | None
+    resulting_task_status: str | None
+
+
+@dataclass(frozen=True)
+class OpenClawSupervisionCycleResult:
+    """Structured result of one supervision polling cycle."""
+
+    queue_status: int
+    generated_at: str | None
+    decision_count: int
+    decisions: tuple[OpenClawSupervisionDecision, ...]
+    action_results: tuple[OpenClawSupervisionActionResult, ...]
+
+
+class OpenClawHarnessSupervisor:
+    """OpenClaw-side supervisor that polls canonical Harness attention state."""
+
+    def __init__(self, base_url: str) -> None:
+        self.client = OpenClawHarnessSpikeClient(base_url)
+
+    def _can_autonomously_dispatch(self, entry: dict[str, Any]) -> bool:
+        return (
+            str(entry.get("attention_type") or "") == "retryable_failure"
+            and str(entry.get("suggested_action") or "") == "retry_or_redispatch"
+            and str(entry.get("current_status") or "") in {"dispatch_ready", "assigned", "blocked"}
+            and str(entry.get("clarification_status") or "") != "required"
+            and str(entry.get("review_status") or "") != "requested"
+        )
+
+    @staticmethod
+    def _dispatch_payload(*, attention_type: str, executor: str) -> dict[str, Any]:
+        return {
+            "request": {
+                "executor": executor,
+                "dispatch_mode": "manual",
+                "dispatch_trigger": "openclaw_supervision_loop",
+                "dispatch_reason": f"OpenClaw supervision loop redispatch for {attention_type}.",
+                "execution_parameters": {
+                    "initiator": "openclaw_supervision_loop",
+                    "attention_type": attention_type,
+                },
+            }
+        }
+
+    def _build_decision(self, entry: dict[str, Any], *, executor: str) -> OpenClawSupervisionDecision:
+        task_id = str(entry.get("task_id") or "")
+        read_model_status, read_model_payload = self.client.get_task_read_model(task_id)
+        timeline_status, timeline_payload = self.client.get_task_timeline(task_id)
+        evaluations_status, evaluations_payload = self.client.get_evaluation_history(task_id)
+        if read_model_status >= 400 or timeline_status >= 400 or evaluations_status >= 400:
+            raise RuntimeError(f"OpenClaw supervision inspection failed for {task_id}")
+
+        can_dispatch = self._can_autonomously_dispatch(entry)
+        return OpenClawSupervisionDecision(
+            task_id=task_id,
+            title=str(entry.get("title") or ""),
+            current_status=str(entry.get("current_status") or ""),
+            attention_type=str(entry.get("attention_type") or ""),
+            suggested_action=str(entry.get("suggested_action") or ""),
+            reason=str(entry.get("reason") or ""),
+            stale=bool(entry.get("stale")),
+            last_activity_at=str(entry.get("last_activity_at")) if entry.get("last_activity_at") is not None else None,
+            read_model_status=read_model_status,
+            timeline_status=timeline_status,
+            evaluation_history_count=len(evaluations_payload.get("evaluations", ())),
+            timeline_event_count=int(timeline_payload.get("event_count") or 0),
+            can_autonomously_dispatch=can_dispatch,
+            proposed_dispatch_payload=(
+                self._dispatch_payload(attention_type=str(entry.get("attention_type") or ""), executor=executor)
+                if can_dispatch
+                else None
+            ),
+            read_model=read_model_payload,
+            timeline=timeline_payload,
+            evaluations=evaluations_payload,
+        )
+
+    @staticmethod
+    def _non_dispatch_action_status(attention_type: str) -> str:
+        return {
+            "review_required": "manual_review_required",
+            "clarification_required": "clarification_required",
+            "invalid_execution_attempt": "fresh_proof_or_rework_required",
+            "retryable_failure": "retryable_failure_observed",
+            "stale_active_task": "staleness_investigation_required",
+        }.get(attention_type, "attention_observed")
+
+    def run_cycle(
+        self,
+        *,
+        allow_redispatch: bool = False,
+        executor: str = "codex",
+    ) -> OpenClawSupervisionCycleResult:
+        queue_status, queue_payload = self.client.get_supervision_queue()
+        if queue_status >= 400:
+            raise RuntimeError(f"OpenClaw supervision queue fetch failed: {queue_payload}")
+        queue = queue_payload.get("queue")
+        if not isinstance(queue, list):
+            raise RuntimeError("OpenClaw supervision queue payload is malformed")
+
+        decisions = tuple(self._build_decision(entry, executor=executor) for entry in queue if isinstance(entry, dict))
+        action_results: list[OpenClawSupervisionActionResult] = []
+        for decision in decisions:
+            if allow_redispatch and decision.can_autonomously_dispatch and decision.proposed_dispatch_payload is not None:
+                dispatch_status, dispatch_payload = self.client.dispatch_task(
+                    decision.task_id,
+                    payload=decision.proposed_dispatch_payload,
+                )
+                action_results.append(
+                    OpenClawSupervisionActionResult(
+                        task_id=decision.task_id,
+                        attention_type=decision.attention_type,
+                        action_status="redispatch_triggered" if dispatch_status < 400 else "redispatch_failed",
+                        http_status=dispatch_status,
+                        action=(
+                            str(dispatch_payload.get("action"))
+                            if isinstance(dispatch_payload, dict) and dispatch_payload.get("action") is not None
+                            else None
+                        ),
+                        resulting_task_status=(
+                            str((dispatch_payload.get("task_envelope") or {}).get("status"))
+                            if isinstance(dispatch_payload, dict)
+                            and isinstance(dispatch_payload.get("task_envelope"), dict)
+                            and (dispatch_payload.get("task_envelope") or {}).get("status") is not None
+                            else None
+                        ),
+                    )
+                )
+                continue
+
+            action_results.append(
+                OpenClawSupervisionActionResult(
+                    task_id=decision.task_id,
+                    attention_type=decision.attention_type,
+                    action_status=self._non_dispatch_action_status(decision.attention_type),
+                    http_status=None,
+                    action=None,
+                    resulting_task_status=decision.current_status,
+                )
+            )
+
+        return OpenClawSupervisionCycleResult(
+            queue_status=queue_status,
+            generated_at=(
+                str(queue_payload.get("generated_at"))
+                if queue_payload.get("generated_at") is not None
+                else None
+            ),
+            decision_count=len(decisions),
+            decisions=decisions,
+            action_results=tuple(action_results),
+        )
+
+
+__all__ = [
+    "OpenClawHarnessSupervisor",
+    "OpenClawSupervisionActionResult",
+    "OpenClawSupervisionCycleResult",
+    "OpenClawSupervisionDecision",
+]

--- a/tests/connectors/test_openclaw_supervisor.py
+++ b/tests/connectors/test_openclaw_supervisor.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import unittest
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from modules.api import run_server
+from modules.connectors.openclaw_harness_spike import (
+    OpenClawHarnessSpikeClient,
+    OpenClawSourceContext,
+    OpenClawTaskIntent,
+    run_openclaw_review_gate_spike_flow,
+)
+from modules.connectors.openclaw_supervisor import OpenClawHarnessSupervisor
+from modules.demo_cases import build_demo_request
+from modules.runtime_scenario_builders import to_jsonable
+
+
+class OpenClawHarnessSupervisorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.server = run_server(host="127.0.0.1", port=0, store_root=self.temp_dir.name)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+        self.client = OpenClawHarnessSpikeClient(self.base_url)
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.temp_dir.cleanup()
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: dict | None = None,
+    ) -> tuple[int, dict]:
+        data = None
+        headers = {}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = Request(self.base_url + path, data=data, headers=headers, method=method)
+        try:
+            with urlopen(request) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            try:
+                return error.code, json.loads(error.read().decode("utf-8"))
+            finally:
+                error.close()
+
+    def _context(self) -> OpenClawSourceContext:
+        return OpenClawSourceContext(
+            conversation_id="conv-supervisor-1",
+            message_id="msg-supervisor-1",
+            channel="cli",
+            workspace_id="workspace-supervisor",
+            user_id="operator@example.com",
+            agent_id="openclaw-assistant",
+        )
+
+    def _intent(self, task_id: str) -> OpenClawTaskIntent:
+        return OpenClawTaskIntent(
+            task_id=task_id,
+            title="OpenClaw supervisor attention test",
+            description="Create canonical supervision attention for the OpenClaw loop.",
+            acceptance_criteria=(
+                "Harness persists the task.",
+                "Harness exposes canonical supervision attention for the task.",
+            ),
+            objective_summary="Exercise canonical attention states through the OpenClaw client boundary.",
+            deliverable_type="integration_spike",
+            success_signal="The OpenClaw supervisor loop can inspect and react to the task.",
+            requested_by="operator@example.com",
+        )
+
+    def test_cycle_collects_canonical_context_for_review_and_clarification_attention(self) -> None:
+        run_openclaw_review_gate_spike_flow(
+            base_url=self.base_url,
+            task_id="task-openclaw-supervisor-review-1",
+        )
+        submit_status, _ = self.client.submit_task(
+            intent=self._intent("task-openclaw-supervisor-clarification-1"),
+            context=self._context(),
+            unresolved_conditions=("Need operator clarification before dispatch can continue.",),
+        )
+        self.assertEqual(submit_status, 200)
+
+        supervisor = OpenClawHarnessSupervisor(self.base_url)
+        cycle = supervisor.run_cycle()
+        decisions = {decision.task_id: decision for decision in cycle.decisions}
+        actions = {result.task_id: result for result in cycle.action_results}
+
+        self.assertEqual(cycle.queue_status, 200)
+        self.assertEqual(cycle.decision_count, 2)
+
+        review_decision = decisions["task-openclaw-supervisor-review-1"]
+        self.assertEqual(review_decision.attention_type, "review_required")
+        self.assertEqual(review_decision.suggested_action, "resolve_review_gate")
+        self.assertEqual(review_decision.read_model_status, 200)
+        self.assertEqual(review_decision.timeline_status, 200)
+        self.assertGreaterEqual(review_decision.evaluation_history_count, 2)
+        self.assertFalse(review_decision.can_autonomously_dispatch)
+        self.assertIsNone(review_decision.proposed_dispatch_payload)
+        self.assertEqual(actions[review_decision.task_id].action_status, "manual_review_required")
+
+        clarification_decision = decisions["task-openclaw-supervisor-clarification-1"]
+        self.assertEqual(clarification_decision.attention_type, "clarification_required")
+        self.assertEqual(clarification_decision.suggested_action, "collect_clarification")
+        self.assertEqual(clarification_decision.read_model_status, 200)
+        self.assertEqual(clarification_decision.timeline_status, 200)
+        self.assertGreaterEqual(clarification_decision.evaluation_history_count, 1)
+        self.assertFalse(clarification_decision.can_autonomously_dispatch)
+        self.assertIsNone(clarification_decision.proposed_dispatch_payload)
+        self.assertEqual(actions[clarification_decision.task_id].action_status, "clarification_required")
+
+    def test_cycle_can_trigger_bounded_redispatch_for_retryable_failure(self) -> None:
+        retry_payload = {"request": to_jsonable(build_demo_request("blocked_insufficient_evidence"))}
+        retry_payload["request"]["runtime_facts"] = {
+            "executor_reported_failure": True,
+            "attempt_count": 1,
+            "latest_attempt_outcome": "failed",
+        }
+        create_status, create_payload = self._request_json("POST", "/evaluate", retry_payload)
+        self.assertEqual(create_status, 200)
+        task_id = create_payload["task_envelope"]["id"]
+
+        supervisor = OpenClawHarnessSupervisor(self.base_url)
+        cycle = supervisor.run_cycle(allow_redispatch=True, executor="codex")
+        decisions = {decision.task_id: decision for decision in cycle.decisions}
+        actions = {result.task_id: result for result in cycle.action_results}
+
+        retry_decision = decisions[task_id]
+        self.assertEqual(retry_decision.attention_type, "retryable_failure")
+        self.assertEqual(retry_decision.suggested_action, "retry_or_redispatch")
+        self.assertTrue(retry_decision.can_autonomously_dispatch)
+        self.assertIsNotNone(retry_decision.proposed_dispatch_payload)
+        self.assertEqual(
+            retry_decision.proposed_dispatch_payload["request"]["dispatch_trigger"],
+            "openclaw_supervision_loop",
+        )
+
+        retry_action = actions[task_id]
+        self.assertEqual(retry_action.action_status, "redispatch_triggered")
+        self.assertEqual(retry_action.http_status, 200)
+        self.assertIsNotNone(retry_action.action)
+        self.assertIn(retry_action.resulting_task_status, {"blocked", "completed", "failed", "in_review"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a thin OpenClaw supervision loop over the canonical Harness queue and inspection APIs
- allow one bounded autonomous follow-up by redispatching retryable tasks through POST /tasks/<id>/dispatch
- document the new client-side supervision slice and cover it with connector tests

## Verification
- python3 -m unittest tests.connectors.test_openclaw_harness_spike tests.connectors.test_openclaw_supervisor
- python3 -m unittest tests.test_api.HarnessHttpApiTests.test_api_exposes_supervision_queue_endpoint tests.test_simulator tests.test_unattended_dryruns
- python3 -m unittest discover -s tests