### PR TITLE
Fix hosted backend startup and document ingress contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The reset routes live under:
 
 These routes intentionally coexist with the older TaskEnvelope routes so the narrower verifier path can ship without first deleting the broader control-plane code.
 
+In hosted Vercel runtimes, the reset slice is not allowed to take the whole backend down if its file-backed store cannot be created. Canonical task APIs must still boot. The hosted fallback now uses writable temp storage for the reset slice, and if even that cannot be created, `/reset/*` fails explicitly instead of crashing `/backend/health` and `/backend/tasks` during import.
+
 ## What Harness Is
 
 - A Python control-plane backend that evaluates canonical `TaskEnvelope` submissions.
@@ -41,6 +43,8 @@ On the inspection side, Harness now also exposes a canonical supervision queue a
 On the execution side, Harness now also contains a real Codex Cloud adapter boundary in addition to the stub dispatch path. That adapter projects canonical dispatch input into a Codex Cloud request shape and enforces the repo/bootstrap preflight contract before it will emit a successful advisory completion signal. Live runtime transport is still a separate integration step, but the proof gate is now encoded at the adapter boundary instead of left to convention.
 
 The same boundary now applies to manual and Linear ingress. Those adapters may submit task intent, coordination metadata, and clarification blockers, but they cannot claim completion, assert acceptance, inject runtime facts, or attach repository execution artifacts such as PRs, commits, branches, or changed-file proofs on initial handoff.
+
+If you are introducing a new ingress such as Hermes, target the canonical `POST /tasks` contract first. The `/ingress/manual`, `/ingress/linear`, and `/ingress/openclaw` routes are translator helpers for those specific payload families, not the universal ingress contract. The source-of-truth ingress shape, prohibited initial-submission fields, and a copyable planning-only example now live in [`docs/api/agent-api-usage.md`](docs/api/agent-api-usage.md) under `Ingress Client Contract`.
 
 That same boundary now applies to the canonical `POST /tasks` and one-shot new-task `POST /evaluate` paths as well. A brand-new task may carry intent, planning state, support artifacts, and clarification blockers, but it may not arrive already carrying execution truth. If a caller tries to create a new task with claimed completion, runtime facts, prevalidated completion evidence, execution attempts, advisory completion claims, reconciliation history, assignment truth, or runtime/terminal lifecycle truth, Harness rejects the request as invalid input instead of storing a polluted task snapshot. Even when initial support artifacts are allowed, Harness strips any caller-submitted `verification_status=verified` before persisting the task so new work cannot begin with pre-certified artifact truth.
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -18,9 +18,41 @@ def _json_response(result: tuple[int, dict[str, Any]]) -> JSONResponse:
     return JSONResponse(status_code=int(status_code), content=payload)
 
 
