### PR TITLE
Fail fast on invalid hosted dry-run PR branches

### DIFF
--- a/modules/hosted_dryrun_flow.py
+++ b/modules/hosted_dryrun_flow.py
@@ -31,6 +31,7 @@ DEFAULT_BASE_BRANCH = "main"
 DEFAULT_TARGET_FILE = "docs/dry-run-proof.md"
 DEFAULT_COMMIT_MESSAGE = "docs: add dry run proof"
 DEFAULT_LABELS = ("linear", "dryrun", "codex-cloud")
+RESERVED_BRANCH_NAMES = frozenset({"work"})
 LINEAR_API_URL = "https://api.linear.app/graphql"
 GITHUB_API_URL = "https://api.github.com"
 
@@ -490,6 +491,29 @@ def ensure_expected_file_present(
         raise DryRunFlowError(f"Expected changed file {expected_path!r} was not present in the PR")
 
 
+def ensure_pull_request_matches_session(
+    session: DryRunSession,
+    pull_request: GitHubPullRequestSnapshot,
+) -> None:
+    expected_repository = f"{session.github_owner}/{session.github_repo}"
+    observed_repository = f"{pull_request.owner}/{pull_request.repo}"
+    if observed_repository != expected_repository:
+        raise DryRunFlowError(
+            f"PR repository {observed_repository} does not match expected {expected_repository}"
+        )
+
+    if pull_request.base_branch != session.base_branch:
+        raise DryRunFlowError(
+            f"PR base branch {pull_request.base_branch!r} does not match expected {session.base_branch!r}"
+        )
+
+    normalized_branch_name = pull_request.branch_name.strip().lower()
+    if normalized_branch_name in RESERVED_BRANCH_NAMES:
+        raise DryRunFlowError(
+            f"PR head branch {pull_request.branch_name!r} is reserved and cannot be used as dry-run proof."
+        )
+
+
 def build_completion_claim_request(
     session: DryRunSession,
     pull_request: GitHubPullRequestSnapshot,
@@ -792,6 +816,7 @@ __all__ = [
     "compact_utc",
     "ensure_directory",
     "ensure_expected_file_present",
+    "ensure_pull_request_matches_session",
     "fetch_github_pull_request_bundle",
     "fetch_linear_issue",
     "fetch_task_inspection",

--- a/scripts/hosted_dryrun.py
+++ b/scripts/hosted_dryrun.py
@@ -29,6 +29,7 @@ from modules.hosted_dryrun_flow import (
     build_operator_summary,
     ensure_directory,
     ensure_expected_file_present,
+    ensure_pull_request_matches_session,
     fetch_github_pull_request_bundle,
     fetch_linear_issue,
     fetch_task_inspection,
@@ -138,10 +139,7 @@ def _cmd_finish(args: argparse.Namespace) -> int:
         github_token=github_token,
         pr_url=args.pr_url,
     )
-    if pull_request.owner != session.github_owner or pull_request.repo != session.github_repo:
-        raise DryRunFlowError(
-            f"PR repository {pull_request.owner}/{pull_request.repo} does not match expected {session.github_owner}/{session.github_repo}"
-        )
+    ensure_pull_request_matches_session(session, pull_request)
     ensure_expected_file_present(changed_files, expected_path=session.target_file)
 
     claim_result = post_completion_claim(client, session=session, pull_request=pull_request, commit=commit)

--- a/tests/test_hosted_dryrun_flow.py
+++ b/tests/test_hosted_dryrun_flow.py
@@ -18,6 +18,7 @@ from modules.hosted_dryrun_flow import (
     build_linear_ingress_payload,
     _build_ssl_context,
     ensure_expected_file_present,
+    ensure_pull_request_matches_session,
     parse_github_pull_request_url,
     summarize_pull_request_review_decision,
 )
@@ -144,6 +145,26 @@ class HostedDryRunFlowTests(unittest.TestCase):
                 ),
                 expected_path="docs/dry-run-proof.md",
             )
+
+    def test_pull_request_match_rejects_reserved_work_branch(self) -> None:
+        reserved_branch_pr = GitHubPullRequestSnapshot(
+            owner=self.pull_request.owner,
+            repo=self.pull_request.repo,
+            number=self.pull_request.number,
+            url=self.pull_request.url,
+            state=self.pull_request.state,
+            merged=self.pull_request.merged,
+            branch_name="work",
+            base_branch=self.pull_request.base_branch,
+            commit_sha=self.pull_request.commit_sha,
+            repository_node_id=self.pull_request.repository_node_id,
+            review_decision=self.pull_request.review_decision,
+        )
+
+        with self.assertRaises(DryRunFlowError) as raised:
+            ensure_pull_request_matches_session(self.session, reserved_branch_pr)
+
+        self.assertIn("reserved", str(raised.exception))
 
     def test_review_decision_summary_prefers_changes_requested(self) -> None:
         reviews = [


### PR DESCRIPTION
## Summary
- reject reserved PR head branches before calling hosted completion-claim APIs
- reject PRs targeting the wrong base branch in the hosted dry-run helper
- add regression coverage for the reserved branch guard

## Testing
- python3 -m unittest tests.test_hosted_dryrun_flow
- python3 -m unittest discover -s tests