### PR TITLE
Add autonomous Codex dry-run coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,17 @@ Run the full Python test suite:
 python -m unittest discover -s tests
 ```
 
+Run the controlled autonomous dry run that exercises:
+
+- canonical task creation through `POST /evaluate`
+- OpenClaw-style retry supervision through `GET /supervision/queue` and redispatch
+- Codex Cloud adapter proof validation
+- post-dispatch GitHub-backed reevaluation that closes the missing changed-file evidence gap
+
+```bash
+python -m unittest tests.test_autonomous_dryrun
+```
+
 Run frontend validation:
 
 ```bash

--- a/docs/architecture/codex-cloud-execution.md
+++ b/docs/architecture/codex-cloud-execution.md
@@ -131,6 +131,25 @@ This keeps the contract aligned with Harness intent:
 
 The default local dispatch path still uses the stub executor unless a real Codex Cloud runtime client is injected. That is intentional. The adapter boundary is now real and test-covered, while live runtime transport remains a separate follow-on integration step.
 
+## Controlled Autonomous Dry Run
+
+Harness now also carries a controlled local dry run at [`modules/autonomous_dryrun.py`](../../modules/autonomous_dryrun.py), covered by [`tests/test_autonomous_dryrun.py`](../../tests/test_autonomous_dryrun.py).
+
+That dry run is intentionally narrow and honest. It does not pretend that executor success alone closes the task. Instead it exercises the real control-plane sequence:
+
+- create a retryable task through canonical `POST /evaluate`
+- let the OpenClaw-style supervision loop notice the retryable blocked state and trigger redispatch
+- let the Codex Cloud adapter enforce current-run proof on the redispatched execution attempt
+- run a follow-up canonical reevaluation that simulates GitHub-backed changed-file synchronization before final completion is accepted
+
+This is important for Harness intent:
+
+- executor output still remains advisory
+- current-run repository proof is validated at dispatch/completion-claim time
+- final completion still depends on canonical artifact ingestion and reevaluation
+
+The dry run is not a replacement for live runtime transport or live GitHub synchronization. It is a deterministic local proof that the supervision, execution-proof, and post-dispatch reevaluation surfaces cooperate correctly enough for autonomous-flow testing.
+
 ## Known Failure Mode
 
 The previously observed failure mode was:

--- a/modules/adapters/codex_cloud/executor_adapter.py
+++ b/modules/adapters/codex_cloud/executor_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -89,14 +90,17 @@ class CodexCloudExecutorAdapter:
         preflight_passed = preflight_reason is None
 
         if preflight_passed:
+            raw_artifacts = _require_list(response_payload.get("artifacts"), "response.artifacts")
+            artifact_context = _build_artifact_context(raw_artifacts)
             artifacts = tuple(
                 self._normalize_artifact(
                     dispatch_input=dispatch_input,
                     run_id=run_id,
                     artifact_payload=artifact_payload,
                     index=index,
+                    artifact_context=artifact_context,
                 )
-                for index, artifact_payload in enumerate(_require_list(response_payload.get("artifacts"), "response.artifacts"))
+                for index, artifact_payload in enumerate(raw_artifacts)
             )
             raw_events = _require_list(response_payload.get("events"), "response.events")
             if not raw_events:
@@ -194,6 +198,7 @@ class CodexCloudExecutorAdapter:
         run_id: str,
         artifact_payload: Any,
         index: int,
+        artifact_context: dict[str, str | None],
     ) -> ArtifactReference:
         if not isinstance(artifact_payload, dict):
             raise CodexCloudAdapterError(f"response.artifacts[{index}] must be an object")
@@ -202,6 +207,11 @@ class CodexCloudExecutorAdapter:
         location = artifact_payload.get("url")
         external_id = artifact_payload.get("external_id")
         commit_sha = artifact_payload.get("commit_sha")
