### PR TITLE
fix: block unreadable current-run PR references

### DIFF
--- a/modules/reconciliation_runtime.py
+++ b/modules/reconciliation_runtime.py
@@ -882,6 +882,16 @@ def _current_execution_attempt_pull_request_reference(
     return None
 
 
+def _current_attempt_pull_request_reference_visibility_missing(attempt: dict[str, Any]) -> bool:
+    details = attempt.get("details")
+    if not isinstance(details, dict):
+        return False
+    reference = details.get("current_execution_attempt_pull_request_reference")
+    if not isinstance(reference, dict):
+        return False
+    return reference.get("found") is True and reference.get("persisted_found") is False
+
+
 def _execution_attempt_count(task_envelope: TaskEnvelope) -> int:
     execution_metadata = ((task_envelope.get("observability") or {}).get("execution_metadata") or {})
     attempts = execution_metadata.get("execution_attempts") or []
@@ -1679,6 +1689,15 @@ class MissingPrAfterExecutionHandler:
                             f"GitHub branch {code_context.branch_name!r} was not found in "
                             f"{code_context.repository_owner}/{code_context.repository_name}"
                         )
+                    if _current_attempt_pull_request_reference_visibility_missing(attempt):
+                        attempt["details"]["final_decision"] = {
+                            "result": "blocked_retryable_failure",
+                            "reason": "current_attempt_pull_request_reference_not_visible",
+                        }
+                        raise RetryableReconciliationRuntimeError(
+                            "GitHub could not re-read the current execution attempt pull request "
+                            "from persisted API state; repository visibility or authentication may be unavailable"
+                        )
                     raise TerminalReconciliationRuntimeError(
                         f"GitHub branch {code_context.branch_name!r} was not found in "
                         f"{code_context.repository_owner}/{code_context.repository_name}"
@@ -1713,6 +1732,15 @@ class MissingPrAfterExecutionHandler:
                 )
                 attempt["details"]["commit_exists"] = commit_exists
                 if not commit_exists:
+                    if _current_attempt_pull_request_reference_visibility_missing(attempt):
+                        attempt["details"]["final_decision"] = {
+                            "result": "blocked_retryable_failure",
+                            "reason": "current_attempt_pull_request_reference_not_visible",
+                        }
+                        raise RetryableReconciliationRuntimeError(
+                            "GitHub could not re-read the current execution attempt pull request "
+                            "from persisted API state; repository visibility or authentication may be unavailable"
+                        )
                     raise TerminalReconciliationRuntimeError(
                         f"GitHub commit {code_context.commit_sha!r} was not found in "
                         f"{code_context.repository_owner}/{code_context.repository_name}"
@@ -1725,6 +1753,15 @@ class MissingPrAfterExecutionHandler:
                 )
 
                 if pull_request is None:
