### PR TITLE
fix: harden hosted Vercel runtime defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 # Local dashboard -> local API override.
+# Hosted Vercel deployments ignore this override and route to the same
+# deployment's /backend service automatically.
 HARNESS_API_BASE_URL=http://127.0.0.1:8000
 
 # Hosted Vercel deployments derive the backend route automatically from

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ config/openclaw/openclaw.local.json5
 .docker-demo-output/
 *.pid
 *.seed
+.vercel

--- a/README.md
+++ b/README.md
@@ -225,13 +225,14 @@ Required frontend environment variable:
 
 - `HARNESS_API_BASE_URL`
   - Local example: `http://127.0.0.1:8000`
-  - Hosted use: local override only; same-project Vercel deployments derive the backend route automatically
+  - Hosted use: local override only; same-project Vercel deployments always derive the backend route automatically and ignore stale hosted overrides
 
 Backend storage environment variables:
 
 - `HARNESS_STORE_BACKEND`
   - Supported values: `file`, `postgres`
   - Default in [`.env.example`](.env.example): `file`
+  - Hosted Vercel deployments auto-select `postgres` when managed Postgres connection variables are present
 - Postgres connection string
   - Harness resolves this in order from `DATABASE_URL`, `POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, `POSTGRES_PRISMA_URL`, then `POSTGRES_URL_NO_SSL`
   - `DATABASE_URL` remains the explicit portable override

--- a/app/api/runtime/storage-health/route.ts
+++ b/app/api/runtime/storage-health/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { getBlobRuntimeHealth } from "@/lib/blob-runtime-health";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const blob = await getBlobRuntimeHealth({
+    BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
+  });
+
+  return NextResponse.json(
+    {
+      status:
+        !blob.configured || blob.accessible ? "ok" : "degraded",
+      blob,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,5 @@
--r ../requirements.txt
+jsonschema==4.25.1
+psycopg[binary]==3.2.10
+fastapi==0.115.12
+uvicorn==0.34.2
+httpx==0.28.1

--- a/docs/setup/vercel-neon.md
+++ b/docs/setup/vercel-neon.md
@@ -70,7 +70,7 @@ The dashboard derives the backend route automatically from:
 - `VERCEL_URL`
 - the backend route prefix `/backend`
 
-`HARNESS_API_BASE_URL` remains available as a local-development override only.
+`HARNESS_API_BASE_URL` remains available as a local-development override only. Hosted Vercel deployments prefer the same-project `/backend` route even if an older external override is still present in project settings.
 
 ## Storage Notes
 

--- a/lib/blob-runtime-health.ts
+++ b/lib/blob-runtime-health.ts
@@ -1,0 +1,44 @@
+type BlobListFn = (options: { token: string; limit: number }) => Promise<unknown>;
+
+export type BlobRuntimeHealth = {
+  configured: boolean;
+  accessible: boolean;
+  error: string | null;
+};
+
+async function listBlobsWithSdk(options: {
+  token: string;
+  limit: number;
+}): Promise<unknown> {
+  const { list } = await import("@vercel/blob");
+  return list(options);
+}
+
+export async function getBlobRuntimeHealth(
+  env: Partial<Record<"BLOB_READ_WRITE_TOKEN", string | undefined>>,
+  listBlobs: BlobListFn = listBlobsWithSdk,
+): Promise<BlobRuntimeHealth> {
+  const token = env.BLOB_READ_WRITE_TOKEN?.trim();
+  if (!token) {
+    return {
+      configured: false,
+      accessible: false,
+      error: null,
+    };
+  }
+
+  try {
+    await listBlobs({ token, limit: 1 });
+    return {
+      configured: true,
+      accessible: true,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      configured: true,
+      accessible: false,
+      error: error instanceof Error ? error.message : "unknown error",
+    };
+  }
+}

--- a/lib/harness-api-base.ts
+++ b/lib/harness-api-base.ts
@@ -7,14 +7,14 @@ function stripTrailingSlash(value: string): string {
 export function resolveHarnessApiBaseUrl(
   env: Partial<Record<"HARNESS_API_BASE_URL" | "VERCEL_URL", string | undefined>>,
 ): string | null {
-  const explicit = env.HARNESS_API_BASE_URL?.trim();
-  if (explicit) {
-    return stripTrailingSlash(explicit);
-  }
-
   const vercelUrl = env.VERCEL_URL?.trim();
   if (vercelUrl) {
     return `https://${stripTrailingSlash(vercelUrl)}${DEFAULT_VERCEL_BACKEND_ROUTE_PREFIX}`;
+  }
+
+  const explicit = env.HARNESS_API_BASE_URL?.trim();
+  if (explicit) {
+    return stripTrailingSlash(explicit);
   }
 
   return null;

--- a/modules/store.py
+++ b/modules/store.py
@@ -247,6 +247,16 @@ def resolve_postgres_database_url(database_url: str | None = None) -> str:
     return ""
 
 