+        metadata = _artifact_metadata(
+            artifact_type=artifact_type,
+            artifact_payload=artifact_payload,
+            artifact_context=artifact_context,
+        )
         return validate_artifact_reference(
             ArtifactReference(
                 artifact_type=artifact_type,
@@ -210,7 +220,7 @@ class CodexCloudExecutorAdapter:
                 external_id=external_id if isinstance(external_id, str) and external_id.strip() else None,
                 commit_sha=commit_sha if isinstance(commit_sha, str) and commit_sha.strip() else None,
                 provenance=_provenance(run_id=run_id, source_id=artifact_id, source_type="executor_artifact"),
-                metadata={"adapter": self.adapter_name},
+                metadata=metadata,
             )
         )
 
@@ -259,6 +269,133 @@ def _require_list(value: Any, field_name: str) -> list[Any]:
     if not isinstance(value, list):
         raise CodexCloudAdapterError(f"{field_name} must be a list")
     return value
+
+
+def _build_artifact_context(raw_artifacts: list[Any]) -> dict[str, str | None]:
+    branch_name: str | None = None
+    commit_sha: str | None = None
+    repository_host: str | None = None
+    repository_owner: str | None = None
+    repository_name: str | None = None
+
+    for artifact in raw_artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        artifact_type = artifact.get("type")
+        if branch_name is None and artifact_type == "branch":
+            branch_name = _string_or_none(artifact.get("branch_name")) or _string_or_none(artifact.get("external_id"))
+        if commit_sha is None:
+            commit_sha = _string_or_none(artifact.get("commit_sha")) or _string_or_none(artifact.get("head_commit_sha"))
+        if artifact_type == "pull_request":
+            location = _string_or_none(artifact.get("url"))
+            if location:
+                parsed = _parse_repository_location(location)
+                if parsed is not None:
+                    repository_host, repository_owner, repository_name = parsed
+        if repository_owner is None or repository_name is None or repository_host is None:
+            repository_payload = artifact.get("repository") if isinstance(artifact.get("repository"), dict) else {}
+            repository_host = repository_host or _string_or_none(repository_payload.get("host"))
+            repository_owner = repository_owner or _string_or_none(repository_payload.get("owner"))
+            repository_name = repository_name or _string_or_none(repository_payload.get("name"))
+
+    return {
+        "branch_name": branch_name,
+        "commit_sha": commit_sha,
+        "repository_host": repository_host,
+        "repository_owner": repository_owner,
+        "repository_name": repository_name,
+    }
+
+
+def _artifact_metadata(
+    *,
+    artifact_type: str,
+    artifact_payload: dict[str, Any],
+    artifact_context: dict[str, str | None],
+) -> dict[str, Any]:
+    metadata = {"adapter": "codex-cloud"}
+    payload_metadata = artifact_payload.get("metadata") if isinstance(artifact_payload.get("metadata"), dict) else {}
+    if payload_metadata:
+        metadata.update(deepcopy(payload_metadata))
+
+    repository_payload = artifact_payload.get("repository") if isinstance(artifact_payload.get("repository"), dict) else {}
+    repository_host = (
+        _string_or_none(repository_payload.get("host"))
+        or _string_or_none(artifact_payload.get("repository_host"))
+        or artifact_context.get("repository_host")
+    )
+    repository_owner = (
+        _string_or_none(repository_payload.get("owner"))
+        or _string_or_none(artifact_payload.get("repository_owner"))
+        or artifact_context.get("repository_owner")
+    )
+    repository_name = (
+        _string_or_none(repository_payload.get("name"))
+        or _string_or_none(artifact_payload.get("repository_name"))
+        or artifact_context.get("repository_name")
+    )
+    if repository_host is not None:
+        metadata.setdefault("repository_host", repository_host)
+    if repository_owner is not None:
+        metadata.setdefault("repository_owner", repository_owner)
+    if repository_name is not None:
+        metadata.setdefault("repository_name", repository_name)
+
+    branch_name = (
+        _string_or_none(artifact_payload.get("branch_name"))
+        or _string_or_none(artifact_payload.get("head_branch"))
+        or _string_or_none(artifact_payload.get("branch"))
+        or (
+            _string_or_none(artifact_payload.get("external_id"))
+            if artifact_type == "branch"
+            else None
+        )
+        or artifact_context.get("branch_name")
+    )
+    if branch_name is not None:
+        metadata.setdefault("branch_name", branch_name)
+
+    commit_sha = (
+        _string_or_none(artifact_payload.get("commit_sha"))
+        or _string_or_none(artifact_payload.get("head_commit_sha"))
+        or artifact_context.get("commit_sha")
+    )
+    if commit_sha is not None:
+        metadata.setdefault("commit_sha", commit_sha)
+        if artifact_type in {"branch", "pull_request"}:
+            metadata.setdefault("head_commit_sha", commit_sha)
+
+    if artifact_type == "pull_request":
+        pr_number = artifact_payload.get("pull_request_number")
+        if pr_number is None:
+            pr_number = artifact_payload.get("number")
+        if pr_number is not None:
+            metadata.setdefault("pull_request_number", pr_number)
+            metadata.setdefault("number", pr_number)
+        pr_state = _string_or_none(artifact_payload.get("pull_request_state")) or _string_or_none(artifact_payload.get("state"))
+        if pr_state is not None:
+            metadata.setdefault("pull_request_state", pr_state)
+            metadata.setdefault("state", pr_state)
+        if "merged" in artifact_payload:
+            metadata.setdefault("merged", artifact_payload.get("merged"))
+        elif "pull_request_merged" in artifact_payload:
+            metadata.setdefault("merged", artifact_payload.get("pull_request_merged"))
+
+    return metadata
+
+
+def _string_or_none(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _parse_repository_location(url: str) -> tuple[str, str, str] | None:
+    match = re.match(r"^https://([^/]+)/([^/]+)/([^/]+)/", url)
+    if match is None:
+        return None
+    return match.group(1), match.group(2), match.group(3)
 
 
 def _normalize_event_type(raw_type: str) -> ExecutionEventType:

--- a/modules/autonomous_dryrun.py
+++ b/modules/autonomous_dryrun.py
@@ -1,0 +1,335 @@
+"""Controlled local autonomous dry runs over canonical Harness APIs."""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+import threading
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from modules.adapters.codex_cloud import CodexCloudExecutorAdapter, CodexCloudRuntimeClient
+from modules.api import HarnessApiService, run_server
+from modules.connectors.openclaw_supervisor import OpenClawHarnessSupervisor
+from modules.runtime_scenario_builders import (
+    build_create_task_payload,
+    build_completion_evidence,
+    build_expected_code_context,
+    build_github_facts,
+    build_linked_artifacts,
+    build_linear_facts,
+)
+from modules.store import FileBackedHarnessStore
+
+
+@dataclass(frozen=True)
+class AutonomousDryRunResult:
+    """Structured result from a controlled local autonomous dry run."""
+
+    task_id: str
+    create_status: int
+    initial_task_status: str | None
+    initial_supervision_queue_status: int
+    initial_supervision_attention_type: str | None
+    supervisor_queue_status: int
+    supervisor_decision_count: int
+    supervisor_action_statuses: tuple[str, ...]
+    final_task_status: str | None
+    final_supervision_queue_status: int
+    final_supervision_attention_type: str | None
+    sample_runtime: bool
+
+
+class SampleCodexCloudRuntimeClient:
+    """Deterministic sample runtime used for local controlled autonomy dry runs."""
+
+    sample_runtime = True
+
+    def execute(self, request_payload: dict[str, Any]) -> dict[str, Any]:
+        branch_name = request_payload["task"]["branch_hint"]
+        commit_sha = "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+        return {
+            "run_id": "sample-codex-cloud-run-1",
+            "preflight": {
+                "pwd": "/workspace/Harness",
+                "git_remote_v": (
+                    "origin\thttps://github.com/sfayka/Harness.git (fetch)\n"
+                    "origin\thttps://github.com/sfayka/Harness.git (push)"
+                ),
+                "bootstrap_proof": "sample bootstrap ok",
+            },
+            "events": [
+                {"id": "evt-1", "type": "run_started", "timestamp": "2026-04-12T16:00:00Z"},
+                {"id": "evt-2", "type": "run_succeeded", "timestamp": "2026-04-12T16:05:00Z"},
+            ],
+            "artifacts": [
+                {
+                    "type": "branch",
+                    "id": "branch-1",
+                    "external_id": branch_name,
+                    "head_commit_sha": commit_sha,
+                },
+                {
+                    "type": "commit",
+                    "id": "commit-1",
+                    "commit_sha": commit_sha,
+                    "url": f"https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/{commit_sha}",
+                },
+                {
+                    "type": "pull_request",
+                    "id": "pr-1",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/2",
+                    "number": 2,
+                    "state": "open",
+                    "merged": False,
+                    "branch_name": branch_name,
+                    "commit_sha": commit_sha,
+                },
+                {
+                    "type": "changed_file",
+                    "id": "changed-file-1",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/blob/main/modules/api.py",
+                    "commit_sha": commit_sha,
+                },
+            ],
+            "completion": {
+                "reported_complete": True,
+                "confidence": "high",
+                "reason": "Sample autonomous dry run produced the full artifact set",
+            },
+        }
+
+
+def _request_json(base_url: str, method: str, path: str, payload: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
+    data = None
+    headers: dict[str, str] = {}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = Request(base_url + path, data=data, headers=headers, method=method)
+    try:
+        with urlopen(request) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        try:
+            return error.code, json.loads(error.read().decode("utf-8"))
+        finally:
+            error.close()
+
+
+def _find_queue_entry(queue_payload: dict[str, Any], *, task_id: str) -> dict[str, Any] | None:
+    queue = queue_payload.get("queue")
+    if not isinstance(queue, list):
+        return None
+    return next(
+        (
+            item
+            for item in queue
+            if isinstance(item, dict) and str(item.get("task_id") or "") == task_id
+        ),
+        None,
+    )
+
+
+def _retryable_creation_payload(task_id: str) -> dict[str, Any]:
+    branch_name = _task_scoped_branch_name(task_id)
+    payload = build_create_task_payload(
+        task_id,
+        title="Controlled autonomous retryable dry run",
+    )
+    payload["request"]["linked_artifacts"] = build_linked_artifacts(branch_name=branch_name)
+    payload["request"]["completion_evidence"] = build_completion_evidence(
+        required_artifact_types=["pull_request", "commit", "changed_file"],
+        validated_artifact_ids=["artifact-pr-1", "artifact-commit-1"],
+    )
+    payload["request"]["external_facts"] = {
+        "expected_code_context": build_expected_code_context(branch_name=branch_name),
+        "github_facts": build_github_facts(branch_name=branch_name),
+        "linear_facts": build_linear_facts(state="completed", workflow_state_type="completed"),
+    }
+    payload["request"]["claimed_completion"] = True
+    payload["request"]["acceptance_criteria_satisfied"] = True
+    payload["request"]["runtime_facts"] = {
+        "executor_reported_failure": True,
+        "attempt_count": 1,
+        "latest_attempt_outcome": "failed",
+    }
+    return payload
+
+
+def _task_scoped_branch_name(task_id: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", task_id.strip().lower()).strip("-")
+    return f"codex/{slug or 'task'}"
+
+
+def _github_sync_reevaluation_payload(task_id: str) -> dict[str, Any]:
+    branch_name = _task_scoped_branch_name(task_id)
+    changed_file_artifact_id = f"artifact-changed-file-{task_id}"
+    commit_sha = "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+    return {
+        "request": {
+            "new_artifacts": [
+                {
+                    "id": changed_file_artifact_id,
+                    "type": "changed_file",
+                    "title": "GitHub changed-file proof",
+                    "description": "Post-dispatch GitHub sync captured the changed file for the latest run.",
+                    "location": f"https://github.com/KnoxAnalytics/HARNESS-DRYRUN/blob/{branch_name}/modules/api.py",
+                    "content_type": None,
+                    "external_id": None,
+                    "commit_sha": commit_sha,
+                    "pull_request_number": None,
+                    "review_state": None,
+                    "provenance": {
+                        "source_system": "github",
+                        "source_type": "api",
+                        "source_id": f"contents/{branch_name}/modules/api.py",
+                        "captured_by": "github-sync",
+                    },
+                    "verification_status": "verified",
+                    "repository": {
+                        "host": "github.com",
+                        "owner": "KnoxAnalytics",
+                        "name": "HARNESS-DRYRUN",
+                        "external_id": "repo-dryrun-1",
+                    },
+                    "branch": {
+                        "name": branch_name,
+                        "base_branch": "main",
+                        "head_commit_sha": commit_sha,
+                    },
+                    "changed_files": [
+                        {
+                            "path": "modules/api.py",
+                            "change_type": "modified",
+                        }
+                    ],
+                    "external_refs": [],
+                    "captured_at": "2026-04-12T16:06:00Z",
+                    "metadata": {},
+                }
+            ],
+            "completion_evidence": {
+                "validated_artifact_ids": [
+                    "artifact-pr-1",
+                    "artifact-commit-1",
+                    changed_file_artifact_id,
+                ],
+                "validation_method": "external_reconciliation",
+            },
+            "external_facts": {
+                "expected_code_context": build_expected_code_context(branch_name=branch_name),
+                "github_facts": build_github_facts(branch_name=branch_name),
+                "linear_facts": build_linear_facts(state="completed", workflow_state_type="completed"),
+            },
+            "claimed_completion": True,
+            "acceptance_criteria_satisfied": True,
+        }
+    }
+
+
+def run_retryable_codex_supervision_dry_run(
+    *,
+    runtime_client: CodexCloudRuntimeClient | None = None,
+    task_id: str = "autonomous-dryrun-retryable-1",
+) -> AutonomousDryRunResult:
+    """Run a controlled local dry run that exercises retryable supervision recovery."""
+
+    resolved_runtime_client = runtime_client or SampleCodexCloudRuntimeClient()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        service = HarnessApiService(
+            store=FileBackedHarnessStore(temp_dir),
+            executor_adapters={
+                "codex": CodexCloudExecutorAdapter(runtime_client=resolved_runtime_client),
+            },
+        )
+        server = run_server(host="127.0.0.1", port=0, service=service)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            base_url = f"http://127.0.0.1:{server.server_port}"
+            create_status, create_payload = _request_json(
+                base_url,
+                "POST",
+                "/evaluate",
+                _retryable_creation_payload(task_id),
+            )
+            if create_status >= 400:
+                raise RuntimeError(f"Autonomous dry run create failed: {create_payload}")
+
+            initial_queue_status, initial_queue_payload = _request_json(base_url, "GET", "/supervision/queue")
+            if initial_queue_status >= 400:
+                raise RuntimeError(f"Autonomous dry run queue fetch failed: {initial_queue_payload}")
+            initial_queue_entry = _find_queue_entry(initial_queue_payload, task_id=task_id)
+
+            supervisor = OpenClawHarnessSupervisor(base_url)
+            cycle = supervisor.run_cycle(allow_redispatch=True, executor="codex")
+
+            post_dispatch_task_status, post_dispatch_task_payload = _request_json(base_url, "GET", f"/tasks/{task_id}")
+            if post_dispatch_task_status >= 400:
+                raise RuntimeError("Autonomous dry run final inspection failed")
+
+            if (
+                isinstance(post_dispatch_task_payload.get("task"), dict)
+                and str((post_dispatch_task_payload.get("task") or {}).get("status") or "") == "blocked"
+            ):
+                reevaluation_status, reevaluation_payload = _request_json(
+                    base_url,
+                    "POST",
+                    f"/tasks/{task_id}/reevaluate",
+                    _github_sync_reevaluation_payload(task_id),
+                )
+                if reevaluation_status >= 400:
+                    raise RuntimeError(f"Autonomous dry run GitHub sync failed: {reevaluation_payload}")
+
+            task_status, task_payload = _request_json(base_url, "GET", f"/tasks/{task_id}")
+            final_queue_status, final_queue_payload = _request_json(base_url, "GET", "/supervision/queue")
+            if task_status >= 400 or final_queue_status >= 400:
+                raise RuntimeError("Autonomous dry run final inspection failed")
+            final_queue_entry = _find_queue_entry(final_queue_payload, task_id=task_id)
+
+            return AutonomousDryRunResult(
+                task_id=task_id,
+                create_status=create_status,
+                initial_task_status=(
+                    str((create_payload.get("task_envelope") or {}).get("status"))
+                    if isinstance(create_payload.get("task_envelope"), dict)
+                    else None
+                ),
+                initial_supervision_queue_status=initial_queue_status,
+                initial_supervision_attention_type=(
+                    str(initial_queue_entry.get("attention_type"))
+                    if isinstance(initial_queue_entry, dict) and initial_queue_entry.get("attention_type") is not None
+                    else None
+                ),
+                supervisor_queue_status=cycle.queue_status,
+                supervisor_decision_count=cycle.decision_count,
+                supervisor_action_statuses=tuple(item.action_status for item in cycle.action_results),
+                final_task_status=(
+                    str((task_payload.get("task") or {}).get("status"))
+                    if isinstance(task_payload.get("task"), dict) and (task_payload.get("task") or {}).get("status") is not None
+                    else None
+                ),
+                final_supervision_queue_status=final_queue_status,
+                final_supervision_attention_type=(
+                    str(final_queue_entry.get("attention_type"))
+                    if isinstance(final_queue_entry, dict) and final_queue_entry.get("attention_type") is not None
+                    else None
+                ),
+                sample_runtime=bool(getattr(resolved_runtime_client, "sample_runtime", False)),
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+
+__all__ = [
+    "AutonomousDryRunResult",
+    "SampleCodexCloudRuntimeClient",
+    "run_retryable_codex_supervision_dry_run",
+]

--- a/tests/adapters/test_codex_cloud_executor_adapter.py
+++ b/tests/adapters/test_codex_cloud_executor_adapter.py
@@ -81,16 +81,23 @@ class CodexCloudExecutorAdapterTests(unittest.TestCase):
                         "type": "branch",
                         "id": "branch-1",
                         "external_id": "codex/task-codex-cloud-1",
+                        "head_commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                     },
                     {
                         "type": "commit",
                         "id": "commit-1",
                         "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                        "url": "https://github.com/sfayka/Harness/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                     },
                     {
                         "type": "pull_request",
                         "id": "pr-1",
                         "url": "https://github.com/sfayka/Harness/pull/999",
+                        "number": 999,
+                        "state": "open",
+                        "merged": False,
+                        "branch_name": "codex/task-codex-cloud-1",
+                        "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
                     },
                 ],
                 "completion": {
@@ -118,6 +125,13 @@ class CodexCloudExecutorAdapterTests(unittest.TestCase):
         self.assertEqual(output.events[-1].event_type.value, "execution_succeeded")
         self.assertTrue(output.events[-1].advisory_completion.reported_complete)
         self.assertEqual(len(output.artifact_references), 3)
+        branch_ref, commit_ref, pr_ref = output.artifact_references
+        self.assertEqual(branch_ref.metadata["branch_name"], "codex/task-codex-cloud-1")
+        self.assertEqual(branch_ref.metadata["head_commit_sha"], "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705")
+        self.assertEqual(commit_ref.metadata["repository_owner"], "sfayka")
+        self.assertEqual(commit_ref.metadata["repository_name"], "Harness")
+        self.assertEqual(pr_ref.metadata["pull_request_state"], "open")
+        self.assertEqual(pr_ref.metadata["pull_request_number"], 999)
         self.assertEqual(output.metadata["adapter"], "codex-cloud")
         self.assertTrue(output.metadata["preflight_passed"])
 

--- a/tests/test_autonomous_dryrun.py
+++ b/tests/test_autonomous_dryrun.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.autonomous_dryrun import (
+    SampleCodexCloudRuntimeClient,
+    run_retryable_codex_supervision_dry_run,
+)
+
+
+class _SuccessfulCodexCloudRuntimeClient:
+    def execute(self, request_payload: dict) -> dict:
+        branch_name = request_payload["task"]["branch_hint"]
+        commit_sha = "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
+        return {
+            "run_id": "codex-autonomous-run-1",
+            "preflight": {
+                "pwd": "/workspace/Harness",
+                "git_remote_v": (
+                    "origin\thttps://github.com/sfayka/Harness.git (fetch)\n"
+                    "origin\thttps://github.com/sfayka/Harness.git (push)"
+                ),
+                "bootstrap_proof": "bootstrap ok",
+            },
+            "events": [
+                {"id": "evt-1", "type": "run_started", "timestamp": "2026-04-12T16:00:00Z"},
+                {"id": "evt-2", "type": "run_succeeded", "timestamp": "2026-04-12T16:05:00Z"},
+            ],
+            "artifacts": [
+                {
+                    "type": "branch",
+                    "id": "branch-1",
+                    "external_id": branch_name,
+                    "head_commit_sha": commit_sha,
+                },
+                {
+                    "type": "commit",
+                    "id": "commit-1",
+                    "commit_sha": commit_sha,
+                    "url": f"https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/{commit_sha}",
+                },
+                {
+                    "type": "pull_request",
+                    "id": "pr-1",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/2",
+                    "number": 2,
+                    "state": "open",
+                    "merged": False,
+                    "branch_name": branch_name,
+                    "commit_sha": commit_sha,
+                },
+                {
+                    "type": "changed_file",
+                    "id": "changed-file-1",
+                    "url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/blob/main/modules/api.py",
+                    "commit_sha": commit_sha,
+                },
+            ],
+            "completion": {
+                "reported_complete": True,
+                "confidence": "high",
+                "reason": "Controlled dry run produced the full artifact set",
+            },
+        }
+
+
+class AutonomousDryRunTests(unittest.TestCase):
+    def test_retryable_codex_supervision_dry_run_recovers_to_completed(self) -> None:
+        result = run_retryable_codex_supervision_dry_run(
+            runtime_client=_SuccessfulCodexCloudRuntimeClient(),
+            task_id="autonomous-dryrun-success-1",
+        )
+
+        self.assertEqual(result.create_status, 200)
+        self.assertEqual(result.initial_task_status, "blocked")
+        self.assertEqual(result.initial_supervision_queue_status, 200)
+        self.assertEqual(result.initial_supervision_attention_type, "retryable_failure")
+        self.assertEqual(result.supervisor_queue_status, 200)
+        self.assertEqual(result.supervisor_decision_count, 1)
+        self.assertEqual(result.supervisor_action_statuses, ("redispatch_triggered",))
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertEqual(result.final_supervision_queue_status, 200)
+        self.assertIsNone(result.final_supervision_attention_type)
+        self.assertFalse(result.sample_runtime)
+
+    def test_retryable_codex_supervision_dry_run_labels_sample_runtime(self) -> None:
+        result = run_retryable_codex_supervision_dry_run(
+            runtime_client=SampleCodexCloudRuntimeClient(),
+            task_id="autonomous-dryrun-sample-1",
+        )
+
+        self.assertTrue(result.sample_runtime)
+        self.assertEqual(result.initial_supervision_attention_type, "retryable_failure")
+        self.assertIn("redispatch_triggered", result.supervisor_action_statuses)
+        self.assertEqual(result.final_task_status, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enrich Codex Cloud artifact references with current-run repository, branch, commit, and PR metadata needed by execution validation
- add a controlled autonomous dry-run helper and tests that exercise canonical evaluate, supervision redispatch, Codex proof validation, and follow-up GitHub-backed reevaluation
- document the new dry-run path in the README and Codex Cloud execution architecture notes

## Testing
- python3 -m unittest tests.adapters.test_codex_cloud_executor_adapter
- python3 -m unittest tests.test_autonomous_dryrun
- python3 -m unittest discover -s tests