### PR TITLE
fix: reconcile current-attempt PR references

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -2483,6 +2483,10 @@ def _validate_execution_attempt(
         request.task_envelope,
         external_facts=_to_jsonable(request.external_facts) if request.external_facts is not None else None,
     )
+    has_valid_current_run_commit_artifact = task_has_valid_current_run_commit_artifact(
+        request.task_envelope,
+        external_facts=_to_jsonable(request.external_facts) if request.external_facts is not None else None,
+    )
     commit_resolution_pending = bool(
         repository_values
         and branch_values
@@ -2620,6 +2624,7 @@ def _validate_execution_attempt(
             "used_task_artifact_fallback": used_task_artifact_fallback,
             "commit_resolution_pending": commit_resolution_pending,
             "has_valid_current_run_pull_request_artifact": has_valid_current_run_pr_artifact,
+            "has_valid_current_run_commit_artifact": has_valid_current_run_commit_artifact,
         },
         "pull_request_observations": deepcopy(pull_request_observations),
         "rule_failures": deepcopy(rule_failures),

--- a/modules/autonomous_dryrun.py
+++ b/modules/autonomous_dryrun.py
@@ -7,6 +7,7 @@ import re
 import tempfile
 import threading
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
@@ -276,8 +277,21 @@ def _seed_stale_assigned_task(service: HarnessApiService, *, task_id: str) -> No
         "validator": None,
         "notes": None,
     }
+    stored_task["timestamps"]["created_at"] = "2026-04-01T10:03:00Z"
     stored_task["timestamps"]["updated_at"] = "2026-04-01T10:03:00Z"
+    timeline = stored_task.get("timeline")
+    if isinstance(timeline, list):
+        for event in timeline:
+            if isinstance(event, dict):
+                event["occurred_at"] = "2026-04-01T10:03:00Z"
     service.store.update_task(stored_task)