+def _is_vercel_runtime() -> bool:
+    return any(
+        (
+            os.environ.get("VERCEL_URL"),
+            os.environ.get("VERCEL_ENV"),
+            os.environ.get("VERCEL_REGION"),
+        )
+    )
+
+
 class PostgresHarnessStore(HarnessStore):
     """Postgres-backed store for canonical tasks and append-only evaluation history."""
 
@@ -458,12 +468,21 @@ def build_harness_store(
 ) -> HarnessStore:
     """Construct the configured persistence backend for the API process."""
 
-    backend = (store_backend or os.environ.get("HARNESS_STORE_BACKEND") or "file").strip().lower()
+    resolved_database_url = resolve_postgres_database_url(database_url)
+    configured_backend = (store_backend or os.environ.get("HARNESS_STORE_BACKEND") or "").strip().lower()
+    if configured_backend:
+        backend = configured_backend
+    elif database_url and database_url.strip():
+        backend = "postgres"
+    elif _is_vercel_runtime() and resolved_database_url:
+        backend = "postgres"
+    else:
+        backend = "file"
+
     if backend == "file":
         resolved_store_root = Path(store_root or os.environ.get("HARNESS_STORE_ROOT") or ".harness-store")
         return FileBackedHarnessStore(resolved_store_root)
     if backend == "postgres":
-        resolved_database_url = resolve_postgres_database_url(database_url)
         return PostgresHarnessStore(resolved_database_url)
     raise StoreError(f"Unsupported HARNESS_STORE_BACKEND {backend!r}; expected 'file' or 'postgres'")
 

