### PR TITLE
Add reset verifier scenario and live smoke coverage

### DIFF
--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -123,6 +123,22 @@ These commands:
   - retryable invalid proof that later verifies successfully
   - retryable invalid proof that exhausts retries and lands in `In Review`
 
+### Live Reset Smoke
+
+The repo also includes a gated live smoke for Set 2 of the reset redesign:
+
+```bash
+HARNESS_RUN_LIVE_RESET_TESTS=1 python3 -m unittest tests.test_reset_live_smoke -v
+```
+
+That live smoke:
+
+- creates throwaway issues in the real Linear `HARNESS-DRYRUN` project
+- creates real branches, commits, and pull requests in `sfayka/HARNESS-DRYRUN`
+- runs the happy path first
+- then runs real GitHub-backed unhappy paths for missing PR linkage and wrong SHA review escalation
+- keeps OpenClaw simulated so the only live systems are Harness, Linear, and GitHub
+
 ### Run The Dashboard
 
 ```bash

--- a/modules/reset/contracts.py
+++ b/modules/reset/contracts.py
@@ -49,10 +49,8 @@ class ResetCompletionClaim:
         object.__setattr__(self, "repository_name", _require_text(self.repository_name, field_name="repository_name"))
         object.__setattr__(self, "branch_name", _require_text(self.branch_name, field_name="branch_name"))
         object.__setattr__(self, "commit_sha", _require_text(self.commit_sha, field_name="commit_sha"))
-        if self.pull_request_number is None and not (self.pull_request_url or "").strip():
-            raise ResetVerificationContractError(
-                "pull_request_number or pull_request_url is required"
-            )
+        if not (self.pull_request_url or "").strip():
+            raise ResetVerificationContractError("pull_request_url is required")
 
     def asdict(self) -> dict[str, Any]:
         return asdict(self)
@@ -77,8 +75,10 @@ class ResetVerificationContract:
     latest_reason: str | None = None
     created_at: str = field(default_factory=_utc_now)
     updated_at: str = field(default_factory=_utc_now)
+    last_activity_at: str | None = None
     last_repair_requested_at: str | None = None
     last_verified_at: str | None = None
+    claim_timeout_seconds: int | None = None
     event_log: tuple[ResetEvent, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
@@ -91,6 +91,8 @@ class ResetVerificationContract:
             raise ResetVerificationContractError("retry_budget must be at least 1")
         if self.retry_count < 0:
             raise ResetVerificationContractError("retry_count must be non-negative")
+        if self.claim_timeout_seconds is not None and self.claim_timeout_seconds < 1:
+            raise ResetVerificationContractError("claim_timeout_seconds must be at least 1 when provided")
 
     def branch_matches(self, branch_name: str) -> bool:
         normalized = branch_name.strip()
@@ -124,8 +126,10 @@ class ResetVerificationContract:
             "latest_reason": self.latest_reason,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "last_activity_at": self.last_activity_at,
             "last_repair_requested_at": self.last_repair_requested_at,
             "last_verified_at": self.last_verified_at,
+            "claim_timeout_seconds": self.claim_timeout_seconds,
             "event_log": [asdict(event) for event in self.event_log],
         }
 
@@ -153,12 +157,18 @@ class ResetVerificationContract:
             latest_reason=str(payload["latest_reason"]) if payload.get("latest_reason") is not None else None,
             created_at=str(payload.get("created_at") or _utc_now()),
             updated_at=str(payload.get("updated_at") or _utc_now()),
+            last_activity_at=str(payload["last_activity_at"]) if payload.get("last_activity_at") is not None else None,
             last_repair_requested_at=(
                 str(payload["last_repair_requested_at"])
                 if payload.get("last_repair_requested_at") is not None
                 else None
             ),
             last_verified_at=str(payload["last_verified_at"]) if payload.get("last_verified_at") is not None else None,
+            claim_timeout_seconds=(
+                int(payload["claim_timeout_seconds"])
+                if payload.get("claim_timeout_seconds") is not None
+                else None
+            ),
             event_log=tuple(
                 item if isinstance(item, ResetEvent) else ResetEvent(**item)
                 for item in event_log

--- a/modules/reset/github_verifier.py
+++ b/modules/reset/github_verifier.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import ssl
 from dataclasses import dataclass
 from typing import Any, Protocol
 from urllib import error, parse, request
@@ -34,6 +36,7 @@ class GitHubRestResetClient:
     def __init__(self, *, token: str | None = None, timeout_seconds: float = 10.0) -> None:
         self.token = token or os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
         self.timeout_seconds = timeout_seconds
+        self.ssl_context = _build_ssl_context()
 
     def _request_json(self, path: str) -> dict[str, Any] | None:
         headers = {"Accept": "application/vnd.github+json"}
@@ -41,11 +44,11 @@ class GitHubRestResetClient:
             headers["Authorization"] = f"Bearer {self.token}"
         req = request.Request(f"https://api.github.com{path}", headers=headers)
         try:
-            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+            with request.urlopen(req, timeout=self.timeout_seconds, context=self.ssl_context) as response:
                 payload = response.read().decode("utf-8")
                 return json.loads(payload) if payload else {}
         except error.HTTPError as http_error:
-            if http_error.code == 404:
+            if http_error.code in {404, 422}:
                 return None
             raise ResetGitHubVerificationError(f"GitHub request failed for {path}: HTTP {http_error.code}") from http_error
         except error.URLError as url_error:
@@ -87,12 +90,17 @@ class ResetGitHubVerifier:
             return ResetGitHubVerdict("retryable_invalid_proof", "claimed repository name does not match the contract")
         if branch_name != expected_branch:
             return ResetGitHubVerdict("retryable_invalid_proof", "claimed branch does not match the contract")
+        if not (pull_request_url or "").strip():
+            return ResetGitHubVerdict("retryable_invalid_proof", "pull request url is required for verification")
         if not self.client.branch_exists(expected_owner, expected_repo, branch_name):
             return ResetGitHubVerdict("retryable_invalid_proof", "remote branch does not exist in the expected repository")
         if not self.client.commit_exists(expected_owner, expected_repo, commit_sha):
             return ResetGitHubVerdict("retryable_invalid_proof", "commit sha does not exist in the expected repository")
         if pull_request_number is None:
-            return ResetGitHubVerdict("retryable_invalid_proof", "pull request number is required for verification")
+            derived_number = _parse_pull_request_number(pull_request_url)
+            if derived_number is None:
+                return ResetGitHubVerdict("retryable_invalid_proof", "pull request number is required for verification")
+            pull_request_number = derived_number
 
         pull_request = self.client.get_pull_request(expected_owner, expected_repo, pull_request_number)
         if pull_request is None:
@@ -131,6 +139,27 @@ class ResetGitHubVerifier:
                 "state": state,
             },
         )
+
+
+_PULL_REQUEST_URL_RE = re.compile(r"/pull/(?P<number>[1-9][0-9]*)/?$")
+
+
+def _parse_pull_request_number(pull_request_url: str | None) -> int | None:
+    if not isinstance(pull_request_url, str):
+        return None
+    match = _PULL_REQUEST_URL_RE.search(pull_request_url.strip())
+    if match is None:
+        return None
+    return int(match.group("number"))
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    try:
+        import certifi  # type: ignore
+    except ImportError:
+        return context
+    return ssl.create_default_context(cafile=certifi.where())
 
 
 __all__ = [

--- a/modules/reset/linear_client.py
+++ b/modules/reset/linear_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import ssl
 from typing import Any
 from urllib import error, request
 
@@ -25,6 +26,7 @@ class LinearResetClient:
         self.api_key = api_key or os.getenv("LINEAR_API_KEY")
         self.api_url = api_url
         self.timeout_seconds = timeout_seconds
+        self.ssl_context = _build_ssl_context()
 
     def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
         if not self.api_key:
@@ -35,7 +37,7 @@ class LinearResetClient:
             headers={"Content-Type": "application/json", "Authorization": self.api_key},
         )
         try:
-            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+            with request.urlopen(req, timeout=self.timeout_seconds, context=self.ssl_context) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except error.HTTPError as http_error:
             raise LinearClientError(f"Linear request failed: HTTP {http_error.code}") from http_error
@@ -116,6 +118,15 @@ class LinearResetClient:
             "state": state,
             "harness_status": harness_status,
         }
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    try:
+        import certifi  # type: ignore
+    except ImportError:
+        return context
+    return ssl.create_default_context(cafile=certifi.where())
 
 
 __all__ = ["LinearClientError", "LinearResetClient"]

--- a/modules/reset/prompting.py
+++ b/modules/reset/prompting.py
@@ -1,0 +1,47 @@
+"""Prompt builder for simulated and live reset-slice dispatch scenarios."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ResetDispatchPromptContext:
+    contract_id: str
+    linear_issue_id: str
+    linear_issue_title: str
+    repository_owner: str
+    repository_name: str
+    branch_name: str
+    base_branch: str
+    required_changed_path: str
+
+
+def build_reset_dispatch_prompt(context: ResetDispatchPromptContext) -> str:
+    return f"""You are executing one Harness verification dry run.
+
+Issue context:
+- Harness contract: `{context.contract_id}`
+- Linear issue: `{context.linear_issue_id}`
+- Linear title: `{context.linear_issue_title}`
+
+Repository contract:
+- Repository: `{context.repository_owner}/{context.repository_name}`
+- Base branch: `{context.base_branch}`
+- Required branch: `{context.branch_name}`
+- Required changed file: `{context.required_changed_path}`
+
+Rules:
+- Work only in the contracted repository and branch context.
+- Do not treat the task as complete until there is a real repository, branch, commit SHA, and PR URL.
+- The PR must be mergeable operator proof, not a local-only branch or a stale link.
+
+Final proof must include exactly these fields:
+Repository: {context.repository_owner}/{context.repository_name}
+Branch: {context.branch_name}
+Commit SHA: <40-char-sha>
+PR URL: <https://github.com/.../pull/...>
+"""
+
+
+__all__ = ["ResetDispatchPromptContext", "build_reset_dispatch_prompt"]

--- a/modules/reset/proofs.py
+++ b/modules/reset/proofs.py
@@ -1,0 +1,67 @@
+"""Proof parsing for reset-slice worker completion output."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+class ResetWorkerProofError(ValueError):
+    """Raised when worker proof output is incomplete or malformed."""
+
+
+@dataclass(frozen=True)
+class ResetWorkerProof:
+    repository_owner: str
+    repository_name: str
+    branch_name: str
+    commit_sha: str
+    pull_request_number: int
+    pull_request_url: str
+
+
+_REPOSITORY_RE = re.compile(
+    r"^\s*Repository:\s*(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\s*$",
+    re.MULTILINE,
+)
+_BRANCH_RE = re.compile(r"^\s*Branch:\s*(?P<branch>.+?)\s*$", re.MULTILINE)
+_COMMIT_SHA_RE = re.compile(r"^\s*Commit SHA:\s*(?P<sha>[0-9a-fA-F]{40})\s*$", re.MULTILINE)
+_PR_URL_RE = re.compile(
+    r"^\s*PR URL:\s*(?P<url>https://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)/pull/(?P<number>[1-9][0-9]*))/?\s*$",
+    re.MULTILINE,
+)
+
+
+def _match_required(pattern: re.Pattern[str], payload: str, *, field_name: str) -> re.Match[str]:
+    match = pattern.search(payload)
+    if match is None:
+        raise ResetWorkerProofError(f"{field_name} is required in worker proof output")
+    return match
+
+
+def parse_worker_proof_output(raw_output: str) -> ResetWorkerProof:
+    if not isinstance(raw_output, str) or not raw_output.strip():
+        raise ResetWorkerProofError("worker proof output is empty")
+
+    repository_match = _match_required(_REPOSITORY_RE, raw_output, field_name="Repository")
+    branch_match = _match_required(_BRANCH_RE, raw_output, field_name="Branch")
+    commit_match = _match_required(_COMMIT_SHA_RE, raw_output, field_name="Commit SHA")
+    pr_url_match = _match_required(_PR_URL_RE, raw_output, field_name="PR URL")
+
+    repository_owner, repository_name = repository_match.group("repository").split("/", 1)
+    pr_owner = pr_url_match.group("owner")
+    pr_repo = pr_url_match.group("repo")
+    if repository_owner != pr_owner or repository_name != pr_repo:
+        raise ResetWorkerProofError("PR URL repository does not match Repository proof line")
+
+    return ResetWorkerProof(
+        repository_owner=repository_owner,
+        repository_name=repository_name,
+        branch_name=branch_match.group("branch").strip(),
+        commit_sha=commit_match.group("sha").lower(),
+        pull_request_number=int(pr_url_match.group("number")),
+        pull_request_url=pr_url_match.group("url"),
+    )
+
+
+__all__ = ["ResetWorkerProof", "ResetWorkerProofError", "parse_worker_proof_output"]

--- a/modules/reset/scenarios.py
+++ b/modules/reset/scenarios.py
@@ -1,0 +1,219 @@
+"""Deterministic scenario helpers for the reset verifier redesign."""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from .contracts import ResetCompletionClaim, ResetVerificationContract
+from .github_verifier import ResetGitHubVerifier
+from .prompting import ResetDispatchPromptContext, build_reset_dispatch_prompt
+from .proofs import ResetWorkerProofError, parse_worker_proof_output
+from .service import ResetVerificationService
+from .store import FileBackedResetStore
+
+
+def _isoformat_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class _MutableClock:
+    def __init__(self, current: datetime) -> None:
+        self.current = current.astimezone(timezone.utc)
+
+    def now(self) -> datetime:
+        return self.current
+
+    def advance(self, *, seconds: int) -> None:
+        self.current = self.current + timedelta(seconds=seconds)
+
+
+class _FakeLinearClient:
+    def __init__(self) -> None:
+        self.actions: list[tuple[str, str | None, str, str]] = []
+
+    def update_issue(self, issue_id: str, *, state: str | None, harness_status: str, comment: str) -> None:
+        self.actions.append((issue_id, state, harness_status, comment))
+
+
+class _FakeOpenClawClient:
+    def __init__(self) -> None:
+        self.repairs: list[tuple[str, str, str | None]] = []
+
+    def request_repair(self, issue_id: str, *, reason: str, contract_id: str | None = None) -> None:
+        self.repairs.append((issue_id, reason, contract_id))
+
+
+@dataclass(frozen=True)
+class SimulatedGitHubState:
+    branch_exists: bool = False
+    commit_exists: bool = False
+    pull_request_payload: dict[str, Any] | None = None
+
+
+class _FakeGitHubClient:
+    def __init__(self, state: SimulatedGitHubState) -> None:
+        self.state = state
+
+    def branch_exists(self, owner: str, repo: str, branch_name: str) -> bool:
+        del owner, repo, branch_name
+        return self.state.branch_exists
+
+    def commit_exists(self, owner: str, repo: str, commit_sha: str) -> bool:
+        del owner, repo, commit_sha
+        return self.state.commit_exists
+
+    def get_pull_request(self, owner: str, repo: str, pull_request_number: int) -> dict[str, Any] | None:
+        del owner, repo, pull_request_number
+        return self.state.pull_request_payload
+
+
+@dataclass(frozen=True)
+class SimulatedResetScenario:
+    name: str
+    contract_id: str
+    linear_issue_id: str
+    linear_issue_title: str
+    repository_owner: str
+    repository_name: str
+    branch_name: str
+    required_changed_path: str
+    worker_output: str
+    github_state: SimulatedGitHubState = field(default_factory=SimulatedGitHubState)
+    base_branch: str = "main"
+    retry_budget: int = 2
+    claim_timeout_seconds: int | None = None
+    tick_count: int = 0
+    tick_advance_seconds: int = 1
+    start_at: str = "2026-04-15T12:00:00Z"
+
+
+@dataclass(frozen=True)
+class SimulatedResetScenarioResult:
+    prompt: str
+    claim_status: int | None
+    claim_verdict: str | None
+    final_contract: dict[str, Any]
+    linear_actions: list[tuple[str, str | None, str, str]]
+    repair_requests: list[tuple[str, str, str | None]]
+    tick_verdicts: tuple[str, ...]
+    proof_error: str | None
+
+
+def build_worker_proof_output(
+    *,
+    repository: str,
+    branch: str,
+    commit_sha: str,
+    pull_request_url: str,
+) -> str:
+    return "\n".join(
+        [
+            f"Repository: {repository}",
+            f"Branch: {branch}",
+            f"Commit SHA: {commit_sha}",
+            f"PR URL: {pull_request_url}",
+        ]
+    )
+
+
+def run_simulated_reset_scenario(scenario: SimulatedResetScenario) -> SimulatedResetScenarioResult:
+    prompt = build_reset_dispatch_prompt(
+        ResetDispatchPromptContext(
+            contract_id=scenario.contract_id,
+            linear_issue_id=scenario.linear_issue_id,
+            linear_issue_title=scenario.linear_issue_title,
+            repository_owner=scenario.repository_owner,
+            repository_name=scenario.repository_name,
+            branch_name=scenario.branch_name,
+            base_branch=scenario.base_branch,
+            required_changed_path=scenario.required_changed_path,
+        )
+    )
+
+    start_at = datetime.fromisoformat(scenario.start_at.replace("Z", "+00:00")).astimezone(timezone.utc)
+    clock = _MutableClock(start_at)
+    linear_client = _FakeLinearClient()
+    openclaw_client = _FakeOpenClawClient()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        service = ResetVerificationService(
+            store=FileBackedResetStore(temp_dir),
+            linear_client=linear_client,
+            verifier=ResetGitHubVerifier(client=_FakeGitHubClient(scenario.github_state)),
+            openclaw_client=openclaw_client,
+            now_provider=clock.now,
+            retry_cooldown_seconds=0,
+            claim_timeout_seconds=float(scenario.claim_timeout_seconds or 900),
+        )
+        contract = ResetVerificationContract(
+            contract_id=scenario.contract_id,
+            linear_issue_id=scenario.linear_issue_id,
+            repository_owner=scenario.repository_owner,
+            repository_name=scenario.repository_name,
+            branch_ref=scenario.branch_name,
+            retry_budget=scenario.retry_budget,
+            created_at=scenario.start_at,
+            updated_at=scenario.start_at,
+            last_activity_at=scenario.start_at,
+            claim_timeout_seconds=scenario.claim_timeout_seconds,
+        )
+        service.register_contract(contract)
+
+        claim_status: int | None = None
+        claim_verdict: str | None = None
+        proof_error: str | None = None
+        try:
+            proof = parse_worker_proof_output(scenario.worker_output)
+        except ResetWorkerProofError as exc:
+            proof_error = str(exc)
+        else:
+            claim_status = 200
+            claim_result = service.submit_claim(
+                scenario.contract_id,
+                ResetCompletionClaim(
+                    repository_owner=proof.repository_owner,
+                    repository_name=proof.repository_name,
+                    branch_name=proof.branch_name,
+                    commit_sha=proof.commit_sha,
+                    pull_request_number=proof.pull_request_number,
+                    pull_request_url=proof.pull_request_url,
+                    claimed_at=_isoformat_utc(clock.now()),
+                ),
+            )
+            claim_verdict = str(claim_result["status"])
+
+        tick_verdicts: list[str] = []
+        for tick_index in range(scenario.tick_count):
+            advance_seconds = scenario.tick_advance_seconds
+            if (
+                tick_index == 0
+                and claim_status is None
+                and scenario.claim_timeout_seconds is not None
+            ):
+                advance_seconds = max(advance_seconds, scenario.claim_timeout_seconds + 1)
+            clock.advance(seconds=advance_seconds)
+            tick_verdicts.extend(result.status for result in service.tick())
+
+        final_contract = service.get_contract(scenario.contract_id).asdict()
+        return SimulatedResetScenarioResult(
+            prompt=prompt,
+            claim_status=claim_status,
+            claim_verdict=claim_verdict,
+            final_contract=final_contract,
+            linear_actions=list(linear_client.actions),
+            repair_requests=list(openclaw_client.repairs),
+            tick_verdicts=tuple(tick_verdicts),
+            proof_error=proof_error,
+        )
+
+
+__all__ = [
+    "SimulatedGitHubState",
+    "SimulatedResetScenario",
+    "SimulatedResetScenarioResult",
+    "build_worker_proof_output",
+    "run_simulated_reset_scenario",
+]

--- a/modules/reset/service.py
+++ b/modules/reset/service.py
@@ -32,6 +32,10 @@ def _parse_iso_timestamp(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
 
 
+def _isoformat_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 @dataclass(frozen=True)
 class ResetTickResult:
     contract_id: str
@@ -52,6 +56,7 @@ class ResetVerificationService:
         openclaw_client: Any,
         now_provider: Any | None = None,
         retry_cooldown_seconds: float = 900.0,
+        claim_timeout_seconds: float = 900.0,
     ) -> None:
         self.store = store
         self.linear_client = linear_client
@@ -59,11 +64,13 @@ class ResetVerificationService:
         self.openclaw_client = openclaw_client
         self.now_provider = now_provider or (lambda: datetime.now(timezone.utc))
         self.retry_cooldown_seconds = retry_cooldown_seconds
+        self.claim_timeout_seconds = claim_timeout_seconds
 
     @classmethod
     def from_env(cls, *, root_dir: str | Path | None = None) -> "ResetVerificationService":
         resolved_root = Path(root_dir or os.environ.get("HARNESS_STORE_ROOT") or ".harness-store")
         cooldown = _coerce_float(os.environ.get("HARNESS_RESET_POLL_SECONDS"), default=900.0)
+        claim_timeout = _coerce_float(os.environ.get("HARNESS_RESET_CLAIM_TIMEOUT_SECONDS"), default=900.0)
         return cls(
             store=FileBackedResetStore(resolved_root),
             linear_client=LinearResetClient(),
@@ -71,11 +78,16 @@ class ResetVerificationService:
             openclaw_client=OpenClawRepairClient(),
             now_provider=None,
             retry_cooldown_seconds=cooldown,
+            claim_timeout_seconds=claim_timeout,
         )
 
     def register_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
+        activity_timestamp = contract.last_activity_at or contract.created_at
         created = self.store.create_contract(
-            contract.append_event(kind="contract_registered", message="Harness verification contract registered.")
+            contract.updated(last_activity_at=activity_timestamp).append_event(
+                kind="contract_registered",
+                message="Harness verification contract registered.",
+            )
         )
         self.linear_client.update_issue(
             created.linear_issue_id,
@@ -95,6 +107,7 @@ class ResetVerificationService:
         contract = self.store.get_contract(contract_id).updated(
             latest_claim=claim,
             harness_status="verifying",
+            last_activity_at=claim.claimed_at,
         ).append_event(
             kind="completion_claim_received",
             message=f"Completion claim received for {claim.repository_owner}/{claim.repository_name}@{claim.branch_name}.",
@@ -105,8 +118,6 @@ class ResetVerificationService:
     def tick(self) -> tuple[ResetTickResult, ...]:
         outcomes: list[ResetTickResult] = []
         for contract in self.store.list_contracts():
-            if contract.latest_claim is None:
-                continue
             if contract.harness_status not in {"verifying", "retrying", "running"}:
                 continue
             if self._within_retry_cooldown(contract):
@@ -116,6 +127,32 @@ class ResetVerificationService:
                         action="cooldown_wait",
                         status="cooldown_wait",
                         reason="retry cooldown window is still active",
+                    )
+                )
+                continue
+            if contract.latest_claim is None:
+                timeout_reason = self._claim_timeout_reason(contract)
+                if timeout_reason is None:
+                    continue
+                if contract.retry_count >= contract.retry_budget:
+                    updated = self._mark_in_review(contract, timeout_reason)
+                    outcomes.append(
+                        ResetTickResult(
+                            contract_id=updated.contract_id,
+                            action="escalated",
+                            status="needs_review",
+                            reason=timeout_reason,
+                        )
+                    )
+                    continue
+
+                updated = self._dispatch_repair(contract, timeout_reason)
+                outcomes.append(
+                    ResetTickResult(
+                        contract_id=updated.contract_id,
+                        action="repair_requested",
+                        status="retryable_invalid_proof",
+                        reason=timeout_reason,
                     )
                 )
                 continue
@@ -166,6 +203,25 @@ class ResetVerificationService:
         elapsed = (self.now_provider() - last_requested).total_seconds()
         return elapsed < self.retry_cooldown_seconds
 
+    def _now_iso(self) -> str:
+        return _isoformat_utc(self.now_provider())
+
+    def _claim_timeout_reason(self, contract: ResetVerificationContract) -> str | None:
+        timeout_seconds = (
+            float(contract.claim_timeout_seconds)
+            if contract.claim_timeout_seconds is not None
+            else self.claim_timeout_seconds
+        )
+        if timeout_seconds <= 0:
+            return None
+        last_activity = _parse_iso_timestamp(contract.last_activity_at or contract.created_at)
+        if last_activity is None:
+            return None
+        elapsed = (self.now_provider() - last_activity).total_seconds()
+        if elapsed < timeout_seconds:
+            return None
+        return "no completion claim arrived before the supervision timeout"
+
     def _evaluate_claim(
         self, contract: ResetVerificationContract, claim: ResetCompletionClaim
     ) -> dict[str, Any]:
@@ -211,12 +267,15 @@ class ResetVerificationService:
         if allow_repair_dispatch:
             updated = self._dispatch_repair(contract, verdict.reason)
         else:
+            timestamp = self._now_iso()
             updated = self.store.update_contract(
                 contract.updated(
                     latest_verdict="retryable_invalid_proof",
                     latest_reason=verdict.reason,
                     harness_status="proof_invalid",
-                ).append_event(kind="verification_failed", message=verdict.reason)
+                    last_activity_at=timestamp,
+                    updated_at=timestamp,
+                ).append_event(kind="verification_failed", message=verdict.reason, timestamp=timestamp)
             )
         return {
             "status": "retryable_invalid_proof",
@@ -236,6 +295,7 @@ class ResetVerificationService:
             latest_reason=verdict.reason,
             harness_status="verified",
             last_verified_at=claim.claimed_at,
+            last_activity_at=claim.claimed_at,
         ).append_event(kind="verified", message=verdict.reason, timestamp=claim.claimed_at)
         self.store.update_contract(updated)
         self.linear_client.update_issue(
@@ -248,6 +308,7 @@ class ResetVerificationService:
 
     def _dispatch_repair(self, contract: ResetVerificationContract, reason: str) -> ResetVerificationContract:
         next_retry_count = contract.retry_count + 1
+        timestamp = self._now_iso()
         self.openclaw_client.request_repair(
             contract.linear_issue_id,
             reason=reason,
@@ -258,10 +319,16 @@ class ResetVerificationService:
             latest_verdict="retryable_invalid_proof",
             latest_reason=reason,
             harness_status="retrying",
+            last_activity_at=timestamp,
+            updated_at=timestamp,
         )
-        updated = updated.updated(last_repair_requested_at=updated.updated_at).append_event(
+        updated = updated.updated(
+            last_repair_requested_at=updated.updated_at,
+            last_activity_at=updated.updated_at,
+        ).append_event(
             kind="repair_requested",
             message=reason,
+            timestamp=timestamp,
         )
         self.store.update_contract(updated)
         self.linear_client.update_issue(
@@ -273,11 +340,14 @@ class ResetVerificationService:
         return updated
 
     def _mark_in_review(self, contract: ResetVerificationContract, reason: str) -> ResetVerificationContract:
+        timestamp = self._now_iso()
         updated = contract.updated(
             latest_verdict="needs_review",
             latest_reason=reason,
             harness_status="needs_review",
-        ).append_event(kind="review_required", message=reason)
+            last_activity_at=timestamp,
+            updated_at=timestamp,
+        ).append_event(kind="review_required", message=reason, timestamp=timestamp)
         self.store.update_contract(updated)
         self.linear_client.update_issue(
             updated.linear_issue_id,

--- a/modules/reset_dryrun.py
+++ b/modules/reset_dryrun.py
@@ -133,6 +133,7 @@ def run_reset_success_dry_run(*, contract_id: str = "reset-dryrun-success-1") ->
                     "branch_name": "codex/reset-verifier-v1",
                     "commit_sha": "bad-sha",
                     "pull_request_number": 42,
+                    "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
                 },
             )
             final_claim_status, final_claim_payload = client.submit_reset_claim(
@@ -143,6 +144,7 @@ def run_reset_success_dry_run(*, contract_id: str = "reset-dryrun-success-1") ->
                     "branch_name": "codex/reset-verifier-v1",
                     "commit_sha": "good-sha",
                     "pull_request_number": 42,
+                    "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
                 },
             )
             return ResetDryRunResult(
@@ -188,6 +190,7 @@ def run_reset_review_dry_run(*, contract_id: str = "reset-dryrun-review-1") -> R
                     "branch_name": "codex/reset-verifier-v1",
                     "commit_sha": "bad-sha",
                     "pull_request_number": 42,
+                    "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
                 },
             )
             tick_statuses: list[int] = []

--- a/modules/reset_live_smoke.py
+++ b/modules/reset_live_smoke.py
@@ -1,0 +1,685 @@
+"""Live smoke runner for reset verification against real Linear and GitHub."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib import parse
+
+from modules.hosted_dryrun_flow import JsonHttpClient
+from modules.local_env import load_native_local_env
+from modules.reset.contracts import ResetCompletionClaim, ResetVerificationContract
+from modules.reset.github_verifier import ResetGitHubVerifier
+from modules.reset.linear_client import LinearResetClient
+from modules.reset.service import ResetVerificationService
+from modules.reset.store import FileBackedResetStore
+
+load_native_local_env()
+
+
+DEFAULT_LINEAR_PROJECT_NAME = "HARNESS-DRYRUN"
+DEFAULT_GITHUB_OWNER = "sfayka"
+DEFAULT_GITHUB_REPO = "HARNESS-DRYRUN"
+DEFAULT_BASE_BRANCH = "main"
+
+
+class LiveResetSmokeError(ValueError):
+    """Raised when live smoke setup or execution fails."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _compact_timestamp() -> str:
+    return _utc_now().strftime("%Y%m%dT%H%M%SZ").lower()
+
+
+@dataclass(frozen=True)
+class LiveLinearProject:
+    id: str
+    name: str
+    team_id: str
+    team_key: str
+
+
+@dataclass(frozen=True)
+class LiveLinearIssue:
+    id: str
+    identifier: str
+    url: str
+    title: str
+    state_name: str
+
+
+@dataclass(frozen=True)
+class LiveGitHubArtifact:
+    owner: str
+    repo: str
+    branch_name: str
+    commit_sha: str
+    pull_request_number: int
+    pull_request_url: str
+
+
+@dataclass(frozen=True)
+class LiveResetScenarioResult:
+    name: str
+    contract_id: str
+    linear_issue_id: str
+    linear_issue_identifier: str
+    linear_issue_url: str
+    pull_request_url: str
+    branch_name: str
+    commit_sha: str
+    claim_verdict: str
+    latest_reason: str | None
+    final_harness_status: str
+    final_linear_state: str
+    repair_request_count: int
+    tick_verdicts: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LiveResetSmokeSuiteResult:
+    happy_path: LiveResetScenarioResult
+    missing_pull_request: LiveResetScenarioResult
+    wrong_sha_review: LiveResetScenarioResult
+
+
+class _RecordingOpenClawClient:
+    def __init__(self) -> None:
+        self.repairs: list[tuple[str, str, str | None]] = []
+
+    def request_repair(self, issue_id: str, *, reason: str, contract_id: str | None = None) -> None:
+        self.repairs.append((issue_id, reason, contract_id))
+
+
+class _LiveLinearClient:
+    def __init__(self, *, api_key: str | None = None, http: JsonHttpClient | None = None) -> None:
+        self.api_key = api_key or os.getenv("LINEAR_API_KEY")
+        if not self.api_key:
+            raise LiveResetSmokeError("LINEAR_API_KEY is required for live reset smoke tests")
+        self.http = http or JsonHttpClient()
+
+    def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        result = self.http.request_json(
+            "POST",
+            "https://api.linear.app/graphql",
+            headers={"Authorization": self.api_key},
+            payload={"query": query, "variables": variables},
+        )
+        if result.status >= 400:
+            raise LiveResetSmokeError(f"Linear request failed with HTTP {result.status}: {result.payload}")
+        if result.payload.get("errors"):
+            raise LiveResetSmokeError(f"Linear GraphQL error: {result.payload['errors']}")
+        data = result.payload.get("data")
+        if not isinstance(data, dict):
+            raise LiveResetSmokeError("Linear GraphQL response did not contain a data object")
+        return data
+
+    def resolve_project(self, project_name: str) -> LiveLinearProject:
+        query = """
+        query ProjectLookup($name: String!) {
+          projects(filter: { name: { eq: $name } }) {
+            nodes {
+              id
+              name
+              teams {
+                nodes {
+                  id
+                  key
+                  name
+                }
+              }
+            }
+          }
+        }
+        """
+        payload = self._graphql(query, {"name": project_name})
+        projects = ((payload.get("projects") or {}).get("nodes")) or []
+        if not projects:
+            raise LiveResetSmokeError(f"Linear project {project_name!r} was not found")
+        project = projects[0]
+        teams = ((project.get("teams") or {}).get("nodes")) or []
+        if not teams:
+            raise LiveResetSmokeError(f"Linear project {project_name!r} has no attached team")
+        team = teams[0]
+        return LiveLinearProject(
+            id=str(project["id"]),
+            name=str(project["name"]),
+            team_id=str(team["id"]),
+            team_key=str(team["key"]),
+        )
+
+    def create_issue(self, *, project: LiveLinearProject, title: str, description: str) -> LiveLinearIssue:
+        mutation = """
+        mutation IssueCreate($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue {
+              id
+              identifier
+              url
+              title
+              state { name }
+            }
+          }
+        }
+        """
+        payload = self._graphql(
+            mutation,
+            {
+                "input": {
+                    "teamId": project.team_id,
+                    "projectId": project.id,
+                    "title": title,
+                    "description": description,
+                }
+            },
+        )
+        issue = ((payload.get("issueCreate") or {}).get("issue")) or None
+        if not isinstance(issue, dict):
+            raise LiveResetSmokeError("Linear issueCreate did not return an issue")
+        return LiveLinearIssue(
+            id=str(issue["id"]),
+            identifier=str(issue["identifier"]),
+            url=str(issue["url"]),
+            title=str(issue["title"]),
+            state_name=str(((issue.get("state") or {}).get("name")) or ""),
+        )
+
+    def get_issue(self, issue_id: str) -> LiveLinearIssue:
+        query = """
+        query IssueLookup($id: String!) {
+          issue(id: $id) {
+            id
+            identifier
+            url
+            title
+            state { name }
+          }
+        }
+        """
+        payload = self._graphql(query, {"id": issue_id})
+        issue = payload.get("issue")
+        if not isinstance(issue, dict):
+            raise LiveResetSmokeError(f"Linear issue {issue_id!r} was not found")
+        return LiveLinearIssue(
+            id=str(issue["id"]),
+            identifier=str(issue["identifier"]),
+            url=str(issue["url"]),
+            title=str(issue["title"]),
+            state_name=str(((issue.get("state") or {}).get("name")) or ""),
+        )
+
+    def wait_for_issue_state(
+        self,
+        issue_id: str,
+        *,
+        expected_state: str,
+        timeout_seconds: float = 30.0,
+        interval_seconds: float = 0.5,
+    ) -> LiveLinearIssue:
+        deadline = time.time() + timeout_seconds
+        latest = self.get_issue(issue_id)
+        while latest.state_name != expected_state and time.time() < deadline:
+            time.sleep(interval_seconds)
+            latest = self.get_issue(issue_id)
+        if latest.state_name != expected_state:
+            raise LiveResetSmokeError(
+                f"Linear issue {latest.identifier} did not reach state {expected_state!r}; current state is {latest.state_name!r}"
+            )
+        return latest
+
+
+class _LiveGitHubClient:
+    def __init__(self, *, token: str | None = None, http: JsonHttpClient | None = None) -> None:
+        self.token = token or os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+        if not self.token:
+            raise LiveResetSmokeError("GITHUB_TOKEN or GH_TOKEN is required for live reset smoke tests")
+        self.http = http or JsonHttpClient()
+
+    def _request(self, method: str, path: str, *, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        result = self.http.request_json(
+            method,
+            f"https://api.github.com{path}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+            },
+            payload=payload,
+        )
+        if result.status >= 400:
+            raise LiveResetSmokeError(f"GitHub request failed for {path}: HTTP {result.status}: {result.payload}")
+        return result.payload
+
+    def get_repository(self, owner: str, repo: str) -> dict[str, Any]:
+        return self._request("GET", f"/repos/{owner}/{repo}")
+
+    def get_ref_sha(self, owner: str, repo: str, ref_name: str) -> str:
+        payload = self._request("GET", f"/repos/{owner}/{repo}/git/ref/heads/{parse.quote(ref_name, safe='')}")
+        sha = ((payload.get("object") or {}).get("sha")) or ""
+        if not isinstance(sha, str) or not sha:
+            raise LiveResetSmokeError(f"GitHub ref lookup for {owner}/{repo}:{ref_name} returned no SHA")
+        return sha
+
+    def create_branch(self, owner: str, repo: str, *, branch_name: str, from_sha: str) -> None:
+        self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/git/refs",
+            payload={"ref": f"refs/heads/{branch_name}", "sha": from_sha},
+        )
+
+    def create_file_commit(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        branch_name: str,
+        file_path: str,
+        content: str,
+        commit_message: str,
+    ) -> str:
+        payload = self._request(
+            "PUT",
+            f"/repos/{owner}/{repo}/contents/{parse.quote(file_path, safe='/')}",
+            payload={
+                "message": commit_message,
+                "branch": branch_name,
+                "content": base64.b64encode(content.encode("utf-8")).decode("utf-8"),
+            },
+        )
+        commit_sha = ((payload.get("commit") or {}).get("sha")) or ""
+        if not isinstance(commit_sha, str) or not commit_sha:
+            raise LiveResetSmokeError("GitHub file commit did not return a commit SHA")
+        return commit_sha
+
+    def create_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        title: str,
+        body: str,
+        head: str,
+        base: str,
+    ) -> tuple[int, str]:
+        payload = self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/pulls",
+            payload={"title": title, "body": body, "head": head, "base": base},
+        )
+        number = int(payload["number"])
+        url = str(payload["html_url"])
+        return number, url
+
+    def create_artifact(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        base_branch: str,
+        branch_name: str,
+        file_path: str,
+        file_content: str,
+        commit_message: str,
+        pull_request_title: str,
+        pull_request_body: str,
+    ) -> LiveGitHubArtifact:
+        from_sha = self.get_ref_sha(owner, repo, base_branch)
+        self.create_branch(owner, repo, branch_name=branch_name, from_sha=from_sha)
+        commit_sha = self.create_file_commit(
+            owner,
+            repo,
+            branch_name=branch_name,
+            file_path=file_path,
+            content=file_content,
+            commit_message=commit_message,
+        )
+        pull_request_number, pull_request_url = self.create_pull_request(
+            owner,
+            repo,
+            title=pull_request_title,
+            body=pull_request_body,
+            head=branch_name,
+            base=base_branch,
+        )
+        return LiveGitHubArtifact(
+            owner=owner,
+            repo=repo,
+            branch_name=branch_name,
+            commit_sha=commit_sha,
+            pull_request_number=pull_request_number,
+            pull_request_url=pull_request_url,
+        )
+
+
+def _make_service(*, store_root: str | Path) -> tuple[ResetVerificationService, _RecordingOpenClawClient]:
+    openclaw = _RecordingOpenClawClient()
+    service = ResetVerificationService(
+        store=FileBackedResetStore(store_root),
+        linear_client=LinearResetClient(),
+        verifier=ResetGitHubVerifier(),
+        openclaw_client=openclaw,
+        retry_cooldown_seconds=0,
+    )
+    return service, openclaw
+
+
+def _make_isolated_service(name: str) -> tuple[ResetVerificationService, _RecordingOpenClawClient]:
+    store_root = Path(".harness-live-reset-smoke") / f"{name}-{_compact_timestamp()}"
+    store_root.mkdir(parents=True, exist_ok=True)
+    return _make_service(store_root=store_root)
+
+
+def _make_contract_id(name: str) -> str:
+    return f"live-reset-{name}-{_compact_timestamp()}"
+
+
+def _issue_title(name: str) -> str:
+    return f"[Harness Live Smoke] {name.replace('_', ' ')} {_compact_timestamp()}"
+
+
+def _issue_description(name: str) -> str:
+    return (
+        "Automated Harness live reset smoke scenario.\n\n"
+        f"Scenario: {name}\n"
+        "This issue is expected to be mutated by Harness during verification."
+    )
+
+
+def _artifact_inputs(name: str, *, issue_identifier: str) -> dict[str, str]:
+    suffix = _compact_timestamp()
+    branch_name = f"codex/live-reset-{name}-{suffix}"
+    file_path = f"proofs/live-reset-smoke/{name}-{suffix}.md"
+    file_content = (
+        f"# Harness live reset smoke\n\n"
+        f"- Scenario: {name}\n"
+        f"- Linear issue: {issue_identifier}\n"
+        f"- Generated at: {_utc_now().isoformat()}\n"
+    )
+    return {
+        "branch_name": branch_name,
+        "file_path": file_path,
+        "file_content": file_content,
+        "commit_message": f"test: add live reset smoke proof for {name}",
+        "pull_request_title": f"[Harness Live Smoke] {name} {issue_identifier}",
+        "pull_request_body": (
+            "Automated live reset smoke proof for Harness.\n\n"
+            f"Scenario: {name}\n"
+            f"Linear issue: {issue_identifier}\n"
+        ),
+    }
+
+
+def _random_sha_different_from(reference_sha: str) -> str:
+    if len(reference_sha) != 40:
+        return "0" * 40
+    replacement = "0" if reference_sha[-1].lower() != "0" else "1"
+    return reference_sha[:-1] + replacement
+
+
+def _build_claim(artifact: LiveGitHubArtifact, *, commit_sha: str | None = None, pr_number: int | None = None, pr_url: str | None = None) -> ResetCompletionClaim:
+    return ResetCompletionClaim(
+        repository_owner=artifact.owner,
+        repository_name=artifact.repo,
+        branch_name=artifact.branch_name,
+        commit_sha=commit_sha or artifact.commit_sha,
+        pull_request_number=pr_number or artifact.pull_request_number,
+        pull_request_url=pr_url or artifact.pull_request_url,
+    )
+
+
+def _run_happy_path(
+    *,
+    service: ResetVerificationService,
+    linear: _LiveLinearClient,
+    github: _LiveGitHubClient,
+    project: LiveLinearProject,
+    owner: str,
+    repo: str,
+    base_branch: str,
+    openclaw: _RecordingOpenClawClient,
+) -> LiveResetScenarioResult:
+    issue = linear.create_issue(
+        project=project,
+        title=_issue_title("happy_path"),
+        description=_issue_description("happy_path"),
+    )
+    artifact = github.create_artifact(
+        owner=owner,
+        repo=repo,
+        base_branch=base_branch,
+        **_artifact_inputs("happy-path", issue_identifier=issue.identifier),
+    )
+    contract_id = _make_contract_id("happy")
+    service.register_contract(
+        ResetVerificationContract(
+            contract_id=contract_id,
+            linear_issue_id=issue.id,
+            repository_owner=owner,
+            repository_name=repo,
+            branch_ref=artifact.branch_name,
+        )
+    )
+    claim_result = service.submit_claim(contract_id, _build_claim(artifact))
+    issue_after = linear.wait_for_issue_state(issue.id, expected_state="Done")
+    contract_after = service.get_contract(contract_id)
+    return LiveResetScenarioResult(
+        name="happy_path",
+        contract_id=contract_id,
+        linear_issue_id=issue_after.id,
+        linear_issue_identifier=issue_after.identifier,
+        linear_issue_url=issue_after.url,
+        pull_request_url=artifact.pull_request_url,
+        branch_name=artifact.branch_name,
+        commit_sha=artifact.commit_sha,
+        claim_verdict=str(claim_result["status"]),
+        latest_reason=contract_after.latest_reason,
+        final_harness_status=contract_after.harness_status,
+        final_linear_state=issue_after.state_name,
+        repair_request_count=len(openclaw.repairs),
+    )
+
+
+def _run_missing_pull_request_path(
+    *,
+    service: ResetVerificationService,
+    linear: _LiveLinearClient,
+    github: _LiveGitHubClient,
+    project: LiveLinearProject,
+    owner: str,
+    repo: str,
+    base_branch: str,
+    openclaw: _RecordingOpenClawClient,
+) -> LiveResetScenarioResult:
+    issue = linear.create_issue(
+        project=project,
+        title=_issue_title("missing_pull_request"),
+        description=_issue_description("missing_pull_request"),
+    )
+    artifact = github.create_artifact(
+        owner=owner,
+        repo=repo,
+        base_branch=base_branch,
+        **_artifact_inputs("missing-pr", issue_identifier=issue.identifier),
+    )
+    contract_id = _make_contract_id("missing-pr")
+    service.register_contract(
+        ResetVerificationContract(
+            contract_id=contract_id,
+            linear_issue_id=issue.id,
+            repository_owner=owner,
+            repository_name=repo,
+            branch_ref=artifact.branch_name,
+        )
+    )
+    missing_number = artifact.pull_request_number + 900000
+    missing_url = f"https://github.com/{owner}/{repo}/pull/{missing_number}"
+    claim_result = service.submit_claim(
+        contract_id,
+        _build_claim(artifact, pr_number=missing_number, pr_url=missing_url),
+    )
+    issue_after = linear.wait_for_issue_state(issue.id, expected_state="In Progress")
+    contract_after = service.get_contract(contract_id)
+    return LiveResetScenarioResult(
+        name="missing_pull_request",
+        contract_id=contract_id,
+        linear_issue_id=issue_after.id,
+        linear_issue_identifier=issue_after.identifier,
+        linear_issue_url=issue_after.url,
+        pull_request_url=artifact.pull_request_url,
+        branch_name=artifact.branch_name,
+        commit_sha=artifact.commit_sha,
+        claim_verdict=str(claim_result["status"]),
+        latest_reason=contract_after.latest_reason,
+        final_harness_status=contract_after.harness_status,
+        final_linear_state=issue_after.state_name,
+        repair_request_count=len(openclaw.repairs),
+    )
+
+
+def _run_wrong_sha_review_path(
+    *,
+    service: ResetVerificationService,
+    linear: _LiveLinearClient,
+    github: _LiveGitHubClient,
+    project: LiveLinearProject,
+    owner: str,
+    repo: str,
+    base_branch: str,
+    openclaw: _RecordingOpenClawClient,
+) -> LiveResetScenarioResult:
+    issue = linear.create_issue(
+        project=project,
+        title=_issue_title("wrong_sha_review"),
+        description=_issue_description("wrong_sha_review"),
+    )
+    artifact = github.create_artifact(
+        owner=owner,
+        repo=repo,
+        base_branch=base_branch,
+        **_artifact_inputs("wrong-sha-review", issue_identifier=issue.identifier),
+    )
+    contract_id = _make_contract_id("wrong-sha-review")
+    service.register_contract(
+        ResetVerificationContract(
+            contract_id=contract_id,
+            linear_issue_id=issue.id,
+            repository_owner=owner,
+            repository_name=repo,
+            branch_ref=artifact.branch_name,
+            retry_budget=1,
+        )
+    )
+    wrong_sha = _random_sha_different_from(artifact.commit_sha)
+    claim_result = service.submit_claim(contract_id, _build_claim(artifact, commit_sha=wrong_sha))
+    tick_results = service.tick()
+    issue_after = linear.wait_for_issue_state(issue.id, expected_state="In Review")
+    contract_after = service.get_contract(contract_id)
+    return LiveResetScenarioResult(
+        name="wrong_sha_review",
+        contract_id=contract_id,
+        linear_issue_id=issue_after.id,
+        linear_issue_identifier=issue_after.identifier,
+        linear_issue_url=issue_after.url,
+        pull_request_url=artifact.pull_request_url,
+        branch_name=artifact.branch_name,
+        commit_sha=artifact.commit_sha,
+        claim_verdict=str(claim_result["status"]),
+        latest_reason=contract_after.latest_reason,
+        final_harness_status=contract_after.harness_status,
+        final_linear_state=issue_after.state_name,
+        repair_request_count=len(openclaw.repairs),
+        tick_verdicts=tuple(result.status for result in tick_results),
+    )
+
+
+def run_live_reset_smoke_suite(
+    *,
+    linear_project_name: str = DEFAULT_LINEAR_PROJECT_NAME,
+    github_owner: str = DEFAULT_GITHUB_OWNER,
+    github_repo: str = DEFAULT_GITHUB_REPO,
+    base_branch: str = DEFAULT_BASE_BRANCH,
+) -> LiveResetSmokeSuiteResult:
+    linear = _LiveLinearClient()
+    github = _LiveGitHubClient()
+    project = linear.resolve_project(linear_project_name)
+
+    happy_service, happy_openclaw = _make_isolated_service("happy-path")
+    happy = _run_happy_path(
+        service=happy_service,
+        linear=linear,
+        github=github,
+        project=project,
+        owner=github_owner,
+        repo=github_repo,
+        base_branch=base_branch,
+        openclaw=happy_openclaw,
+    )
+
+    missing_pr_service, missing_pr_openclaw = _make_isolated_service("missing-pr")
+    missing_pr = _run_missing_pull_request_path(
+        service=missing_pr_service,
+        linear=linear,
+        github=github,
+        project=project,
+        owner=github_owner,
+        repo=github_repo,
+        base_branch=base_branch,
+        openclaw=missing_pr_openclaw,
+    )
+
+    wrong_sha_service, wrong_sha_openclaw = _make_isolated_service("wrong-sha-review")
+    wrong_sha_review = _run_wrong_sha_review_path(
+        service=wrong_sha_service,
+        linear=linear,
+        github=github,
+        project=project,
+        owner=github_owner,
+        repo=github_repo,
+        base_branch=base_branch,
+        openclaw=wrong_sha_openclaw,
+    )
+    return LiveResetSmokeSuiteResult(
+        happy_path=happy,
+        missing_pull_request=missing_pr,
+        wrong_sha_review=wrong_sha_review,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run live reset smoke tests against real Linear and GitHub.")
+    parser.add_argument("--project", default=DEFAULT_LINEAR_PROJECT_NAME)
+    parser.add_argument("--owner", default=DEFAULT_GITHUB_OWNER)
+    parser.add_argument("--repo", default=DEFAULT_GITHUB_REPO)
+    parser.add_argument("--base-branch", default=DEFAULT_BASE_BRANCH)
+    args = parser.parse_args()
+
+    result = run_live_reset_smoke_suite(
+        linear_project_name=args.project,
+        github_owner=args.owner,
+        github_repo=args.repo,
+        base_branch=args.base_branch,
+    )
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+
+
+__all__ = [
+    "LiveResetScenarioResult",
+    "LiveResetSmokeError",
+    "LiveResetSmokeSuiteResult",
+    "run_live_reset_smoke_suite",
+]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/connectors/test_openclaw_reset_end_to_end.py
+++ b/tests/connectors/test_openclaw_reset_end_to_end.py
@@ -118,6 +118,7 @@ class OpenClawResetEndToEndTests(unittest.TestCase):
                     "branch_name": "codex/reset-verifier-v1",
                     "commit_sha": "bad-sha",
                     "pull_request_number": 42,
+                    "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
                 },
             )
             fetch_after_invalid_status, fetch_after_invalid_payload = client.get_reset_contract("contract-recovery")
@@ -150,6 +151,7 @@ class OpenClawResetEndToEndTests(unittest.TestCase):
                     "branch_name": "codex/reset-verifier-v1",
                     "commit_sha": "good-sha",
                     "pull_request_number": 42,
+                    "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
                 },
             )
             fetch_after_verified_status, fetch_after_verified_payload = client.get_reset_contract("contract-recovery")
@@ -197,6 +199,7 @@ class OpenClawResetEndToEndTests(unittest.TestCase):
                     "branch_name": "codex/reset-verifier-v1",
                     "commit_sha": "bad-sha",
                     "pull_request_number": 42,
+                    "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
                 },
             )
             first_tick_status, first_tick_payload = client.tick_reset()

--- a/tests/connectors/test_openclaw_reset_spike.py
+++ b/tests/connectors/test_openclaw_reset_spike.py
@@ -98,6 +98,7 @@ class OpenClawResetSpikeTests(unittest.TestCase):
                 "branch_name": "codex/reset-verifier-v1",
                 "commit_sha": "abc123",
                 "pull_request_number": 42,
+                "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
             },
         )
         self.assertEqual(claim_status, 200)

--- a/tests/reset/test_contracts.py
+++ b/tests/reset/test_contracts.py
@@ -20,13 +20,14 @@ class ResetContractTests(unittest.TestCase):
                 branch_ref="",
             )
 
-    def test_claim_requires_pull_request_reference(self) -> None:
+    def test_claim_requires_pull_request_url(self) -> None:
         with self.assertRaises(ResetVerificationContractError):
             ResetCompletionClaim(
                 repository_owner="sfayka",
                 repository_name="Harness",
                 branch_name="codex/reset-verifier-v1",
                 commit_sha="abc123",
+                pull_request_number=42,
             )
 
     def test_branch_ref_supports_glob_matching(self) -> None:
@@ -41,3 +42,14 @@ class ResetContractTests(unittest.TestCase):
         self.assertTrue(contract.branch_matches("codex/reset-verifier-v1"))
         self.assertFalse(contract.branch_matches("main"))
 
+    def test_contract_tracks_claim_timeout_policy(self) -> None:
+        contract = ResetVerificationContract(
+            contract_id="contract-1",
+            linear_issue_id="KNO-999",
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_ref="codex/*",
+            claim_timeout_seconds=120,
+        )
+
+        self.assertEqual(contract.claim_timeout_seconds, 120)

--- a/tests/reset/test_github_rest_client.py
+++ b/tests/reset/test_github_rest_client.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import io
+import unittest
+from unittest.mock import patch
+from urllib import error
+
+from modules.reset.github_verifier import GitHubRestResetClient
+
+
+def _http_error(code: int) -> error.HTTPError:
+    return error.HTTPError(
+        url="https://api.github.com/repos/sfayka/HARNESS-DRYRUN/commits/deadbeef",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=None,
+        fp=io.BytesIO(b"{}"),
+    )
+
+
+class GitHubRestResetClientTests(unittest.TestCase):
+    @patch("modules.reset.github_verifier.request.urlopen")
+    def test_commit_exists_treats_http_422_as_missing_commit(self, mocked_urlopen) -> None:
+        mocked_urlopen.side_effect = _http_error(422)
+
+        client = GitHubRestResetClient(token="github-test-token")
+
+        self.assertFalse(client.commit_exists("sfayka", "HARNESS-DRYRUN", "0" * 40))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/reset/test_github_verifier.py
+++ b/tests/reset/test_github_verifier.py
@@ -59,6 +59,7 @@ class ResetGitHubVerifierTests(unittest.TestCase):
             branch_name="codex/reset-verifier-v1",
             commit_sha="wrong",
             pull_request_number=42,
+            pull_request_url="https://github.com/sfayka/Harness/pull/42",
         )
 
         self.assertEqual(verdict.status, "retryable_invalid_proof")
@@ -76,8 +77,24 @@ class ResetGitHubVerifierTests(unittest.TestCase):
             branch_name="codex/reset-verifier-v1",
             commit_sha="abc123",
             pull_request_number=42,
+            pull_request_url="https://github.com/sfayka/Harness/pull/42",
         )
 
         self.assertEqual(verdict.status, "retryable_invalid_proof")
         self.assertIn("branch", verdict.reason)
 
+    def test_rejects_missing_pull_request_url_even_when_number_exists(self) -> None:
+        verifier = ResetGitHubVerifier(client=FakeGitHubClient())
+
+        verdict = verifier.verify(
+            expected_owner="sfayka",
+            expected_repo="Harness",
+            expected_branch="codex/reset-verifier-v1",
+            branch_name="codex/reset-verifier-v1",
+            commit_sha="abc123",
+            pull_request_number=42,
+            pull_request_url=None,
+        )
+
+        self.assertEqual(verdict.status, "retryable_invalid_proof")
+        self.assertIn("url", verdict.reason)

--- a/tests/reset/test_prompting.py
+++ b/tests/reset/test_prompting.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.reset.prompting import ResetDispatchPromptContext, build_reset_dispatch_prompt
+
+
+class ResetPromptingTests(unittest.TestCase):
+    def test_happy_path_prompt_demands_real_github_proof(self) -> None:
+        prompt = build_reset_dispatch_prompt(
+            ResetDispatchPromptContext(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                linear_issue_title="Dryrun happy path",
+                repository_owner="sfayka",
+                repository_name="HARNESS-DRYRUN",
+                branch_name="codex/kno-999-happy-path",
+                base_branch="main",
+                required_changed_path="proofs/kno-999.md",
+            )
+        )
+
+        self.assertIn("KNO-999", prompt)
+        self.assertIn("sfayka/HARNESS-DRYRUN", prompt)
+        self.assertIn("codex/kno-999-happy-path", prompt)
+        self.assertIn("proofs/kno-999.md", prompt)
+        self.assertIn("PR URL:", prompt)
+        self.assertIn("real repository, branch, commit SHA, and PR URL", prompt)

--- a/tests/reset/test_proofs.py
+++ b/tests/reset/test_proofs.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.reset.proofs import ResetWorkerProofError, parse_worker_proof_output
+
+
+class ResetWorkerProofParsingTests(unittest.TestCase):
+    def test_parses_happy_path_final_proof_lines(self) -> None:
+        proof = parse_worker_proof_output(
+            """
+            Repository: sfayka/HARNESS-DRYRUN
+            Branch: codex/kno-999-happy-path
+            Commit SHA: 1234567890abcdef1234567890abcdef12345678
+            PR URL: https://github.com/sfayka/HARNESS-DRYRUN/pull/42
+            """
+        )
+
+        self.assertEqual(proof.repository_owner, "sfayka")
+        self.assertEqual(proof.repository_name, "HARNESS-DRYRUN")
+        self.assertEqual(proof.branch_name, "codex/kno-999-happy-path")
+        self.assertEqual(proof.commit_sha, "1234567890abcdef1234567890abcdef12345678")
+        self.assertEqual(proof.pull_request_number, 42)
+        self.assertEqual(proof.pull_request_url, "https://github.com/sfayka/HARNESS-DRYRUN/pull/42")
+
+    def test_rejects_missing_pull_request_url(self) -> None:
+        with self.assertRaises(ResetWorkerProofError):
+            parse_worker_proof_output(
+                """
+                Repository: sfayka/HARNESS-DRYRUN
+                Branch: codex/kno-999-happy-path
+                Commit SHA: 1234567890abcdef1234567890abcdef12345678
+                """
+            )

--- a/tests/reset/test_scenarios.py
+++ b/tests/reset/test_scenarios.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.reset.scenarios import (
+    SimulatedGitHubState,
+    SimulatedResetScenario,
+    build_worker_proof_output,
+    run_simulated_reset_scenario,
+)
+
+
+class SimulatedResetScenarioTests(unittest.TestCase):
+    def test_happy_path_verifies_without_babysitting(self) -> None:
+        scenario = SimulatedResetScenario(
+            name="happy_path",
+            contract_id="contract-happy",
+            linear_issue_id="KNO-999",
+            linear_issue_title="Happy path",
+            repository_owner="sfayka",
+            repository_name="HARNESS-DRYRUN",
+            branch_name="codex/kno-999-happy-path",
+            required_changed_path="proofs/kno-999.md",
+            worker_output=build_worker_proof_output(
+                repository="sfayka/HARNESS-DRYRUN",
+                branch="codex/kno-999-happy-path",
+                commit_sha="1234567890abcdef1234567890abcdef12345678",
+                pull_request_url="https://github.com/sfayka/HARNESS-DRYRUN/pull/42",
+            ),
+            github_state=SimulatedGitHubState(
+                branch_exists=True,
+                commit_exists=True,
+                pull_request_payload={
+                    "number": 42,
+                    "html_url": "https://github.com/sfayka/HARNESS-DRYRUN/pull/42",
+                    "state": "open",
+                    "merged_at": None,
+                    "head": {
+                        "ref": "codex/kno-999-happy-path",
+                        "sha": "1234567890abcdef1234567890abcdef12345678",
+                        "repo": {"owner": {"login": "sfayka"}, "name": "HARNESS-DRYRUN"},
+                    },
+                },
+            ),
+        )
+
+        result = run_simulated_reset_scenario(scenario)
+
+        self.assertEqual(result.claim_status, 200)
+        self.assertEqual(result.claim_verdict, "verified_done")
+        self.assertEqual(result.final_contract["harness_status"], "verified")
+        self.assertEqual(result.linear_actions[-1][:3], ("KNO-999", "Done", "verified"))
+        self.assertEqual(result.repair_requests, [])
+        self.assertIsNone(result.proof_error)
+        self.assertEqual(result.tick_verdicts, ())
+        self.assertIn("PR URL:", result.prompt)
+
+    def test_missing_pr_url_times_out_and_requests_repair(self) -> None:
+        scenario = SimulatedResetScenario(
+            name="missing_pr_url",
+            contract_id="contract-missing-url",
+            linear_issue_id="KNO-1000",
+            linear_issue_title="Missing PR URL",
+            repository_owner="sfayka",
+            repository_name="HARNESS-DRYRUN",
+            branch_name="codex/kno-1000-missing-url",
+            required_changed_path="proofs/kno-1000.md",
+            worker_output="""
+            Repository: sfayka/HARNESS-DRYRUN
+            Branch: codex/kno-1000-missing-url
+            Commit SHA: 1234567890abcdef1234567890abcdef12345678
+            """,
+            claim_timeout_seconds=1,
+            tick_count=1,
+        )
+
+        result = run_simulated_reset_scenario(scenario)
+
+        self.assertIsNone(result.claim_status)
+        self.assertIsNone(result.claim_verdict)
+        self.assertIsNotNone(result.proof_error)
+        self.assertEqual(result.tick_verdicts, ("retryable_invalid_proof",))
+        self.assertEqual(result.final_contract["harness_status"], "retrying")
+        self.assertEqual(result.linear_actions[-1][:3], ("KNO-1000", "In Progress", "retrying"))
+        self.assertEqual(len(result.repair_requests), 1)
+        self.assertIn("no completion claim", result.repair_requests[0][1])
+
+    def test_wrong_sha_claim_enters_retrying_with_real_repair_request(self) -> None:
+        scenario = SimulatedResetScenario(
+            name="wrong_sha",
+            contract_id="contract-wrong-sha",
+            linear_issue_id="KNO-1001",
+            linear_issue_title="Wrong SHA",
+            repository_owner="sfayka",
+            repository_name="HARNESS-DRYRUN",
+            branch_name="codex/kno-1001-wrong-sha",
+            required_changed_path="proofs/kno-1001.md",
+            worker_output=build_worker_proof_output(
+                repository="sfayka/HARNESS-DRYRUN",
+                branch="codex/kno-1001-wrong-sha",
+                commit_sha="deadbeef90abcdef1234567890abcdef12345678",
+                pull_request_url="https://github.com/sfayka/HARNESS-DRYRUN/pull/41",
+            ),
+            github_state=SimulatedGitHubState(
+                branch_exists=True,
+                commit_exists=False,
+                pull_request_payload={
+                    "number": 41,
+                    "html_url": "https://github.com/sfayka/HARNESS-DRYRUN/pull/41",
+                    "state": "open",
+                    "merged_at": None,
+                    "head": {
+                        "ref": "codex/kno-1001-wrong-sha",
+                        "sha": "1234567890abcdef1234567890abcdef12345678",
+                        "repo": {"owner": {"login": "sfayka"}, "name": "HARNESS-DRYRUN"},
+                    },
+                },
+            ),
+        )
+
+        result = run_simulated_reset_scenario(scenario)
+
+        self.assertEqual(result.claim_status, 200)
+        self.assertEqual(result.claim_verdict, "retryable_invalid_proof")
+        self.assertEqual(result.final_contract["harness_status"], "retrying")
+        self.assertEqual(result.linear_actions[-1][:3], ("KNO-1001", "In Progress", "retrying"))
+        self.assertEqual(len(result.repair_requests), 1)
+        self.assertIn("commit sha", result.repair_requests[0][1])
+
+    def test_wrong_repository_claim_is_rejected_before_github_lookup(self) -> None:
+        scenario = SimulatedResetScenario(
+            name="wrong_repository",
+            contract_id="contract-wrong-repo",
+            linear_issue_id="KNO-1002",
+            linear_issue_title="Wrong repository",
+            repository_owner="sfayka",
+            repository_name="HARNESS-DRYRUN",
+            branch_name="codex/kno-1002-wrong-repo",
+            required_changed_path="proofs/kno-1002.md",
+            worker_output=build_worker_proof_output(
+                repository="someone-else/HARNESS-DRYRUN",
+                branch="codex/kno-1002-wrong-repo",
+                commit_sha="1234567890abcdef1234567890abcdef12345678",
+                pull_request_url="https://github.com/someone-else/HARNESS-DRYRUN/pull/55",
+            ),
+        )
+
+        result = run_simulated_reset_scenario(scenario)
+
+        self.assertEqual(result.claim_status, 200)
+        self.assertEqual(result.claim_verdict, "retryable_invalid_proof")
+        self.assertEqual(result.final_contract["harness_status"], "retrying")
+        self.assertEqual(len(result.repair_requests), 1)
+        self.assertIn("repository owner", result.repair_requests[0][1])
+
+    def test_missing_pull_request_object_requests_repair(self) -> None:
+        scenario = SimulatedResetScenario(
+            name="missing_pr_object",
+            contract_id="contract-missing-pr",
+            linear_issue_id="KNO-1003",
+            linear_issue_title="Missing pull request object",
+            repository_owner="sfayka",
+            repository_name="HARNESS-DRYRUN",
+            branch_name="codex/kno-1003-missing-pr",
+            required_changed_path="proofs/kno-1003.md",
+            worker_output=build_worker_proof_output(
+                repository="sfayka/HARNESS-DRYRUN",
+                branch="codex/kno-1003-missing-pr",
+                commit_sha="1234567890abcdef1234567890abcdef12345678",
+                pull_request_url="https://github.com/sfayka/HARNESS-DRYRUN/pull/56",
+            ),
+            github_state=SimulatedGitHubState(
+                branch_exists=True,
+                commit_exists=True,
+                pull_request_payload=None,
+            ),
+        )
+
+        result = run_simulated_reset_scenario(scenario)
+
+        self.assertEqual(result.claim_status, 200)
+        self.assertEqual(result.claim_verdict, "retryable_invalid_proof")
+        self.assertEqual(result.final_contract["harness_status"], "retrying")
+        self.assertEqual(len(result.repair_requests), 1)
+        self.assertIn("pull request does not exist", result.repair_requests[0][1])
+
+    def test_closed_unmerged_pull_request_requests_repair(self) -> None:
+        scenario = SimulatedResetScenario(
+            name="closed_unmerged_pr",
+            contract_id="contract-closed-pr",
+            linear_issue_id="KNO-1004",
+            linear_issue_title="Closed unmerged pull request",
+            repository_owner="sfayka",
+            repository_name="HARNESS-DRYRUN",
+            branch_name="codex/kno-1004-closed-pr",
+            required_changed_path="proofs/kno-1004.md",
+            worker_output=build_worker_proof_output(
+                repository="sfayka/HARNESS-DRYRUN",
+                branch="codex/kno-1004-closed-pr",
+                commit_sha="1234567890abcdef1234567890abcdef12345678",
+                pull_request_url="https://github.com/sfayka/HARNESS-DRYRUN/pull/57",
+            ),
+            github_state=SimulatedGitHubState(
+                branch_exists=True,
+                commit_exists=True,
+                pull_request_payload={
+                    "number": 57,
+                    "html_url": "https://github.com/sfayka/HARNESS-DRYRUN/pull/57",
+                    "state": "closed",
+                    "merged_at": None,
+                    "head": {
+                        "ref": "codex/kno-1004-closed-pr",
+                        "sha": "1234567890abcdef1234567890abcdef12345678",
+                        "repo": {"owner": {"login": "sfayka"}, "name": "HARNESS-DRYRUN"},
+                    },
+                },
+            ),
+        )
+
+        result = run_simulated_reset_scenario(scenario)
+
+        self.assertEqual(result.claim_status, 200)
+        self.assertEqual(result.claim_verdict, "retryable_invalid_proof")
+        self.assertEqual(result.final_contract["harness_status"], "retrying")
+        self.assertEqual(len(result.repair_requests), 1)
+        self.assertIn("closed without being merged", result.repair_requests[0][1])
+
+    def test_retry_budget_exhaustion_escalates_to_review(self) -> None:
+        scenario = SimulatedResetScenario(
+            name="retry_budget_exhaustion",
+            contract_id="contract-retry-budget",
+            linear_issue_id="KNO-1005",
+            linear_issue_title="Retry budget exhaustion",
+            repository_owner="sfayka",
+            repository_name="HARNESS-DRYRUN",
+            branch_name="codex/kno-1005-retry-budget",
+            required_changed_path="proofs/kno-1005.md",
+            worker_output=build_worker_proof_output(
+                repository="sfayka/HARNESS-DRYRUN",
+                branch="codex/kno-1005-retry-budget",
+                commit_sha="deadbeef90abcdef1234567890abcdef12345678",
+                pull_request_url="https://github.com/sfayka/HARNESS-DRYRUN/pull/58",
+            ),
+            github_state=SimulatedGitHubState(
+                branch_exists=True,
+                commit_exists=False,
+                pull_request_payload={
+                    "number": 58,
+                    "html_url": "https://github.com/sfayka/HARNESS-DRYRUN/pull/58",
+                    "state": "open",
+                    "merged_at": None,
+                    "head": {
+                        "ref": "codex/kno-1005-retry-budget",
+                        "sha": "1234567890abcdef1234567890abcdef12345678",
+                        "repo": {"owner": {"login": "sfayka"}, "name": "HARNESS-DRYRUN"},
+                    },
+                },
+            ),
+            retry_budget=1,
+            tick_count=1,
+        )
+
+        result = run_simulated_reset_scenario(scenario)
+
+        self.assertEqual(result.claim_status, 200)
+        self.assertEqual(result.claim_verdict, "retryable_invalid_proof")
+        self.assertEqual(result.tick_verdicts, ("needs_review",))
+        self.assertEqual(result.final_contract["harness_status"], "needs_review")
+        self.assertEqual(result.linear_actions[-1][:3], ("KNO-1005", "In Review", "needs_review"))

--- a/tests/reset/test_service.py
+++ b/tests/reset/test_service.py
@@ -64,6 +64,7 @@ class ResetVerificationServiceTests(unittest.TestCase):
                     branch_name="codex/reset-verifier-v1",
                     commit_sha="bad",
                     pull_request_number=42,
+                    pull_request_url="https://github.com/sfayka/Harness/pull/42",
                 ),
             )
 
@@ -99,6 +100,7 @@ class ResetVerificationServiceTests(unittest.TestCase):
                     branch_name="codex/reset-verifier-v1",
                     commit_sha="abc123",
                     pull_request_number=42,
+                    pull_request_url="https://github.com/sfayka/Harness/pull/42",
                 ),
             )
 
@@ -138,6 +140,7 @@ class ResetVerificationServiceTests(unittest.TestCase):
                     branch_name="codex/reset-verifier-v1",
                     commit_sha="bad",
                     pull_request_number=42,
+                    pull_request_url="https://github.com/sfayka/Harness/pull/42",
                 ),
             )
 
@@ -176,6 +179,7 @@ class ResetVerificationServiceTests(unittest.TestCase):
                     branch_name="codex/reset-verifier-v1",
                     commit_sha="bad",
                     pull_request_number=42,
+                    pull_request_url="https://github.com/sfayka/Harness/pull/42",
                 ),
                 retry_count=1,
                 last_repair_requested_at=requested_at.isoformat().replace("+00:00", "Z"),
@@ -188,3 +192,86 @@ class ResetVerificationServiceTests(unittest.TestCase):
             self.assertEqual(tick_results[0].status, "cooldown_wait")
             self.assertEqual(openclaw.repairs, [])
             self.assertEqual(linear.actions, [])
+
+    def test_tick_requests_repair_when_no_claim_arrives_before_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            linear = FakeLinearClient()
+            openclaw = FakeOpenClawClient()
+            service = ResetVerificationService(
+                store=store,
+                linear_client=linear,
+                verifier=FakeVerifier(("retryable_invalid_proof", "unused")),
+                openclaw_client=openclaw,
+                now_provider=lambda: datetime(2026, 4, 15, 12, 5, tzinfo=timezone.utc),
+                retry_cooldown_seconds=0,
+                claim_timeout_seconds=60,
+            )
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+                created_at="2026-04-15T12:00:00Z",
+                updated_at="2026-04-15T12:00:00Z",
+                last_activity_at="2026-04-15T12:00:00Z",
+            )
+            service.register_contract(contract)
+
+            tick_results = service.tick()
+            updated = service.get_contract("contract-1")
+
+            self.assertEqual(len(tick_results), 1)
+            self.assertEqual(tick_results[0].status, "retryable_invalid_proof")
+            self.assertEqual(updated.harness_status, "retrying")
+            self.assertEqual(updated.retry_count, 1)
+            self.assertEqual(
+                [event.kind for event in updated.event_log][-1],
+                "repair_requested",
+            )
+            self.assertEqual(openclaw.repairs[0][0], "KNO-999")
+            self.assertIn("no completion claim", openclaw.repairs[0][1])
+            self.assertEqual(linear.actions[-1][1], "In Progress")
+            self.assertEqual(linear.actions[-1][2], "retrying")
+
+    def test_tick_escalates_to_review_when_claim_timeout_retries_are_spent(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            linear = FakeLinearClient()
+            openclaw = FakeOpenClawClient()
+            service = ResetVerificationService(
+                store=store,
+                linear_client=linear,
+                verifier=FakeVerifier(("retryable_invalid_proof", "unused")),
+                openclaw_client=openclaw,
+                now_provider=lambda: datetime(2026, 4, 15, 12, 5, tzinfo=timezone.utc),
+                retry_cooldown_seconds=0,
+                claim_timeout_seconds=60,
+            )
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+                retry_count=2,
+                retry_budget=2,
+                harness_status="retrying",
+                created_at="2026-04-15T12:00:00Z",
+                updated_at="2026-04-15T12:00:00Z",
+                last_activity_at="2026-04-15T12:00:00Z",
+                last_repair_requested_at="2026-04-15T12:01:00Z",
+            )
+            store.create_contract(contract)
+
+            tick_results = service.tick()
+            updated = service.get_contract("contract-1")
+
+            self.assertEqual(len(tick_results), 1)
+            self.assertEqual(tick_results[0].status, "needs_review")
+            self.assertEqual(updated.harness_status, "needs_review")
+            self.assertEqual(updated.latest_verdict, "needs_review")
+            self.assertEqual(openclaw.repairs, [])
+            self.assertEqual(linear.actions[-1][1], "In Review")
+            self.assertEqual(linear.actions[-1][2], "needs_review")

--- a/tests/test_fastapi_backend.py
+++ b/tests/test_fastapi_backend.py
@@ -151,6 +151,7 @@ class FastApiBackendTests(unittest.TestCase):
                 "branch_name": "codex/reset-verifier-v1",
                 "commit_sha": "abc123",
                 "pull_request_number": 42,
+                "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
             },
         )
         self.assertEqual(claimed.status_code, 200)

--- a/tests/test_reset_live_smoke.py
+++ b/tests/test_reset_live_smoke.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+import unittest
+
+from modules.reset_live_smoke import run_live_reset_smoke_suite
+
+
+@unittest.skipUnless(
+    os.getenv("HARNESS_RUN_LIVE_RESET_TESTS") == "1",
+    "set HARNESS_RUN_LIVE_RESET_TESTS=1 to run live Linear/GitHub smoke tests",
+)
+class LiveResetSmokeTests(unittest.TestCase):
+    def test_live_linear_and_github_smoke_suite(self) -> None:
+        result = run_live_reset_smoke_suite()
+
+        self.assertEqual(result.happy_path.claim_verdict, "verified_done")
+        self.assertEqual(result.happy_path.final_harness_status, "verified")
+        self.assertEqual(result.happy_path.final_linear_state, "Done")
+        self.assertEqual(result.happy_path.repair_request_count, 0)
+
+        self.assertEqual(result.missing_pull_request.claim_verdict, "retryable_invalid_proof")
+        self.assertEqual(result.missing_pull_request.final_harness_status, "retrying")
+        self.assertEqual(result.missing_pull_request.final_linear_state, "In Progress")
+        self.assertGreaterEqual(result.missing_pull_request.repair_request_count, 1)
+
+        self.assertEqual(result.wrong_sha_review.claim_verdict, "retryable_invalid_proof")
+        self.assertEqual(result.wrong_sha_review.tick_verdicts, ("needs_review",))
+        self.assertEqual(result.wrong_sha_review.final_harness_status, "needs_review")
+        self.assertEqual(result.wrong_sha_review.final_linear_state, "In Review")
+        self.assertGreaterEqual(result.wrong_sha_review.repair_request_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- tighten the reset verifier contract so completion claims require a PR URL and supervision can bump contracts that never produce a claim
- add deterministic scenario tooling and tests for happy-path, invalid-proof, timeout, and review-escalation reset flows using the existing OpenClaw spike as the stand-in
- add a gated live smoke for Set 2 against real Linear and real GitHub, and harden the reset Linear/GitHub clients for TLS and GitHub 422 missing-commit behavior

## Validation
- `python3 -m unittest tests.reset.test_contracts tests.reset.test_github_verifier tests.reset.test_service tests.reset.test_prompting tests.reset.test_proofs tests.reset.test_scenarios tests.connectors.test_openclaw_reset_spike tests.connectors.test_openclaw_reset_end_to_end tests.test_reset_dryrun tests.test_fastapi_backend -v`
- `HARNESS_RUN_LIVE_RESET_TESTS=1 python3 -m unittest tests.test_reset_live_smoke -v`
- `python3 -m unittest discover -s tests`

## Notes
- Set 1 and Set 2 are complete.
- Set 3 is intentionally not in this PR; real OpenClaw/Codex runtime is still deferred and the existing spike remains the OpenClaw stand-in.
