### PR TITLE
feat: persist reset verifier contracts in postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The reset routes live under:
 
 These routes intentionally coexist with the older TaskEnvelope routes so the narrower verifier path can ship without first deleting the broader control-plane code.
 
-In hosted Vercel runtimes, the reset slice is not allowed to take the whole backend down if its file-backed store cannot be created. Canonical task APIs must still boot. The hosted fallback now uses writable temp storage for the reset slice, and if even that cannot be created, `/reset/*` fails explicitly instead of crashing `/backend/health` and `/backend/tasks` during import.
+In hosted Vercel runtimes, the reset slice is not allowed to take the whole backend down during startup. When Postgres is available, `/reset/*` now persists contracts there so multi-request verification survives cold starts. If no database URL is available, the fallback remains writable temp storage, and if even that cannot be created, `/reset/*` fails explicitly instead of crashing `/backend/health` and `/backend/tasks` during import.
 
 ## What Harness Is
 

--- a/docs/setup/vercel-neon.md
+++ b/docs/setup/vercel-neon.md
@@ -41,13 +41,19 @@ For a Vercel-managed Neon project, the normal hosted path is to leave `DATABASE_
 
 Leave `HARNESS_STORE_ROOT` unset in hosted mode.
 
-Reset-slice storage is different from canonical task storage. The reset verifier still uses a local file-backed store today. In hosted Vercel runtimes, the application filesystem is read-only outside writable temp space, so the reset slice now defaults to:
+Reset-slice storage is different from canonical task storage. In hosted Vercel runtimes, the reset verifier now prefers Postgres-backed contract storage, with temp filesystem fallback only when no database URL is available:
+
+- Postgres-backed `reset_contracts` storage when `POSTGRES_URL` or another supported database URL is available
+
+That is now the default hosted path. `/reset/*` contracts survive across requests the same way the canonical task store does.
+
+If the hosted runtime does not have a database URL, the reset slice falls back to:
 
 - `HARNESS_RESET_STORE_ROOT=/tmp/harness-reset`
 
 That keeps `/backend/health`, `/backend/tasks`, and the canonical task API healthy instead of crashing the whole service at import time.
 
-That path is writable on Vercel but not durable across cold starts. Do not treat it as canonical hosted persistence.
+That temp path is writable on Vercel but not durable across cold starts. Do not treat it as canonical hosted persistence.
 
 If even the reset temp root cannot be created, `/reset/*` now fails explicitly with `503` instead of taking down the whole backend.
 

--- a/modules/reset/service.py
+++ b/modules/reset/service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,9 +13,10 @@ from .github_verifier import ResetGitHubVerdict, ResetGitHubVerifier
 from .linear_client import LinearResetClient
 from .openclaw_client import OpenClawRepairClient
 from .store import (
-    FileBackedResetStore,
     ResetContractAlreadyExistsError,
     ResetContractNotFoundError,
+    ResetStore,
+    build_reset_store,
 )
 
 
@@ -51,7 +51,7 @@ class ResetVerificationService:
     def __init__(
         self,
         *,
-        store: FileBackedResetStore,
+        store: ResetStore,
         linear_client: Any,
         verifier: ResetGitHubVerifier,
         openclaw_client: Any,
@@ -69,11 +69,10 @@ class ResetVerificationService:
 
     @classmethod
     def from_env(cls, *, root_dir: str | Path | None = None) -> "ResetVerificationService":
-        resolved_root = _resolve_reset_store_root(root_dir=root_dir)
         cooldown = _coerce_float(os.environ.get("HARNESS_RESET_POLL_SECONDS"), default=900.0)
         claim_timeout = _coerce_float(os.environ.get("HARNESS_RESET_CLAIM_TIMEOUT_SECONDS"), default=900.0)
         return cls(
-            store=FileBackedResetStore(resolved_root),
+            store=build_reset_store(store_root=root_dir),
             linear_client=LinearResetClient(),
             verifier=ResetGitHubVerifier(),
             openclaw_client=OpenClawRepairClient(),
@@ -398,24 +397,5 @@ class ResetVerificationService:
                 for result in results
             ]
         }
-
-
-def _resolve_reset_store_root(*, root_dir: str | Path | None = None) -> Path:
-    if root_dir is not None:
-        return Path(root_dir)
-
-    explicit_reset_root = os.environ.get("HARNESS_RESET_STORE_ROOT")
-    if explicit_reset_root:
-        return Path(explicit_reset_root)
-
-    shared_root = os.environ.get("HARNESS_STORE_ROOT")
-    if shared_root:
-        return Path(shared_root)
-
-    if any((os.environ.get("VERCEL_URL"), os.environ.get("VERCEL_ENV"), os.environ.get("VERCEL_REGION"))):
-        return Path(tempfile.gettempdir()) / "harness-reset"
-
-    return Path(".harness-store")
-
 
 __all__ = ["ResetTickResult", "ResetVerificationService"]

--- a/modules/reset/store.py
+++ b/modules/reset/store.py
@@ -1,11 +1,24 @@
-"""File-backed persistence for reset verifier contracts."""
+"""Persistence backends for reset verifier contracts."""
 
 from __future__ import annotations
 
 import json
+import os
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Protocol, cast
 
 from .contracts import ResetVerificationContract
+from modules.store import POSTGRES_DATABASE_URL_ENV_VARS, StoreError, resolve_postgres_database_url
+
+try:
+    import psycopg
+    from psycopg.errors import UniqueViolation
+    from psycopg.types.json import Jsonb
+except ImportError:  # pragma: no cover - exercised when postgres backend is requested without dependency.
+    psycopg = None
+    UniqueViolation = None
+    Jsonb = None
 
 
 class ResetContractNotFoundError(ValueError):
@@ -16,7 +29,19 @@ class ResetContractAlreadyExistsError(ValueError):
     """Raised when a contract ID collision occurs."""
 
 
-class FileBackedResetStore:
+class ResetStore(Protocol):
+    """Persistence boundary for reset verifier contracts."""
+
+    def create_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract: ...
+
+    def get_contract(self, contract_id: str) -> ResetVerificationContract: ...
+
+    def update_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract: ...
+
+    def list_contracts(self) -> tuple[ResetVerificationContract, ...]: ...
+
+
+class FileBackedResetStore(ResetStore):
     """Simple JSON-file store for the reset verifier slice."""
 
     def __init__(self, root_dir: str | Path) -> None:
@@ -56,8 +81,160 @@ class FileBackedResetStore:
         return tuple(contracts)
 
 
+class PostgresResetStore(ResetStore):
+    """Postgres-backed store for reset verifier contracts."""
+
+    def __init__(self, database_url: str) -> None:
+        if psycopg is None or Jsonb is None or UniqueViolation is None:
+            raise StoreError("psycopg is required for HARNESS_RESET_STORE_BACKEND=postgres")
+        if not database_url.strip():
+            supported_envs = ", ".join(POSTGRES_DATABASE_URL_ENV_VARS)
+            raise StoreError(
+                "A Postgres connection string is required for HARNESS_RESET_STORE_BACKEND=postgres "
+                f"(checked: {supported_envs})"
+            )
+        self.database_url = database_url
+
+    def _connect(self):
+        return psycopg.connect(self.database_url)
+
+    def create_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
+        contract_payload = cast(dict[str, Any], contract.asdict())
+        try:
+            with self._connect() as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        INSERT INTO reset_contracts (
+                            contract_id,
+                            linear_issue_id,
+                            contract_json,
+                            created_at,
+                            updated_at
+                        )
+                        VALUES (%s, %s, %s, %s, %s)
+                        """,
+                        (
+                            contract.contract_id,
+                            contract.linear_issue_id,
+                            Jsonb(contract_payload),
+                            _parse_iso_timestamp(contract.created_at),
+                            _parse_iso_timestamp(contract.updated_at),
+                        ),
+                    )
+        except UniqueViolation as error:
+            raise ResetContractAlreadyExistsError(f"contract {contract.contract_id!r} already exists") from error
+        return contract
+
+    def get_contract(self, contract_id: str) -> ResetVerificationContract:
+        with self._connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT contract_json FROM reset_contracts WHERE contract_id = %s",
+                    (contract_id,),
+                )
+                row = cursor.fetchone()
+        if row is None:
+            raise ResetContractNotFoundError(f"contract {contract_id!r} was not found")
+        return ResetVerificationContract.from_dict(cast(dict[str, Any], row[0]))
+
+    def update_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
+        contract_payload = cast(dict[str, Any], contract.asdict())
+        with self._connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE reset_contracts
+                    SET linear_issue_id = %s,
+                        contract_json = %s,
+                        updated_at = %s
+                    WHERE contract_id = %s
+                    """,
+                    (
+                        contract.linear_issue_id,
+                        Jsonb(contract_payload),
+                        _parse_iso_timestamp(contract.updated_at),
+                        contract.contract_id,
+                    ),
+                )
+                if cursor.rowcount == 0:
+                    raise ResetContractNotFoundError(f"contract {contract.contract_id!r} was not found")
+        return contract
+
+    def list_contracts(self) -> tuple[ResetVerificationContract, ...]:
+        with self._connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT contract_json
+                    FROM reset_contracts
+                    ORDER BY updated_at DESC, contract_id DESC
+                    """
+                )
+                rows = cursor.fetchall()
+        return tuple(ResetVerificationContract.from_dict(cast(dict[str, Any], row[0])) for row in rows)
+
+
+def _parse_iso_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _is_vercel_runtime() -> bool:
+    return any(
+        (
+            os.environ.get("VERCEL_URL"),
+            os.environ.get("VERCEL_ENV"),
+            os.environ.get("VERCEL_REGION"),
+        )
+    )
+
+
+def build_reset_store(
+    *,
+    store_backend: str | None = None,
+    store_root: str | Path | None = None,
+    database_url: str | None = None,
+) -> ResetStore:
+    """Construct the configured persistence backend for reset verifier contracts."""
+
+    resolved_database_url = resolve_postgres_database_url(database_url)
+    configured_backend = (
+        store_backend
+        or os.environ.get("HARNESS_RESET_STORE_BACKEND")
+        or os.environ.get("HARNESS_STORE_BACKEND")
+        or ""
+    ).strip().lower()
+    if configured_backend:
+        backend = configured_backend
+    elif database_url and database_url.strip():
+        backend = "postgres"
+    elif _is_vercel_runtime() and resolved_database_url:
+        backend = "postgres"
+    else:
+        backend = "file"
+
+    if backend == "postgres":
+        return PostgresResetStore(resolved_database_url)
+
+    explicit_reset_root = store_root or os.environ.get("HARNESS_RESET_STORE_ROOT")
+    if explicit_reset_root:
+        return FileBackedResetStore(explicit_reset_root)
+
+    shared_root = os.environ.get("HARNESS_STORE_ROOT")
+    if shared_root:
+        return FileBackedResetStore(shared_root)
+
+    if _is_vercel_runtime():
+        return FileBackedResetStore(Path("/tmp/harness-reset"))
+
+    return FileBackedResetStore(Path(".harness-store"))
+
+
 __all__ = [
+    "build_reset_store",
     "FileBackedResetStore",
+    "PostgresResetStore",
     "ResetContractAlreadyExistsError",
     "ResetContractNotFoundError",
+    "ResetStore",
 ]

--- a/sql/postgres/001_harness_store.sql
+++ b/sql/postgres/001_harness_store.sql
@@ -18,3 +18,14 @@ CREATE TABLE IF NOT EXISTS evaluation_records (
 
 CREATE INDEX IF NOT EXISTS idx_evaluation_records_task_recorded_at
     ON evaluation_records (task_id, recorded_at);
+
+CREATE TABLE IF NOT EXISTS reset_contracts (
+    contract_id TEXT PRIMARY KEY,
+    linear_issue_id TEXT NOT NULL,
+    contract_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_reset_contracts_updated_at_desc
+    ON reset_contracts (updated_at DESC);

--- a/tests/reset/test_service.py
+++ b/tests/reset/test_service.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from modules.reset.contracts import ResetCompletionClaim, ResetVerificationContract
 from modules.reset.service import ResetVerificationService
+from modules.reset.store import PostgresResetStore
 from modules.reset.store import FileBackedResetStore
 
 
@@ -37,6 +38,20 @@ class FakeVerifier:
 
 
 class ResetVerificationServiceTests(unittest.TestCase):
+    def test_from_env_uses_postgres_reset_store_in_vercel_runtime_when_database_url_is_available(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {
+                "VERCEL_URL": "harness-preview.vercel.app",
+                "POSTGRES_URL": "postgresql://env-vercel",
+            },
+            clear=True,
+        ):
+            service = ResetVerificationService.from_env()
+
+        self.assertIsInstance(service.store, PostgresResetStore)
+        self.assertEqual(service.store.database_url, "postgresql://env-vercel")
+
     def test_from_env_prefers_explicit_reset_store_root(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             with patch.dict(
@@ -55,7 +70,7 @@ class ResetVerificationServiceTests(unittest.TestCase):
         with patch.dict("os.environ", {"VERCEL_URL": "harness-umber.vercel.app"}, clear=True):
             service = ResetVerificationService.from_env()
 
-        self.assertEqual(service.store.root_dir, Path(tempfile.gettempdir()) / "harness-reset")
+        self.assertEqual(service.store.root_dir, Path("/tmp/harness-reset"))
 
     def test_invalid_proof_requests_repair_and_keeps_issue_in_progress(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/reset/test_store.py
+++ b/tests/reset/test_store.py
@@ -1,52 +1,194 @@
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from modules.reset.contracts import ResetVerificationContract
+from modules.reset.contracts import ResetCompletionClaim, ResetVerificationContract
 from modules.reset.store import (
     FileBackedResetStore,
+    PostgresResetStore,
     ResetContractAlreadyExistsError,
     ResetContractNotFoundError,
+    build_reset_store,
 )
 
 
-class ResetStoreTests(unittest.TestCase):
-    def test_round_trips_contracts(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            store = FileBackedResetStore(temp_dir)
-            contract = ResetVerificationContract(
-                contract_id="contract-1",
-                linear_issue_id="KNO-999",
+POSTGRES_TEST_DATABASE_URL = os.environ.get("HARNESS_TEST_DATABASE_URL")
+POSTGRES_SCHEMA_SQL = (
+    Path(__file__).resolve().parents[2] / "sql" / "postgres" / "001_harness_store.sql"
+).read_text(encoding="utf-8")
+
+
+class ResetStoreResolutionTests(unittest.TestCase):
+    def test_build_reset_store_uses_postgres_in_vercel_when_database_url_exists(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "VERCEL_URL": "harness-preview.vercel.app",
+                "POSTGRES_URL": "postgresql://env-vercel",
+            },
+            clear=True,
+        ):
+            store = build_reset_store()
+
+        self.assertIsInstance(store, PostgresResetStore)
+        self.assertEqual(store.database_url, "postgresql://env-vercel")
+
+    def test_build_reset_store_honors_explicit_file_backend(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "HARNESS_RESET_STORE_BACKEND": "file",
+                "VERCEL_URL": "harness-preview.vercel.app",
+                "POSTGRES_URL": "postgresql://env-vercel",
+            },
+            clear=True,
+        ):
+            store = build_reset_store(store_root="/tmp/harness-reset-test")
+
+        self.assertIsInstance(store, FileBackedResetStore)
+
+
+class ResetStoreContractTests:
+    store = None
+
+    def _sample_contract(self) -> ResetVerificationContract:
+        return ResetVerificationContract(
+            contract_id="contract-1",
+            linear_issue_id="KNO-999",
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_ref="codex/reset-verifier-v1",
+        )
+
+    def test_create_and_get_contract_round_trip(self) -> None:
+        contract = self._sample_contract()
+
+        self.store.create_contract(contract)
+        stored = self.store.get_contract(contract.contract_id)
+
+        self.assertEqual(stored.contract_id, contract.contract_id)
+        self.assertEqual(stored.harness_status, "running")
+
+    def test_create_rejects_duplicate_contract_id(self) -> None:
+        contract = self._sample_contract()
+
+        self.store.create_contract(contract)
+
+        with self.assertRaises(ResetContractAlreadyExistsError):
+            self.store.create_contract(contract)
+
+    def test_update_persists_latest_claim_and_event_log(self) -> None:
+        contract = self._sample_contract()
+        self.store.create_contract(contract)
+
+        updated = contract.updated(
+            latest_claim=ResetCompletionClaim(
                 repository_owner="sfayka",
                 repository_name="Harness",
-                branch_ref="main",
-            )
+                branch_name="codex/reset-verifier-v1",
+                commit_sha="abc123",
+                pull_request_number=42,
+                pull_request_url="https://github.com/sfayka/Harness/pull/42",
+            ),
+            latest_verdict="verified_done",
+            latest_reason="github proof verified",
+            harness_status="verified",
+            last_activity_at="2026-04-17T12:00:00Z",
+            last_verified_at="2026-04-17T12:00:00Z",
+        ).append_event(
+            kind="verified",
+            message="github proof verified",
+            timestamp="2026-04-17T12:00:00Z",
+        )
 
-            store.create_contract(contract)
-            loaded = store.get_contract("contract-1")
+        self.store.update_contract(updated)
+        stored = self.store.get_contract(contract.contract_id)
 
-            self.assertEqual(loaded.contract_id, "contract-1")
-            self.assertEqual(loaded.linear_issue_id, "KNO-999")
+        self.assertEqual(stored.harness_status, "verified")
+        self.assertEqual(stored.latest_claim.commit_sha, "abc123")
+        self.assertEqual(stored.event_log[-1].kind, "verified")
 
-    def test_duplicate_ids_are_rejected(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            store = FileBackedResetStore(temp_dir)
-            contract = ResetVerificationContract(
-                contract_id="contract-1",
-                linear_issue_id="KNO-999",
-                repository_owner="sfayka",
-                repository_name="Harness",
-                branch_ref="main",
-            )
+    def test_list_contracts_orders_by_updated_at_desc(self) -> None:
+        older = ResetVerificationContract(
+            contract_id="contract-older",
+            linear_issue_id="KNO-998",
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_ref="codex/reset-verifier-v1",
+            created_at="2026-04-17T11:00:00Z",
+            updated_at="2026-04-17T11:00:00Z",
+        )
+        newer = ResetVerificationContract(
+            contract_id="contract-newer",
+            linear_issue_id="KNO-999",
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_ref="codex/reset-verifier-v2",
+            created_at="2026-04-17T12:00:00Z",
+            updated_at="2026-04-17T12:00:00Z",
+        )
 
-            store.create_contract(contract)
-            with self.assertRaises(ResetContractAlreadyExistsError):
-                store.create_contract(contract)
+        self.store.create_contract(older)
+        self.store.create_contract(newer)
 
-    def test_missing_contract_raises_not_found(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            store = FileBackedResetStore(temp_dir)
-            with self.assertRaises(ResetContractNotFoundError):
-                store.get_contract("missing")
+        listed = self.store.list_contracts()
 
+        self.assertEqual([contract.contract_id for contract in listed[:2]], ["contract-newer", "contract-older"])
+
+    def test_get_missing_contract_raises(self) -> None:
+        with self.assertRaises(ResetContractNotFoundError):
+            self.store.get_contract("missing-contract")
+
+
+class FileBackedResetStoreTests(ResetStoreContractTests, unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = FileBackedResetStore(self.temp_dir.name)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+
+@unittest.skipUnless(POSTGRES_TEST_DATABASE_URL, "HARNESS_TEST_DATABASE_URL is required for Postgres reset store tests")
+class PostgresResetStoreTests(ResetStoreContractTests, unittest.TestCase):
+    def setUp(self) -> None:
+        self.store = PostgresResetStore(POSTGRES_TEST_DATABASE_URL or "")
+        with self.store._connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(POSTGRES_SCHEMA_SQL)
+                cursor.execute("DELETE FROM reset_contracts")
+
+    def tearDown(self) -> None:
+        with self.store._connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("DELETE FROM reset_contracts")
+
+    def test_persists_contract_jsonb_payloads(self) -> None:
+        contract = ResetVerificationContract(
+            contract_id="contract-postgres-1",
+            linear_issue_id="KNO-999",
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_ref="codex/reset-verifier-v1",
+        )
+
+        self.store.create_contract(contract)
+
+        with self.store._connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT contract_json->>'contract_id', updated_at FROM reset_contracts WHERE contract_id = %s",
+                    (contract.contract_id,),
+                )
+                row = cursor.fetchone()
+
+        self.assertEqual(row[0], contract.contract_id)
+        self.assertIsNotNone(row[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reset-store abstraction with file and Postgres backends
- persist `/reset/*` contracts in Postgres by default in hosted Vercel runtimes
- extend reset-store tests and update hosted docs for the new durability contract

## Testing
- python3 -m unittest tests.reset.test_store tests.reset.test_service
- python3 -m unittest tests.test_fastapi_backend tests.test_reset_dryrun tests.reset.test_store tests.reset.test_service
- python3 -m unittest tests.test_store tests.test_hosted_docs

## Live validation note
- attempted `run_live_reset_smoke_suite()`, but the current `LINEAR_API_KEY` loaded from repo env returned Linear HTTP 401, so live Linear validation is blocked on refreshing or replacing that key