--- a/package.json
+++ b/package.json
@@ -10,23 +10,24 @@
     "test:frontend": "tsx --test tests/frontend/**/*.test.ts"
   },
   "dependencies": {
+    "@vercel/blob": "^2.3.3",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.468.0",
     "next": "^16",
     "react": "^19",
     "react-dom": "^19",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^3.0.0",
-    "lucide-react": "^0.468.0"
+    "tailwind-merge": "^3.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "tailwindcss": "^4",
-    "@tailwindcss/postcss": "^4",
     "eslint": "^9.23.0",
     "eslint-config-next": "^16.2.1",
-    "tsx": "^4.20.0"
+    "tailwindcss": "^4",
+    "tsx": "^4.20.0",
+    "typescript": "^5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@vercel/blob':
+        specifier: ^2.3.3
+        version: 2.3.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -879,6 +882,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/blob@2.3.3':
+    resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
+    engines: {node: '>=20.0.0'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -941,6 +948,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1447,6 +1457,10 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
@@ -1489,6 +1503,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -1895,6 +1912,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2039,6 +2060,10 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2102,6 +2127,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2826,6 +2855,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vercel/blob@2.3.3':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.25.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2917,6 +2954,10 @@ snapshots:
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -3591,6 +3632,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-buffer@2.0.5: {}
+
   is-bun-module@2.0.0:
     dependencies:
       semver: 7.7.4
@@ -3633,6 +3676,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -4023,6 +4068,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   run-parallel@1.2.0:
@@ -4224,6 +4271,8 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  throttleit@2.1.0: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4311,6 +4360,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@6.25.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:

--- a/server.py
+++ b/server.py
@@ -1,0 +1,1 @@
+from backend.server import app

--- a/tests/frontend/blob-runtime-health.test.ts
+++ b/tests/frontend/blob-runtime-health.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getBlobRuntimeHealth } from "../../lib/blob-runtime-health";
+
+test("reports Blob as unconfigured when no token is present", async () => {
+  const health = await getBlobRuntimeHealth({});
+
+  assert.deepEqual(health, {
+    configured: false,
+    accessible: false,
+    error: null,
+  });
+});
+
+test("reports Blob as accessible when the SDK call succeeds", async () => {
+  const health = await getBlobRuntimeHealth(
+    {
+      BLOB_READ_WRITE_TOKEN: "blob_rw_token",
+    },
+    async () => ({ blobs: [] }),
+  );
+
+  assert.deepEqual(health, {
+    configured: true,
+    accessible: true,
+    error: null,
+  });
+});
+
+test("reports Blob as degraded when the SDK call fails", async () => {
+  const health = await getBlobRuntimeHealth(
+    {
+      BLOB_READ_WRITE_TOKEN: "blob_rw_token",
+    },
+    async () => {
+      throw new Error("blob probe failed");
+    },
+  );
+
+  assert.deepEqual(health, {
+    configured: true,
+    accessible: false,
+    error: "blob probe failed",
+  });
+});

--- a/tests/frontend/harness-api-base.test.ts
+++ b/tests/frontend/harness-api-base.test.ts
@@ -6,10 +6,18 @@ import { resolveHarnessApiBaseUrl } from "../../lib/harness-api-base";
 test("prefers explicit HARNESS_API_BASE_URL and strips a trailing slash", () => {
   const resolved = resolveHarnessApiBaseUrl({
     HARNESS_API_BASE_URL: "https://api.example.com/",
-    VERCEL_URL: "ignored.example.vercel.app",
   });
 
   assert.equal(resolved, "https://api.example.com");
+});
+
+test("prefers same-project Vercel routing over explicit overrides in hosted deployments", () => {
+  const resolved = resolveHarnessApiBaseUrl({
+    HARNESS_API_BASE_URL: "https://stale-backend.example.com/",
+    VERCEL_URL: "harness-preview.vercel.app",
+  });
+
+  assert.equal(resolved, "https://harness-preview.vercel.app/backend");
 });
 
 test("derives the hosted backend url from VERCEL_URL when no override is set", () => {

--- a/tests/test_hosted_deployment_contract.py
+++ b/tests/test_hosted_deployment_contract.py
@@ -16,6 +16,10 @@ class HostedDeploymentContractTests(unittest.TestCase):
         self.assertEqual(services["api"]["entrypoint"], "backend/server.py")
         self.assertEqual(services["api"]["framework"], "fastapi")
         self.assertEqual(services["api"]["routePrefix"], "/backend")
+        self.assertEqual(
+            services["api"]["includeFiles"],
+            ["modules/**", "schemas/**", "sql/postgres/**"],
+        )
 
     def test_env_example_documents_local_override_only(self) -> None:
         env_example = Path(".env.example").read_text(encoding="utf-8")

--- a/tests/test_hosted_deployment_contract.py
+++ b/tests/test_hosted_deployment_contract.py
@@ -13,13 +13,9 @@ class HostedDeploymentContractTests(unittest.TestCase):
         self.assertEqual(services["web"]["entrypoint"], ".")
         self.assertEqual(services["web"]["framework"], "nextjs")
         self.assertEqual(services["web"]["routePrefix"], "/")
-        self.assertEqual(services["api"]["entrypoint"], "backend/server.py")
+        self.assertEqual(services["api"]["entrypoint"], "server.py")
         self.assertEqual(services["api"]["framework"], "fastapi")
         self.assertEqual(services["api"]["routePrefix"], "/backend")
-        self.assertEqual(
-            services["api"]["includeFiles"],
-            ["modules/**", "schemas/**", "sql/postgres/**"],
-        )
 
     def test_env_example_documents_local_override_only(self) -> None:
         env_example = Path(".env.example").read_text(encoding="utf-8")

--- a/tests/test_hosted_deployment_contract.py
+++ b/tests/test_hosted_deployment_contract.py
@@ -24,3 +24,9 @@ class HostedDeploymentContractTests(unittest.TestCase):
         self.assertIn("Hosted Vercel deployments derive the backend route automatically", env_example)
         self.assertIn("POSTGRES_URL", env_example)
         self.assertIn("BLOB_READ_WRITE_TOKEN", env_example)
+
+    def test_backend_requirements_are_declared_inline_for_vercel_python_builds(self) -> None:
+        backend_requirements = Path("backend/requirements.txt").read_text(encoding="utf-8")
+
+        self.assertNotIn("-r ../requirements.txt", backend_requirements)
+        self.assertIn("fastapi==0.115.12", backend_requirements)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -191,6 +191,27 @@ class PostgresDatabaseUrlResolutionTests(unittest.TestCase):
         self.assertIsInstance(store, PostgresHarnessStore)
         self.assertEqual(store.database_url, "postgresql://env-vercel")
 
+    def test_build_harness_store_defaults_to_postgres_in_vercel_when_database_url_is_available(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "VERCEL_URL": "harness-preview.vercel.app",
+                "POSTGRES_URL": "postgresql://env-vercel",
+            },
+            clear=True,
+        ):
+            store = build_harness_store()
+
+        self.assertIsInstance(store, PostgresHarnessStore)
+        self.assertEqual(store.database_url, "postgresql://env-vercel")
+
+    def test_build_harness_store_defaults_to_postgres_when_explicit_database_url_is_passed(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            store = build_harness_store(database_url="postgresql://explicit")
+
+        self.assertIsInstance(store, PostgresHarnessStore)
+        self.assertEqual(store.database_url, "postgresql://explicit")
+
     def test_postgres_backend_error_lists_supported_environment_variables(self) -> None:
         with self.assertRaises(StoreError) as context:
             PostgresHarnessStore("")

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,8 @@
     "api": {
       "entrypoint": "backend/server.py",
       "framework": "fastapi",
-      "routePrefix": "/backend"
+      "routePrefix": "/backend",
+      "includeFiles": ["modules/**", "schemas/**", "sql/postgres/**"]
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -7,10 +7,9 @@
       "routePrefix": "/"
     },
     "api": {
-      "entrypoint": "backend/server.py",
+      "entrypoint": "server.py",
       "framework": "fastapi",
-      "routePrefix": "/backend",
-      "includeFiles": ["modules/**", "schemas/**", "sql/postgres/**"]
+      "routePrefix": "/backend"
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix the Vercel Python service packaging so the backend boots from a repo-root FastAPI entrypoint
- harden hosted defaults so Vercel deployments prefer same-project backend routing and auto-select Postgres when managed envs are present
- add a runtime Blob health endpoint and verify Neon schema initialization for the live deployment

## Verification
- pnpm lint
- pnpm exec node --import tsx --test tests/frontend/*.test.ts
- pnpm build
- python3 -m unittest discover -s tests
- live Vercel checks against /backend/health, /api/harness/health, and /api/runtime/storage-health
