### PR TITLE
feat: add reset verifier slice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@
 # deployment's /backend service automatically.
 HARNESS_API_BASE_URL=http://127.0.0.1:8000
 
+# Reset-slice verifier secrets for local development.
+# GITHUB_TOKEN=ghp_...
+# LINEAR_API_KEY=lin_api_...
+# OPENCLAW_BASE_URL=http://127.0.0.1:18789
+# OPENCLAW_REPAIR_ENDPOINT=/repair
+
 # Hosted Vercel deployments derive the backend route automatically from
 # VERCEL_URL and the /backend service prefix.
 HARNESS_STORE_BACKEND=file

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ Harness is a control plane and reliability layer for AI-assisted work.
 
 It does not trust agent-reported completion on its own. It accepts or blocks lifecycle transitions only after evaluating canonical task state, evidence, reconciliation facts, and explicit review decisions.
 
+## Reset Slice
+
+The repo now also carries a narrower reset-oriented path alongside the broader TaskEnvelope control plane.
+
+That reset slice is the current fastest path to something operationally useful:
+
+- OpenClaw owns intake, PRD generation, decomposition, Linear issue creation, and Codex dispatch.
+- Harness owns verification contracts, GitHub proof validation, retry budgeting, and Linear truth updates.
+- Linear is the operator UI for V1.
+- GitHub is the proof source for code-bearing completion.
+
+The reset routes live under:
+
+- `POST /reset/contracts`
+- `GET /reset/contracts`
+- `GET /reset/contracts/<contract_id>`
+- `POST /reset/contracts/<contract_id>/claims`
+- `POST /reset/tick`
+
+These routes intentionally coexist with the older TaskEnvelope routes so the narrower verifier path can ship without first deleting the broader control-plane code.
+
 ## What Harness Is
 
 - A Python control-plane backend that evaluates canonical `TaskEnvelope` submissions.
@@ -241,6 +262,17 @@ Backend storage environment variables:
   - Auto-injected when a Vercel Blob store is connected to the project
   - Not required for canonical task state today; Postgres remains the source of truth
 
+Reset-slice verifier environment variables:
+
+- `GITHUB_TOKEN`
+  - Used by the reset verifier to validate branch, commit SHA, and PR proof against GitHub
+- `LINEAR_API_KEY`
+  - Used by the reset verifier to move Linear issues and leave canonical Harness comments
+- `OPENCLAW_BASE_URL`
+  - Used by the reset verifier to request OpenClaw repair when proof is invalid but retryable
+- `OPENCLAW_REPAIR_ENDPOINT`
+  - Optional override for the OpenClaw repair callback path
+
 Relevant supporting files:
 
 - [`.env.example`](.env.example)
@@ -265,6 +297,8 @@ Run the backend with the file store:
 ```bash
 python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
+
+`backend.server` now auto-loads repo-root `.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and `OPENCLAW_BASE_URL` without manual shell export steps.
 
 Run the backend with Postgres:
 
@@ -302,6 +336,16 @@ Run the frontend:
 ```bash
 pnpm dev
 ```
+
+### Reset-Slice Smoke Path
+
+Once the backend is running and `.env.local` contains `GITHUB_TOKEN`, `LINEAR_API_KEY`, and `OPENCLAW_BASE_URL`, the narrow verifier path is available through:
+
+- `POST /reset/contracts`
+- `POST /reset/contracts/<contract_id>/claims`
+- `POST /reset/tick`
+
+Use this path when you want Harness to verify GitHub proof for a Linear issue and push canonical truth back into Linear without depending on the dashboard.
 
 ## Test Execution
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -6,7 +6,11 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from modules.api import HarnessApiService
+from modules.local_env import load_repo_root_env
+from modules.reset.service import ResetVerificationService
 from modules.store import HarnessStore
+
+load_repo_root_env()
 
 
 def _json_response(result: tuple[int, dict[str, Any]]) -> JSONResponse:
@@ -14,8 +18,18 @@ def _json_response(result: tuple[int, dict[str, Any]]) -> JSONResponse:
     return JSONResponse(status_code=int(status_code), content=payload)
 
 
-def create_app(*, store: HarnessStore | None = None) -> FastAPI:
+def _build_reset_service(store: HarnessStore | None) -> ResetVerificationService:
+    root_dir = getattr(store, "root_dir", None) if store is not None else None
+    return ResetVerificationService.from_env(root_dir=root_dir)
+
+
+def create_app(
+    *,
+    store: HarnessStore | None = None,
+    reset_service: ResetVerificationService | None = None,
+) -> FastAPI:
     service = HarnessApiService(store=store)
+    reset_verifier = reset_service or _build_reset_service(store)
     app = FastAPI(title="Harness API", version="0.1.0")
 
     @app.get("/health")
@@ -90,6 +104,28 @@ def create_app(*, store: HarnessStore | None = None) -> FastAPI:
     async def evaluate(request: Request) -> JSONResponse:
         payload = await request.json()
         return _json_response(service.evaluate(payload))
+
+    @app.post("/reset/contracts")
+    async def register_reset_contract(request: Request) -> JSONResponse:
+        payload = await request.json()
+        return _json_response(reset_verifier.register_contract_http(payload))
+
+    @app.get("/reset/contracts")
+    def list_reset_contracts() -> JSONResponse:
+        return _json_response(reset_verifier.list_contracts_http())
+
+    @app.get("/reset/contracts/{contract_id}")
+    def get_reset_contract(contract_id: str) -> JSONResponse:
+        return _json_response(reset_verifier.get_contract_http(contract_id))
+
+    @app.post("/reset/contracts/{contract_id}/claims")
+    async def submit_reset_claim(contract_id: str, request: Request) -> JSONResponse:
+        payload = await request.json()
+        return _json_response(reset_verifier.submit_claim_http(contract_id, payload))
+
+    @app.post("/reset/tick")
+    def run_reset_tick() -> JSONResponse:
+        return _json_response(reset_verifier.tick_http())
 
     return app
 

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -56,6 +56,13 @@ pnpm build
 python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
 
+`backend.server` now auto-loads repo-root `.env.local` during native local startup. For the reset verifier slice, put these there:
+
+- `GITHUB_TOKEN`
+- `LINEAR_API_KEY`
+- `OPENCLAW_BASE_URL`
+- optional `OPENCLAW_REPAIR_ENDPOINT`
+
 To run the same backend against Postgres instead of the file-backed store:
 
 ```bash
@@ -73,6 +80,23 @@ python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
 
 The backend defaults to `http://127.0.0.1:8000` in the local runbook above. Hosted deployments use the Vercel `api` service rather than a separate Render process.
+
+### Reset Verifier Endpoints
+
+The narrow verifier slice is exposed alongside the older TaskEnvelope routes:
+
+- `POST /reset/contracts`
+- `GET /reset/contracts`
+- `GET /reset/contracts/<contract_id>`
+- `POST /reset/contracts/<contract_id>/claims`
+- `POST /reset/tick`
+
+Use this path when you want Harness to:
+
+- register a Linear issue verification contract
+- verify GitHub proof for a claimed completion
+- trigger OpenClaw repair on invalid proof
+- escalate to `In Review` after the retry budget is exhausted
 
 ### Run The Dashboard
 