+class _UnavailableResetService:
+    """Fail-closed reset adapter used when reset startup cannot succeed."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+
+    def _response(self) -> tuple[int, dict[str, Any]]:
+        return 503, {
+            "status": "unavailable",
+            "message": "Reset verifier is unavailable in this runtime.",
+            "reason": self.reason,
+        }
+
+    def register_contract_http(self, _: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._response()
+
+    def list_contracts_http(self) -> tuple[int, dict[str, Any]]:
+        return self._response()
+
+    def get_contract_http(self, __: str) -> tuple[int, dict[str, Any]]:
+        return self._response()
+
+    def submit_claim_http(self, __: str, _: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._response()
+
+    def tick_http(self) -> tuple[int, dict[str, Any]]:
+        return self._response()
+
+
 def _build_reset_service(store: HarnessStore | None) -> ResetVerificationService:
     root_dir = getattr(store, "root_dir", None) if store is not None else None
-    return ResetVerificationService.from_env(root_dir=root_dir)
+    try:
+        return ResetVerificationService.from_env(root_dir=root_dir)
+    except (OSError, ValueError) as error:
+        return _UnavailableResetService(str(error))
 
 
 def create_app(

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -49,6 +49,176 @@ Fresh task creation also cannot inject assignment truth. Do not send `request.as
 
 Ingress adapters are intake/planning surfaces, not execution-reporting surfaces. `POST /ingress/manual`, `POST /ingress/linear`, and `POST /ingress/openclaw` must not be used to claim completion, assert acceptance, submit executor runtime facts, or attach repository execution artifacts as proof. Those inputs belong to dispatch, completion-claim, and reevaluation paths where Harness can verify them mechanically.
 
+## Ingress Client Contract
+
+If you are building a new ingress client such as Hermes, do not start from `/ingress/manual` just because it is easy to hit. The `/ingress/*` routes are source-specific translators. They exist for callers that already have manual-, Linear-, or OpenClaw-shaped payloads.
+
+For a new ingress that wants to speak Harness directly, the stable contract is:
+
+- `POST /tasks` for new planning/intake submissions
+- `POST /tasks/<task_id>/reevaluate` for later fact, artifact, clarification, or review updates
+- `GET /tasks/<task_id>/read-model` and `GET /tasks/<task_id>/timeline` for canonical inspection
+
+On hosted Vercel deployments, the same canonical backend path is exposed under the `/backend` prefix. In other words, a hosted caller should normally target `POST /backend/tasks`, not the frontend route and not a convenience ingress wrapper.
+
+### What An Ingress Client Should Send
+
+For a planning-only new task, send:
+
+- `request.acceptance_criteria_satisfied=false`
+- `request.claimed_completion=false`
+- `request.external_facts={}`
+- `request.task_envelope` with canonical task identity, origin, planning status, timestamps, objective, acceptance criteria, deferred completion evidence, and any ingress-specific metadata under `task_envelope.extensions.<ingress_name>`
+
+Use `task_envelope.origin` for canonical provenance:
+
+- `source_system`: the ingress system name such as `hermes`
+- `source_type`: normally `ingress_request`
+- `source_id`: the ingress-side message or request identifier
+- `ingress_id`: the ingress-side conversation or submission identifier
+- `ingress_name`: human-readable ingress name such as `Hermes`
+- `requested_by`: operator identity when known
+
+Use `task_envelope.extensions` for ingress-local metadata that should survive ingestion without becoming canonical policy truth.
+
+### What An Ingress Client Must Not Send On Initial Submission
+
+Do not send any of the following on a fresh `POST /tasks` request:
+
+- runtime or terminal lifecycle states such as `executing`, `reconciling`, `completed`, `failed`, or `canceled`
+- `request.claimed_completion=true`
+- `request.acceptance_criteria_satisfied=true`
+- `request.runtime_facts`
+- satisfied or validated completion evidence
+- execution attempts or advisory completion claims
+- PR, commit, branch, or changed-file proof
+- assignment truth meant to imply the task is already actively dispatched
+
+If the ingress needs to report completion, runtime telemetry, repository proof, or executor-side artifacts later, that belongs to dispatch, completion-claim, sync, or reevaluation paths after the task already exists.
+
+### Planning-Only Example
+
+This is a canonical planning-only payload for a generic ingress client. Replace `{{now_iso}}` and `{{run_id}}` before sending.
+
+```json
+{
+  "request": {
+    "acceptance_criteria_satisfied": false,
+    "claimed_completion": false,
+    "external_facts": {},
+    "task_envelope": {
+      "id": "task-{{run_id}}",
+      "title": "Hermes ingress validation",
+      "description": "Submit a planning-only ingress task through the canonical Harness API boundary.",
+      "origin": {
+        "source_system": "hermes",
+        "source_type": "ingress_request",
+        "source_id": "telegram:7762711117:{{run_id}}",
+        "ingress_id": "{{run_id}}",
+        "ingress_name": "Hermes",
+        "requested_by": "Sean Fay via Hermes"
+      },
+      "status": "planned",
+      "timestamps": {
+        "created_at": "{{now_iso}}",
+        "updated_at": "{{now_iso}}",
+        "completed_at": null
+      },
+      "status_history": [],
+      "objective": {
+        "summary": "Validate that a generic ingress client can submit work into Harness through the canonical task contract while remaining ingress-only.",
+        "deliverable_type": "planning_validation",
+        "success_signal": "Harness accepts the task, preserves ingress provenance, and exposes canonical read-model and timeline surfaces without any completion proof."
+      },
+      "constraints": [
+        {
+          "label": "mode",
+          "value": "planning-only"
+        },
+        {
+          "label": "executor_boundary",
+          "value": "Ingress client only, not executor"
+        }
+      ],
+      "acceptance_criteria": [
+        {
+          "id": "ac-1",
+          "description": "Task is created through POST /tasks as a planning-only canonical submission.",
+          "required": true
+        },
+        {
+          "id": "ac-2",
+          "description": "Canonical inspection surfaces expose the stored task, read-model, and timeline.",
+          "required": true
+        },
+        {
+          "id": "ac-3",
+          "description": "Ingress provenance remains visible in canonical task origin and extensions metadata.",
+          "required": true
+        }
+      ],
+      "parent_task_id": null,
+      "child_task_ids": [],
+      "dependencies": [],
+      "assigned_executor": null,
+      "required_capabilities": [],
+      "priority": "normal",
+      "artifacts": {
+        "completion_evidence": {
+          "notes": null,
+          "policy": "deferred",
+          "required_artifact_types": [],
+          "status": "deferred",
+          "validated_artifact_ids": [],
+          "validated_at": null,
+          "validation_method": "deferred",
+          "validator": null
+        },
+        "items": []
+      },
+      "observability": {
+        "errors": [],
+        "execution_metadata": {
+          "schema_required_deferred_fields": [
+            "parent_task_id",
+            "child_task_ids",
+            "dependencies",
+            "assigned_executor",
+            "required_capabilities",
+            "priority",
+            "artifacts.items",
+            "artifacts.completion_evidence",
+            "observability"
+          ]
+        },
+        "retries": {
+          "attempt_count": 0,
+          "last_retry_at": null,
+          "max_attempts": 0
+        }
+      },
+      "extensions": {
+        "hermes": {
+          "agent_id": "hermes",
+          "platform": "telegram",
+          "channel": "dm:Sean Fay",
+          "conversation_id": "{{run_id}}",
+          "message_id": "{{run_id}}",
+          "user_id": "telegram:7762711117",
+          "submitted_at": "{{now_iso}}",
+          "purpose": "planning-only ingress validation"
+        }
+      }
+    }
+  }
+}
+```
+
+If that task is accepted, the ingress client should treat these as the canonical follow-up inspection surfaces:
+
+- `GET /tasks/task-{{run_id}}/read-model`
+- `GET /tasks/task-{{run_id}}/timeline`
+
 ### Completion Claim Interception Helper
 
 - `POST /tasks/<task_id>/completion-claims` is an executor-facing helper for advisory completion claims.

--- a/docs/setup/vercel-neon.md
+++ b/docs/setup/vercel-neon.md
@@ -41,6 +41,16 @@ For a Vercel-managed Neon project, the normal hosted path is to leave `DATABASE_
 
 Leave `HARNESS_STORE_ROOT` unset in hosted mode.
 
+Reset-slice storage is different from canonical task storage. The reset verifier still uses a local file-backed store today. In hosted Vercel runtimes, the application filesystem is read-only outside writable temp space, so the reset slice now defaults to:
+
+- `HARNESS_RESET_STORE_ROOT=/tmp/harness-reset`
+
+That keeps `/backend/health`, `/backend/tasks`, and the canonical task API healthy instead of crashing the whole service at import time.
+
+That path is writable on Vercel but not durable across cold starts. Do not treat it as canonical hosted persistence.
+
+If even the reset temp root cannot be created, `/reset/*` now fails explicitly with `503` instead of taking down the whole backend.
+
 Apply the schema before first real use:
 
 ```bash

--- a/modules/reset/service.py
+++ b/modules/reset/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -68,7 +69,7 @@ class ResetVerificationService:
 
     @classmethod
     def from_env(cls, *, root_dir: str | Path | None = None) -> "ResetVerificationService":
-        resolved_root = Path(root_dir or os.environ.get("HARNESS_STORE_ROOT") or ".harness-store")
+        resolved_root = _resolve_reset_store_root(root_dir=root_dir)
         cooldown = _coerce_float(os.environ.get("HARNESS_RESET_POLL_SECONDS"), default=900.0)
         claim_timeout = _coerce_float(os.environ.get("HARNESS_RESET_CLAIM_TIMEOUT_SECONDS"), default=900.0)
         return cls(
@@ -282,7 +283,6 @@ class ResetVerificationService:
             "reason": verdict.reason,
             "contract": updated.asdict(),
         }
-
     def _mark_verified(
         self,
         contract: ResetVerificationContract,
@@ -398,6 +398,24 @@ class ResetVerificationService:
                 for result in results
             ]
         }
+
+
+def _resolve_reset_store_root(*, root_dir: str | Path | None = None) -> Path:
+    if root_dir is not None:
+        return Path(root_dir)
+
+    explicit_reset_root = os.environ.get("HARNESS_RESET_STORE_ROOT")
+    if explicit_reset_root:
+        return Path(explicit_reset_root)
+
+    shared_root = os.environ.get("HARNESS_STORE_ROOT")
+    if shared_root:
+        return Path(shared_root)
+
+    if any((os.environ.get("VERCEL_URL"), os.environ.get("VERCEL_ENV"), os.environ.get("VERCEL_REGION"))):
+        return Path(tempfile.gettempdir()) / "harness-reset"
+
+    return Path(".harness-store")
 
 
 __all__ = ["ResetTickResult", "ResetVerificationService"]

--- a/tests/reset/test_service.py
+++ b/tests/reset/test_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
 
 from modules.reset.contracts import ResetCompletionClaim, ResetVerificationContract
 from modules.reset.service import ResetVerificationService
@@ -35,6 +37,26 @@ class FakeVerifier:
 
 
 class ResetVerificationServiceTests(unittest.TestCase):
+    def test_from_env_prefers_explicit_reset_store_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.dict(
+                "os.environ",
+                {
+                    "HARNESS_RESET_STORE_ROOT": temp_dir,
+                    "HARNESS_STORE_ROOT": "ignored-shared-root",
+                },
+                clear=False,
+            ):
+                service = ResetVerificationService.from_env()
+
+            self.assertEqual(service.store.root_dir, Path(temp_dir))
+
+    def test_from_env_uses_tmp_root_in_vercel_runtime_without_explicit_override(self) -> None:
+        with patch.dict("os.environ", {"VERCEL_URL": "harness-umber.vercel.app"}, clear=True):
+            service = ResetVerificationService.from_env()
+
+        self.assertEqual(service.store.root_dir, Path(tempfile.gettempdir()) / "harness-reset")
+
     def test_invalid_proof_requests_repair_and_keeps_issue_in_progress(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             store = FileBackedResetStore(temp_dir)

--- a/tests/test_fastapi_backend.py
+++ b/tests/test_fastapi_backend.py
@@ -113,6 +113,18 @@ class FastApiBackendTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("store_backend", response.json())
 
+    def test_backend_stays_healthy_when_reset_startup_is_unavailable(self) -> None:
+        with patch("backend.server.ResetVerificationService.from_env", side_effect=OSError("read-only file system")):
+            client = TestClient(create_app(store=self.store))
+
+        health = client.get("/health")
+        reset_contracts = client.get("/reset/contracts")
+
+        self.assertEqual(health.status_code, 200)
+        self.assertEqual(reset_contracts.status_code, 503)
+        self.assertEqual(reset_contracts.json()["status"], "unavailable")
+        self.assertIn("read-only file system", reset_contracts.json()["reason"])
+
     def test_submit_and_read_model_round_trip_through_fastapi_adapter(self) -> None:
         created = self.client.post(
             "/tasks",


### PR DESCRIPTION
## Summary
- keep the FastAPI backend bootable on Vercel when the reset slice cannot use the default local file store
- route hosted reset storage to `/tmp/harness-reset` by default and fail `/reset/*` explicitly if reset startup still cannot succeed
- document the canonical ingress `POST /tasks` contract and the hosted reset-store behavior

## Validation
- `python3 -m unittest tests.test_fastapi_backend tests.reset.test_service tests.test_hosted_deployment_contract tests.test_hosted_docs -v`
- `python3 -m unittest discover -s tests`
- preview deploy verified: `/backend/health`, `/backend/tasks`, `/backend/reset/contracts`
- production deploy verified: `/backend/health`, `/backend/tasks`, `/backend/reset/contracts`

## Notes
- the full suite still reports unrelated stale-supervision failures in `tests/test_autonomous_dryrun.py` and `tests/connectors/test_openclaw_supervisor.py`; the hosted bootstrap fix does not touch those files or code paths
