### PR TITLE
Add GitHub sync reevaluation bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Harness also keeps new-task submission separate from persisted-task mutation. `P
 That same fail-closed rule now applies to the persisted-task helpers themselves. `POST /tasks/<task_id>/reevaluate` and `POST /tasks/<task_id>/completion-claims` reject submission-style mutation fields such as `task_envelope`, `task_status`, `assigned_executor`, and `linked_artifacts` instead of silently ignoring them.
 Generic reevaluation is also no longer allowed to combine executor runtime telemetry with repository execution artifacts such as PRs, commits, branches, or changed-file proofs. If a caller is reporting executor-side execution evidence, it must use `POST /tasks/<task_id>/completion-claims`, where Harness records the execution attempt and applies executor-side contract validation before completion can proceed. Fact-only reevaluation can still attach externally synchronized repository artifacts without pretending they came from a fresh executor run.
 
+For GitHub-backed sync specifically, Harness now also exposes `POST /sync/github` as a thin wrapper over canonical reevaluation. That helper accepts a GitHub-shaped payload plus `task_id`, derives normalized `external_facts.github_facts`, and may attach trusted `github/api` branch, commit, and pull-request artifacts. It is sync-only: it cannot claim completion, assert acceptance, attach completion evidence, or carry executor runtime telemetry.
+
 Evaluation and reevaluation also cannot self-certify newly attached support artifacts. If a caller sends review notes, handoff artifacts, or other non-execution artifacts already marked `verification_status=verified`, Harness downgrades the artifact back to `unverified`, strips it from validated evidence, and forces canonical verification to re-attest it before it counts. Caller-claimed provenance such as `github/api` or `harness/manual_review` is still caller input, not trust for support artifacts. Canonical GitHub-backed code-artifact overlays remain a separate path for normalized external sync.
 
 ## Governed Reconciliation
@@ -157,6 +159,7 @@ See:
 - Canonical mutation surfaces:
 - `POST /tasks`
 - `POST /tasks/<task_id>/reevaluate`
+- `POST /sync/github`
 - Completion-claim interception helper (delegates into canonical reevaluation semantics):
   - `POST /tasks/<task_id>/completion-claims`
 - `POST /tasks` is an intake/planning submission path. It may create only fresh task truth, not pre-executed completion truth.

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -6,11 +6,13 @@ This document is the source-of-truth API usage guide for execution agents and do
 
 - `POST /tasks`: submit a new canonical task payload
 - `POST /tasks/<task_id>/reevaluate`: submit new facts, artifacts, or review decisions for an existing task
+- `POST /sync/github`: submit a GitHub-shaped sync payload for an existing task and let Harness translate it into canonical reevaluation input
 - `POST /ingress/manual`: submit a manually initiated task and let Harness intake assign a canonical `task_id` when one is not provided
 - `POST /ingress/linear`: submit a Linear-shaped work item that is normalized into canonical Harness task input
 - `POST /ingress/openclaw`: submit an OpenClaw-shaped ingress payload that is normalized into canonical `TaskEnvelope` submission
 
 For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritative mutation path.
+`POST /sync/github` is a thin convenience wrapper only. It must delegate back into canonical reevaluation semantics; it is not a separate truth path.
 
 ## Canonical Inspection Paths
 
@@ -90,6 +92,17 @@ Those overlays are merged into `request.task_envelope` before evaluation for new
 For `POST /tasks/<task_id>/reevaluate`, only canonical reevaluation fields are allowed for persisted mutation. Use `request.new_artifacts` instead of `request.linked_artifacts`, and do not send `request.task_envelope`, `request.task_status`, or `request.assigned_executor`. Those submission-style fields are rejected so callers cannot pretend a stored task was updated when Harness ignored the payload.
 
 `POST /tasks/<task_id>/reevaluate` is not an executor proof-ingestion shortcut. It may attach support artifacts such as review notes, progress artifacts, or handoff artifacts, and it may carry fact-only repository artifacts from external sync, but it must not combine repository execution artifacts with `runtime_facts`. If a caller needs to report executor-side runtime telemetry plus new PR/commit/branch/changed-file proof for an existing task, use `POST /tasks/<task_id>/completion-claims` so Harness can bind the artifacts to an execution attempt and enforce executor contract validation.
+
+`POST /sync/github` exists for the specific case where an external sync process has observed GitHub state and wants Harness to ingest that reality without hand-assembling a canonical reevaluation body. It accepts a GitHub-shaped payload plus `task_id`, derives normalized `external_facts.github_facts`, and may attach trusted `github/api` branch, commit, and pull-request artifacts through the canonical reevaluation path. It must not carry:
+
+- `runtime_facts`
+- `claimed_completion=true`
+- `acceptance_criteria_satisfied=true`
+- `completion_evidence`
+- `review_request` or `review_decision`
+- caller-supplied canonical `new_artifacts` or `external_facts`
+
+That wrapper is for artifact synchronization only. Completion claims, acceptance assertions, and executor telemetry still belong to `POST /tasks/<task_id>/completion-claims`.
 
 Like completion claims, evaluation overlays and reevaluation do not trust caller-submitted `verification_status=verified` on support artifacts. If a caller attaches review notes, handoff artifacts, or other non-execution artifacts already marked verified, Harness downgrades those artifacts back to `unverified`, strips them from validated evidence, and requires canonical verification to earn that trust again. Claimed provenance such as `github/api` sync or `harness/manual_review|verification` does not change that for support artifacts when it arrives through a public API request. Canonical GitHub-backed code-artifact overlays remain allowed for normalized external synchronization paths.
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -22,12 +22,14 @@ from modules.adapters.executor_adapter import (
 )
 from modules.connectors import (
     GitHubConnectorInputError,
+    GitHubSyncInputError,
     LinearConnectorInputError,
     LinearIngressInputError,
     ManualIngressInputError,
     OpenClawIngressInputError,
     translate_openclaw_submission_payload,
     translate_github_artifact_facts,
+    translate_github_sync_reevaluation_payload,
     translate_linear_facts,
     translate_linear_submission_payload,
     translate_manual_submission_payload,
@@ -3673,6 +3675,17 @@ class HarnessApiService:
 
         return self.submit(canonical_payload)
 
+    def submit_github_sync(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            canonical_payload = translate_github_sync_reevaluation_payload(payload)
+        except (GitHubSyncInputError, ValueError) as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        return self.reevaluate(canonical_payload["task_id"], {"request": canonical_payload["request"]})
+
     def evaluate(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:
             request = parse_evaluation_request(payload)
@@ -4253,7 +4266,14 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         path_components = _task_path_components(self.path)
         request_path = urlparse(self.path).path
 
-        if request_path not in {"/evaluate", "/tasks", "/ingress/linear", "/ingress/manual", "/ingress/openclaw"} and not (
+        if request_path not in {
+            "/evaluate",
+            "/tasks",
+            "/ingress/linear",
+            "/ingress/manual",
+            "/ingress/openclaw",
+            "/sync/github",
+        } and not (
             len(path_components) == 3
             and path_components[0] == "tasks"
             and path_components[2] in {"reevaluate", "completion-claims", "dispatch"}
@@ -4278,6 +4298,8 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             status, response_payload = service.submit_manual_ingress(payload)
         elif request_path == "/ingress/openclaw":
             status, response_payload = service.submit_openclaw_ingress(payload)
+        elif request_path == "/sync/github":
+            status, response_payload = service.submit_github_sync(payload)
         elif request_path == "/evaluate":
             status, response_payload = service.evaluate(payload)
         elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "completion-claims":

--- a/modules/connectors/__init__.py
+++ b/modules/connectors/__init__.py
@@ -10,6 +10,10 @@ from .github_facts import (
     translate_github_pull_request,
     translate_github_repository,
 )
+from .github_sync import (
+    GitHubSyncInputError,
+    translate_github_sync_reevaluation_payload,
+)
 from .github_artifact_validation import (
     GitHubArtifactLookup,
     GitHubArtifactValidationError,
@@ -63,6 +67,7 @@ from .openclaw_supervisor import (
 
 __all__ = [
     "GitHubConnectorInputError",
+    "GitHubSyncInputError",
     "GitHubArtifactLookup",
     "GitHubArtifactValidationError",
     "GitHubArtifactValidationIssue",
@@ -97,6 +102,7 @@ __all__ = [
     "translate_github_commit",
     "translate_github_pull_request",
     "translate_github_repository",
+    "translate_github_sync_reevaluation_payload",
     "translate_linear_facts",
     "translate_manual_submission_payload",
     "translate_openclaw_submission_payload",

--- a/modules/connectors/github_sync.py
+++ b/modules/connectors/github_sync.py
@@ -1,0 +1,358 @@
+"""GitHub-shaped sync adapter for canonical Harness reevaluation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from modules.contracts.task_envelope_external_facts import (
+    BranchFact,
+    ChangedFilesSummary,
+    CommitFact,
+    GitHubArtifactFacts,
+    PullRequestFact,
+    RepositoryFact,
+)
+
+from .github_facts import GitHubConnectorInputError, translate_github_artifact_facts
+
+
+class GitHubSyncInputError(ValueError):
+    """Raised when a GitHub sync payload cannot be normalized canonically."""
+
+
+def _require_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise GitHubSyncInputError(f"{field_name} must be a mapping")
+    return payload
+
+
+def _optional_mapping(payload: Any, *, field_name: str) -> Mapping[str, Any] | None:
+    if payload is None:
+        return None
+    return _require_mapping(payload, field_name=field_name)
+
+
+def _require_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise GitHubSyncInputError(f"{field_name} is required")
+    return value.strip()
+
+
+def _optional_string(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise GitHubSyncInputError(f"{field_name} must be a string when provided")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _artifact_id_suffix(value: str) -> str:
+    return value.replace("/", "-").replace(" ", "-")
+
+
+def _changed_files_payload(changed_files: ChangedFilesSummary | None) -> list[dict[str, Any]]:
+    if changed_files is None:
+        return []
+    return [
+        {
+            "path": file_fact.path,
+            "change_type": file_fact.change_type,
+            "additions": file_fact.additions,
+            "deletions": file_fact.deletions,
+            "previous_path": file_fact.previous_path,
+        }
+        for file_fact in changed_files.files
+    ]
+
+
+def _repository_payload(repository: RepositoryFact | None) -> dict[str, Any] | None:
+    return _to_jsonable(repository) if repository is not None else None
+
+
+def _branch_payload(branch: BranchFact | None) -> dict[str, Any] | None:
+    return _to_jsonable(branch) if branch is not None else None
+
+
+def _derive_branch_location(repository: RepositoryFact | None, branch: BranchFact | None) -> str | None:
+    if repository is None or branch is None:
+        return None
+    return f"https://{repository.host}/{repository.owner}/{repository.name}/tree/{branch.name}"
+
+
+def _derive_commit_location(repository: RepositoryFact | None, commit: CommitFact | None) -> str | None:
+    if commit is None:
+        return None
+    if commit.url:
+        return commit.url
+    if repository is None:
+        return None
+    return f"https://{repository.host}/{repository.owner}/{repository.name}/commit/{commit.sha}"
+
+
+def _derive_pull_request_location(repository: RepositoryFact | None, pull_request: PullRequestFact | None) -> str | None:
+    if pull_request is None:
+        return None
+    if pull_request.url:
+        return pull_request.url
+    if repository is None:
+        return None
+    return f"https://{repository.host}/{repository.owner}/{repository.name}/pull/{pull_request.number}"
+
+
+def _branch_artifact(
+    *,
+    repository: RepositoryFact | None,
+    branch: BranchFact,
+    captured_at: str,
+    captured_by: str,
+) -> dict[str, Any]:
+    return {
+        "id": f"artifact-branch-{_artifact_id_suffix(branch.name)}",
+        "type": "branch",
+        "title": "GitHub branch sync",
+        "description": "Attached by GitHub sync through canonical reevaluation.",
+        "location": _derive_branch_location(repository, branch),
+        "content_type": None,
+        "external_id": branch.name,
+        "commit_sha": None,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "github",
+            "source_type": "api",
+            "source_id": f"branch/{branch.name}",
+            "captured_by": captured_by,
+        },
+        "verification_status": "verified",
+        "repository": _repository_payload(repository),
+        "branch": _branch_payload(branch),
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": captured_at,
+        "metadata": {},
+    }
+
+
+def _commit_artifact(
+    *,
+    repository: RepositoryFact | None,
+    branch: BranchFact | None,
+    commit: CommitFact,
+    captured_at: str,
+    captured_by: str,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if commit.message_summary is not None:
+        metadata["message_summary"] = commit.message_summary
+
+    return {
+        "id": f"artifact-commit-{commit.sha[:12]}",
+        "type": "commit",
+        "title": None,
+        "description": "Attached by GitHub sync through canonical reevaluation.",
+        "location": _derive_commit_location(repository, commit),
+        "content_type": None,
+        "external_id": f"commit-{commit.sha}",
+        "commit_sha": commit.sha,
+        "pull_request_number": None,
+        "review_state": None,
+        "provenance": {
+            "source_system": "github",
+            "source_type": "api",
+            "source_id": f"commit/{commit.sha}",
+            "captured_by": captured_by,
+        },
+        "verification_status": "verified",
+        "repository": _repository_payload(repository),
+        "branch": _branch_payload(branch),
+        "changed_files": [],
+        "external_refs": [],
+        "captured_at": captured_at,
+        "metadata": metadata,
+    }
+
+
+def _pull_request_artifact(
+    *,
+    repository: RepositoryFact | None,
+    branch: BranchFact | None,
+    pull_request: PullRequestFact,
+    changed_files: ChangedFilesSummary | None,
+    captured_at: str,
+    captured_by: str,
+) -> dict[str, Any]:
+    return {
+        "id": f"artifact-pr-{pull_request.number}",
+        "type": "pull_request",
+        "title": "GitHub pull request sync",
+        "description": "Attached by GitHub sync through canonical reevaluation.",
+        "location": _derive_pull_request_location(repository, pull_request),
+        "content_type": None,
+        "external_id": f"PR-{pull_request.number}",
+        "commit_sha": None,
+        "pull_request_number": pull_request.number,
+        "review_state": pull_request.review_state,
+        "provenance": {
+            "source_system": "github",
+            "source_type": "api",
+            "source_id": f"pull/{pull_request.number}",
+            "captured_by": captured_by,
+        },
+        "verification_status": "verified",
+        "repository": _repository_payload(repository),
+        "branch": _branch_payload(branch),
+        "changed_files": _changed_files_payload(changed_files),
+        "external_refs": [],
+        "captured_at": captured_at,
+        "metadata": {
+            "pull_request_state": pull_request.state,
+            "pull_request_merged": pull_request.merged,
+        },
+    }
+
+
+def _new_artifacts_from_github_facts(
+    github_facts: GitHubArtifactFacts,
+    *,
+    captured_at: str,
+    captured_by: str,
+) -> tuple[dict[str, Any], ...]:
+    artifacts: list[dict[str, Any]] = []
+    repository = github_facts.repository
+    branch = github_facts.branch
+    commit = github_facts.commit
+    pull_request = github_facts.pull_request
+
+    if branch is not None:
+        artifacts.append(
+            _branch_artifact(
+                repository=repository,
+                branch=branch,
+                captured_at=captured_at,
+                captured_by=captured_by,
+            )
+        )
+    if commit is not None:
+        artifacts.append(
+            _commit_artifact(
+                repository=repository,
+                branch=branch,
+                commit=commit,
+                captured_at=captured_at,
+                captured_by=captured_by,
+            )
+        )
+    if pull_request is not None:
+        artifacts.append(
+            _pull_request_artifact(
+                repository=repository,
+                branch=branch,
+                pull_request=pull_request,
+                changed_files=github_facts.changed_files,
+                captured_at=captured_at,
+                captured_by=captured_by,
+            )
+        )
+    return tuple(artifacts)
+
+
+def _validate_github_sync_contract(payload: Mapping[str, Any]) -> None:
+    _require_string(payload.get("task_id"), field_name="task_id")
+    _require_mapping(payload.get("github"), field_name="github")
+
+    if bool(payload.get("claimed_completion", False)):
+        raise GitHubSyncInputError(
+            "GitHub sync cannot claim completion; completion must flow through executor/reporting paths"
+        )
+    if bool(payload.get("acceptance_criteria_satisfied", False)):
+        raise GitHubSyncInputError(
+            "GitHub sync cannot assert acceptance_criteria_satisfied; completion policy remains separate from artifact sync"
+        )
+    runtime_facts = _optional_mapping(payload.get("runtime_facts"), field_name="runtime_facts")
+    if runtime_facts:
+        raise GitHubSyncInputError(
+            "GitHub sync cannot submit runtime_facts; executor telemetry must flow through completion-claim paths"
+        )
+    if payload.get("completion_evidence") is not None:
+        raise GitHubSyncInputError(
+            "GitHub sync cannot submit completion_evidence; evidence validation remains Harness-owned"
+        )
+    if payload.get("review_request") is not None or payload.get("review_decision") is not None:
+        raise GitHubSyncInputError("GitHub sync cannot submit review mutations")
+    if payload.get("new_artifacts") is not None or payload.get("external_facts") is not None:
+        raise GitHubSyncInputError(
+            "GitHub sync cannot carry canonical new_artifacts or external_facts; use the GitHub-shaped sync fields only"
+        )
+    unresolved_conditions = payload.get("unresolved_conditions")
+    if unresolved_conditions not in (None, [], ()):
+        raise GitHubSyncInputError("GitHub sync cannot submit unresolved_conditions")
+    _optional_mapping(payload.get("expected_code_context"), field_name="expected_code_context")
+    _optional_string(payload.get("captured_at"), field_name="captured_at")
+    _optional_string(payload.get("captured_by"), field_name="captured_by")
+
+
+def translate_github_sync_reevaluation_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate a GitHub sync payload into a canonical ``POST /tasks/<id>/reevaluate`` body."""
+
+    payload = _require_mapping(payload, field_name="github_sync_payload")
+    _validate_github_sync_contract(payload)
+
+    task_id = _require_string(payload.get("task_id"), field_name="task_id")
+    github_payload = _require_mapping(payload.get("github"), field_name="github")
+    expected_code_context = _optional_mapping(payload.get("expected_code_context"), field_name="expected_code_context")
+    captured_at = _optional_string(payload.get("captured_at"), field_name="captured_at") or _iso_now()
+    captured_by = _optional_string(payload.get("captured_by"), field_name="captured_by") or "github-sync"
+
+    try:
+        github_facts = translate_github_artifact_facts(github_payload)
+        canonical_payload = {
+            "request": {
+                "external_facts": {
+                    **({"expected_code_context": dict(expected_code_context)} if expected_code_context is not None else {}),
+                    "github_facts": _to_jsonable(github_facts),
+                },
+                "new_artifacts": list(
+                    _new_artifacts_from_github_facts(
+                        github_facts,
+                        captured_at=captured_at,
+                        captured_by=captured_by,
+                    )
+                ),
+                "claimed_completion": False,
+                "acceptance_criteria_satisfied": False,
+            }
+        }
+    except GitHubConnectorInputError as error:
+        raise GitHubSyncInputError(str(error)) from error
+
+    return {
+        "task_id": task_id,
+        "request": canonical_payload["request"],
+    }
+
+
+__all__ = [
+    "GitHubSyncInputError",
+    "translate_github_sync_reevaluation_payload",
+]

--- a/tests/connectors/test_github_sync.py
+++ b/tests/connectors/test_github_sync.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+
+from modules.connectors import GitHubSyncInputError, translate_github_sync_reevaluation_payload
+
+
+def _to_jsonable(value):
+    if is_dataclass(value):
+        return {key: _to_jsonable(val) for key, val in asdict(value).items()}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _github_sync_payload() -> dict:
+    return {
+        "task_id": "task-github-sync-1",
+        "captured_at": "2026-04-13T15:00:00Z",
+        "expected_code_context": {
+            "repository_host": "github.com",
+            "repository_owner": "KnoxAnalytics",
+            "repository_name": "HARNESS-DRYRUN",
+            "branch_name": "codex/e2e-test",
+            "base_branch": "main",
+        },
+        "github": {
+            "repository": {
+                "host": "github.com",
+                "owner": "KnoxAnalytics",
+                "name": "HARNESS-DRYRUN",
+                "node_id": "repo-dryrun-1",
+            },
+            "branch": {
+                "name": "codex/e2e-test",
+                "baseRefName": "main",
+                "target": {"oid": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"},
+            },
+            "commit": {
+                "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "html_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "commit": {"message": "Attach GitHub sync bridge"},
+            },
+            "pull_request": {
+                "number": 2,
+                "state": "open",
+                "reviewDecision": "approved",
+                "html_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/2",
+                "merged": False,
+            },
+            "files": [
+                {
+                    "filename": "modules/api.py",
+                    "status": "modified",
+                    "additions": 12,
+                    "deletions": 1,
+                }
+            ],
+        },
+    }
+
+
+class GitHubSyncTranslationTests(unittest.TestCase):
+    def test_translates_github_sync_payload_into_canonical_reevaluation_request(self) -> None:
+        canonical_payload = translate_github_sync_reevaluation_payload(_github_sync_payload())
+
+        self.assertEqual(canonical_payload["task_id"], "task-github-sync-1")
+        request = canonical_payload["request"]
+        self.assertFalse(request["claimed_completion"])
+        self.assertFalse(request["acceptance_criteria_satisfied"])
+        self.assertEqual(
+            request["external_facts"]["expected_code_context"]["branch_name"],
+            "codex/e2e-test",
+        )
+        github_facts = request["external_facts"]["github_facts"]
+        self.assertEqual(github_facts["repository"]["name"], "HARNESS-DRYRUN")
+        self.assertEqual(github_facts["pull_request"]["number"], 2)
+        self.assertEqual(len(request["new_artifacts"]), 3)
+        artifact_types = [artifact["type"] for artifact in request["new_artifacts"]]
+        self.assertEqual(artifact_types, ["branch", "commit", "pull_request"])
+        self.assertTrue(all(artifact["verification_status"] == "verified" for artifact in request["new_artifacts"]))
+        self.assertEqual(
+            request["new_artifacts"][2]["changed_files"][0]["path"],
+            "modules/api.py",
+        )
+
+    def test_rejects_runtime_and_completion_shaped_fields(self) -> None:
+        payload = _github_sync_payload()
+        payload["runtime_facts"] = {"executor_reported_success": True}
+        with self.assertRaisesRegex(GitHubSyncInputError, "cannot submit runtime_facts"):
+            translate_github_sync_reevaluation_payload(payload)
+
+        payload = _github_sync_payload()
+        payload["claimed_completion"] = True
+        with self.assertRaisesRegex(GitHubSyncInputError, "cannot claim completion"):
+            translate_github_sync_reevaluation_payload(payload)
+
+        payload = _github_sync_payload()
+        payload["acceptance_criteria_satisfied"] = True
+        with self.assertRaisesRegex(GitHubSyncInputError, "cannot assert acceptance_criteria_satisfied"):
+            translate_github_sync_reevaluation_payload(payload)
+
+        payload = _github_sync_payload()
+        payload["completion_evidence"] = {"status": "satisfied"}
+        with self.assertRaisesRegex(GitHubSyncInputError, "cannot submit completion_evidence"):
+            translate_github_sync_reevaluation_payload(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -697,6 +697,53 @@ def _openclaw_ingress_payload(*, task_id: str | None = None) -> dict:
         payload["task_id"] = task_id
     return payload
 
+
+def _github_sync_payload(*, task_id: str) -> dict:
+    return {
+        "task_id": task_id,
+        "captured_at": "2026-04-13T15:00:00Z",
+        "expected_code_context": {
+            "repository_host": "github.com",
+            "repository_owner": "KnoxAnalytics",
+            "repository_name": "HARNESS-DRYRUN",
+            "branch_name": "codex/e2e-test",
+            "base_branch": "main",
+        },
+        "github": {
+            "repository": {
+                "host": "github.com",
+                "owner": "KnoxAnalytics",
+                "name": "HARNESS-DRYRUN",
+                "node_id": "repo-dryrun-1",
+            },
+            "branch": {
+                "name": "codex/e2e-test",
+                "baseRefName": "main",
+                "target": {"oid": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"},
+            },
+            "commit": {
+                "sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "html_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                "commit": {"message": "Attach GitHub sync bridge"},
+            },
+            "pull_request": {
+                "number": 2,
+                "state": "open",
+                "reviewDecision": "approved",
+                "html_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/2",
+                "merged": False,
+            },
+            "files": [
+                {
+                    "filename": "modules/api.py",
+                    "status": "modified",
+                    "additions": 12,
+                    "deletions": 1,
+                }
+            ],
+        },
+    }
+
 def _review_note_artifact(artifact_id: str = "artifact-review-note-1") -> dict:
     return {
         "id": artifact_id,
@@ -5719,6 +5766,50 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(payload["task_envelope"]["origin"]["ingress_name"], "OpenClaw")
         self.assertEqual(read_status, 200)
         self.assertEqual(read_payload["task"]["extensions"]["openclaw"]["metadata"]["request_kind"], "openclaw")
+
+    def test_api_github_sync_delegates_to_canonical_reevaluation(self) -> None:
+        submit_status, submit_payload = self._post_json("/ingress/manual", _manual_ingress_payload())
+        task_id = submit_payload["task_envelope"]["id"]
+
+        status, payload = self._post_json("/sync/github", _github_sync_payload(task_id=task_id))
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(task_status, 200)
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 2)
+        artifacts = payload["task_envelope"]["artifacts"]["items"]
+        self.assertEqual([artifact["type"] for artifact in artifacts], ["branch", "commit", "pull_request"])
+        self.assertTrue(all(artifact["verification_status"] == "verified" for artifact in artifacts))
+        self.assertEqual(
+            task_payload["task"]["artifacts"]["items"][2]["changed_files"][0]["path"],
+            "modules/api.py",
+        )
+        self.assertEqual(
+            history_payload["evaluations"][1]["request"]["external_facts"]["github_facts"]["pull_request"]["number"],
+            2,
+        )
+
+    def test_api_github_sync_rejects_runtime_facts_without_mutating_task(self) -> None:
+        submit_status, submit_payload = self._post_json("/ingress/manual", _manual_ingress_payload())
+        task_id = submit_payload["task_envelope"]["id"]
+        payload = _github_sync_payload(task_id=task_id)
+        payload["runtime_facts"] = {"executor_reported_success": True}
+
+        status, response_payload = self._post_json("/sync/github", payload)
+        task_status, task_payload = self._get_json(f"/tasks/{task_id}")
+        history_status, history_payload = self._get_json(f"/tasks/{task_id}/evaluations")
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(status, 400)
+        self.assertTrue(response_payload["invalid_input"])
+        self.assertIn("cannot submit runtime_facts", response_payload["error"].lower())
+        self.assertEqual(task_status, 200)
+        self.assertEqual(task_payload["task"]["artifacts"]["items"], [])
+        self.assertEqual(history_status, 200)
+        self.assertEqual(len(history_payload["evaluations"]), 1)
 
     def test_api_exposes_supervision_queue_endpoint(self) -> None:
         create_status, create_payload = self._post_json("/evaluate", _request_payload("review_required"))


### PR DESCRIPTION
## Summary
- add a thin `/sync/github` API wrapper that translates GitHub-shaped sync payloads into canonical reevaluation input
- attach trusted GitHub-backed branch, commit, and pull request artifacts through the existing reevaluation path without allowing runtime telemetry or completion claims
- document the new sync-only wrapper and cover it with connector and HTTP tests

## Testing
- python3 -m unittest discover -s tests