--- a/docs/superpowers/plans/2026-04-15-verifier-reset-v1.md
+++ b/docs/superpowers/plans/2026-04-15-verifier-reset-v1.md
@@ -1,0 +1,646 @@
+# Harness Verifier Reset V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a local-first reset slice that verifies GitHub proof for Linear issues, writes canonical truth back into Linear, and triggers bounded OpenClaw repair without depending on the dashboard or the broad TaskEnvelope flow.
+
+**Architecture:** Keep the existing TaskEnvelope control-plane routes intact, but add a parallel reset-specific service with its own contract store, verification engine, Linear/OpenClaw clients, and deterministic supervision tick endpoint. Use existing GitHub lookup patterns where they help, but make the reset slice explicit and small so it can ship before any larger repo cleanup.
+
+**Tech Stack:** Python 3, FastAPI, file-backed JSON persistence, GitHub REST API, Linear GraphQL API, existing local OpenClaw bootstrap/config, `unittest`
+
+---
+
+## File Map
+
+- `backend/server.py`
+  Add reset-specific HTTP routes next to the existing API.
+
+- `modules/reset/__init__.py`
+  Reset slice package boundary.
+
+- `modules/reset/contracts.py`
+  Dataclasses and validation for verification contracts, completion claims, and verdicts.
+
+- `modules/reset/store.py`
+  File-backed persistence for reset contracts and event history.
+
+- `modules/reset/github_verifier.py`
+  Strict GitHub verification of repo, branch, commit SHA, and PR alignment.
+
+- `modules/reset/linear_client.py`
+  Thin Linear GraphQL client for issue state/substatus/comment updates.
+
+- `modules/reset/openclaw_client.py`
+  Thin HTTP client that sends repair requests to OpenClaw.
+
+- `modules/reset/service.py`
+  Orchestrates registration, completion claim handling, verdict evaluation, Linear updates, and supervision ticks.
+
+- `modules/local_env.py`
+  Lightweight local `.env.local` loader for local runtime convenience.
+
+- `tests/reset/test_contracts.py`
+  Validation tests for reset contract objects.
+
+- `tests/reset/test_store.py`
+  Persistence tests for reset contract state and event history.
+
+- `tests/reset/test_github_verifier.py`
+  GitHub proof validation tests with fake API responses.
+
+- `tests/reset/test_service.py`
+  End-to-end service tests covering registration, invalid proof, retries, review escalation, and verified completion.
+
+- `tests/test_fastapi_backend.py`
+  HTTP route coverage for the new reset endpoints.
+
+- `README.md`
+  Narrow product description and reset-slice local run instructions.
+
+- `docs/setup/local-development.md`
+  Add reset-slice local run/test instructions and `.env.local` autoload notes.
+
+### Task 1: Add local `.env.local` autoload for native backend runs
+
+**Files:**
+- Create: `modules/local_env.py`
+- Modify: `backend/server.py`
+- Test: `tests/test_fastapi_backend.py`
+
+- [ ] **Step 1: Write the failing backend env-loader tests**
+
+```python
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from modules.local_env import load_local_env_file
+
+
+class LocalEnvLoaderTests(unittest.TestCase):
+    def test_loads_key_value_pairs_without_overwriting_existing_values(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / ".env.local"
+            env_path.write_text("FIRST=one\nSECOND=two\n", encoding="utf-8")
+
+            os.environ["SECOND"] = "existing"
+            self.addCleanup(lambda: os.environ.pop("SECOND", None))
+            self.addCleanup(lambda: os.environ.pop("FIRST", None))
+
+            loaded = load_local_env_file(env_path)
+
+            self.assertEqual(loaded, ("FIRST",))
+            self.assertEqual(os.environ["FIRST"], "one")
+            self.assertEqual(os.environ["SECOND"], "existing")
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `python3 -m unittest tests.test_fastapi_backend.LocalEnvLoaderTests -v`
+Expected: FAIL because `modules.local_env` and `load_local_env_file` do not exist yet.
+
+- [ ] **Step 3: Add the local env loader and call it during backend startup**
+
+```python
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def load_local_env_file(path: str | Path, *, override: bool = False) -> tuple[str, ...]:
+    env_path = Path(path)
+    if not env_path.exists():
+        return ()
+
+    loaded: list[str] = []
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if key in os.environ and not override:
+            continue
+        os.environ[key] = value
+        loaded.append(key)
+    return tuple(loaded)
+
+
+def load_repo_root_env() -> tuple[str, ...]:
+    repo_root = Path(__file__).resolve().parents[1]
+    return load_local_env_file(repo_root / ".env.local")
+```
+
+```python
+from modules.local_env import load_repo_root_env
+
+load_repo_root_env()
+```
+
+- [ ] **Step 4: Re-run the focused backend test**
+
+Run: `python3 -m unittest tests.test_fastapi_backend.LocalEnvLoaderTests -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/local_env.py backend/server.py tests/test_fastapi_backend.py
+git commit -m "feat: autoload local Harness env file"
+```
+
+### Task 2: Add reset contract models and file-backed persistence
+
+**Files:**
+- Create: `modules/reset/__init__.py`
+- Create: `modules/reset/contracts.py`
+- Create: `modules/reset/store.py`
+- Create: `tests/reset/test_contracts.py`
+- Create: `tests/reset/test_store.py`
+
+- [ ] **Step 1: Write the failing reset contract and store tests**
+
+```python
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from modules.reset.contracts import (
+    ResetCompletionClaim,
+    ResetVerificationContract,
+    ResetVerificationContractError,
+)
+from modules.reset.store import FileBackedResetStore
+
+
+class ResetContractTests(unittest.TestCase):
+    def test_contract_requires_linear_issue_and_repository(self) -> None:
+        with self.assertRaises(ResetVerificationContractError):
+            ResetVerificationContract(
+                contract_id="",
+                linear_issue_id="",
+                repository_owner="",
+                repository_name="",
+                branch_ref="",
+            )
+
+
+class ResetStoreTests(unittest.TestCase):
+    def test_round_trips_contracts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="main",
+            )
+
+            store.create_contract(contract)
+            loaded = store.get_contract("contract-1")
+
+            self.assertEqual(loaded.contract_id, "contract-1")
+            self.assertEqual(loaded.linear_issue_id, "KNO-999")
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `python3 -m unittest tests.reset.test_contracts tests.reset.test_store -v`
+Expected: FAIL because the reset modules do not exist yet.
+
+- [ ] **Step 3: Add the reset contract dataclasses and file-backed store**
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class ResetVerificationContractError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ResetCompletionClaim:
+    repository_owner: str
+    repository_name: str
+    branch_name: str
+    commit_sha: str
+    pull_request_number: int | None = None
+    pull_request_url: str | None = None
+
+
+@dataclass(frozen=True)
+class ResetVerificationContract:
+    contract_id: str
+    linear_issue_id: str
+    repository_owner: str
+    repository_name: str
+    branch_ref: str
+    retry_count: int = 0
+    retry_budget: int = 2
+    harness_status: str = "running"
+    latest_claim: ResetCompletionClaim | None = None
+    latest_verdict: str | None = None
+    event_log: tuple[dict[str, str], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not self.contract_id.strip():
+            raise ResetVerificationContractError("contract_id is required")
+        if not self.linear_issue_id.strip():
+            raise ResetVerificationContractError("linear_issue_id is required")
+        if not self.repository_owner.strip() or not self.repository_name.strip():
+            raise ResetVerificationContractError("repository owner/name are required")
+        if not self.branch_ref.strip():
+            raise ResetVerificationContractError("branch_ref is required")
+```
+
+```python
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from .contracts import ResetVerificationContract
+
+
+class FileBackedResetStore:
+    def __init__(self, root_dir: str | Path) -> None:
+        self.root_dir = Path(root_dir)
+        self.contracts_dir = self.root_dir / "reset-contracts"
+        self.contracts_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, contract_id: str) -> Path:
+        return self.contracts_dir / f"{contract_id}.json"
+
+    def create_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
+        path = self._path(contract.contract_id)
+        if path.exists():
+            raise ValueError(f"contract {contract.contract_id!r} already exists")
+        path.write_text(json.dumps(asdict(contract), indent=2, sort_keys=True), encoding="utf-8")
+        return contract
+
+    def get_contract(self, contract_id: str) -> ResetVerificationContract:
+        payload = json.loads(self._path(contract_id).read_text(encoding="utf-8"))
+        return ResetVerificationContract(**payload)
+```
+
+- [ ] **Step 4: Re-run the focused reset tests**
+
+Run: `python3 -m unittest tests.reset.test_contracts tests.reset.test_store -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/reset/__init__.py modules/reset/contracts.py modules/reset/store.py tests/reset/test_contracts.py tests/reset/test_store.py
+git commit -m "feat: add reset verification contract store"
+```
+
+### Task 3: Add strict GitHub verification for repo, branch, commit, and PR alignment
+
+**Files:**
+- Create: `modules/reset/github_verifier.py`
+- Create: `tests/reset/test_github_verifier.py`
+
+- [ ] **Step 1: Write the failing GitHub verifier tests**
+
+```python
+from __future__ import annotations
+
+import unittest
+
+from modules.reset.github_verifier import ResetGitHubVerifier, ResetGitHubVerdict
+
+
+class FakeGitHubClient:
+    def __init__(self) -> None:
+        self.branch_exists_result = True
+        self.commit_exists_result = True
+        self.pull_request_payload = {
+            "number": 42,
+            "html_url": "https://github.com/sfayka/Harness/pull/42",
+            "state": "open",
+            "head": {
+                "ref": "codex/reset-verifier-v1",
+                "sha": "abc123",
+                "repo": {"owner": {"login": "sfayka"}, "name": "Harness"},
+            },
+        }
+
+
+class ResetGitHubVerifierTests(unittest.TestCase):
+    def test_returns_verified_done_for_matching_claim(self) -> None:
+        verifier = ResetGitHubVerifier(client=FakeGitHubClient())
+
+        verdict = verifier.verify(
+            expected_owner="sfayka",
+            expected_repo="Harness",
+            expected_branch="codex/reset-verifier-v1",
+            branch_name="codex/reset-verifier-v1",
+            commit_sha="abc123",
+            pull_request_number=42,
+        )
+
+        self.assertEqual(verdict.status, "verified_done")
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `python3 -m unittest tests.reset.test_github_verifier -v`
+Expected: FAIL because the verifier does not exist yet.
+
+- [ ] **Step 3: Add a strict reset verifier**
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ResetGitHubVerdict:
+    status: str
+    reason: str
+
+
+class ResetGitHubVerifier:
+    def __init__(self, client) -> None:
+        self.client = client
+
+    def verify(
+        self,
+        *,
+        expected_owner: str,
+        expected_repo: str,
+        expected_branch: str,
+        branch_name: str,
+        commit_sha: str,
+        pull_request_number: int,
+    ) -> ResetGitHubVerdict:
+        pull_request = self.client.get_pull_request(expected_owner, expected_repo, pull_request_number)
+        if pull_request is None:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request does not exist")
+
+        head = pull_request["head"]
+        head_repo = head["repo"]
+        if head_repo["owner"]["login"] != expected_owner or head_repo["name"] != expected_repo:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request points at the wrong repository")
+        if head["ref"] != branch_name or branch_name != expected_branch:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request head branch does not match expected branch")
+        if head["sha"] != commit_sha:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request head sha does not match claim")
+        return ResetGitHubVerdict("verified_done", "github proof verified")
+```
+
+- [ ] **Step 4: Re-run the GitHub verifier tests**
+
+Run: `python3 -m unittest tests.reset.test_github_verifier -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/reset/github_verifier.py tests/reset/test_github_verifier.py
+git commit -m "feat: add strict reset github proof verifier"
+```
+
+### Task 4: Add Linear writeback, OpenClaw repair callback, and reset service orchestration
+
+**Files:**
+- Create: `modules/reset/linear_client.py`
+- Create: `modules/reset/openclaw_client.py`
+- Create: `modules/reset/service.py`
+- Create: `tests/reset/test_service.py`
+
+- [ ] **Step 1: Write the failing reset service tests**
+
+```python
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from modules.reset.contracts import ResetCompletionClaim, ResetVerificationContract
+from modules.reset.service import ResetVerificationService
+from modules.reset.store import FileBackedResetStore
+
+
+class FakeLinearClient:
+    def __init__(self) -> None:
+        self.actions = []
+
+    def update_issue(self, issue_id: str, *, state: str | None, harness_status: str, comment: str) -> None:
+        self.actions.append((issue_id, state, harness_status, comment))
+
+
+class FakeOpenClawClient:
+    def __init__(self) -> None:
+        self.repairs = []
+
+    def request_repair(self, issue_id: str, *, reason: str) -> None:
+        self.repairs.append((issue_id, reason))
+
+
+class FakeVerifier:
+    def __init__(self, status: str, reason: str) -> None:
+        self.status = status
+        self.reason = reason
+
+    def verify(self, **_: object):
+        return type("Verdict", (), {"status": self.status, "reason": self.reason})()
+
+
+class ResetVerificationServiceTests(unittest.TestCase):
+    def test_invalid_proof_requests_repair_and_keeps_issue_in_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            linear = FakeLinearClient()
+            openclaw = FakeOpenClawClient()
+            service = ResetVerificationService(store=store, linear_client=linear, verifier=FakeVerifier("retryable_invalid_proof", "wrong sha"), openclaw_client=openclaw)
+
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+            )
+            service.register_contract(contract)
+
+            result = service.submit_claim(
+                "contract-1",
+                ResetCompletionClaim(
+                    repository_owner="sfayka",
+                    repository_name="Harness",
+                    branch_name="codex/reset-verifier-v1",
+                    commit_sha="bad",
+                    pull_request_number=42,
+                ),
+            )
+
+            self.assertEqual(result["status"], "retryable_invalid_proof")
+            self.assertEqual(openclaw.repairs[0][0], "KNO-999")
+            self.assertEqual(linear.actions[-1][1], "In Progress")
+```
+
+- [ ] **Step 2: Run the reset service tests and verify they fail**
+
+Run: `python3 -m unittest tests.reset.test_service -v`
+Expected: FAIL because the reset service and clients do not exist yet.
+
+- [ ] **Step 3: Add the thin Linear client, OpenClaw repair client, and reset orchestration service**
+
+```python
+class ResetVerificationService:
+    def __init__(self, *, store, linear_client, verifier, openclaw_client) -> None:
+        self.store = store
+        self.linear_client = linear_client
+        self.verifier = verifier
+        self.openclaw_client = openclaw_client
+
+    def register_contract(self, contract):
+        self.store.create_contract(contract)
+        self.linear_client.update_issue(
+            contract.linear_issue_id,
+            state="In Progress",
+            harness_status="running",
+            comment="Harness verification contract registered.",
+        )
+        return contract
+
+    def submit_claim(self, contract_id, claim):
+        contract = self.store.get_contract(contract_id)
+        verdict = self.verifier.verify(
+            expected_owner=contract.repository_owner,
+            expected_repo=contract.repository_name,
+            expected_branch=contract.branch_ref,
+            branch_name=claim.branch_name,
+            commit_sha=claim.commit_sha,
+            pull_request_number=claim.pull_request_number,
+        )
+
+        if verdict.status == "verified_done":
+            self.linear_client.update_issue(
+                contract.linear_issue_id,
+                state="Done",
+                harness_status="verified",
+                comment=verdict.reason,
+            )
+            return {"status": "verified_done", "reason": verdict.reason}
+
+        self.openclaw_client.request_repair(contract.linear_issue_id, reason=verdict.reason)
+        self.linear_client.update_issue(
+            contract.linear_issue_id,
+            state="In Progress",
+            harness_status="retrying",
+            comment=verdict.reason,
+        )
+        return {"status": "retryable_invalid_proof", "reason": verdict.reason}
+```
+
+- [ ] **Step 4: Re-run the reset service tests**
+
+Run: `python3 -m unittest tests.reset.test_service -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/reset/linear_client.py modules/reset/openclaw_client.py modules/reset/service.py tests/reset/test_service.py
+git commit -m "feat: add reset verification service orchestration"
+```
+
+### Task 5: Expose reset HTTP endpoints and add a deterministic supervision tick
+
+**Files:**
+- Modify: `backend/server.py`
+- Modify: `modules/reset/service.py`
+- Modify: `tests/test_fastapi_backend.py`
+- Modify: `README.md`
+- Modify: `docs/setup/local-development.md`
+
+- [ ] **Step 1: Write the failing reset HTTP route tests**
+
+```python
+def test_register_claim_and_tick_routes_round_trip(self) -> None:
+    response = self.client.post(
+        "/reset/contracts",
+        json={
+            "contract_id": "contract-1",
+            "linear_issue_id": "KNO-999",
+            "repository_owner": "sfayka",
+            "repository_name": "Harness",
+            "branch_ref": "codex/reset-verifier-v1",
+        },
+    )
+    self.assertEqual(response.status_code, 201)
+
+    claim = self.client.post(
+        "/reset/contracts/contract-1/claims",
+        json={
+            "repository_owner": "sfayka",
+            "repository_name": "Harness",
+            "branch_name": "codex/reset-verifier-v1",
+            "commit_sha": "abc123",
+            "pull_request_number": 42,
+        },
+    )
+    self.assertIn(claim.status_code, (200, 409, 422))
+```
+
+- [ ] **Step 2: Run the HTTP route tests and verify they fail**
+
+Run: `python3 -m unittest tests.test_fastapi_backend.FastApiBackendTests -v`
+Expected: FAIL because the reset routes do not exist yet.
+
+- [ ] **Step 3: Add the reset HTTP routes and supervision tick path**
+
+```python
+@app.post("/reset/contracts")
+async def register_reset_contract(request: Request) -> JSONResponse:
+    payload = await request.json()
+    return _json_response(reset_service.register_contract_http(payload))
+
+@app.get("/reset/contracts")
+def list_reset_contracts() -> JSONResponse:
+    return _json_response(reset_service.list_contracts_http())
+
+@app.get("/reset/contracts/{contract_id}")
+def get_reset_contract(contract_id: str) -> JSONResponse:
+    return _json_response(reset_service.get_contract_http(contract_id))
+
+@app.post("/reset/contracts/{contract_id}/claims")
+async def submit_reset_claim(contract_id: str, request: Request) -> JSONResponse:
+    payload = await request.json()
+    return _json_response(reset_service.submit_claim_http(contract_id, payload))
+
+@app.post("/reset/tick")
+async def run_reset_tick() -> JSONResponse:
+    return _json_response(reset_service.tick_http())
+```
+
+- [ ] **Step 4: Run backend validation and the focused reset suite**
+
+Run: `python3 -m unittest tests.reset.test_contracts tests.reset.test_store tests.reset.test_github_verifier tests.reset.test_service tests.test_fastapi_backend -v`
+Expected: PASS
+
+Run: `python3 -m unittest discover -s tests -p 'test_*.py'`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/server.py modules/reset/service.py tests/test_fastapi_backend.py README.md docs/setup/local-development.md
+git commit -m "feat: expose reset verifier api"
+```

