### PR TITLE
Resume completion context through GitHub sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Harness also keeps new-task submission separate from persisted-task mutation. `P
 That same fail-closed rule now applies to the persisted-task helpers themselves. `POST /tasks/<task_id>/reevaluate` and `POST /tasks/<task_id>/completion-claims` reject submission-style mutation fields such as `task_envelope`, `task_status`, `assigned_executor`, and `linked_artifacts` instead of silently ignoring them.
 Generic reevaluation is also no longer allowed to combine executor runtime telemetry with repository execution artifacts such as PRs, commits, branches, or changed-file proofs. If a caller is reporting executor-side execution evidence, it must use `POST /tasks/<task_id>/completion-claims`, where Harness records the execution attempt and applies executor-side contract validation before completion can proceed. Fact-only reevaluation can still attach externally synchronized repository artifacts without pretending they came from a fresh executor run.
 
-For GitHub-backed sync specifically, Harness now also exposes `POST /sync/github` as a thin wrapper over canonical reevaluation. That helper accepts a GitHub-shaped payload plus `task_id`, derives normalized `external_facts.github_facts`, and may attach trusted `github/api` branch, commit, and pull-request artifacts. It is sync-only: it cannot claim completion, assert acceptance, attach completion evidence, or carry executor runtime telemetry.
+For GitHub-backed sync specifically, Harness now also exposes `POST /sync/github` as a thin wrapper over canonical reevaluation. That helper accepts a GitHub-shaped payload plus `task_id`, derives normalized `external_facts.github_facts`, and may attach trusted `github/api` branch, commit, pull-request, and changed-file artifacts. The caller still cannot claim completion, assert acceptance, attach completion evidence, or carry executor runtime telemetry. When Harness already has an unresolved advisory completion claim for the same task, the sync bridge may resume that persisted completion context and advance validated artifact evidence from the newly trusted GitHub sync artifacts.
 
 Evaluation and reevaluation also cannot self-certify newly attached support artifacts. If a caller sends review notes, handoff artifacts, or other non-execution artifacts already marked `verification_status=verified`, Harness downgrades the artifact back to `unverified`, strips it from validated evidence, and forces canonical verification to re-attest it before it counts. Caller-claimed provenance such as `github/api` or `harness/manual_review` is still caller input, not trust for support artifacts. Canonical GitHub-backed code-artifact overlays remain a separate path for normalized external sync.
 
@@ -323,7 +323,7 @@ Run the controlled autonomous dry run that exercises:
 - canonical task creation through `POST /evaluate`
 - OpenClaw-style retry supervision through `GET /supervision/queue` and redispatch
 - Codex Cloud adapter proof validation
-- post-dispatch GitHub-backed reevaluation that closes the missing changed-file evidence gap
+- post-dispatch GitHub-backed sync through `POST /sync/github` that closes the missing changed-file evidence gap
 
 ```bash
 python -m unittest tests.test_autonomous_dryrun

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -93,7 +93,7 @@ For `POST /tasks/<task_id>/reevaluate`, only canonical reevaluation fields are a
 
 `POST /tasks/<task_id>/reevaluate` is not an executor proof-ingestion shortcut. It may attach support artifacts such as review notes, progress artifacts, or handoff artifacts, and it may carry fact-only repository artifacts from external sync, but it must not combine repository execution artifacts with `runtime_facts`. If a caller needs to report executor-side runtime telemetry plus new PR/commit/branch/changed-file proof for an existing task, use `POST /tasks/<task_id>/completion-claims` so Harness can bind the artifacts to an execution attempt and enforce executor contract validation.
 
-`POST /sync/github` exists for the specific case where an external sync process has observed GitHub state and wants Harness to ingest that reality without hand-assembling a canonical reevaluation body. It accepts a GitHub-shaped payload plus `task_id`, derives normalized `external_facts.github_facts`, and may attach trusted `github/api` branch, commit, and pull-request artifacts through the canonical reevaluation path. It must not carry:
+`POST /sync/github` exists for the specific case where an external sync process has observed GitHub state and wants Harness to ingest that reality without hand-assembling a canonical reevaluation body. It accepts a GitHub-shaped payload plus `task_id`, derives normalized `external_facts.github_facts`, and may attach trusted `github/api` branch, commit, pull-request, and changed-file artifacts through the canonical reevaluation path. It must not carry:
 
 - `runtime_facts`
 - `claimed_completion=true`
