### PR TITLE
fix: escalate failed repair dispatch to review

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,11 @@ Reset-slice verifier environment variables:
   - Used by the reset verifier to move Linear issues and leave canonical Harness comments
 - `OPENCLAW_BASE_URL`
   - Optional HTTP fallback used when the reset verifier requests OpenClaw repair through a remote callback endpoint
+  - In hosted Vercel runtimes this must be a remote-reachable OpenClaw receiver, not `127.0.0.1`, `localhost`, or another loopback/private-only address
 - `OPENCLAW_REPAIR_ENDPOINT`
   - Optional override for the OpenClaw repair callback path
+
+If the reset verifier rejects a claim and the repair callback itself cannot be delivered, Harness now preserves the failed claim, moves the contract into `needs_review`, and updates Linear to `In Review` instead of returning a transport-shaped false negative that leaves the contract looking untouched.
 
 For native local development, `backend.server` now auto-loads both repo-root `.env.local` and `config/openclaw/.env.local`. When the OpenClaw local config exports `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, Harness prefers a local `openclaw agent --local` repair dispatch over the HTTP callback path.
 

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -70,6 +70,8 @@ For the reset verifier slice, put these in repo-root `.env.local`:
 
 When `config/openclaw/.env.local` provides `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, the reset verifier prefers local OpenClaw CLI dispatch over the HTTP callback. `OPENCLAW_BASE_URL` and `OPENCLAW_REPAIR_ENDPOINT` remain the fallback for remote OpenClaw receivers.
 