--- a/docs/superpowers/specs/2026-04-15-verifier-reset-design.md
+++ b/docs/superpowers/specs/2026-04-15-verifier-reset-design.md
@@ -1,0 +1,276 @@
+# Harness Verifier Reset Design
+
+## Goal
+
+Reset Harness around the smallest useful product: a local-first verification service that can prove whether OpenClaw and Codex Cloud actually produced a real GitHub result for a Linear issue.
+
+The system should optimize for operator trust and low setup friction, not for broad control-plane completeness.
+
+## Problem
+
+The current repository has grown into a broad control-plane implementation:
+
+- canonical `TaskEnvelope` ingestion and reevaluation
+- multiple ingress adapters
+- lifecycle enforcement
+- read models and timelines
+- a dashboard
+- hosted deployment work
+- autonomy queue and reconciliation flows
+
+That architecture is coherent, but it is not solving the operator's immediate problem quickly enough.
+
+The current pain is concrete:
+
+- too much time is spent on environment variables, auth, and runtime wiring
+- the product still does not provide one reliable end-to-end workflow
+- Codex Cloud and similar systems still cannot be trusted to honestly report whether they created a real PR
+- the operator already uses Linear as the work surface and does not need a second UI if Linear can show canonical truth
+
+The reset must favor a thin vertical slice that saves operator time before expanding system scope again.
+
+## Product Thesis
+
+Harness V1 should be a verifier plus a small supervision loop.
+
+It should not be the planner, the interview surface, the PRD author, the decomposition engine, or the executor.
+
+For V1:
+
+- OpenClaw owns intake, clarification, PRD generation, decomposition, Linear issue creation, and Codex dispatch.
+- Harness owns verification contracts, GitHub proof validation, retry budgeting, and Linear truth updates.
+- Linear remains the operator UI and source of record for work coordination.
+- GitHub remains the proof source for code-bearing work.
+
+## Core Workflow
+
+The first shippable loop is:
+
+1. OpenClaw creates a Linear issue and knows the expected repository and target branch context.
+2. OpenClaw registers that issue with Harness by sending the verification contract.
+3. OpenClaw dispatches Codex Cloud.
+4. When Codex claims completion, OpenClaw sends a completion claim to Harness.
+5. Harness validates the claim against GitHub.
+6. Harness updates Linear with the canonical result.
+7. If proof is invalid but retryable, Harness asks OpenClaw to repair the issue and tries again with a bounded retry budget.
+8. If proof still does not become valid after the retry budget is exhausted, Harness moves the Linear issue to `In Review`.
+
+This workflow exists specifically to catch false completion claims such as:
+
+- no real PR
+- PR in the wrong repository
+- PR on a local-only or wrong branch
+- missing commit SHA
+- stale or unrelated PR URL
+
+## V1 Scope
+
+### Included
+
+- local-first backend runtime
+- repo-root `.env.local` for Harness runtime configuration
+- OpenClaw local config under `config/openclaw/.env.local`
+- file-backed persistence for reset-specific verification contracts
+- GitHub REST validation of repo, branch, commit SHA, and PR
+- Linear updates for workflow state and Harness substatus
+- OpenClaw repair callback endpoint invocation
+- bounded retry budget
+- deterministic supervision tick for active issues
+- focused tests around the new verifier path
+
+### Explicitly Out Of Scope
+
+- dashboard-driven operator workflow
+- hosted deployment as a requirement for usefulness
+- broad TaskEnvelope-first architecture for V1 product behavior
+- generic multi-ingress control-plane semantics
+- generalized read-model and timeline expansion
+- direct Codex Cloud credentials inside Harness
+- OS-process tracking
+- open-ended autonomous orchestration beyond verification and bounded retry
+
+## State Model
+
+Linear remains the visible workflow surface. Harness should reuse existing Linear states rather than inventing a second workflow taxonomy.
+
+### Linear workflow states
+
+- `In Progress`
+- `In Review`
+- `Done`
+
+### Harness substatus
+
+Harness writes a substatus through a Linear field or label:
+
+- `running`
+- `verifying`
+- `retrying`
+- `verified`
+- `proof_invalid`
+- `needs_review`
+
+Only Harness should move an issue to `Done` in the reset slice.
+
+`Done` means verified, not merely claimed complete.
+
+## Verification Contract
+
+The reset slice should store a per-issue verification contract rather than using the full TaskEnvelope machinery as the primary product object.
+
+Required contract fields:
+
+- Harness contract ID
+- Linear issue ID
+- expected GitHub owner/repo
+- expected target branch or branch pattern
+- current retry count
+- max retry budget
+- current Harness substatus
+- latest completion claim summary
+- timestamps for creation and last evaluation
+
+OpenClaw is responsible for setting the expected repository and branch data correctly when it creates the Linear issue.
+
+Harness does not infer those values.
+
+## Completion Claim Contract
+
+When OpenClaw says work is done, it sends a completion claim containing:
+
+- Linear issue ID
+- claimed repo owner/name
+- claimed branch name
+- claimed commit SHA
+- claimed PR number and/or PR URL
+
+Harness then verifies:
+
+- the repository is the expected repository
+- the branch exists remotely
+- the commit exists in the expected repository
+- the PR exists and is real
+- the PR belongs to the expected repository
+- the PR head branch matches the claim
+- the PR head SHA matches the claim
+
+The acceptance bar is strict: it must be a real PR the operator can click and merge.
+
+## Verdicts
+
+Harness should produce machine-readable verdicts so OpenClaw can act immediately.
+
+Canonical reset-slice verdicts:
+
+- `verified_done`
+- `retryable_invalid_proof`
+- `needs_review`
+
+`retryable_invalid_proof` is not terminal. It means the claim is unacceptable in its current form, but OpenClaw should dispatch Codex to repair the issue.
+
+After the retry budget is exhausted, the verdict becomes `needs_review`.
+
+## Supervision Loop
+
+OpenClaw cannot be trusted to remember future-time follow-up on its own. That means Harness must own a small deterministic supervision clock.
+
+The supervision loop should:
+
+- look only at Harness-managed issues still in `In Progress`
+- revisit issues whose latest state is `running`, `verifying`, or `retrying`
+- re-check GitHub proof when a claim exists but is not yet verified
+- trigger OpenClaw repair when proof is invalid and retries remain
+- escalate to `In Review` when retries are exhausted
+
+The loop should not:
+
+- inspect local OS processes
+- poll every issue in Linear
+- become a general workflow engine
+
+## Environment Contract
+
+Harness runtime configuration should be intentionally small.
+
+Required local secrets and endpoints:
+
+- `GITHUB_TOKEN`
+- `LINEAR_API_KEY`
+- `OPENCLAW_BASE_URL`
+
+Optional local config:
+
+- `HARNESS_STORE_BACKEND=file`
+- `HARNESS_STORE_ROOT`
+- `HARNESS_RESET_POLL_SECONDS`
+- `HARNESS_RESET_RETRY_BUDGET`
+- `LINEAR_TEAM_ID` or other workflow mapping helpers if required by the issue update path
+
+The backend should automatically load repo-root `.env.local` in local development so operators and agents do not need to keep exporting variables manually.
+
+## API Surface
+
+The reset should add a narrow API surface alongside the existing backend routes rather than replacing the old API in one step.
+
+Recommended reset routes:
+
+- `POST /reset/contracts`
+  Register a Linear issue verification contract.
+
+- `GET /reset/contracts`
+  List reset-slice contracts for local inspection and tests.
+
+- `GET /reset/contracts/{contract_id}`
+  Inspect one contract.
+
+- `POST /reset/contracts/{contract_id}/claims`
+  Submit a completion claim and get an immediate verification verdict.
+
+- `POST /reset/tick`
+  Run one deterministic supervision cycle for local testing.
+
+This keeps the reset path explicit while allowing the older TaskEnvelope surface to coexist during migration.
+
+## Implementation Strategy
+
+The reset should be additive first.
+
+That means:
+
+- preserve the existing broad control-plane code for now
+- add a new reset-specific service and storage path
+- write focused tests for the reset slice
+- prove the narrow loop locally
+- only then decide which older surfaces should be deprecated or removed
+
+This is safer than trying to collapse the existing architecture before a working replacement exists.
+
+## Success Criteria
+
+The reset is successful when all of the following are true:
+
+1. A local agent can run Harness with one command against repo-root `.env.local`.
+2. OpenClaw can register a Linear issue contract through a thin HTTP client.
+3. A fake completion claim with bad proof is rejected.
+4. Harness updates Linear to show canonical non-acceptance.
+5. Harness can trigger OpenClaw repair with a structured reason.
+6. A valid completion claim with a real repo, branch, commit SHA, and PR is accepted.
+7. Harness moves the Linear issue to `Done` only after successful verification.
+
+## Rejected Alternatives
+
+### Keep the dashboard as the main operator surface
+
+Rejected because it adds another surface to keep truthful and increases local setup friction. Linear already satisfies the operator UI need.
+
+### Make Harness push-only with no supervision loop
+
+Rejected because OpenClaw is not a reliable owner of future-time follow-up.
+
+### Give Harness Codex Cloud credentials and direct dispatch responsibility in V1
+
+Rejected because it adds substantial environment and orchestration complexity without being required for the core trust problem.
+
+### Preserve the full TaskEnvelope-centric architecture as the V1 product shape
+
+Rejected because the product needs a narrow vertical slice that works before it needs generalized control-plane breadth.