@@ -103,6 +103,8 @@ For `POST /tasks/<task_id>/reevaluate`, only canonical reevaluation fields are a
 - caller-supplied canonical `new_artifacts` or `external_facts`
 
 That wrapper is for artifact synchronization only. Completion claims, acceptance assertions, and executor telemetry still belong to `POST /tasks/<task_id>/completion-claims`.
+
+If Harness already has an unresolved advisory completion claim and successful execution attempt recorded for that task, the sync bridge may resume that persisted completion evaluation context and advance `completion_evidence.validated_artifact_ids` from the newly trusted synced artifacts. That resumption is Harness-derived state, not caller authority.
 
 Like completion claims, evaluation overlays and reevaluation do not trust caller-submitted `verification_status=verified` on support artifacts. If a caller attaches review notes, handoff artifacts, or other non-execution artifacts already marked verified, Harness downgrades those artifacts back to `unverified`, strips them from validated evidence, and requires canonical verification to earn that trust again. Claimed provenance such as `github/api` sync or `harness/manual_review|verification` does not change that for support artifacts when it arrives through a public API request. Canonical GitHub-backed code-artifact overlays remain allowed for normalized external synchronization paths.
 

--- a/docs/architecture/codex-cloud-execution.md
+++ b/docs/architecture/codex-cloud-execution.md
@@ -140,7 +140,7 @@ That dry run is intentionally narrow and honest. It does not pretend that execut
 - create a retryable task through canonical `POST /evaluate`
 - let the OpenClaw-style supervision loop notice the retryable blocked state and trigger redispatch
 - let the Codex Cloud adapter enforce current-run proof on the redispatched execution attempt
-- run a follow-up canonical reevaluation that simulates GitHub-backed changed-file synchronization before final completion is accepted
+- run a follow-up `POST /sync/github` bridge call that simulates GitHub-backed changed-file synchronization before final completion is accepted
 
 This is important for Harness intent:
 
@@ -148,7 +148,7 @@ This is important for Harness intent:
 - current-run repository proof is validated at dispatch/completion-claim time
 - final completion still depends on canonical artifact ingestion and reevaluation
 
