### PR TITLE
fix: bootstrap reset postgres schema on demand

### DIFF
--- a/docs/setup/vercel-neon.md
+++ b/docs/setup/vercel-neon.md
@@ -63,6 +63,8 @@ Apply the schema before first real use:
 psql "$POSTGRES_URL" -f sql/postgres/001_harness_store.sql
 ```
 
+The reset verifier now also bootstraps its own `reset_contracts` table on first Postgres access if that slice has not been migrated yet. That protects hosted `/backend/reset/*` routes from failing with opaque `500` errors when the canonical task schema exists but the reset slice has not been applied yet.
+
 The backend health endpoint remains:
 
 - `GET /backend/health`

--- a/modules/reset/store.py
+++ b/modules/reset/store.py
@@ -21,6 +21,23 @@ except ImportError:  # pragma: no cover - exercised when postgres backend is req
     Jsonb = None
 
 
+RESET_CONTRACTS_SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS reset_contracts (
+        contract_id TEXT PRIMARY KEY,
+        linear_issue_id TEXT NOT NULL,
+        contract_json JSONB NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_reset_contracts_updated_at_desc
+        ON reset_contracts (updated_at DESC)
+    """,
+)
+
+
 class ResetContractNotFoundError(ValueError):
     """Raised when a reset verifier contract is missing."""
 
@@ -98,10 +115,16 @@ class PostgresResetStore(ResetStore):
     def _connect(self):
         return psycopg.connect(self.database_url)
 
+    def _ensure_schema(self, connection: Any) -> None:
+        with connection.cursor() as cursor:
+            for statement in RESET_CONTRACTS_SCHEMA_STATEMENTS:
+                cursor.execute(statement)
+
     def create_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
         contract_payload = cast(dict[str, Any], contract.asdict())
         try:
             with self._connect() as connection:
+                self._ensure_schema(connection)
                 with connection.cursor() as cursor:
                     cursor.execute(
                         """
@@ -128,6 +151,7 @@ class PostgresResetStore(ResetStore):
 
     def get_contract(self, contract_id: str) -> ResetVerificationContract:
         with self._connect() as connection:
+            self._ensure_schema(connection)
             with connection.cursor() as cursor:
                 cursor.execute(
                     "SELECT contract_json FROM reset_contracts WHERE contract_id = %s",
@@ -141,6 +165,7 @@ class PostgresResetStore(ResetStore):
     def update_contract(self, contract: ResetVerificationContract) -> ResetVerificationContract:
         contract_payload = cast(dict[str, Any], contract.asdict())
         with self._connect() as connection:
+            self._ensure_schema(connection)
             with connection.cursor() as cursor:
                 cursor.execute(
                     """
@@ -163,6 +188,7 @@ class PostgresResetStore(ResetStore):
 
     def list_contracts(self) -> tuple[ResetVerificationContract, ...]:
         with self._connect() as connection:
+            self._ensure_schema(connection)
             with connection.cursor() as cursor:
                 cursor.execute(
                     """

--- a/tests/reset/test_store.py
+++ b/tests/reset/test_store.py
@@ -52,6 +52,61 @@ class ResetStoreResolutionTests(unittest.TestCase):
         self.assertIsInstance(store, FileBackedResetStore)
 
 
+class _RecordingCursor:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+        self.rowcount = 1
+
+    def execute(self, sql: str, params=None) -> None:  # noqa: ANN001
+        self.statements.append(" ".join(sql.split()))
+
+    def fetchone(self):  # noqa: ANN201
+        return None
+
+    def fetchall(self):  # noqa: ANN201
+        return []
+
+    def __enter__(self) -> "_RecordingCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+class _RecordingConnection:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _RecordingCursor:
+        return self._cursor
+
+    def __enter__(self) -> "_RecordingConnection":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+class PostgresResetStoreSchemaBootstrapTests(unittest.TestCase):
+    def test_create_contract_bootstraps_reset_schema_before_insert(self) -> None:
+        store = PostgresResetStore("postgresql://example")
+        cursor = _RecordingCursor()
+        contract = ResetVerificationContract(
+            contract_id="contract-bootstrap",
+            linear_issue_id="KNO-999",
+            repository_owner="sfayka",
+            repository_name="Harness",
+            branch_ref="codex/reset-verifier-v1",
+        )
+
+        with patch.object(store, "_connect", return_value=_RecordingConnection(cursor)):
+            store.create_contract(contract)
+
+        self.assertGreaterEqual(len(cursor.statements), 2)
+        self.assertIn("CREATE TABLE IF NOT EXISTS reset_contracts", cursor.statements[0])
+        self.assertIn("INSERT INTO reset_contracts", cursor.statements[-1])
+
+
 class ResetStoreContractTests:
     store = None
 


### PR DESCRIPTION
## Summary
- bootstrap the Postgres `reset_contracts` schema on first reset-store access
- add a deterministic unit test proving schema bootstrap runs before the first insert
- document the hosted reset bootstrap behavior in the Vercel/Neon setup guide

## Testing
- python3 -m unittest tests.reset.test_store tests.reset.test_service tests.test_fastapi_backend tests.test_reset_dryrun tests.test_hosted_docs

## Live verification
- reproduced the hosted production failure on `https://harness-umber.vercel.app/backend/reset/*`: register and claim returned `500` while the same reset happy path worked locally
- root-cause matched the new PR #300 code path depending on `reset_contracts` in Postgres while hosted schema had only canonical task tables
- deployed a preview with this patch and runtime envs, then ran a real hosted reset happy path against `/backend/reset/*`
- verified success on Linear issue `KNO-216` with real GitHub PR `https://github.com/sfayka/HARNESS-DRYRUN/pull/37`
- hosted preview result: `register_status=201`, `claim_status=200`, hosted contract `verified_done`, final Linear state `Done`

## Operational note
- the preview deployment also required `LINEAR_API_KEY` and `GITHUB_TOKEN` to be present at runtime for the hosted proof path