+That loopback-style fallback is only appropriate for native local development. Do not copy `OPENCLAW_BASE_URL=http://127.0.0.1:...` into hosted Vercel environments, because the reset verifier will not be able to reach your laptop from a serverless runtime.
+
 To run the same backend against Postgres instead of the file-backed store:
 
 ```bash

--- a/docs/setup/vercel-neon.md
+++ b/docs/setup/vercel-neon.md
@@ -65,6 +65,10 @@ psql "$POSTGRES_URL" -f sql/postgres/001_harness_store.sql
 
 The reset verifier now also bootstraps its own `reset_contracts` table on first Postgres access if that slice has not been migrated yet. That protects hosted `/backend/reset/*` routes from failing with opaque `500` errors when the canonical task schema exists but the reset slice has not been applied yet.
 
+For hosted repair dispatch, set `OPENCLAW_BASE_URL` to a real remote receiver that the Vercel runtime can reach. Do not reuse a local development value like `http://127.0.0.1:18789`, because that only points back at the serverless container itself.
+
+If Harness rejects a completion claim and the OpenClaw repair callback is unreachable, the reset verifier now records the failed claim, moves the contract to `needs_review`, and updates Linear to `In Review`. It no longer returns a transport-only `400` that leaves the contract looking idle.
+
 The backend health endpoint remains:
 
 - `GET /backend/health`

--- a/modules/reset/service.py
+++ b/modules/reset/service.py
@@ -11,7 +11,7 @@ from typing import Any
 from .contracts import ResetCompletionClaim, ResetVerificationContract
 from .github_verifier import ResetGitHubVerdict, ResetGitHubVerifier
 from .linear_client import LinearResetClient
-from .openclaw_client import OpenClawRepairClient
+from .openclaw_client import OpenClawRepairClient, OpenClawRepairClientError
 from .store import (
     ResetContractAlreadyExistsError,
     ResetContractNotFoundError,
@@ -146,13 +146,22 @@ class ResetVerificationService:
                     )
                     continue
 
-                updated = self._dispatch_repair(contract, timeout_reason)
+                try:
+                    updated = self._dispatch_repair(contract, timeout_reason)
+                    outcome_status = "retryable_invalid_proof"
+                    outcome_action = "repair_requested"
+                    outcome_reason = timeout_reason
+                except (OpenClawRepairClientError, ValueError) as error:
+                    outcome_reason = self._repair_dispatch_failure_reason(timeout_reason, error)
+                    updated = self._mark_in_review(contract, outcome_reason)
+                    outcome_status = "needs_review"
+                    outcome_action = "escalated"
                 outcomes.append(
                     ResetTickResult(
                         contract_id=updated.contract_id,
-                        action="repair_requested",
-                        status="retryable_invalid_proof",
-                        reason=timeout_reason,
+                        action=outcome_action,
+                        status=outcome_status,
+                        reason=outcome_reason,
                     )
                 )
                 continue
@@ -183,13 +192,22 @@ class ResetVerificationService:
                 )
                 continue
 
-            updated = self._dispatch_repair(contract, verdict.reason)
+            try:
+                updated = self._dispatch_repair(contract, verdict.reason)
+                outcome_status = "retryable_invalid_proof"
+                outcome_action = "repair_requested"
+                outcome_reason = verdict.reason
+            except (OpenClawRepairClientError, ValueError) as error:
+                outcome_reason = self._repair_dispatch_failure_reason(verdict.reason, error)
+                updated = self._mark_in_review(contract, outcome_reason)
+                outcome_status = "needs_review"
+                outcome_action = "escalated"
             outcomes.append(
                 ResetTickResult(
                     contract_id=updated.contract_id,
-                    action="repair_requested",
-                    status="retryable_invalid_proof",
-                    reason=verdict.reason,
+                    action=outcome_action,
+                    status=outcome_status,
+                    reason=outcome_reason,
                 )
             )
         return tuple(outcomes)
@@ -265,7 +283,16 @@ class ResetVerificationService:
             }
 
         if allow_repair_dispatch:
-            updated = self._dispatch_repair(contract, verdict.reason)
+            try:
+                updated = self._dispatch_repair(contract, verdict.reason)
+            except (OpenClawRepairClientError, ValueError) as error:
+                effective_reason = self._repair_dispatch_failure_reason(verdict.reason, error)
+                updated = self._mark_in_review(contract, effective_reason)
+                return {
+                    "status": "needs_review",
+                    "reason": effective_reason,
+                    "contract": updated.asdict(),
+                }
         else:
             timestamp = self._now_iso()
             updated = self.store.update_contract(
@@ -337,6 +364,10 @@ class ResetVerificationService:
             comment=reason,
         )
         return updated
+
+    def _repair_dispatch_failure_reason(self, reason: str, error: ValueError) -> str:
+        detail = str(error).strip() or "unknown repair dispatch failure"
+        return f"{reason}; repair dispatch failed: {detail}"
 
     def _mark_in_review(self, contract: ResetVerificationContract, reason: str) -> ResetVerificationContract:
         timestamp = self._now_iso()

--- a/tests/reset/test_service.py
+++ b/tests/reset/test_service.py
@@ -28,6 +28,11 @@ class FakeOpenClawClient:
         self.repairs.append((issue_id, reason, contract_id))
 
 
+class FailingOpenClawClient:
+    def request_repair(self, issue_id: str, *, reason: str, contract_id: str | None = None) -> None:
+        raise ValueError("OpenClaw repair callback failed: connection refused")
+
+
 class FakeVerifier:
     def __init__(self, *statuses: tuple[str, str]) -> None:
         self.statuses = list(statuses)
@@ -109,6 +114,47 @@ class ResetVerificationServiceTests(unittest.TestCase):
             self.assertEqual(openclaw.repairs[0][0], "KNO-999")
             self.assertEqual(linear.actions[-1][1], "In Progress")
             self.assertEqual(linear.actions[-1][2], "retrying")
+
+    def test_invalid_proof_escalates_to_review_when_repair_dispatch_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            linear = FakeLinearClient()
+            service = ResetVerificationService(
+                store=store,
+                linear_client=linear,
+                verifier=FakeVerifier(("retryable_invalid_proof", "wrong sha")),
+                openclaw_client=FailingOpenClawClient(),
+            )
+
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+            )
+            service.register_contract(contract)
+
+            result = service.submit_claim(
+                "contract-1",
+                ResetCompletionClaim(
+                    repository_owner="sfayka",
+                    repository_name="Harness",
+                    branch_name="codex/reset-verifier-v1",
+                    commit_sha="bad",
+                    pull_request_number=42,
+                    pull_request_url="https://github.com/sfayka/Harness/pull/42",
+                ),
+            )
+            updated = service.get_contract("contract-1")
+
+            self.assertEqual(result["status"], "needs_review")
+            self.assertEqual(updated.harness_status, "needs_review")
+            self.assertEqual(updated.latest_verdict, "needs_review")
+            self.assertEqual(linear.actions[-1][1], "In Review")
+            self.assertEqual(linear.actions[-1][2], "needs_review")
+            self.assertIn("wrong sha", result["reason"])
+            self.assertIn("repair callback failed", result["reason"])
 
     def test_verified_claim_moves_issue_to_done(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -271,6 +317,42 @@ class ResetVerificationServiceTests(unittest.TestCase):
             self.assertIn("no completion claim", openclaw.repairs[0][1])
             self.assertEqual(linear.actions[-1][1], "In Progress")
             self.assertEqual(linear.actions[-1][2], "retrying")
+
+    def test_tick_escalates_to_review_when_timeout_repair_dispatch_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            linear = FakeLinearClient()
+            service = ResetVerificationService(
+                store=store,
+                linear_client=linear,
+                verifier=FakeVerifier(("retryable_invalid_proof", "unused")),
+                openclaw_client=FailingOpenClawClient(),
+                now_provider=lambda: datetime(2026, 4, 15, 12, 5, tzinfo=timezone.utc),
+                retry_cooldown_seconds=0,
+                claim_timeout_seconds=60,
+            )
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+                created_at="2026-04-15T12:00:00Z",
+                updated_at="2026-04-15T12:00:00Z",
+                last_activity_at="2026-04-15T12:00:00Z",
+            )
+            service.register_contract(contract)
+
+            tick_results = service.tick()
+            updated = service.get_contract("contract-1")
+
+            self.assertEqual(len(tick_results), 1)
+            self.assertEqual(tick_results[0].status, "needs_review")
+            self.assertEqual(updated.harness_status, "needs_review")
+            self.assertEqual(updated.latest_verdict, "needs_review")
+            self.assertEqual(linear.actions[-1][1], "In Review")
+            self.assertEqual(linear.actions[-1][2], "needs_review")
+            self.assertIn("repair dispatch failed", tick_results[0].reason)
 
     def test_tick_escalates_to_review_when_claim_timeout_retries_are_spent(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_fastapi_backend.py
+++ b/tests/test_fastapi_backend.py
@@ -173,3 +173,67 @@ class FastApiBackendTests(unittest.TestCase):
         ticked = self.client.post("/reset/tick")
         self.assertEqual(ticked.status_code, 200)
         self.assertEqual(ticked.json()["results"], [])
+
+    def test_reset_claim_invalid_proof_returns_review_instead_of_bad_request_when_repair_dispatch_fails(self) -> None:
+        class _FailingVerifier:
+            def verify(inner_self, **_: object):
+                return type(
+                    "Verdict",
+                    (),
+                    {"status": "retryable_invalid_proof", "reason": "wrong sha", "details": None},
+                )()
+
+        class _FailingOpenClawClient:
+            def request_repair(
+                inner_self,
+                issue_id: str,
+                *,
+                reason: str,
+                contract_id: str | None = None,
+            ) -> None:
+                raise ValueError("OpenClaw repair callback failed: connection refused")
+
+        reset_service = ResetVerificationService(
+            store=FileBackedResetStore(self.temp_dir.name),
+            linear_client=type(
+                "_FakeLinearClient",
+                (),
+                {
+                    "update_issue": lambda inner_self, issue_id, *, state, harness_status, comment: self.linear_actions.append(
+                        (issue_id, state, harness_status, comment)
+                    )
+                },
+            )(),
+            verifier=_FailingVerifier(),
+            openclaw_client=_FailingOpenClawClient(),
+        )
+        client = TestClient(create_app(store=self.store, reset_service=reset_service))
+
+        created = client.post(
+            "/reset/contracts",
+            json={
+                "contract_id": "contract-1",
+                "linear_issue_id": "KNO-999",
+                "repository_owner": "sfayka",
+                "repository_name": "Harness",
+                "branch_ref": "codex/reset-verifier-v1",
+            },
+        )
+        self.assertEqual(created.status_code, 201)
+
+        claimed = client.post(
+            "/reset/contracts/contract-1/claims",
+            json={
+                "repository_owner": "sfayka",
+                "repository_name": "Harness",
+                "branch_name": "codex/reset-verifier-v1",
+                "commit_sha": "bad",
+                "pull_request_number": 42,
+                "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
+            },
+        )
+
+        self.assertEqual(claimed.status_code, 200)
+        self.assertEqual(claimed.json()["status"], "needs_review")
+        self.assertEqual(self.linear_actions[-1][1], "In Review")
+        self.assertEqual(self.linear_actions[-1][2], "needs_review")


### PR DESCRIPTION
## Summary
- preserve reset claims and escalate to review when OpenClaw repair dispatch itself fails
- cover claim and tick failure paths with regression tests instead of returning a 400 that leaves the contract looking idle
- document that hosted OPENCLAW_BASE_URL must be remote-reachable and not a loopback address

## Validation
- python3 -m unittest discover -s tests
- live hosted production happy path against /backend/reset/* after adding missing Vercel secrets: real GitHub PR proof verified and Linear issue moved to Done
- live real Linear/GitHub repair-dispatch-failure validation: invalid proof now moves Linear issue KNO-221 to In Review with Harness contract status needs_review