-The dry run is not a replacement for live runtime transport or live GitHub synchronization. It is a deterministic local proof that the supervision, execution-proof, and post-dispatch reevaluation surfaces cooperate correctly enough for autonomous-flow testing.
+The dry run is not a replacement for live runtime transport or live GitHub synchronization. It is a deterministic local proof that the supervision, execution-proof, and post-dispatch GitHub sync/reevaluation surfaces cooperate correctly enough for autonomous-flow testing.
 
 ## Known Failure Mode
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -1903,6 +1903,106 @@ def _execution_attempt_for_completion_claim(
     return matching_attempts[0] if len(matching_attempts) == 1 else None
 
 
+def _historical_acceptance_criteria_satisfied(records: tuple[EvaluationRecord, ...]) -> bool:
+    return any(
+        isinstance(record.request, dict) and bool(record.request.get("acceptance_criteria_satisfied", False))
+        for record in records
+    )
+
+
+def _github_sync_should_resume_completion(
+    stored_task: dict[str, Any],
+    *,
+    records: tuple[EvaluationRecord, ...],
+) -> tuple[bool, bool]:
+    if str(stored_task.get("status") or "") in _TERMINAL_TASK_STATUSES:
+        return False, False
+    latest_claim = _latest_advisory_completion_claim(stored_task)
+    if latest_claim is None:
+        return False, False
+    if not _is_successful_execution_attempt(
+        _execution_attempt_for_completion_claim(stored_task, completion_claim=latest_claim)
+    ):
+        return False, False
+    return True, _historical_acceptance_criteria_satisfied(records)
+
+
+def _github_sync_completion_evidence_update(
+    stored_task: dict[str, Any],
+    *,
+    new_artifacts: tuple[dict[str, Any], ...],
+) -> dict[str, Any] | None:
+    completion_evidence = ((stored_task.get("artifacts") or {}).get("completion_evidence") or {})
+    if not isinstance(completion_evidence, dict):
+        return None
+
+    required_types = [
+        _normalized_string(item)
+        for item in completion_evidence.get("required_artifact_types") or []
+        if _normalized_string(item) is not None
+    ]
+    if not required_types:
+        return None
+
+    existing_validated_ids = [
+        str(item)
+        for item in completion_evidence.get("validated_artifact_ids") or []
+        if _normalized_string(item) is not None
+    ]
+
+    synced_validated_ids = [
+        str(artifact.get("id"))
+        for artifact in new_artifacts
+        if isinstance(artifact, dict)
+        and artifact.get("id") is not None
+        and _normalized_string(artifact.get("verification_status")) == "verified"
+        and _normalized_string(artifact.get("type")) in required_types
+    ]
+
+    merged_validated_ids: list[str] = []
+    for artifact_id in [*existing_validated_ids, *synced_validated_ids]:
+        if artifact_id not in merged_validated_ids:
+            merged_validated_ids.append(artifact_id)
+    if merged_validated_ids == existing_validated_ids:
+        return None
+
+    artifact_type_by_id: dict[str, str] = {}
+    artifact_items = ((stored_task.get("artifacts") or {}).get("items") or [])
+    if isinstance(artifact_items, list):
+        for item in artifact_items:
+            if not isinstance(item, dict) or item.get("id") is None:
+                continue
+            artifact_type = _normalized_string(item.get("type"))
+            if artifact_type is not None:
+                artifact_type_by_id[str(item.get("id"))] = artifact_type
+    for artifact in new_artifacts:
+        if not isinstance(artifact, dict) or artifact.get("id") is None:
+            continue
+        artifact_type = _normalized_string(artifact.get("type"))
+        if artifact_type is not None:
+            artifact_type_by_id[str(artifact.get("id"))] = artifact_type
+
+    validated_types = {
+        artifact_type_by_id.get(str(artifact_id))
+        for artifact_id in merged_validated_ids
+    }
+    validated_types.discard(None)
+    all_required_types_present = all(required_type in validated_types for required_type in required_types)
+
+    return {
+        "validated_artifact_ids": merged_validated_ids,
+        "validation_method": "external_reconciliation",
+        "validated_at": _iso_now(),
+        "validator": {
+            "source_system": "harness",
+            "source_type": "verification",
+            "source_id": "sync/github",
+            "captured_by": "github-sync",
+        },
+        "status": "satisfied" if all_required_types_present else "deferred",
+    }
+
+
 def _is_replayed_completion_claim(
     stored_task: dict[str, Any],
     *,
@@ -3684,7 +3784,33 @@ class HarnessApiService:
                 "invalid_input": True,
             }
 
-        return self.reevaluate(canonical_payload["task_id"], {"request": canonical_payload["request"]})
+        task_id = canonical_payload["task_id"]
+        try:
+            stored_task = self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+
+        records = self.store.list_evaluation_records(task_id)
+        request_payload = deepcopy(canonical_payload["request"])
+        new_artifacts = tuple(
+            item for item in (request_payload.get("new_artifacts") or []) if isinstance(item, dict)
+        )
+        resume_claimed_completion, resume_acceptance = _github_sync_should_resume_completion(
+            stored_task,
+            records=records,
+        )
+        if resume_claimed_completion:
+            request_payload["claimed_completion"] = True
+            request_payload["acceptance_criteria_satisfied"] = resume_acceptance
+
+        completion_evidence_update = _github_sync_completion_evidence_update(
+            stored_task,
+            new_artifacts=new_artifacts,
+        )
+        if completion_evidence_update is not None:
+            request_payload["completion_evidence"] = completion_evidence_update
+
+        return self.reevaluate(task_id, {"request": request_payload})
 
     def evaluate(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:

--- a/modules/autonomous_dryrun.py
+++ b/modules/autonomous_dryrun.py
@@ -166,69 +166,46 @@ def _task_scoped_branch_name(task_id: str) -> str:
     return f"codex/{slug or 'task'}"
 
 
-def _github_sync_reevaluation_payload(task_id: str) -> dict[str, Any]:
+def _github_sync_payload(task_id: str) -> dict[str, Any]:
     branch_name = _task_scoped_branch_name(task_id)
-    changed_file_artifact_id = f"artifact-changed-file-{task_id}"
     commit_sha = "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705"
     return {
-        "request": {
-            "new_artifacts": [
+        "task_id": task_id,
+        "captured_at": "2026-04-12T16:06:00Z",
+        "expected_code_context": build_expected_code_context(branch_name=branch_name),
+        "github": {
+            "repository": {
+                "host": "github.com",
+                "owner": "KnoxAnalytics",
+                "name": "HARNESS-DRYRUN",
+                "node_id": "repo-dryrun-1",
+            },
+            "branch": {
+                "name": branch_name,
+                "baseRefName": "main",
+                "target": {"oid": commit_sha},
+            },
+            "commit": {
+                "sha": commit_sha,
+                "html_url": f"https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/{commit_sha}",
+                "commit": {"message": "GitHub sync filled the missing changed-file evidence"},
+            },
+            "pull_request": {
+                "number": 2,
+                "state": "open",
+                "reviewDecision": "approved",
+                "html_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/2",
+                "merged": False,
+            },
+            "files": [
                 {
-                    "id": changed_file_artifact_id,
-                    "type": "changed_file",
-                    "title": "GitHub changed-file proof",
-                    "description": "Post-dispatch GitHub sync captured the changed file for the latest run.",
-                    "location": f"https://github.com/KnoxAnalytics/HARNESS-DRYRUN/blob/{branch_name}/modules/api.py",
-                    "content_type": None,
-                    "external_id": None,
-                    "commit_sha": commit_sha,
-                    "pull_request_number": None,
-                    "review_state": None,
-                    "provenance": {
-                        "source_system": "github",
-                        "source_type": "api",
-                        "source_id": f"contents/{branch_name}/modules/api.py",
-                        "captured_by": "github-sync",
-                    },
-                    "verification_status": "verified",
-                    "repository": {
-                        "host": "github.com",
-                        "owner": "KnoxAnalytics",
-                        "name": "HARNESS-DRYRUN",
-                        "external_id": "repo-dryrun-1",
-                    },
-                    "branch": {
-                        "name": branch_name,
-                        "base_branch": "main",
-                        "head_commit_sha": commit_sha,
-                    },
-                    "changed_files": [
-                        {
-                            "path": "modules/api.py",
-                            "change_type": "modified",
-                        }
-                    ],
-                    "external_refs": [],
-                    "captured_at": "2026-04-12T16:06:00Z",
-                    "metadata": {},
+                    "filename": "modules/api.py",
+                    "status": "modified",
+                    "additions": 12,
+                    "deletions": 1,
                 }
             ],
-            "completion_evidence": {
-                "validated_artifact_ids": [
-                    "artifact-pr-1",
-                    "artifact-commit-1",
-                    changed_file_artifact_id,
-                ],
-                "validation_method": "external_reconciliation",
-            },
-            "external_facts": {
-                "expected_code_context": build_expected_code_context(branch_name=branch_name),
-                "github_facts": build_github_facts(branch_name=branch_name),
-                "linear_facts": build_linear_facts(state="completed", workflow_state_type="completed"),
-            },
-            "claimed_completion": True,
-            "acceptance_criteria_satisfied": True,
-        }
+        },
     }
 
 
@@ -280,8 +257,8 @@ def run_retryable_codex_supervision_dry_run(
                 reevaluation_status, reevaluation_payload = _request_json(
                     base_url,
                     "POST",
-                    f"/tasks/{task_id}/reevaluate",
-                    _github_sync_reevaluation_payload(task_id),
+                    "/sync/github",
+                    _github_sync_payload(task_id),
                 )
                 if reevaluation_status >= 400:
                     raise RuntimeError(f"Autonomous dry run GitHub sync failed: {reevaluation_payload}")

--- a/modules/connectors/github_sync.py
+++ b/modules/connectors/github_sync.py
@@ -120,6 +120,25 @@ def _derive_pull_request_location(repository: RepositoryFact | None, pull_reques
     return f"https://{repository.host}/{repository.owner}/{repository.name}/pull/{pull_request.number}"
 
 
+def _derive_changed_file_location(
+    *,
+    repository: RepositoryFact | None,
+    branch: BranchFact | None,
+    commit: CommitFact | None,
+    path: str,
+) -> str | None:
+    if repository is None:
+        return None
+    revision = None
+    if commit is not None and commit.sha:
+        revision = commit.sha
+    elif branch is not None and branch.name:
+        revision = branch.name
+    if revision is None:
+        return None
+    return f"https://{repository.host}/{repository.owner}/{repository.name}/blob/{revision}/{path}"
+
+
 def _branch_artifact(
     *,
     repository: RepositoryFact | None,
@@ -232,6 +251,70 @@ def _pull_request_artifact(
     }
 
 
+def _changed_file_artifacts(
+    *,
+    repository: RepositoryFact | None,
+    branch: BranchFact | None,
+    commit: CommitFact | None,
+    pull_request: PullRequestFact | None,
+    changed_files: ChangedFilesSummary | None,
+    captured_at: str,
+    captured_by: str,
+) -> tuple[dict[str, Any], ...]:
+    if changed_files is None:
+        return ()
+
+    artifacts: list[dict[str, Any]] = []
+    commit_sha = None
+    if commit is not None:
+        commit_sha = commit.sha
+    elif branch is not None:
+        commit_sha = branch.head_commit_sha
+
+    for index, file_fact in enumerate(changed_files.files, start=1):
+        artifacts.append(
+            {
+                "id": f"artifact-changed-file-{_artifact_id_suffix(file_fact.path)}-{index}",
+                "type": "changed_file",
+                "title": "GitHub changed-file sync",
+                "description": "Attached by GitHub sync through canonical reevaluation.",
+                "location": _derive_changed_file_location(
+                    repository=repository,
+                    branch=branch,
+                    commit=commit,
+                    path=file_fact.path,
+                ),
+                "content_type": None,
+                "external_id": file_fact.path,
+                "commit_sha": commit_sha,
+                "pull_request_number": pull_request.number if pull_request is not None else None,
+                "review_state": None,
+                "provenance": {
+                    "source_system": "github",
+                    "source_type": "api",
+                    "source_id": f"contents/{file_fact.path}",
+                    "captured_by": captured_by,
+                },
+                "verification_status": "verified",
+                "repository": _repository_payload(repository),
+                "branch": _branch_payload(branch),
+                "changed_files": [
+                    {
+                        "path": file_fact.path,
+                        "change_type": file_fact.change_type,
+                        "additions": file_fact.additions,
+                        "deletions": file_fact.deletions,
+                        "previous_path": file_fact.previous_path,
+                    }
+                ],
+                "external_refs": [],
+                "captured_at": captured_at,
+                "metadata": {},
+            }
+        )
+    return tuple(artifacts)
+
+
 def _new_artifacts_from_github_facts(
     github_facts: GitHubArtifactFacts,
     *,
@@ -274,6 +357,17 @@ def _new_artifacts_from_github_facts(
                 captured_by=captured_by,
             )
         )
+    artifacts.extend(
+        _changed_file_artifacts(
+            repository=repository,
+            branch=branch,
+            commit=commit,
+            pull_request=pull_request,
+            changed_files=github_facts.changed_files,
+            captured_at=captured_at,
+            captured_by=captured_by,
+        )
+    )
     return tuple(artifacts)
 
 

--- a/tests/connectors/test_github_sync.py
+++ b/tests/connectors/test_github_sync.py
@@ -81,14 +81,12 @@ class GitHubSyncTranslationTests(unittest.TestCase):
         github_facts = request["external_facts"]["github_facts"]
         self.assertEqual(github_facts["repository"]["name"], "HARNESS-DRYRUN")
         self.assertEqual(github_facts["pull_request"]["number"], 2)
-        self.assertEqual(len(request["new_artifacts"]), 3)
+        self.assertEqual(len(request["new_artifacts"]), 4)
         artifact_types = [artifact["type"] for artifact in request["new_artifacts"]]
-        self.assertEqual(artifact_types, ["branch", "commit", "pull_request"])
+        self.assertEqual(artifact_types, ["branch", "commit", "pull_request", "changed_file"])
         self.assertTrue(all(artifact["verification_status"] == "verified" for artifact in request["new_artifacts"]))
-        self.assertEqual(
-            request["new_artifacts"][2]["changed_files"][0]["path"],
-            "modules/api.py",
-        )
+        self.assertEqual(request["new_artifacts"][2]["changed_files"][0]["path"], "modules/api.py")
+        self.assertEqual(request["new_artifacts"][3]["changed_files"][0]["path"], "modules/api.py")
 
     def test_rejects_runtime_and_completion_shaped_fields(self) -> None:
         payload = _github_sync_payload()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5781,10 +5781,10 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(history_status, 200)
         self.assertEqual(len(history_payload["evaluations"]), 2)
         artifacts = payload["task_envelope"]["artifacts"]["items"]
-        self.assertEqual([artifact["type"] for artifact in artifacts], ["branch", "commit", "pull_request"])
+        self.assertEqual([artifact["type"] for artifact in artifacts], ["branch", "commit", "pull_request", "changed_file"])
         self.assertTrue(all(artifact["verification_status"] == "verified" for artifact in artifacts))
         self.assertEqual(
-            task_payload["task"]["artifacts"]["items"][2]["changed_files"][0]["path"],
+            task_payload["task"]["artifacts"]["items"][3]["changed_files"][0]["path"],
             "modules/api.py",
         )
         self.assertEqual(

--- a/tests/test_autonomous_dryrun.py
+++ b/tests/test_autonomous_dryrun.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
+import modules.autonomous_dryrun as autonomous_dryrun
 from modules.autonomous_dryrun import (
     SampleCodexCloudRuntimeClient,
     run_retryable_codex_supervision_dry_run,
@@ -65,6 +67,25 @@ class _SuccessfulCodexCloudRuntimeClient:
 
 
 class AutonomousDryRunTests(unittest.TestCase):
+    def test_retryable_codex_supervision_dry_run_uses_github_sync_endpoint(self) -> None:
+        with patch(
+            "modules.autonomous_dryrun._request_json",
+            wraps=autonomous_dryrun._request_json,
+        ) as request_json:
+            result = run_retryable_codex_supervision_dry_run(
+                runtime_client=_SuccessfulCodexCloudRuntimeClient(),
+                task_id="autonomous-dryrun-sync-endpoint-1",
+            )
+
+        request_pairs = [(call.args[1], call.args[2]) for call in request_json.call_args_list]
+
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertIn(("POST", "/sync/github"), request_pairs)
+        self.assertNotIn(
+            ("POST", f"/tasks/{result.task_id}/reevaluate"),
+            request_pairs,
+        )
+
     def test_retryable_codex_supervision_dry_run_recovers_to_completed(self) -> None:
         result = run_retryable_codex_supervision_dry_run(
             runtime_client=_SuccessfulCodexCloudRuntimeClient(),


### PR DESCRIPTION
## Summary
- make `/sync/github` synthesize changed-file artifacts and resume previously recorded completion evaluation context from Harness-owned history
- let trusted GitHub sync artifacts advance validated completion evidence without caller-supplied completion mutations
- switch the controlled autonomous dry run to prove the public GitHub sync bridge instead of hand-building a reevaluation payload

## Testing
- python3 -m unittest tests.test_autonomous_dryrun tests.connectors.test_github_sync tests.test_api.HarnessHttpApiTests.test_api_github_sync_delegates_to_canonical_reevaluation tests.test_api.HarnessHttpApiTests.test_api_github_sync_rejects_runtime_facts_without_mutating_task
- python3 -m unittest discover -s tests