--- a/modules/connectors/openclaw_harness_spike.py
+++ b/modules/connectors/openclaw_harness_spike.py
@@ -223,6 +223,21 @@ class OpenClawHarnessSpikeClient:
     def dispatch_task(self, task_id: str, *, payload: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
         return self._request_json("POST", f"/tasks/{task_id}/dispatch", payload or {})
 
+    def register_reset_contract(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", "/reset/contracts", payload)
+
+    def list_reset_contracts(self) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", "/reset/contracts")
+
+    def get_reset_contract(self, contract_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/reset/contracts/{contract_id}")
+
+    def submit_reset_claim(self, contract_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", f"/reset/contracts/{contract_id}/claims", payload)
+
+    def tick_reset(self) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", "/reset/tick", {})
+
 
 def _demo_review_note_artifact() -> dict[str, Any]:
     return {

--- a/modules/local_env.py
+++ b/modules/local_env.py
@@ -1,0 +1,53 @@
+"""Local environment helpers for native Harness development."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _strip_wrapping_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def load_local_env_file(path: str | Path, *, override: bool = False) -> tuple[str, ...]:
+    """Load simple KEY=VALUE pairs from a local env file into process env.
+
+    This is intentionally narrow. It supports the local repo convention and avoids
+    bringing in another dependency just to remove repetitive shell export steps.
+    """
+
+    env_path = Path(path)
+    if not env_path.exists():
+        return ()
+
+    loaded: list[str] = []
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        normalized_key = key.strip()
+        if not normalized_key:
+            continue
+
+        if normalized_key in os.environ and not override:
+            continue
+
+        os.environ[normalized_key] = _strip_wrapping_quotes(value.strip())
+        loaded.append(normalized_key)
+
+    return tuple(loaded)
+
+
+def load_repo_root_env(*, override: bool = False) -> tuple[str, ...]:
+    """Load the repo-root `.env.local` file for native local development."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    return load_local_env_file(repo_root / ".env.local", override=override)
+
+
+__all__ = ["load_local_env_file", "load_repo_root_env"]

--- a/modules/reset/__init__.py
+++ b/modules/reset/__init__.py
@@ -1,0 +1,2 @@
+"""Reset-slice verifier package."""
+

--- a/modules/reset/contracts.py
+++ b/modules/reset/contracts.py
@@ -1,0 +1,174 @@
+"""Contracts for the reset-slice verifier workflow."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from fnmatch import fnmatch
+from typing import Any
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class ResetVerificationContractError(ValueError):
+    """Raised when reset-slice contract input is malformed."""
+
+
+def _require_text(value: str, *, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ResetVerificationContractError(f"{field_name} is required")
+    return normalized
+
+
+@dataclass(frozen=True)
+class ResetEvent:
+    timestamp: str
+    kind: str
+    message: str
+
+    @classmethod
+    def create(cls, *, kind: str, message: str, timestamp: str | None = None) -> "ResetEvent":
+        return cls(timestamp=timestamp or _utc_now(), kind=kind, message=message)
+
+
+@dataclass(frozen=True)
+class ResetCompletionClaim:
+    repository_owner: str
+    repository_name: str
+    branch_name: str
+    commit_sha: str
+    pull_request_number: int | None = None
+    pull_request_url: str | None = None
+    claimed_at: str = field(default_factory=_utc_now)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "repository_owner", _require_text(self.repository_owner, field_name="repository_owner"))
+        object.__setattr__(self, "repository_name", _require_text(self.repository_name, field_name="repository_name"))
+        object.__setattr__(self, "branch_name", _require_text(self.branch_name, field_name="branch_name"))
+        object.__setattr__(self, "commit_sha", _require_text(self.commit_sha, field_name="commit_sha"))
+        if self.pull_request_number is None and not (self.pull_request_url or "").strip():
+            raise ResetVerificationContractError(
+                "pull_request_number or pull_request_url is required"
+            )
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ResetCompletionClaim":
+        return cls(**payload)
+
+
+@dataclass(frozen=True)
+class ResetVerificationContract:
+    contract_id: str
+    linear_issue_id: str
+    repository_owner: str
+    repository_name: str
+    branch_ref: str
+    retry_count: int = 0
+    retry_budget: int = 2
+    harness_status: str = "running"
+    latest_claim: ResetCompletionClaim | None = None
+    latest_verdict: str | None = None
+    latest_reason: str | None = None
+    created_at: str = field(default_factory=_utc_now)
+    updated_at: str = field(default_factory=_utc_now)
+    last_repair_requested_at: str | None = None
+    last_verified_at: str | None = None
+    event_log: tuple[ResetEvent, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "contract_id", _require_text(self.contract_id, field_name="contract_id"))
+        object.__setattr__(self, "linear_issue_id", _require_text(self.linear_issue_id, field_name="linear_issue_id"))
+        object.__setattr__(self, "repository_owner", _require_text(self.repository_owner, field_name="repository_owner"))
+        object.__setattr__(self, "repository_name", _require_text(self.repository_name, field_name="repository_name"))
+        object.__setattr__(self, "branch_ref", _require_text(self.branch_ref, field_name="branch_ref"))
+        if self.retry_budget < 1:
+            raise ResetVerificationContractError("retry_budget must be at least 1")
+        if self.retry_count < 0:
+            raise ResetVerificationContractError("retry_count must be non-negative")
+
+    def branch_matches(self, branch_name: str) -> bool:
+        normalized = branch_name.strip()
+        if "*" in self.branch_ref or "?" in self.branch_ref:
+            return fnmatch(normalized, self.branch_ref)
+        return normalized == self.branch_ref
+
+    def append_event(self, *, kind: str, message: str, timestamp: str | None = None) -> "ResetVerificationContract":
+        return self.updated(
+            event_log=self.event_log + (ResetEvent.create(kind=kind, message=message, timestamp=timestamp),)
+        )
+
+    def updated(self, **changes: Any) -> "ResetVerificationContract":
+        payload = self.asdict()
+        payload.update(changes)
+        payload["updated_at"] = changes.get("updated_at", _utc_now())
+        return self.from_dict(payload)
+
+    def asdict(self) -> dict[str, Any]:
+        return {
+            "contract_id": self.contract_id,
+            "linear_issue_id": self.linear_issue_id,
+            "repository_owner": self.repository_owner,
+            "repository_name": self.repository_name,
+            "branch_ref": self.branch_ref,
+            "retry_count": self.retry_count,
+            "retry_budget": self.retry_budget,
+            "harness_status": self.harness_status,
+            "latest_claim": self.latest_claim.asdict() if self.latest_claim is not None else None,
+            "latest_verdict": self.latest_verdict,
+            "latest_reason": self.latest_reason,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "last_repair_requested_at": self.last_repair_requested_at,
+            "last_verified_at": self.last_verified_at,
+            "event_log": [asdict(event) for event in self.event_log],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ResetVerificationContract":
+        latest_claim = payload.get("latest_claim")
+        event_log = payload.get("event_log") or ()
+        return cls(
+            contract_id=str(payload["contract_id"]),
+            linear_issue_id=str(payload["linear_issue_id"]),
+            repository_owner=str(payload["repository_owner"]),
+            repository_name=str(payload["repository_name"]),
+            branch_ref=str(payload["branch_ref"]),
+            retry_count=int(payload.get("retry_count", 0)),
+            retry_budget=int(payload.get("retry_budget", 2)),
+            harness_status=str(payload.get("harness_status") or "running"),
+            latest_claim=(
+                latest_claim
+                if isinstance(latest_claim, ResetCompletionClaim)
+                else ResetCompletionClaim.from_dict(latest_claim)
+                if isinstance(latest_claim, dict)
+                else None
+            ),
+            latest_verdict=str(payload["latest_verdict"]) if payload.get("latest_verdict") is not None else None,
+            latest_reason=str(payload["latest_reason"]) if payload.get("latest_reason") is not None else None,
+            created_at=str(payload.get("created_at") or _utc_now()),
+            updated_at=str(payload.get("updated_at") or _utc_now()),
+            last_repair_requested_at=(
+                str(payload["last_repair_requested_at"])
+                if payload.get("last_repair_requested_at") is not None
+                else None
+            ),
+            last_verified_at=str(payload["last_verified_at"]) if payload.get("last_verified_at") is not None else None,
+            event_log=tuple(
+                item if isinstance(item, ResetEvent) else ResetEvent(**item)
+                for item in event_log
+            ),
+        )
+
+
+__all__ = [
+    "ResetCompletionClaim",
+    "ResetEvent",
+    "ResetVerificationContract",
+    "ResetVerificationContractError",
+]

--- a/modules/reset/github_verifier.py
+++ b/modules/reset/github_verifier.py
@@ -1,0 +1,141 @@
+"""Strict GitHub proof verification for the reset slice."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib import error, parse, request
+
+
+class ResetGitHubVerificationError(ValueError):
+    """Raised when GitHub verification cannot be executed."""
+
+
+@dataclass(frozen=True)
+class ResetGitHubVerdict:
+    status: str
+    reason: str
+    details: dict[str, Any] | None = None
+
+
+class ResetGitHubClient(Protocol):
+    def branch_exists(self, owner: str, repo: str, branch_name: str) -> bool: ...
+
+    def commit_exists(self, owner: str, repo: str, commit_sha: str) -> bool: ...
+
+    def get_pull_request(self, owner: str, repo: str, pull_request_number: int) -> dict[str, Any] | None: ...
+
+
+class GitHubRestResetClient:
+    """Minimal GitHub REST client used by the reset verifier."""
+
+    def __init__(self, *, token: str | None = None, timeout_seconds: float = 10.0) -> None:
+        self.token = token or os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+        self.timeout_seconds = timeout_seconds
+
+    def _request_json(self, path: str) -> dict[str, Any] | None:
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        req = request.Request(f"https://api.github.com{path}", headers=headers)
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                payload = response.read().decode("utf-8")
+                return json.loads(payload) if payload else {}
+        except error.HTTPError as http_error:
+            if http_error.code == 404:
+                return None
+            raise ResetGitHubVerificationError(f"GitHub request failed for {path}: HTTP {http_error.code}") from http_error
+        except error.URLError as url_error:
+            raise ResetGitHubVerificationError(f"GitHub request failed for {path}: {url_error.reason}") from url_error
+
+    def branch_exists(self, owner: str, repo: str, branch_name: str) -> bool:
+        safe_branch = parse.quote(branch_name, safe="")
+        return self._request_json(f"/repos/{owner}/{repo}/branches/{safe_branch}") is not None
+
+    def commit_exists(self, owner: str, repo: str, commit_sha: str) -> bool:
+        return self._request_json(f"/repos/{owner}/{repo}/commits/{commit_sha}") is not None
+
+    def get_pull_request(self, owner: str, repo: str, pull_request_number: int) -> dict[str, Any] | None:
+        return self._request_json(f"/repos/{owner}/{repo}/pulls/{pull_request_number}")
+
+
+class ResetGitHubVerifier:
+    """Strict GitHub verification against the operator's acceptance bar."""
+
+    def __init__(self, client: ResetGitHubClient | None = None) -> None:
+        self.client = client or GitHubRestResetClient()
+
+    def verify(
+        self,
+        *,
+        expected_owner: str,
+        expected_repo: str,
+        expected_branch: str,
+        branch_name: str,
+        commit_sha: str,
+        pull_request_number: int | None = None,
+        pull_request_url: str | None = None,
+        claimed_owner: str | None = None,
+        claimed_repo: str | None = None,
+    ) -> ResetGitHubVerdict:
+        if claimed_owner is not None and claimed_owner != expected_owner:
+            return ResetGitHubVerdict("retryable_invalid_proof", "claimed repository owner does not match the contract")
+        if claimed_repo is not None and claimed_repo != expected_repo:
+            return ResetGitHubVerdict("retryable_invalid_proof", "claimed repository name does not match the contract")
+        if branch_name != expected_branch:
+            return ResetGitHubVerdict("retryable_invalid_proof", "claimed branch does not match the contract")
+        if not self.client.branch_exists(expected_owner, expected_repo, branch_name):
+            return ResetGitHubVerdict("retryable_invalid_proof", "remote branch does not exist in the expected repository")
+        if not self.client.commit_exists(expected_owner, expected_repo, commit_sha):
+            return ResetGitHubVerdict("retryable_invalid_proof", "commit sha does not exist in the expected repository")
+        if pull_request_number is None:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request number is required for verification")
+
+        pull_request = self.client.get_pull_request(expected_owner, expected_repo, pull_request_number)
+        if pull_request is None:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request does not exist in the expected repository")
+
+        if pull_request_url and pull_request.get("html_url") != pull_request_url:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request url does not match the claimed pull request")
+
+        head = pull_request.get("head") or {}
+        head_repo = head.get("repo") or {}
+        head_owner = ((head_repo.get("owner") or {}).get("login") or "").strip()
+        head_repo_name = (head_repo.get("name") or "").strip()
+        head_ref = (head.get("ref") or "").strip()
+        head_sha = (head.get("sha") or "").strip()
+
+        if head_owner != expected_owner or head_repo_name != expected_repo:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request head repository does not match the contract")
+        if head_ref != branch_name:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request head branch does not match the claim")
+        if head_sha.lower() != commit_sha.lower():
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request head sha does not match the claim")
+
+        state = (pull_request.get("state") or "").strip().lower()
+        merged_at = pull_request.get("merged_at")
+        if state == "closed" and merged_at is None:
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request is closed without being merged")
+
+        return ResetGitHubVerdict(
+            "verified_done",
+            "github proof verified",
+            details={
+                "pull_request_number": pull_request_number,
+                "pull_request_url": pull_request.get("html_url"),
+                "branch_name": head_ref,
+                "commit_sha": head_sha,
+                "state": state,
+            },
+        )
+
+
+__all__ = [
+    "GitHubRestResetClient",
+    "ResetGitHubVerificationError",
+    "ResetGitHubVerifier",
+    "ResetGitHubVerdict",
+]

--- a/modules/reset/linear_client.py
+++ b/modules/reset/linear_client.py
@@ -1,0 +1,114 @@
+"""Thin Linear GraphQL client for reset-slice writeback."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib import error, request
+
+
+class LinearClientError(ValueError):
+    """Raised when Linear API interaction fails."""
+
+
+class LinearResetClient:
+    """Minimal Linear client that updates issue state and writes Harness comments."""
+
+    def __init__(self, *, api_key: str | None = None, timeout_seconds: float = 10.0) -> None:
+        self.api_key = api_key or os.getenv("LINEAR_API_KEY")
+        self.timeout_seconds = timeout_seconds
+
+    def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise LinearClientError("LINEAR_API_KEY is required")
+        req = request.Request(
+            "https://api.linear.app/graphql",
+            data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
+            headers={"Content-Type": "application/json", "Authorization": self.api_key},
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except error.HTTPError as http_error:
+            raise LinearClientError(f"Linear request failed: HTTP {http_error.code}") from http_error
+        except error.URLError as url_error:
+            raise LinearClientError(f"Linear request failed: {url_error.reason}") from url_error
+
+        if payload.get("errors"):
+            message = "; ".join(str(item.get("message", "unknown error")) for item in payload["errors"])
+            raise LinearClientError(f"Linear GraphQL error: {message}")
+        return payload["data"]
+
+    def _get_issue_context(self, issue_ref: str) -> dict[str, Any]:
+        query = """
+        query IssueContext($id: String!) {
+          issue(id: $id) {
+            id
+            identifier
+            url
+            title
+            state { id name type }
+            team {
+              id
+              name
+              states {
+                nodes {
+                  id
+                  name
+                  type
+                }
+              }
+            }
+          }
+        }
+        """
+        payload = self._graphql(query, {"id": issue_ref})
+        issue = payload.get("issue")
+        if not isinstance(issue, dict):
+            raise LinearClientError(f"Linear issue {issue_ref!r} was not found")
+        return issue
+
+    @staticmethod
+    def _state_id_for_name(issue: dict[str, Any], desired_state_name: str) -> str:
+        team = issue.get("team") if isinstance(issue.get("team"), dict) else {}
+        states = team.get("states") if isinstance(team.get("states"), dict) else {}
+        for state in states.get("nodes") or ():
+            if isinstance(state, dict) and str(state.get("name") or "").lower() == desired_state_name.lower():
+                return str(state["id"])
+        raise LinearClientError(f"Linear team state {desired_state_name!r} is not available on issue team")
+
+    def update_issue(self, issue_ref: str, *, state: str | None, harness_status: str, comment: str) -> dict[str, Any]:
+        issue = self._get_issue_context(issue_ref)
+        issue_id = str(issue["id"])
+
+        if state:
+            state_id = self._state_id_for_name(issue, state)
+            update_mutation = """
+            mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
+              issueUpdate(id: $id, input: $input) {
+                success
+              }
+            }
+            """
+            self._graphql(update_mutation, {"id": issue_ref, "input": {"stateId": state_id}})
+
+        comment_body = f"Harness status: {harness_status}\n\n{comment}"
+        comment_mutation = """
+        mutation CreateComment($input: CommentCreateInput!) {
+          commentCreate(input: $input) {
+            success
+          }
+        }
+        """
+        self._graphql(comment_mutation, {"input": {"issueId": issue_id, "body": comment_body}})
+        return {
+            "issue_id": issue_id,
+            "issue_identifier": issue["identifier"],
+            "issue_url": issue["url"],
+            "state": state,
+            "harness_status": harness_status,
+        }
+
+
+__all__ = ["LinearClientError", "LinearResetClient"]

--- a/modules/reset/openclaw_client.py
+++ b/modules/reset/openclaw_client.py
@@ -1,0 +1,50 @@
+"""Thin OpenClaw callback client for repair requests."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib import error, request
+
+
+class OpenClawRepairClientError(ValueError):
+    """Raised when the repair callback cannot be delivered."""
+
+
+class OpenClawRepairClient:
+    """Minimal HTTP client that asks OpenClaw to repair an issue."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        repair_endpoint: str | None = None,
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        self.base_url = (base_url or os.getenv("OPENCLAW_BASE_URL") or "").rstrip("/")
+        self.repair_endpoint = repair_endpoint or os.getenv("OPENCLAW_REPAIR_ENDPOINT") or "/repair"
+        self.timeout_seconds = timeout_seconds
+
+    def request_repair(self, issue_id: str, *, reason: str, contract_id: str | None = None) -> dict[str, Any]:
+        if not self.base_url:
+            raise OpenClawRepairClientError("OPENCLAW_BASE_URL is required")
+        url = f"{self.base_url}{self.repair_endpoint}"
+        payload = {"linear_issue_id": issue_id, "reason": reason, "contract_id": contract_id}
+        req = request.Request(
+            url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                raw_body = response.read().decode("utf-8")
+                return json.loads(raw_body) if raw_body else {"status": "ok"}
+        except error.HTTPError as http_error:
+            raise OpenClawRepairClientError(f"OpenClaw repair callback failed: HTTP {http_error.code}") from http_error
+        except error.URLError as url_error:
+            raise OpenClawRepairClientError(f"OpenClaw repair callback failed: {url_error.reason}") from url_error
+
+
+__all__ = ["OpenClawRepairClient", "OpenClawRepairClientError"]

--- a/modules/reset/service.py
+++ b/modules/reset/service.py
@@ -1,0 +1,304 @@
+"""Reset-slice verification service orchestration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .contracts import ResetCompletionClaim, ResetVerificationContract
+from .github_verifier import ResetGitHubVerdict, ResetGitHubVerifier
+from .linear_client import LinearResetClient
+from .openclaw_client import OpenClawRepairClient
+from .store import (
+    FileBackedResetStore,
+    ResetContractAlreadyExistsError,
+    ResetContractNotFoundError,
+)
+
+
+def _coerce_float(value: str | None, *, default: float) -> float:
+    try:
+        return float(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class ResetTickResult:
+    contract_id: str
+    action: str
+    status: str
+    reason: str
+
+
+class ResetVerificationService:
+    """Owns reset-slice contract registration, verification, and supervision."""
+
+    def __init__(
+        self,
+        *,
+        store: FileBackedResetStore,
+        linear_client: Any,
+        verifier: ResetGitHubVerifier,
+        openclaw_client: Any,
+        retry_cooldown_seconds: float = 900.0,
+    ) -> None:
+        self.store = store
+        self.linear_client = linear_client
+        self.verifier = verifier
+        self.openclaw_client = openclaw_client
+        self.retry_cooldown_seconds = retry_cooldown_seconds
+
+    @classmethod
+    def from_env(cls, *, root_dir: str | Path | None = None) -> "ResetVerificationService":
+        resolved_root = Path(root_dir or os.environ.get("HARNESS_STORE_ROOT") or ".harness-store")
+        cooldown = _coerce_float(os.environ.get("HARNESS_RESET_POLL_SECONDS"), default=900.0)
+        return cls(
+            store=FileBackedResetStore(resolved_root),
+            linear_client=LinearResetClient(),
+            verifier=ResetGitHubVerifier(),
+            openclaw_client=OpenClawRepairClient(),
+            retry_cooldown_seconds=cooldown,
+        )
+
+    def register_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
+        created = self.store.create_contract(
+            contract.append_event(kind="contract_registered", message="Harness verification contract registered.")
+        )
+        self.linear_client.update_issue(
+            created.linear_issue_id,
+            state="In Progress",
+            harness_status="running",
+            comment="Harness verification contract registered.",
+        )
+        return created
+
+    def list_contracts(self) -> tuple[ResetVerificationContract, ...]:
+        return self.store.list_contracts()
+
+    def get_contract(self, contract_id: str) -> ResetVerificationContract:
+        return self.store.get_contract(contract_id)
+
+    def submit_claim(self, contract_id: str, claim: ResetCompletionClaim) -> dict[str, Any]:
+        contract = self.store.get_contract(contract_id).updated(
+            latest_claim=claim,
+            harness_status="verifying",
+        ).append_event(
+            kind="completion_claim_received",
+            message=f"Completion claim received for {claim.repository_owner}/{claim.repository_name}@{claim.branch_name}.",
+            timestamp=claim.claimed_at,
+        )
+        return self._evaluate_and_persist(contract, claim=claim, allow_repair_dispatch=True)
+
+    def tick(self) -> tuple[ResetTickResult, ...]:
+        outcomes: list[ResetTickResult] = []
+        for contract in self.store.list_contracts():
+            if contract.latest_claim is None:
+                continue
+            if contract.harness_status not in {"verifying", "retrying", "running"}:
+                continue
+
+            evaluation = self._evaluate_claim(contract, contract.latest_claim)
+            verdict = evaluation["verdict"]
+            if verdict.status == "verified_done":
+                updated = self._mark_verified(contract, contract.latest_claim, verdict)
+                outcomes.append(
+                    ResetTickResult(
+                        contract_id=updated.contract_id,
+                        action="verified",
+                        status="verified_done",
+                        reason=verdict.reason,
+                    )
+                )
+                continue
+
+            if contract.retry_count >= contract.retry_budget:
+                updated = self._mark_in_review(contract, verdict.reason)
+                outcomes.append(
+                    ResetTickResult(
+                        contract_id=updated.contract_id,
+                        action="escalated",
+                        status="needs_review",
+                        reason=verdict.reason,
+                    )
+                )
+                continue
+
+            updated = self._dispatch_repair(contract, verdict.reason)
+            outcomes.append(
+                ResetTickResult(
+                    contract_id=updated.contract_id,
+                    action="repair_requested",
+                    status="retryable_invalid_proof",
+                    reason=verdict.reason,
+                )
+            )
+        return tuple(outcomes)
+
+    def _evaluate_claim(
+        self, contract: ResetVerificationContract, claim: ResetCompletionClaim
+    ) -> dict[str, Any]:
+        verdict = self.verifier.verify(
+            expected_owner=contract.repository_owner,
+            expected_repo=contract.repository_name,
+            expected_branch=contract.branch_ref,
+            claimed_owner=claim.repository_owner,
+            claimed_repo=claim.repository_name,
+            branch_name=claim.branch_name,
+            commit_sha=claim.commit_sha,
+            pull_request_number=claim.pull_request_number,
+            pull_request_url=claim.pull_request_url,
+        )
+        return {"verdict": verdict}
+
+    def _evaluate_and_persist(
+        self,
+        contract: ResetVerificationContract,
+        *,
+        claim: ResetCompletionClaim,
+        allow_repair_dispatch: bool,
+    ) -> dict[str, Any]:
+        evaluation = self._evaluate_claim(contract, claim)
+        verdict = evaluation["verdict"]
+        if verdict.status == "verified_done":
+            updated = self._mark_verified(contract, claim, verdict)
+            return {
+                "status": "verified_done",
+                "reason": verdict.reason,
+                "contract": updated.asdict(),
+                "details": verdict.details or {},
+            }
+
+        if contract.retry_count >= contract.retry_budget:
+            updated = self._mark_in_review(contract, verdict.reason)
+            return {
+                "status": "needs_review",
+                "reason": verdict.reason,
+                "contract": updated.asdict(),
+            }
+
+        if allow_repair_dispatch:
+            updated = self._dispatch_repair(contract, verdict.reason)
+        else:
+            updated = self.store.update_contract(
+                contract.updated(
+                    latest_verdict="retryable_invalid_proof",
+                    latest_reason=verdict.reason,
+                    harness_status="proof_invalid",
+                ).append_event(kind="verification_failed", message=verdict.reason)
+            )
+        return {
+            "status": "retryable_invalid_proof",
+            "reason": verdict.reason,
+            "contract": updated.asdict(),
+        }
+
+    def _mark_verified(
+        self,
+        contract: ResetVerificationContract,
+        claim: ResetCompletionClaim,
+        verdict: ResetGitHubVerdict,
+    ) -> ResetVerificationContract:
+        updated = contract.updated(
+            latest_claim=claim,
+            latest_verdict="verified_done",
+            latest_reason=verdict.reason,
+            harness_status="verified",
+            last_verified_at=claim.claimed_at,
+        ).append_event(kind="verified", message=verdict.reason, timestamp=claim.claimed_at)
+        self.store.update_contract(updated)
+        self.linear_client.update_issue(
+            updated.linear_issue_id,
+            state="Done",
+            harness_status="verified",
+            comment=verdict.reason,
+        )
+        return updated
+
+    def _dispatch_repair(self, contract: ResetVerificationContract, reason: str) -> ResetVerificationContract:
+        next_retry_count = contract.retry_count + 1
+        self.openclaw_client.request_repair(
+            contract.linear_issue_id,
+            reason=reason,
+            contract_id=contract.contract_id,
+        )
+        updated = contract.updated(
+            retry_count=next_retry_count,
+            latest_verdict="retryable_invalid_proof",
+            latest_reason=reason,
+            harness_status="retrying",
+        )
+        updated = updated.updated(last_repair_requested_at=updated.updated_at).append_event(
+            kind="repair_requested",
+            message=reason,
+        )
+        self.store.update_contract(updated)
+        self.linear_client.update_issue(
+            updated.linear_issue_id,
+            state="In Progress",
+            harness_status="retrying",
+            comment=reason,
+        )
+        return updated
+
+    def _mark_in_review(self, contract: ResetVerificationContract, reason: str) -> ResetVerificationContract:
+        updated = contract.updated(
+            latest_verdict="needs_review",
+            latest_reason=reason,
+            harness_status="needs_review",
+        ).append_event(kind="review_required", message=reason)
+        self.store.update_contract(updated)
+        self.linear_client.update_issue(
+            updated.linear_issue_id,
+            state="In Review",
+            harness_status="needs_review",
+            comment=reason,
+        )
+        return updated
+
+    def register_contract_http(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            contract = ResetVerificationContract.from_dict(payload)
+            created = self.register_contract(contract)
+        except (ResetContractAlreadyExistsError, ValueError) as error:
+            return 400, {"error": str(error)}
+        return 201, {"contract": created.asdict()}
+
+    def list_contracts_http(self) -> tuple[int, dict[str, Any]]:
+        return 200, {"contracts": [contract.asdict() for contract in self.list_contracts()]}
+
+    def get_contract_http(self, contract_id: str) -> tuple[int, dict[str, Any]]:
+        try:
+            contract = self.get_contract(contract_id)
+        except ResetContractNotFoundError as error:
+            return 404, {"error": str(error)}
+        return 200, {"contract": contract.asdict()}
+
+    def submit_claim_http(self, contract_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            claim = ResetCompletionClaim.from_dict(payload)
+            result = self.submit_claim(contract_id, claim)
+        except ResetContractNotFoundError as error:
+            return 404, {"error": str(error)}
+        except ValueError as error:
+            return 400, {"error": str(error)}
+        return 200, result
+
+    def tick_http(self) -> tuple[int, dict[str, Any]]:
+        results = self.tick()
+        return 200, {
+            "results": [
+                {
+                    "contract_id": result.contract_id,
+                    "action": result.action,
+                    "status": result.status,
+                    "reason": result.reason,
+                }
+                for result in results
+            ]
+        }
+
+
+__all__ = ["ResetTickResult", "ResetVerificationService"]

--- a/modules/reset/store.py
+++ b/modules/reset/store.py
@@ -1,0 +1,63 @@
+"""File-backed persistence for reset verifier contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .contracts import ResetVerificationContract
+
+
+class ResetContractNotFoundError(ValueError):
+    """Raised when a reset verifier contract is missing."""
+
+
+class ResetContractAlreadyExistsError(ValueError):
+    """Raised when a contract ID collision occurs."""
+
+
+class FileBackedResetStore:
+    """Simple JSON-file store for the reset verifier slice."""
+
+    def __init__(self, root_dir: str | Path) -> None:
+        self.root_dir = Path(root_dir)
+        self.contracts_dir = self.root_dir / "reset-contracts"
+        self.contracts_dir.mkdir(parents=True, exist_ok=True)
+
+    def _contract_path(self, contract_id: str) -> Path:
+        return self.contracts_dir / f"{contract_id}.json"
+
+    def create_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
+        path = self._contract_path(contract.contract_id)
+        if path.exists():
+            raise ResetContractAlreadyExistsError(f"contract {contract.contract_id!r} already exists")
+        path.write_text(json.dumps(contract.asdict(), indent=2, sort_keys=True), encoding="utf-8")
+        return contract
+
+    def get_contract(self, contract_id: str) -> ResetVerificationContract:
+        path = self._contract_path(contract_id)
+        if not path.exists():
+            raise ResetContractNotFoundError(f"contract {contract_id!r} was not found")
+        return ResetVerificationContract.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    def update_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
+        path = self._contract_path(contract.contract_id)
+        if not path.exists():
+            raise ResetContractNotFoundError(f"contract {contract.contract_id!r} was not found")
+        path.write_text(json.dumps(contract.asdict(), indent=2, sort_keys=True), encoding="utf-8")
+        return contract
+
+    def list_contracts(self) -> tuple[ResetVerificationContract, ...]:
+        contracts = [
+            ResetVerificationContract.from_dict(json.loads(path.read_text(encoding="utf-8")))
+            for path in self.contracts_dir.glob("*.json")
+        ]
+        contracts.sort(key=lambda contract: (contract.updated_at, contract.contract_id), reverse=True)
+        return tuple(contracts)
+
+
+__all__ = [
+    "FileBackedResetStore",
+    "ResetContractAlreadyExistsError",
+    "ResetContractNotFoundError",
+]

--- a/tests/connectors/test_openclaw_reset_spike.py
+++ b/tests/connectors/test_openclaw_reset_spike.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import socket
+import tempfile
+import threading
+import time
+import unittest
+
+import uvicorn
+
+from backend.server import create_app
+from modules.connectors.openclaw_harness_spike import OpenClawHarnessSpikeClient
+from modules.reset.service import ResetVerificationService
+from modules.reset.store import FileBackedResetStore
+from modules.store import FileBackedHarnessStore
+
+
+class _FakeLinearClient:
+    def __init__(self) -> None:
+        self.actions: list[tuple[str, str | None, str, str]] = []
+
+    def update_issue(self, issue_id: str, *, state: str | None, harness_status: str, comment: str) -> None:
+        self.actions.append((issue_id, state, harness_status, comment))
+
+
+class _FakeOpenClawClient:
+    def __init__(self) -> None:
+        self.repairs: list[tuple[str, str, str | None]] = []
+
+    def request_repair(self, issue_id: str, *, reason: str, contract_id: str | None = None) -> None:
+        self.repairs.append((issue_id, reason, contract_id))
+
+
+class _FakeVerifier:
+    def verify(self, **_: object):
+        return type(
+            "Verdict",
+            (),
+            {"status": "verified_done", "reason": "github proof verified", "details": None},
+        )()
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class OpenClawResetSpikeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.linear = _FakeLinearClient()
+        self.openclaw = _FakeOpenClawClient()
+        self.app = create_app(
+            store=FileBackedHarnessStore(self.temp_dir.name),
+            reset_service=ResetVerificationService(
+                store=FileBackedResetStore(self.temp_dir.name),
+                linear_client=self.linear,
+                verifier=_FakeVerifier(),
+                openclaw_client=self.openclaw,
+            ),
+        )
+        self.port = _free_port()
+        self.server = uvicorn.Server(
+            uvicorn.Config(self.app, host="127.0.0.1", port=self.port, log_level="error")
+        )
+        self.thread = threading.Thread(target=self.server.run, daemon=True)
+        self.thread.start()
+        for _ in range(50):
+            if getattr(self.server, "started", False):
+                break
+            time.sleep(0.05)
+        self.client = OpenClawHarnessSpikeClient(f"http://127.0.0.1:{self.port}")
+
+    def tearDown(self) -> None:
+        self.server.should_exit = True
+        self.thread.join(timeout=5)
+        self.temp_dir.cleanup()
+
+    def test_reset_routes_work_through_openclaw_spike_client(self) -> None:
+        status, payload = self.client.register_reset_contract(
+            {
+                "contract_id": "contract-1",
+                "linear_issue_id": "KNO-999",
+                "repository_owner": "sfayka",
+                "repository_name": "Harness",
+                "branch_ref": "codex/reset-verifier-v1",
+            }
+        )
+        self.assertEqual(status, 201)
+        self.assertEqual(payload["contract"]["contract_id"], "contract-1")
+
+        claim_status, claim_payload = self.client.submit_reset_claim(
+            "contract-1",
+            {
+                "repository_owner": "sfayka",
+                "repository_name": "Harness",
+                "branch_name": "codex/reset-verifier-v1",
+                "commit_sha": "abc123",
+                "pull_request_number": 42,
+            },
+        )
+        self.assertEqual(claim_status, 200)
+        self.assertEqual(claim_payload["status"], "verified_done")
+
+        listed_status, listed_payload = self.client.list_reset_contracts()
+        self.assertEqual(listed_status, 200)
+        self.assertEqual(len(listed_payload["contracts"]), 1)
+
+        tick_status, tick_payload = self.client.tick_reset()
+        self.assertEqual(tick_status, 200)
+        self.assertEqual(tick_payload["results"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/reset/__init__.py
+++ b/tests/reset/__init__.py
@@ -1,0 +1,2 @@
+"""Reset-slice backend tests."""
+

--- a/tests/reset/test_contracts.py
+++ b/tests/reset/test_contracts.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.reset.contracts import (
+    ResetCompletionClaim,
+    ResetVerificationContract,
+    ResetVerificationContractError,
+)
+
+
+class ResetContractTests(unittest.TestCase):
+    def test_contract_requires_linear_issue_and_repository(self) -> None:
+        with self.assertRaises(ResetVerificationContractError):
+            ResetVerificationContract(
+                contract_id="",
+                linear_issue_id="",
+                repository_owner="",
+                repository_name="",
+                branch_ref="",
+            )
+
+    def test_claim_requires_pull_request_reference(self) -> None:
+        with self.assertRaises(ResetVerificationContractError):
+            ResetCompletionClaim(
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_name="codex/reset-verifier-v1",
+                commit_sha="abc123",
+            )
+
+    def test_branch_ref_supports_glob_matching(self) -> None:
+        contract = ResetVerificationContract(
+            contract_id="contract-1",
+            linear_issue_id="KNO-999",
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_ref="codex/*",
+        )
+
+        self.assertTrue(contract.branch_matches("codex/reset-verifier-v1"))
+        self.assertFalse(contract.branch_matches("main"))
+

--- a/tests/reset/test_github_verifier.py
+++ b/tests/reset/test_github_verifier.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.reset.github_verifier import ResetGitHubVerifier
+
+
+class FakeGitHubClient:
+    def __init__(self) -> None:
+        self.branch_exists_result = True
+        self.commit_exists_result = True
+        self.pull_request_payload = {
+            "number": 42,
+            "html_url": "https://github.com/sfayka/Harness/pull/42",
+            "state": "open",
+            "merged_at": None,
+            "head": {
+                "ref": "codex/reset-verifier-v1",
+                "sha": "abc123",
+                "repo": {"owner": {"login": "sfayka"}, "name": "Harness"},
+            },
+        }
+
+    def branch_exists(self, owner: str, repo: str, branch_name: str) -> bool:
+        return self.branch_exists_result
+
+    def commit_exists(self, owner: str, repo: str, commit_sha: str) -> bool:
+        return self.commit_exists_result
+
+    def get_pull_request(self, owner: str, repo: str, pull_request_number: int) -> dict | None:
+        return self.pull_request_payload
+
+
+class ResetGitHubVerifierTests(unittest.TestCase):
+    def test_returns_verified_done_for_matching_claim(self) -> None:
+        verifier = ResetGitHubVerifier(client=FakeGitHubClient())
+
+        verdict = verifier.verify(
+            expected_owner="sfayka",
+            expected_repo="Harness",
+            expected_branch="codex/reset-verifier-v1",
+            branch_name="codex/reset-verifier-v1",
+            commit_sha="abc123",
+            pull_request_number=42,
+            pull_request_url="https://github.com/sfayka/Harness/pull/42",
+            claimed_owner="sfayka",
+            claimed_repo="Harness",
+        )
+
+        self.assertEqual(verdict.status, "verified_done")
+
+    def test_rejects_wrong_sha(self) -> None:
+        verifier = ResetGitHubVerifier(client=FakeGitHubClient())
+
+        verdict = verifier.verify(
+            expected_owner="sfayka",
+            expected_repo="Harness",
+            expected_branch="codex/reset-verifier-v1",
+            branch_name="codex/reset-verifier-v1",
+            commit_sha="wrong",
+            pull_request_number=42,
+        )
+
+        self.assertEqual(verdict.status, "retryable_invalid_proof")
+        self.assertIn("sha", verdict.reason)
+
+    def test_rejects_missing_remote_branch(self) -> None:
+        client = FakeGitHubClient()
+        client.branch_exists_result = False
+        verifier = ResetGitHubVerifier(client=client)
+
+        verdict = verifier.verify(
+            expected_owner="sfayka",
+            expected_repo="Harness",
+            expected_branch="codex/reset-verifier-v1",
+            branch_name="codex/reset-verifier-v1",
+            commit_sha="abc123",
+            pull_request_number=42,
+        )
+
+        self.assertEqual(verdict.status, "retryable_invalid_proof")
+        self.assertIn("branch", verdict.reason)
+

--- a/tests/reset/test_service.py
+++ b/tests/reset/test_service.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from modules.reset.contracts import ResetCompletionClaim, ResetVerificationContract
+from modules.reset.service import ResetVerificationService
+from modules.reset.store import FileBackedResetStore
+
+
+class FakeLinearClient:
+    def __init__(self) -> None:
+        self.actions = []
+
+    def update_issue(self, issue_id: str, *, state: str | None, harness_status: str, comment: str) -> None:
+        self.actions.append((issue_id, state, harness_status, comment))
+
+
+class FakeOpenClawClient:
+    def __init__(self) -> None:
+        self.repairs = []
+
+    def request_repair(self, issue_id: str, *, reason: str, contract_id: str | None = None) -> None:
+        self.repairs.append((issue_id, reason, contract_id))
+
+
+class FakeVerifier:
+    def __init__(self, *statuses: tuple[str, str]) -> None:
+        self.statuses = list(statuses)
+
+    def verify(self, **_: object):
+        status, reason = self.statuses.pop(0)
+        return type("Verdict", (), {"status": status, "reason": reason, "details": None})()
+
+
+class ResetVerificationServiceTests(unittest.TestCase):
+    def test_invalid_proof_requests_repair_and_keeps_issue_in_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            linear = FakeLinearClient()
+            openclaw = FakeOpenClawClient()
+            service = ResetVerificationService(
+                store=store,
+                linear_client=linear,
+                verifier=FakeVerifier(("retryable_invalid_proof", "wrong sha")),
+                openclaw_client=openclaw,
+            )
+
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+            )
+            service.register_contract(contract)
+
+            result = service.submit_claim(
+                "contract-1",
+                ResetCompletionClaim(
+                    repository_owner="sfayka",
+                    repository_name="Harness",
+                    branch_name="codex/reset-verifier-v1",
+                    commit_sha="bad",
+                    pull_request_number=42,
+                ),
+            )
+
+            self.assertEqual(result["status"], "retryable_invalid_proof")
+            self.assertEqual(openclaw.repairs[0][0], "KNO-999")
+            self.assertEqual(linear.actions[-1][1], "In Progress")
+            self.assertEqual(linear.actions[-1][2], "retrying")
+
+    def test_verified_claim_moves_issue_to_done(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            linear = FakeLinearClient()
+            service = ResetVerificationService(
+                store=store,
+                linear_client=linear,
+                verifier=FakeVerifier(("verified_done", "github proof verified")),
+                openclaw_client=FakeOpenClawClient(),
+            )
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+            )
+            service.register_contract(contract)
+
+            result = service.submit_claim(
+                "contract-1",
+                ResetCompletionClaim(
+                    repository_owner="sfayka",
+                    repository_name="Harness",
+                    branch_name="codex/reset-verifier-v1",
+                    commit_sha="abc123",
+                    pull_request_number=42,
+                ),
+            )
+
+            self.assertEqual(result["status"], "verified_done")
+            self.assertEqual(linear.actions[-1][1], "Done")
+            self.assertEqual(linear.actions[-1][2], "verified")
+
+    def test_tick_escalates_to_review_after_retry_budget_is_spent(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            linear = FakeLinearClient()
+            openclaw = FakeOpenClawClient()
+            service = ResetVerificationService(
+                store=store,
+                linear_client=linear,
+                verifier=FakeVerifier(
+                    ("retryable_invalid_proof", "wrong sha"),
+                    ("retryable_invalid_proof", "still wrong"),
+                    ("retryable_invalid_proof", "still wrong"),
+                ),
+                openclaw_client=openclaw,
+            )
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+            )
+            service.register_contract(contract)
+            service.submit_claim(
+                "contract-1",
+                ResetCompletionClaim(
+                    repository_owner="sfayka",
+                    repository_name="Harness",
+                    branch_name="codex/reset-verifier-v1",
+                    commit_sha="bad",
+                    pull_request_number=42,
+                ),
+            )
+
+            first_tick = service.tick()
+            second_tick = service.tick()
+
+            self.assertEqual(first_tick[0].status, "retryable_invalid_proof")
+            self.assertEqual(second_tick[0].status, "needs_review")
+            self.assertEqual(linear.actions[-1][1], "In Review")
+            self.assertEqual(linear.actions[-1][2], "needs_review")
+

--- a/tests/reset/test_store.py
+++ b/tests/reset/test_store.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from modules.reset.contracts import ResetVerificationContract
+from modules.reset.store import (
+    FileBackedResetStore,
+    ResetContractAlreadyExistsError,
+    ResetContractNotFoundError,
+)
+
+
+class ResetStoreTests(unittest.TestCase):
+    def test_round_trips_contracts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="main",
+            )
+
+            store.create_contract(contract)
+            loaded = store.get_contract("contract-1")
+
+            self.assertEqual(loaded.contract_id, "contract-1")
+            self.assertEqual(loaded.linear_issue_id, "KNO-999")
+
+    def test_duplicate_ids_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="main",
+            )
+
+            store.create_contract(contract)
+            with self.assertRaises(ResetContractAlreadyExistsError):
+                store.create_contract(contract)
+
+    def test_missing_contract_raises_not_found(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            with self.assertRaises(ResetContractNotFoundError):
+                store.get_contract("missing")
+

--- a/tests/test_fastapi_backend.py
+++ b/tests/test_fastapi_backend.py
@@ -1,21 +1,88 @@
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from copy import deepcopy
+from pathlib import Path
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
 from backend.server import create_app
+from modules.local_env import load_local_env_file
+from modules.reset.service import ResetVerificationService
+from modules.reset.store import FileBackedResetStore
 from modules.store import FileBackedHarnessStore
 from tests.test_api import _manual_happy_path_overlay_payload
+
+
+class LocalEnvLoaderTests(unittest.TestCase):
+    def test_loads_key_value_pairs_without_overwriting_existing_values(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / ".env.local"
+            env_path.write_text(
+                "# local-only config\nFIRST=one\nSECOND='two words'\nTHIRD=three\n",
+                encoding="utf-8",
+            )
+
+            with patch.dict(os.environ, {"SECOND": "existing"}, clear=False):
+                loaded = load_local_env_file(env_path)
+                self.assertEqual(loaded, ("FIRST", "THIRD"))
+                self.assertEqual(os.environ["FIRST"], "one")
+                self.assertEqual(os.environ["SECOND"], "existing")
+                self.assertEqual(os.environ["THIRD"], "three")
 
 
 class FastApiBackendTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()
         self.store = FileBackedHarnessStore(self.temp_dir.name)
-        self.client = TestClient(create_app(store=self.store))
+        self.linear_actions: list[tuple[str, str | None, str, str]] = []
+        self.repair_requests: list[tuple[str, str, str | None]] = []
+
+        class _FakeLinearClient:
+            def __init__(inner_self, actions: list[tuple[str, str | None, str, str]]) -> None:
+                inner_self.actions = actions
+
+            def update_issue(
+                inner_self,
+                issue_id: str,
+                *,
+                state: str | None,
+                harness_status: str,
+                comment: str,
+            ) -> None:
+                inner_self.actions.append((issue_id, state, harness_status, comment))
+
+        class _FakeOpenClawClient:
+            def __init__(inner_self, repairs: list[tuple[str, str, str | None]]) -> None:
+                inner_self.repairs = repairs
+
+            def request_repair(
+                inner_self,
+                issue_id: str,
+                *,
+                reason: str,
+                contract_id: str | None = None,
+            ) -> None:
+                inner_self.repairs.append((issue_id, reason, contract_id))
+
+        class _FakeVerifier:
+            def verify(inner_self, **_: object):
+                return type(
+                    "Verdict",
+                    (),
+                    {"status": "verified_done", "reason": "github proof verified", "details": None},
+                )()
+
+        self.reset_service = ResetVerificationService(
+            store=FileBackedResetStore(self.temp_dir.name),
+            linear_client=_FakeLinearClient(self.linear_actions),
+            verifier=_FakeVerifier(),
+            openclaw_client=_FakeOpenClawClient(self.repair_requests),
+        )
+        self.client = TestClient(create_app(store=self.store, reset_service=self.reset_service))
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
@@ -38,3 +105,38 @@ class FastApiBackendTests(unittest.TestCase):
         read_model = self.client.get(f"/tasks/{task_id}/read-model")
         self.assertEqual(read_model.status_code, 200)
         self.assertEqual(read_model.json()["task"]["task_id"], task_id)
+
+    def test_reset_contract_registration_and_claim_routes_round_trip(self) -> None:
+        created = self.client.post(
+            "/reset/contracts",
+            json={
+                "contract_id": "contract-1",
+                "linear_issue_id": "KNO-999",
+                "repository_owner": "sfayka",
+                "repository_name": "Harness",
+                "branch_ref": "codex/reset-verifier-v1",
+            },
+        )
+        self.assertEqual(created.status_code, 201)
+
+        listed = self.client.get("/reset/contracts")
+        self.assertEqual(listed.status_code, 200)
+        self.assertEqual(len(listed.json()["contracts"]), 1)
+
+        claimed = self.client.post(
+            "/reset/contracts/contract-1/claims",
+            json={
+                "repository_owner": "sfayka",
+                "repository_name": "Harness",
+                "branch_name": "codex/reset-verifier-v1",
+                "commit_sha": "abc123",
+                "pull_request_number": 42,
+            },
+        )
+        self.assertEqual(claimed.status_code, 200)
+        self.assertEqual(claimed.json()["status"], "verified_done")
+        self.assertEqual(self.linear_actions[-1][1], "Done")
+
+        ticked = self.client.post("/reset/tick")
+        self.assertEqual(ticked.status_code, 200)
+        self.assertEqual(ticked.json()["results"], [])


### PR DESCRIPTION
## Summary
- add a narrow reset-slice verifier path alongside the existing TaskEnvelope routes
- add local .env.local autoload, reset-specific storage/service modules, and FastAPI reset endpoints
- add focused reset tests plus an OpenClaw-style client smoke test

## Testing
- python3 -m unittest tests.reset.test_contracts tests.reset.test_store tests.reset.test_github_verifier tests.reset.test_service -v
- python3 -m unittest tests.test_fastapi_backend -v
- python3 -m unittest tests.connectors.test_openclaw_reset_spike -v
- python3 -m unittest discover -s tests -p 'test_*.py'