+                    if _current_attempt_pull_request_reference_visibility_missing(attempt):
+                        attempt["details"]["final_decision"] = {
+                            "result": "blocked_retryable_failure",
+                            "reason": "current_attempt_pull_request_reference_not_visible",
+                        }
+                        raise RetryableReconciliationRuntimeError(
+                            "GitHub could not re-read the current execution attempt pull request "
+                            "from persisted API state; repository visibility or authentication may be unavailable"
+                        )
                     base_branch = code_context.base_branch or self.github.default_branch(
                         owner=code_context.repository_owner,
                         repo=code_context.repository_name,

--- a/tests/test_completion_claim_reconciliation.py
+++ b/tests/test_completion_claim_reconciliation.py
@@ -498,6 +498,53 @@ def _remove_commit_context(payload: dict) -> dict:
     return payload
 
 
+def _with_current_attempt_pr_reference(
+    payload: dict,
+    *,
+    claim_id: str,
+    number: int = 21,
+    branch_name: str = "codex/e2e-test",
+    commit_sha: str = "8a32c6f29d34bbdb80b5ec0b5a97415f8e66e705",
+    repository_owner: str = "KnoxAnalytics",
+    repository_name: str = "HARNESS-DRYRUN",
+) -> dict:
+    request = payload["request"]
+    request["execution_attempt"]["artifact_references"] = [
+        {
+            "reference_id": f"{claim_id}:attempt:commit",
+            "artifact_type": "commit",
+            "location": (
+                f"https://github.com/{repository_owner}/{repository_name}/commit/{commit_sha}"
+            ),
+            "commit_sha": commit_sha,
+            "metadata": {
+                "repository_host": "github.com",
+                "repository_owner": repository_owner,
+                "repository_name": repository_name,
+                "branch_name": branch_name,
+                "commit_sha": commit_sha,
+            },
+        },
+        {
+            "reference_id": f"{claim_id}:attempt:pr",
+            "artifact_type": "pull_request",
+            "location": f"https://github.com/{repository_owner}/{repository_name}/pull/{number}",
+            "commit_sha": commit_sha,
+            "metadata": {
+                "repository_host": "github.com",
+                "repository_owner": repository_owner,
+                "repository_name": repository_name,
+                "branch_name": branch_name,
+                "commit_sha": commit_sha,
+                "pull_request_url": f"https://github.com/{repository_owner}/{repository_name}/pull/{number}",
+                "pull_request_state": "open",
+                "pull_request_number": number,
+            },
+        },
+    ]
+    return payload
+
+
 def _prepare_branch_only_reconciliation_task(task: dict) -> dict:
     task["artifacts"]["items"] = []
     task["artifacts"]["completion_evidence"] = {
@@ -1116,6 +1163,76 @@ class CompletionClaimReconciliationTests(unittest.TestCase):
         self.assertEqual(payload["reconciliation_attempt"]["details"]["error_disposition"], "blocked_retryable")
         self.assertEqual(stored_status, 200)
         self.assertEqual(stored_payload["task"]["status"], "blocked")
+
+    def test_submit_completion_claim_blocks_when_current_attempt_pr_reference_cannot_be_re_read(self) -> None:
+        gateway = _FakeGitHubGateway(
+            branch_exists=False,
+            commit_exists=False,
+            persisted_created_pr=None,
+        )
+        service = HarnessApiService(
+            store=FileBackedHarnessStore(self.temp_dir.name),
+            reconciliation_registry=_registry_with_gateway(gateway),
+        )
+        task = _prepare_branch_only_reconciliation_task(
+            _task_envelope(task_id="task-pr-reconcile-current-attempt-pr-not-visible")
+        )
+        service.store.create_task(task)
+
+        payload = _with_current_attempt_pr_reference(
+            _completion_claim_payload("claim-current-attempt-pr-not-visible"),
+            claim_id="claim-current-attempt-pr-not-visible",
+        )
+        status, response = service.submit_completion_claim(task["id"], payload)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["action"], "reconciliation_blocked")
+        self.assertEqual(response["task_envelope"]["status"], "blocked")
+        self.assertFalse(response["requires_review"])
+        attempt = response["reconciliation_attempt"]
+        self.assertEqual(attempt["details"]["error_disposition"], "blocked_retryable")
+        self.assertEqual(
+            attempt["details"]["final_decision"]["reason"],
+            "current_attempt_pull_request_reference_not_visible",
+        )
+        self.assertTrue(attempt["details"]["pull_request_lookup"]["searched_by_reference"])
+        self.assertFalse(attempt["details"]["pull_request_lookup"]["searched_by_branch"])
+        self.assertFalse(attempt["details"]["pull_request_lookup"]["searched_by_commit"])
+        self.assertTrue(attempt["details"]["current_execution_attempt_pull_request_reference"]["found"])
+        self.assertFalse(attempt["details"]["current_execution_attempt_pull_request_reference"]["persisted_found"])
+        self.assertEqual(gateway.create_calls, 0)
+
+    def test_submit_completion_claim_does_not_create_new_pr_when_current_attempt_pr_reference_is_unreadable(self) -> None:
+        gateway = _FakeGitHubGateway(
+            existing_branch_prs=(),
+            existing_commit_prs=(),
+            persisted_created_pr=None,
+        )
+        service = HarnessApiService(
+            store=FileBackedHarnessStore(self.temp_dir.name),
+            reconciliation_registry=_registry_with_gateway(gateway),
+        )
+        task = _prepare_branch_only_reconciliation_task(
+            _task_envelope(task_id="task-pr-reconcile-current-attempt-pr-no-duplicate")
+        )
+        service.store.create_task(task)
+
+        payload = _with_current_attempt_pr_reference(
+            _completion_claim_payload("claim-current-attempt-pr-no-duplicate"),
+            claim_id="claim-current-attempt-pr-no-duplicate",
+        )
+        status, response = service.submit_completion_claim(task["id"], payload)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response["action"], "reconciliation_blocked")
+        self.assertEqual(response["task_envelope"]["status"], "blocked")
+        attempt = response["reconciliation_attempt"]
+        self.assertEqual(attempt["details"]["error_disposition"], "blocked_retryable")
+        self.assertEqual(
+            attempt["details"]["final_decision"]["reason"],
+            "current_attempt_pull_request_reference_not_visible",
+        )
+        self.assertEqual(gateway.create_calls, 0)
 
     def test_submit_completion_claim_moves_task_to_blocked_for_retryable_provider_failure(self) -> None:
         gateway = _FakeGitHubGateway(


### PR DESCRIPTION
## Summary
- treat a claimed current-run PR that cannot be re-read from GitHub as a blocked retryable ambiguity instead of a terminal contradiction
- prevent reconciliation from creating a duplicate PR when the current execution attempt already claims a specific PR reference that Harness cannot verify yet
- add regressions for the live private-repo visibility failure mode observed in Hermes e2e runs

## Validation
- python3 -m unittest discover -s tests