+    if isinstance(service.store, FileBackedHarnessStore):
+        evaluation_records = service.store.list_evaluation_records(task_id)
+        for record in evaluation_records:
+            evaluation_path = Path(service.store.root_dir) / "evaluations" / task_id / f"{record.evaluation_id}.json"
+            evaluation_payload = json.loads(evaluation_path.read_text(encoding="utf-8"))
+            evaluation_payload["recorded_at"] = "2026-04-01T10:03:00Z"
+            evaluation_path.write_text(json.dumps(evaluation_payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def run_retryable_codex_supervision_dry_run(

--- a/modules/reconciliation_runtime.py
+++ b/modules/reconciliation_runtime.py
@@ -803,6 +803,85 @@ def _current_execution_attempt(task_envelope: TaskEnvelope) -> dict[str, Any] | 
     return _latest_recorded_execution_attempt(attempts)
 
 
+def _current_execution_attempt_pull_request_reference(
+    task_envelope: TaskEnvelope,
+    *,
+    code_context: ReconciliationCodeContext,
+) -> dict[str, Any] | None:
+    attempt = _current_execution_attempt(task_envelope)
+    if not isinstance(attempt, dict):
+        return None
+
+    artifact_references = attempt.get("artifact_references")
+    if not isinstance(artifact_references, list):
+        return None
+
+    for artifact_reference in artifact_references:
+        if not isinstance(artifact_reference, dict):
+            continue
+        if _normalize_sha(artifact_reference.get("artifact_type")) != "pull_request":
+            continue
+
+        metadata = artifact_reference.get("metadata") if isinstance(artifact_reference.get("metadata"), dict) else {}
+        location = _normalize_sha(artifact_reference.get("location"))
+        explicit_url = _normalize_sha(metadata.get("pull_request_url")) or _normalize_sha(metadata.get("url"))
+        candidate_url = location
+        parsed_location = _parse_github_location(location) if location is not None else None
+        if parsed_location is None or parsed_location[2] != "pull":
+            candidate_url = explicit_url
+            parsed_location = _parse_github_location(candidate_url) if candidate_url is not None else None
+        if parsed_location is None or parsed_location[2] != "pull" or not parsed_location[3].isdigit():
+            continue
+
+        owner, repo, _, raw_identifier = parsed_location
+        if owner != code_context.repository_owner or repo != code_context.repository_name:
+            continue
+
+        branch_name = (
+            _normalize_sha(metadata.get("branch_name"))
+            or _normalize_sha(metadata.get("head_branch"))
+            or _normalize_sha(metadata.get("branch"))
+        )
+        if branch_name is not None:
+            if branch_name != code_context.branch_name:
+                continue
+            if branch_name.casefold() in _RESERVED_SHARED_BRANCH_NAMES:
+                continue
+
+        commit_sha = (
+            _normalize_sha(artifact_reference.get("commit_sha"))
+            or _normalize_sha(metadata.get("commit_sha"))
+            or _normalize_sha(metadata.get("head_commit_sha"))
+            or _normalize_sha(metadata.get("head_sha"))
+            or _normalize_sha(metadata.get("sha"))
+        )
+        if code_context.commit_sha and commit_sha and commit_sha != code_context.commit_sha:
+            continue
+
+        raw_number = metadata.get("pull_request_number")
+        if raw_number is None:
+            raw_number = metadata.get("number")
+        parsed_number = int(raw_identifier)
+        if raw_number is not None and raw_number != parsed_number:
+            continue
+
+        state = _normalize_sha(metadata.get("pull_request_state")) or _normalize_sha(metadata.get("state"))
+        if state is not None and state.strip().lower() != "open":
+            continue
+        if metadata.get("merged") is True:
+            continue
+
+        return {
+            "reference_id": _normalize_sha(artifact_reference.get("reference_id")),
+            "url": candidate_url,
+            "number": parsed_number,
+            "branch_name": branch_name,
+            "commit_sha": commit_sha,
+        }
+
+    return None
+
+
 def _execution_attempt_count(task_envelope: TaskEnvelope) -> int:
     execution_metadata = ((task_envelope.get("observability") or {}).get("execution_metadata") or {})
     attempts = execution_metadata.get("execution_attempts") or []
@@ -1486,6 +1565,7 @@ class MissingPrAfterExecutionHandler:
                 "pull_request_lookup": {
                     "searched_by_branch": False,
                     "searched_by_commit": False,
+                    "searched_by_reference": False,
                     "found": False,
                     "source": None,
                     "number": None,
@@ -1495,6 +1575,13 @@ class MissingPrAfterExecutionHandler:
                     "ambiguous": False,
                 },
                 "pull_request_candidates": [],
+                "current_execution_attempt_pull_request_reference": {
+                    "found": False,
+                    "reference_id": None,
+                    "number": None,
+                    "url": None,
+                    "persisted_found": None,
+                },
                 "created_pull_request": False,
                 "created_pull_request_revalidated": False,
                 "error_disposition": None,
@@ -1507,185 +1594,246 @@ class MissingPrAfterExecutionHandler:
         }
 
         try:
-            branch_exists = self.github.branch_exists(
-                owner=code_context.repository_owner,
-                repo=code_context.repository_name,
-                branch_name=code_context.branch_name,
-            )
-            attempt["details"]["branch_exists"] = branch_exists
-            if not branch_exists:
-                commit_exists = None
-                if code_context.commit_sha.strip():
-                    commit_exists = self.github.commit_exists(
-                        owner=code_context.repository_owner,
-                        repo=code_context.repository_name,
-                        commit_sha=code_context.commit_sha,
-                    )
-                    attempt["details"]["commit_exists"] = commit_exists
-                if commit_exists:
-                    attempt["details"]["final_decision"] = {
-                        "result": "blocked_retryable_failure",
-                        "reason": "branch_visibility_pending_with_current_commit",
-                    }
-                    raise RetryableReconciliationRuntimeError(
-                        f"GitHub branch {code_context.branch_name!r} was not found in "
-                        f"{code_context.repository_owner}/{code_context.repository_name}"
-                    )
-                raise TerminalReconciliationRuntimeError(
-                    f"GitHub branch {code_context.branch_name!r} was not found in "
-                    f"{code_context.repository_owner}/{code_context.repository_name}"
-                )
+            pull_request = None
+            source = None
 
-            if not code_context.commit_sha.strip():
-                branch_head_commit_sha = self.github.branch_head_commit_sha(
-                    owner=code_context.repository_owner,
-                    repo=code_context.repository_name,
-                    branch_name=code_context.branch_name,
-                )
-                attempt["details"]["branch_head_commit_sha"] = branch_head_commit_sha
-                if not branch_head_commit_sha:
-                    raise TerminalReconciliationRuntimeError(
-                        "Commit SHA is required for missing_pr_after_execution reconciliation and "
-                        "could not be resolved from the branch head"
-                    )
-                code_context = ReconciliationCodeContext(
-                    repository_host=code_context.repository_host,
-                    repository_owner=code_context.repository_owner,
-                    repository_name=code_context.repository_name,
-                    branch_name=code_context.branch_name,
-                    base_branch=code_context.base_branch,
-                    commit_sha=branch_head_commit_sha,
-                )
-                attempt["details"]["commit_sha"] = branch_head_commit_sha
-
-            commit_exists = self.github.commit_exists(
-                owner=code_context.repository_owner,
-                repo=code_context.repository_name,
-                commit_sha=code_context.commit_sha,
-            )
-            attempt["details"]["commit_exists"] = commit_exists
-            if not commit_exists:
-                raise TerminalReconciliationRuntimeError(
-                    f"GitHub commit {code_context.commit_sha!r} was not found in "
-                    f"{code_context.repository_owner}/{code_context.repository_name}"
-                )
-
-            pull_request = self._select_existing_pull_request(
-                task_envelope=context.task_envelope,
+            current_attempt_reference = _current_execution_attempt_pull_request_reference(
+                context.task_envelope,
                 code_context=code_context,
-                attempt=attempt,
             )
-
-            if pull_request is None:
-                base_branch = code_context.base_branch or self.github.default_branch(
-                    owner=code_context.repository_owner,
-                    repo=code_context.repository_name,
-                )
-                if not base_branch:
-                    raise ReconciliationRuntimeError(
-                        f"Unable to resolve a base branch for {code_context.repository_owner}/{code_context.repository_name}"
-                    )
-                pull_request = self.github.create_pull_request(
-                    owner=code_context.repository_owner,
-                    repo=code_context.repository_name,
-                    title=_created_pull_request_title(context.task_envelope),
-                    body=_created_pull_request_body(
-                        context.task_envelope,
-                        code_context=code_context,
-                    ),
-                    head=code_context.branch_name,
-                    base=base_branch,
-                )
-                source = "created"
-                attempt["details"]["created_pull_request"] = True
-                created_sources = {"created_response"}
-                created_accepted, created_reasons, created_matched_by, created_task_linkage, created_run_linkage, created_linkage_policy = self._validate_candidate(
-                    pull_request,
-                    code_context=code_context,
-                    task_envelope=context.task_envelope,
-                    sources=created_sources,
-                )
-                attempt["details"]["pull_request_candidates"].append(
-                    self._candidate_details(
-                        pull_request,
-                        sources=created_sources,
-                        accepted=created_accepted,
-                        reasons=created_reasons,
-                        matched_by=created_matched_by,
-                        task_linkage=created_task_linkage,
-                        run_linkage=created_run_linkage,
-                        linkage_policy=created_linkage_policy,
-                        code_context=code_context,
-                    )
-                )
-                attempt["details"]["pull_request_lookup"]["candidate_count"] += 1
-                if not created_accepted:
-                    attempt["details"]["final_decision"] = {
-                        "result": "created_candidate_rejected",
-                        "reason": "created_pull_request_failed_validation",
-                    }
-                    raise ReconciliationRuntimeError(
-                        "Created pull request did not satisfy current-run validation policy"
-                    )
+            if current_attempt_reference is not None:
+                attempt["details"]["current_execution_attempt_pull_request_reference"] = {
+                    "found": True,
+                    "reference_id": current_attempt_reference.get("reference_id"),
+                    "number": current_attempt_reference.get("number"),
+                    "url": current_attempt_reference.get("url"),
+                    "persisted_found": False,
+                }
+                attempt["details"]["pull_request_lookup"]["searched_by_reference"] = True
                 persisted_pull_request = self.github.get_pull_request(
                     owner=code_context.repository_owner,
                     repo=code_context.repository_name,
-                    number=pull_request.number,
+                    number=int(current_attempt_reference["number"]),
                 )
-                if persisted_pull_request is None:
-                    attempt["details"]["final_decision"] = {
-                        "result": "created_pull_request_revalidation_failed",
-                        "reason": "created_pull_request_not_visible_after_create",
-                    }
-                    raise ReconciliationRuntimeError(
-                        "Created pull request could not be revalidated from persisted GitHub state"
-                    )
-                persisted_sources = {"created_persisted"}
-                persisted_accepted, persisted_reasons, persisted_matched_by, persisted_task_linkage, persisted_run_linkage, persisted_linkage_policy = self._validate_candidate(
-                    persisted_pull_request,
-                    code_context=code_context,
-                    task_envelope=context.task_envelope,
-                    sources=persisted_sources,
-                )
-                attempt["details"]["pull_request_candidates"].append(
-                    self._candidate_details(
+                if persisted_pull_request is not None:
+                    attempt["details"]["current_execution_attempt_pull_request_reference"]["persisted_found"] = True
+                    reference_sources = {"execution_attempt_reference"}
+                    (
+                        reference_accepted,
+                        reference_reasons,
+                        reference_matched_by,
+                        reference_task_linkage,
+                        reference_run_linkage,
+                        reference_linkage_policy,
+                    ) = self._validate_candidate(
                         persisted_pull_request,
-                        sources=persisted_sources,
-                        accepted=persisted_accepted,
-                        reasons=persisted_reasons,
-                        matched_by=persisted_matched_by,
-                        task_linkage=persisted_task_linkage,
-                        run_linkage=persisted_run_linkage,
-                        linkage_policy=persisted_linkage_policy,
                         code_context=code_context,
+                        task_envelope=context.task_envelope,
+                        sources=reference_sources,
                     )
-                )
-                attempt["details"]["pull_request_lookup"]["candidate_count"] += 1
-                if not persisted_accepted:
-                    attempt["details"]["final_decision"] = {
-                        "result": "created_pull_request_revalidation_failed",
-                        "reason": "persisted_pull_request_failed_validation",
-                    }
-                    raise ReconciliationRuntimeError(
-                        "Created pull request did not satisfy current-run validation policy after read-back"
+                    attempt["details"]["pull_request_candidates"].append(
+                        self._candidate_details(
+                            persisted_pull_request,
+                            sources=reference_sources,
+                            accepted=reference_accepted,
+                            reasons=reference_reasons,
+                            matched_by=reference_matched_by,
+                            task_linkage=reference_task_linkage,
+                            run_linkage=reference_run_linkage,
+                            linkage_policy=reference_linkage_policy,
+                            code_context=code_context,
+                        )
                     )
-                attempt["details"]["created_pull_request_revalidated"] = True
-                attempt["details"]["pull_request_lookup"]["valid_candidate_count"] += 1
-                attempt["details"]["final_decision"] = {
-                    "result": "created_new",
-                    "reason": "no_valid_existing_candidate",
-                }
-                pull_request = persisted_pull_request
-                code_context = ReconciliationCodeContext(
-                    repository_host=code_context.repository_host,
-                    repository_owner=code_context.repository_owner,
-                    repository_name=code_context.repository_name,
+                    attempt["details"]["pull_request_lookup"]["candidate_count"] += 1
+                    if reference_accepted:
+                        attempt["details"]["pull_request_lookup"]["valid_candidate_count"] += 1
+                        attempt["details"]["final_decision"] = {
+                            "result": "attached_existing",
+                            "reason": "execution_attempt_pull_request_reference_validated",
+                        }
+                        pull_request = persisted_pull_request
+                        source = "execution_attempt_reference"
+
+            if pull_request is None:
+                branch_exists = self.github.branch_exists(
+                    owner=code_context.repository_owner,
+                    repo=code_context.repository_name,
                     branch_name=code_context.branch_name,
-                    base_branch=base_branch,
+                )
+                attempt["details"]["branch_exists"] = branch_exists
+                if not branch_exists:
+                    commit_exists = None
+                    if code_context.commit_sha.strip():
+                        commit_exists = self.github.commit_exists(
+                            owner=code_context.repository_owner,
+                            repo=code_context.repository_name,
+                            commit_sha=code_context.commit_sha,
+                        )
+                        attempt["details"]["commit_exists"] = commit_exists
+                    if commit_exists:
+                        attempt["details"]["final_decision"] = {
+                            "result": "blocked_retryable_failure",
+                            "reason": "branch_visibility_pending_with_current_commit",
+                        }
+                        raise RetryableReconciliationRuntimeError(
+                            f"GitHub branch {code_context.branch_name!r} was not found in "
+                            f"{code_context.repository_owner}/{code_context.repository_name}"
+                        )
+                    raise TerminalReconciliationRuntimeError(
+                        f"GitHub branch {code_context.branch_name!r} was not found in "
+                        f"{code_context.repository_owner}/{code_context.repository_name}"
+                    )
+
+                if not code_context.commit_sha.strip():
+                    branch_head_commit_sha = self.github.branch_head_commit_sha(
+                        owner=code_context.repository_owner,
+                        repo=code_context.repository_name,
+                        branch_name=code_context.branch_name,
+                    )
+                    attempt["details"]["branch_head_commit_sha"] = branch_head_commit_sha
+                    if not branch_head_commit_sha:
+                        raise TerminalReconciliationRuntimeError(
+                            "Commit SHA is required for missing_pr_after_execution reconciliation and "
+                            "could not be resolved from the branch head"
+                        )
+                    code_context = ReconciliationCodeContext(
+                        repository_host=code_context.repository_host,
+                        repository_owner=code_context.repository_owner,
+                        repository_name=code_context.repository_name,
+                        branch_name=code_context.branch_name,
+                        base_branch=code_context.base_branch,
+                        commit_sha=branch_head_commit_sha,
+                    )
+                    attempt["details"]["commit_sha"] = branch_head_commit_sha
+
+                commit_exists = self.github.commit_exists(
+                    owner=code_context.repository_owner,
+                    repo=code_context.repository_name,
                     commit_sha=code_context.commit_sha,
                 )
-            else:
-                source = "existing"
+                attempt["details"]["commit_exists"] = commit_exists
+                if not commit_exists:
+                    raise TerminalReconciliationRuntimeError(
+                        f"GitHub commit {code_context.commit_sha!r} was not found in "
+                        f"{code_context.repository_owner}/{code_context.repository_name}"
+                    )
+
+                pull_request = self._select_existing_pull_request(
+                    task_envelope=context.task_envelope,
+                    code_context=code_context,
+                    attempt=attempt,
+                )
+
+                if pull_request is None:
+                    base_branch = code_context.base_branch or self.github.default_branch(
+                        owner=code_context.repository_owner,
+                        repo=code_context.repository_name,
+                    )
+                    if not base_branch:
+                        raise ReconciliationRuntimeError(
+                            f"Unable to resolve a base branch for {code_context.repository_owner}/{code_context.repository_name}"
+                        )
+                    pull_request = self.github.create_pull_request(
+                        owner=code_context.repository_owner,
+                        repo=code_context.repository_name,
+                        title=_created_pull_request_title(context.task_envelope),
+                        body=_created_pull_request_body(
+                            context.task_envelope,
+                            code_context=code_context,
+                        ),
+                        head=code_context.branch_name,
+                        base=base_branch,
+                    )
+                    source = "created"
+                    attempt["details"]["created_pull_request"] = True
+                    created_sources = {"created_response"}
+                    created_accepted, created_reasons, created_matched_by, created_task_linkage, created_run_linkage, created_linkage_policy = self._validate_candidate(
+                        pull_request,
+                        code_context=code_context,
+                        task_envelope=context.task_envelope,
+                        sources=created_sources,
+                    )
+                    attempt["details"]["pull_request_candidates"].append(
+                        self._candidate_details(
+                            pull_request,
+                            sources=created_sources,
+                            accepted=created_accepted,
+                            reasons=created_reasons,
+                            matched_by=created_matched_by,
+                            task_linkage=created_task_linkage,
+                            run_linkage=created_run_linkage,
+                            linkage_policy=created_linkage_policy,
+                            code_context=code_context,
+                        )
+                    )
+                    attempt["details"]["pull_request_lookup"]["candidate_count"] += 1
+                    if not created_accepted:
+                        attempt["details"]["final_decision"] = {
+                            "result": "created_candidate_rejected",
+                            "reason": "created_pull_request_failed_validation",
+                        }
+                        raise ReconciliationRuntimeError(
+                            "Created pull request did not satisfy current-run validation policy"
+                        )
+                    persisted_pull_request = self.github.get_pull_request(
+                        owner=code_context.repository_owner,
+                        repo=code_context.repository_name,
+                        number=pull_request.number,
+                    )
+                    if persisted_pull_request is None:
+                        attempt["details"]["final_decision"] = {
+                            "result": "created_pull_request_revalidation_failed",
+                            "reason": "created_pull_request_not_visible_after_create",
+                        }
+                        raise ReconciliationRuntimeError(
+                            "Created pull request could not be revalidated from persisted GitHub state"
+                        )
+                    persisted_sources = {"created_persisted"}
+                    persisted_accepted, persisted_reasons, persisted_matched_by, persisted_task_linkage, persisted_run_linkage, persisted_linkage_policy = self._validate_candidate(
+                        persisted_pull_request,
+                        code_context=code_context,
+                        task_envelope=context.task_envelope,
+                        sources=persisted_sources,
+                    )
+                    attempt["details"]["pull_request_candidates"].append(
+                        self._candidate_details(
+                            persisted_pull_request,
+                            sources=persisted_sources,
+                            accepted=persisted_accepted,
+                            reasons=persisted_reasons,
+                            matched_by=persisted_matched_by,
+                            task_linkage=persisted_task_linkage,
+                            run_linkage=persisted_run_linkage,
+                            linkage_policy=persisted_linkage_policy,
+                            code_context=code_context,
+                        )
+                    )
+                    attempt["details"]["pull_request_lookup"]["candidate_count"] += 1
+                    if not persisted_accepted:
+                        attempt["details"]["final_decision"] = {
+                            "result": "created_pull_request_revalidation_failed",
+                            "reason": "persisted_pull_request_failed_validation",
+                        }
+                        raise ReconciliationRuntimeError(
+                            "Created pull request did not satisfy current-run validation policy after read-back"
+                        )
+                    attempt["details"]["created_pull_request_revalidated"] = True
+                    attempt["details"]["pull_request_lookup"]["valid_candidate_count"] += 1
+                    attempt["details"]["final_decision"] = {
+                        "result": "created_new",
+                        "reason": "no_valid_existing_candidate",
+                    }
+                    pull_request = persisted_pull_request
+                    code_context = ReconciliationCodeContext(
+                        repository_host=code_context.repository_host,
+                        repository_owner=code_context.repository_owner,
+                        repository_name=code_context.repository_name,
+                        branch_name=code_context.branch_name,
+                        base_branch=base_branch,
+                        commit_sha=code_context.commit_sha,
+                    )
+                else:
+                    source = "existing"
 
             attempt["details"]["pull_request_lookup"]["found"] = True
             attempt["details"]["pull_request_lookup"]["source"] = source

--- a/tests/connectors/test_openclaw_supervisor.py
+++ b/tests/connectors/test_openclaw_supervisor.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 import threading
 import unittest
+from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
@@ -188,7 +189,19 @@ class OpenClawHarnessSupervisorTests(unittest.TestCase):
             "assignment_reason": "Exercise supervisor stale-task redispatch.",
         }
         stored_task["timestamps"]["updated_at"] = "2026-04-01T10:03:00Z"
+        stored_task["timestamps"]["created_at"] = "2026-04-01T10:03:00Z"
+        timeline = stored_task.get("timeline")
+        if isinstance(timeline, list):
+            for event in timeline:
+                if isinstance(event, dict):
+                    event["occurred_at"] = "2026-04-01T10:03:00Z"
         self.service.store.update_task(stored_task)
+        evaluation_records = self.service.store.list_evaluation_records(task_id)
+        for record in evaluation_records:
+            evaluation_path = Path(self.temp_dir.name) / "evaluations" / task_id / f"{record.evaluation_id}.json"
+            evaluation_payload = json.loads(evaluation_path.read_text(encoding="utf-8"))
+            evaluation_payload["recorded_at"] = "2026-04-01T10:03:00Z"
+            evaluation_path.write_text(json.dumps(evaluation_payload, indent=2, sort_keys=True), encoding="utf-8")
 
         supervisor = OpenClawHarnessSupervisor(self.base_url)
         cycle = supervisor.run_cycle(allow_redispatch=True, executor="codex")

--- a/tests/e2e/test_control_plane_task_list_reconciliation_flows.py
+++ b/tests/e2e/test_control_plane_task_list_reconciliation_flows.py
@@ -114,7 +114,7 @@ class ControlPlaneTaskListReconciliationFlowTests(RuntimeApiTestCase):
             attempt_id="attempt-list-reconciliation-blocked-1",
         )
 
-        self.set_reconciliation_registry(failure_registry(FailureGateway(branch_exists=False)))
+        self.set_reconciliation_registry(_registry_with_gateway(_FakeGitHubGateway(branch_exists=False, commit_exists=False)))
         failed = self.create_task_scenario(
             build_create_task_payload(
                 "e2e-list-reconciliation-failed",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -211,6 +211,10 @@ class _NoCreatePullRequestGateway:
         del owner, repo, title, body, head, base
         raise RuntimeError("PR creation intentionally disabled for deterministic tests")
 
+    def get_pull_request(self, *, owner: str, repo: str, number: int):
+        del owner, repo, number
+        return None
+
 
 class _CurrentRunPullRequestGateway(_NoCreatePullRequestGateway):
     """Deterministic gateway stub that exposes one valid current-run PR."""
@@ -242,6 +246,12 @@ class _CurrentRunPullRequestGateway(_NoCreatePullRequestGateway):
         if commit_sha == "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705":
             return (self._record(),)
         return ()
+
+    def get_pull_request(self, *, owner: str, repo: str, number: int):
+        del owner, repo
+        if number == 2:
+            return self._record()
+        return None
 
 
 class _TransientMissingBranchGateway(_NoCreatePullRequestGateway):
@@ -3494,6 +3504,112 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertTrue(claim_response["accepted_completion"])
         latest_attempt = claim_response["task_envelope"]["observability"]["execution_metadata"]["execution_attempts"][-1]
         self.assertEqual(latest_attempt["metadata"]["attempt_validation"]["status"], "valid")
+
+    def test_service_completion_claim_uses_current_attempt_proof_before_reconciliation(self) -> None:
+        service = HarnessApiService(
+            store=FileBackedHarnessStore(self.temp_dir.name),
+            reconciliation_registry=_registry_with_current_run_pull_request_gateway(),
+        )
+        payload = _manual_happy_path_overlay_payload()
+        task_envelope = deepcopy(payload["request"]["task_envelope"])
+        task_envelope["id"] = "task-current-attempt-proof-1"
+        task_envelope["title"] = "Current attempt proof avoids unnecessary reconciliation"
+        task_envelope["description"] = (
+            "A real current-run PR URL and commit SHA from the completion claim should suppress "
+            "missing_pr_after_execution and missing_commit_after_execution."
+        )
+        task_envelope["artifacts"]["items"] = []
+        task_envelope["artifacts"]["completion_evidence"] = {
+            "policy": "deferred",
+            "status": "deferred",
+            "required_artifact_types": ["pull_request", "commit"],
+            "validated_artifact_ids": [],
+            "validation_method": "deferred",
+            "validated_at": None,
+            "validator": None,
+            "notes": None,
+        }
+        submit_status, submit_response = service.submit({"request": {"task_envelope": task_envelope}})
+        task_id = submit_response["task_envelope"]["id"]
+
+        claim_status, claim_response = service.submit_completion_claim(
+            task_id,
+            {
+                "request": {
+                    "completion_claim": {
+                        "claim_id": "claim-current-attempt-proof-1",
+                        "reported_at": "2026-04-16T20:37:07Z",
+                        "reported_by": "hermes",
+                        "reason": "Hermes completed the dry-run task and reported real GitHub proof.",
+                        "metadata": {"attempt_id": "attempt-current-attempt-proof-1"},
+                    },
+                    "execution_attempt": {
+                        "attempt_id": "attempt-current-attempt-proof-1",
+                        "recorded_at": "2026-04-16T20:37:07Z",
+                        "status": "succeeded",
+                        "reported_by": "hermes",
+                        "artifact_references": [
+                            {
+                                "reference_id": "attempt-current-attempt-proof-1:commit",
+                                "artifact_type": "commit",
+                                "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/commit/8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                                "metadata": {
+                                    "repository_host": "github.com",
+                                    "repository_owner": "KnoxAnalytics",
+                                    "repository_name": "HARNESS-DRYRUN",
+                                    "branch_name": "codex/e2e-test",
+                                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                                },
+                            },
+                            {
+                                "reference_id": "attempt-current-attempt-proof-1:pr",
+                                "artifact_type": "pull_request",
+                                "location": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/2",
+                                "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                                "metadata": {
+                                    "repository_host": "github.com",
+                                    "repository_owner": "KnoxAnalytics",
+                                    "repository_name": "HARNESS-DRYRUN",
+                                    "branch_name": "codex/e2e-test",
+                                    "commit_sha": "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+                                    "pull_request_url": "https://github.com/KnoxAnalytics/HARNESS-DRYRUN/pull/2",
+                                    "pull_request_number": 2,
+                                    "pull_request_state": "open",
+                                },
+                            },
+                        ],
+                        "metadata": {"executor_run_id": "hermes:attempt-current-attempt-proof-1"},
+                    },
+                    "acceptance_criteria_satisfied": True,
+                    "runtime_facts": {"executor_reported_success": True, "attempt_count": 1},
+                    "external_facts": {
+                        "expected_code_context": {
+                            "repository_host": "github.com",
+                            "repository_owner": "KnoxAnalytics",
+                            "repository_name": "HARNESS-DRYRUN",
+                            "branch_name": "codex/e2e-test",
+                            "base_branch": "main",
+                        }
+                    },
+                }
+            },
+        )
+
+        self.assertEqual(submit_status, 200)
+        self.assertEqual(claim_status, 200)
+        self.assertEqual(claim_response["action"], "transition_applied")
+        self.assertTrue(claim_response["accepted_completion"])
+        self.assertEqual(claim_response["task_envelope"]["status"], "completed")
+        self.assertNotIn("reconciliation_attempt", claim_response)
+        latest_attempt = claim_response["task_envelope"]["observability"]["execution_metadata"]["execution_attempts"][-1]
+        context = latest_attempt["metadata"]["attempt_validation"]["context_observations"]
+        self.assertFalse(context["has_valid_current_run_pull_request_artifact"])
+        self.assertFalse(context["has_valid_current_run_commit_artifact"])
+        self.assertEqual(
+            [attempt["failure_type"] for attempt in claim_response["task_envelope"]["reconciliation"]["attempts"][-2:]],
+            ["missing_pr_after_execution", "missing_commit_after_execution"],
+        )
 
     def test_service_completion_claim_reconciliation_sets_required_policy_when_artifact_evidence_becomes_satisfied(self) -> None:
         service = HarnessApiService(

--- a/tests/test_completion_claim_reconciliation.py
+++ b/tests/test_completion_claim_reconciliation.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import tempfile
 import unittest
 
-from modules.api import HarnessApiService, _requires_missing_pr_reconciliation, parse_completion_claim_request
+from modules.api import (
+    HarnessApiService,
+    _requires_missing_pr_reconciliation,
+    parse_completion_claim_request,
+)
 from modules.reconciliation_runtime import (
     GitHubPullRequestRecord,
     ReconciliationFailureType,


### PR DESCRIPTION
## Summary
- validate and reconcile current execution-attempt PR references before falling back to branch lookup
- add Hermes-shaped regression coverage for completion claims that carry real PR and commit references
- fix stale supervision test seeding and restore a true terminal reconciliation task-list scenario

## Validation
- python3 -m unittest discover -s tests
