### PR TITLE
Allow OpenClaw to redispatch stale active work

### DIFF
--- a/docs/integration/openclaw-harness-spike.md
+++ b/docs/integration/openclaw-harness-spike.md
@@ -104,18 +104,19 @@ The loop remains intentionally narrow:
 
 - `review_required` stays a manual-review requirement
 - `clarification_required` stays a clarification collection requirement
-- `invalid_execution_attempt` stays a proof-or-rework requirement
-- `stale_active_task` stays an investigation requirement
+- `invalid_execution_attempt` stays a proof-or-rework requirement unless a stronger canonical recovery path is added later
 
-It currently performs one bounded autonomous follow-up:
+It currently performs bounded autonomous follow-ups only when the canonical task state is still dispatchable:
 
-- if the queue surfaces `retryable_failure`, and the canonical task state is dispatchable, the loop may call `POST /tasks/<task_id>/dispatch` with an explicit `dispatch_trigger=openclaw_supervision_loop`
+- if the queue surfaces `retryable_failure`, the loop may call `POST /tasks/<task_id>/dispatch` with an explicit `dispatch_trigger=openclaw_supervision_loop`
+- if the queue surfaces `stale_active_task` for an `assigned` or `dispatch_ready` task, the loop may call the same canonical dispatch endpoint to kick stalled work back into motion
+- if the queue surfaces `github_sync_required`, the loop may call `POST /sync/github` using repository and branch facts already recorded in the canonical execution summary
 
 That keeps OpenClaw thin while proving the next autonomy step:
 
 - OpenClaw can observe what needs attention
 - OpenClaw can inspect the canonical evidence behind that attention
-- OpenClaw can trigger a governed redispatch without bypassing Harness lifecycle enforcement
+- OpenClaw can trigger a governed redispatch or GitHub sync without bypassing Harness lifecycle enforcement
 
 Since the spike was written, Harness added a dedicated OpenClaw ingress adapter endpoint (`POST /ingress/openclaw`) that still delegates into canonical submission semantics (`POST /tasks`) rather than introducing a separate control-plane contract.
 

--- a/modules/connectors/openclaw_supervisor.py
+++ b/modules/connectors/openclaw_supervisor.py
@@ -64,10 +64,20 @@ class OpenClawHarnessSupervisor:
         self.client = OpenClawHarnessSpikeClient(base_url)
 
     def _can_autonomously_dispatch(self, entry: dict[str, Any]) -> bool:
+        attention_type = str(entry.get("attention_type") or "")
+        suggested_action = str(entry.get("suggested_action") or "")
+        dispatchable_attention = (
+            (attention_type == "retryable_failure" and suggested_action == "retry_or_redispatch")
+            or (attention_type == "stale_active_task" and suggested_action == "investigate_staleness")
+        )
+        dispatchable_statuses = {"dispatch_ready", "assigned"} if attention_type == "stale_active_task" else {
+            "dispatch_ready",
+            "assigned",
+            "blocked",
+        }
         return (
-            str(entry.get("attention_type") or "") == "retryable_failure"
-            and str(entry.get("suggested_action") or "") == "retry_or_redispatch"
-            and str(entry.get("current_status") or "") in {"dispatch_ready", "assigned", "blocked"}
+            dispatchable_attention
+            and str(entry.get("current_status") or "") in dispatchable_statuses
             and str(entry.get("clarification_status") or "") != "required"
             and str(entry.get("review_status") or "") != "requested"
         )

--- a/tests/connectors/test_openclaw_supervisor.py
+++ b/tests/connectors/test_openclaw_supervisor.py
@@ -18,6 +18,7 @@ from modules.connectors.openclaw_supervisor import OpenClawHarnessSupervisor
 from modules.demo_cases import build_demo_request
 from modules.runtime_scenario_builders import to_jsonable
 from modules.store import FileBackedHarnessStore
+from modules.supervision import HarnessSupervisionService
 from tests.test_api import (
     _registry_with_current_run_pull_request_gateway,
     _registry_with_no_create_pull_request_gateway,
@@ -166,6 +167,49 @@ class OpenClawHarnessSupervisorTests(unittest.TestCase):
         self.assertEqual(retry_action.http_status, 200)
         self.assertIsNotNone(retry_action.action)
         self.assertIn(retry_action.resulting_task_status, {"blocked", "completed", "failed", "in_review"})
+
+    def test_cycle_can_trigger_bounded_redispatch_for_stale_active_task(self) -> None:
+        self.service.supervision_service = HarnessSupervisionService(
+            store=self.service.store,
+            now_provider=lambda: "2026-04-16T12:00:00Z",
+        )
+        submit_status, submit_payload = self.client.submit_task(
+            intent=self._intent("task-openclaw-supervisor-stale-1"),
+            context=self._context(),
+        )
+        self.assertEqual(submit_status, 200)
+        task_id = submit_payload["task_envelope"]["id"]
+
+        stored_task = self.service.store.get_task(task_id)
+        stored_task["status"] = "assigned"
+        stored_task["assigned_executor"] = {
+            "executor_type": "codex",
+            "executor_id": "executor-openclaw-supervisor-stale-1",
+            "assignment_reason": "Exercise supervisor stale-task redispatch.",
+        }
+        stored_task["timestamps"]["updated_at"] = "2026-04-01T10:03:00Z"
+        self.service.store.update_task(stored_task)
+
+        supervisor = OpenClawHarnessSupervisor(self.base_url)
+        cycle = supervisor.run_cycle(allow_redispatch=True, executor="codex")
+        decisions = {decision.task_id: decision for decision in cycle.decisions}
+        actions = {result.task_id: result for result in cycle.action_results}
+
+        stale_decision = decisions[task_id]
+        self.assertEqual(stale_decision.attention_type, "stale_active_task")
+        self.assertEqual(stale_decision.suggested_action, "investigate_staleness")
+        self.assertTrue(stale_decision.can_autonomously_dispatch)
+        self.assertIsNotNone(stale_decision.proposed_dispatch_payload)
+        self.assertEqual(
+            stale_decision.proposed_dispatch_payload["request"]["dispatch_trigger"],
+            "openclaw_supervision_loop",
+        )
+
+        stale_action = actions[task_id]
+        self.assertEqual(stale_action.action_status, "redispatch_triggered")
+        self.assertEqual(stale_action.http_status, 200)
+        self.assertIsNotNone(stale_action.action)
+        self.assertIn(stale_action.resulting_task_status, {"blocked", "completed", "failed", "in_review"})
 
     def test_cycle_can_trigger_github_sync_for_sync_required_attention(self) -> None:
         submit_status, submit_payload = self.client.submit_task(


### PR DESCRIPTION
## Summary
- let the OpenClaw supervisor redispatch stale assigned or dispatch-ready work through the canonical dispatch endpoint
- add an integration test covering stale-task redispatch through the public API boundary
- update the OpenClaw spike doc to reflect the current bounded autonomous follow-ups

## Testing
- python3 -m unittest tests.connectors.test_openclaw_supervisor
- python3 -m unittest tests.test_supervision tests.test_autonomous_dryrun tests.e2e.test_control_plane_supervision_queue_flows
