### PR TITLE
fix: verify reset linear writeback

### DIFF
--- a/modules/reset/linear_client.py
+++ b/modules/reset/linear_client.py
@@ -87,6 +87,12 @@ class LinearResetClient:
                 return str(state["id"])
         raise LinearClientError(f"Linear team state {desired_state_name!r} is not available on issue team")
 
+    @staticmethod
+    def _require_mutation_success(payload: dict[str, Any], mutation_name: str) -> None:
+        mutation = payload.get(mutation_name)
+        if not isinstance(mutation, dict) or mutation.get("success") is not True:
+            raise LinearClientError(f"Linear {mutation_name} did not succeed")
+
     def update_issue(self, issue_ref: str, *, state: str | None, harness_status: str, comment: str) -> dict[str, Any]:
         issue = self._get_issue_context(issue_ref)
         issue_id = str(issue["id"])
@@ -100,7 +106,14 @@ class LinearResetClient:
               }
             }
             """
-            self._graphql(update_mutation, {"id": issue_id, "input": {"stateId": state_id}})
+            update_result = self._graphql(update_mutation, {"id": issue_id, "input": {"stateId": state_id}})
+            self._require_mutation_success(update_result, "issueUpdate")
+            issue = self._get_issue_context(issue_id)
+            current_state_name = str(((issue.get("state") or {}).get("name")) or "")
+            if current_state_name.lower() != state.lower():
+                raise LinearClientError(
+                    f"Linear issue state did not update to {state!r}; current state is {current_state_name!r}"
+                )
 
         comment_body = f"Harness status: {harness_status}\n\n{comment}"
         comment_mutation = """
@@ -110,7 +123,8 @@ class LinearResetClient:
           }
         }
         """
-        self._graphql(comment_mutation, {"input": {"issueId": issue_id, "body": comment_body}})
+        comment_result = self._graphql(comment_mutation, {"input": {"issueId": issue_id, "body": comment_body}})
+        self._require_mutation_success(comment_result, "commentCreate")
         return {
             "issue_id": issue_id,
             "issue_identifier": issue["identifier"],

--- a/modules/reset/service.py
+++ b/modules/reset/service.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from .contracts import ResetCompletionClaim, ResetVerificationContract
 from .github_verifier import ResetGitHubVerdict, ResetGitHubVerifier
-from .linear_client import LinearResetClient
+from .linear_client import LinearClientError, LinearResetClient
 from .openclaw_client import OpenClawRepairClient, OpenClawRepairClientError
 from .store import (
     ResetContractAlreadyExistsError,
@@ -89,13 +89,12 @@ class ResetVerificationService:
                 message="Harness verification contract registered.",
             )
         )
-        self.linear_client.update_issue(
-            created.linear_issue_id,
+        return self._sync_linear_writeback(
+            created,
             state="In Progress",
             harness_status="running",
             comment="Harness verification contract registered.",
         )
-        return created
 
     def list_contracts(self) -> tuple[ResetVerificationContract, ...]:
         return self.store.list_contracts()
@@ -309,6 +308,7 @@ class ResetVerificationService:
             "reason": verdict.reason,
             "contract": updated.asdict(),
         }
+
     def _mark_verified(
         self,
         contract: ResetVerificationContract,
@@ -324,13 +324,12 @@ class ResetVerificationService:
             last_activity_at=claim.claimed_at,
         ).append_event(kind="verified", message=verdict.reason, timestamp=claim.claimed_at)
         self.store.update_contract(updated)
-        self.linear_client.update_issue(
-            updated.linear_issue_id,
+        return self._sync_linear_writeback(
+            contract=updated,
             state="Done",
             harness_status="verified",
             comment=verdict.reason,
         )
-        return updated
 
     def _dispatch_repair(self, contract: ResetVerificationContract, reason: str) -> ResetVerificationContract:
         next_retry_count = contract.retry_count + 1
@@ -357,13 +356,12 @@ class ResetVerificationService:
             timestamp=timestamp,
         )
         self.store.update_contract(updated)
-        self.linear_client.update_issue(
-            updated.linear_issue_id,
+        return self._sync_linear_writeback(
             state="In Progress",
+            contract=updated,
             harness_status="retrying",
             comment=reason,
         )
-        return updated
 
     def _repair_dispatch_failure_reason(self, reason: str, error: ValueError) -> str:
         detail = str(error).strip() or "unknown repair dispatch failure"
@@ -379,13 +377,40 @@ class ResetVerificationService:
             updated_at=timestamp,
         ).append_event(kind="review_required", message=reason, timestamp=timestamp)
         self.store.update_contract(updated)
-        self.linear_client.update_issue(
-            updated.linear_issue_id,
+        return self._sync_linear_writeback(
+            contract=updated,
             state="In Review",
             harness_status="needs_review",
             comment=reason,
         )
-        return updated
+
+    def _sync_linear_writeback(
+        self,
+        contract: ResetVerificationContract,
+        *,
+        state: str | None,
+        harness_status: str,
+        comment: str,
+    ) -> ResetVerificationContract:
+        try:
+            self.linear_client.update_issue(
+                contract.linear_issue_id,
+                state=state,
+                harness_status=harness_status,
+                comment=comment,
+            )
+        except LinearClientError as error:
+            timestamp = self._now_iso()
+            updated = contract.updated(
+                last_activity_at=timestamp,
+                updated_at=timestamp,
+            ).append_event(
+                kind="linear_writeback_failed",
+                message=str(error),
+                timestamp=timestamp,
+            )
+            return self.store.update_contract(updated)
+        return contract
 
     def register_contract_http(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:

--- a/tests/reset/test_linear_client.py
+++ b/tests/reset/test_linear_client.py
@@ -17,6 +17,22 @@ def _free_port() -> int:
 
 class _LinearHandler(BaseHTTPRequestHandler):
     calls: list[dict] = []
+    issue_update_success = True
+    comment_create_success = True
+    apply_state_change = True
+    current_state_id = "state-in-progress"
+    current_state_name = "In Progress"
+    current_state_type = "started"
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.calls = []
+        cls.issue_update_success = True
+        cls.comment_create_success = True
+        cls.apply_state_change = True
+        cls.current_state_id = "state-in-progress"
+        cls.current_state_name = "In Progress"
+        cls.current_state_type = "started"
 
     def do_POST(self) -> None:  # noqa: N802
         body = self.rfile.read(int(self.headers.get("Content-Length", "0"))).decode("utf-8")
@@ -38,7 +54,11 @@ class _LinearHandler(BaseHTTPRequestHandler):
                         "identifier": "KNO-999",
                         "url": "https://linear.app/knoxanalytics/issue/KNO-999/example",
                         "title": "Example",
-                        "state": {"id": "state-in-progress", "name": "In Progress", "type": "started"},
+                        "state": {
+                            "id": _LinearHandler.current_state_id,
+                            "name": _LinearHandler.current_state_name,
+                            "type": _LinearHandler.current_state_type,
+                        },
                         "team": {
                             "id": "team-1",
                             "name": "Knoxanalytics",
@@ -54,9 +74,21 @@ class _LinearHandler(BaseHTTPRequestHandler):
                 }
             }
         elif "mutation UpdateIssue" in query:
-            response = {"data": {"issueUpdate": {"success": True}}}
+            state_id = payload["variables"]["input"]["stateId"]
+            if _LinearHandler.issue_update_success and _LinearHandler.apply_state_change:
+                state_lookup = {
+                    "state-in-progress": ("state-in-progress", "In Progress", "started"),
+                    "state-review": ("state-review", "In Review", "started"),
+                    "state-done": ("state-done", "Done", "completed"),
+                }
+                (
+                    _LinearHandler.current_state_id,
+                    _LinearHandler.current_state_name,
+                    _LinearHandler.current_state_type,
+                ) = state_lookup[state_id]
+            response = {"data": {"issueUpdate": {"success": _LinearHandler.issue_update_success}}}
         elif "mutation CreateComment" in query:
-            response = {"data": {"commentCreate": {"success": True}}}
+            response = {"data": {"commentCreate": {"success": _LinearHandler.comment_create_success}}}
         else:
             response = {"errors": [{"message": "unexpected query"}]}
 
@@ -73,7 +105,7 @@ class _LinearHandler(BaseHTTPRequestHandler):
 
 class LinearResetClientTests(unittest.TestCase):
     def setUp(self) -> None:
-        _LinearHandler.calls = []
+        _LinearHandler.reset()
         self.port = _free_port()
         self.server = ThreadingHTTPServer(("127.0.0.1", self.port), _LinearHandler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
@@ -98,11 +130,12 @@ class LinearResetClientTests(unittest.TestCase):
 
         self.assertEqual(result["issue_id"], "uuid-123")
         self.assertEqual(result["state"], "Done")
-        self.assertEqual(len(_LinearHandler.calls), 3)
-        issue_query, update_mutation, comment_mutation = _LinearHandler.calls
+        self.assertEqual(len(_LinearHandler.calls), 4)
+        issue_query, update_mutation, state_readback_query, comment_mutation = _LinearHandler.calls
         self.assertEqual(issue_query["headers"]["Authorization"], "linear-test-token")
         self.assertEqual(update_mutation["variables"]["id"], "uuid-123")
         self.assertEqual(update_mutation["variables"]["input"]["stateId"], "state-done")
+        self.assertIn("query IssueContext", state_readback_query["query"])
         self.assertEqual(comment_mutation["variables"]["input"]["issueId"], "uuid-123")
         self.assertIn("Harness status: verified", comment_mutation["variables"]["input"]["body"])
 
@@ -113,6 +146,39 @@ class LinearResetClientTests(unittest.TestCase):
                 state="Blocked",
                 harness_status="retrying",
                 comment="missing state",
+            )
+
+    def test_raises_when_issue_update_reports_unsuccessful_mutation(self) -> None:
+        _LinearHandler.issue_update_success = False
+
+        with self.assertRaises(LinearClientError):
+            self.client.update_issue(
+                "KNO-999",
+                state="In Review",
+                harness_status="needs_review",
+                comment="state update failed",
+            )
+
+    def test_raises_when_comment_create_reports_unsuccessful_mutation(self) -> None:
+        _LinearHandler.comment_create_success = False
+
+        with self.assertRaises(LinearClientError):
+            self.client.update_issue(
+                "KNO-999",
+                state="In Review",
+                harness_status="needs_review",
+                comment="comment failed",
+            )
+
+    def test_raises_when_state_readback_does_not_match_requested_state(self) -> None:
+        _LinearHandler.apply_state_change = False
+
+        with self.assertRaises(LinearClientError):
+            self.client.update_issue(
+                "KNO-999",
+                state="In Review",
+                harness_status="needs_review",
+                comment="state readback mismatch",
             )
 
 

--- a/tests/reset/test_service.py
+++ b/tests/reset/test_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from modules.reset.contracts import ResetCompletionClaim, ResetVerificationContract
+from modules.reset.linear_client import LinearClientError
 from modules.reset.service import ResetVerificationService
 from modules.reset.store import PostgresResetStore
 from modules.reset.store import FileBackedResetStore
@@ -18,6 +19,11 @@ class FakeLinearClient:
 
     def update_issue(self, issue_id: str, *, state: str | None, harness_status: str, comment: str) -> None:
         self.actions.append((issue_id, state, harness_status, comment))
+
+
+class FailingLinearClient:
+    def update_issue(self, issue_id: str, *, state: str | None, harness_status: str, comment: str) -> None:
+        raise LinearClientError("Linear issueUpdate did not succeed")
 
 
 class FakeOpenClawClient:
@@ -190,6 +196,43 @@ class ResetVerificationServiceTests(unittest.TestCase):
             self.assertEqual(result["status"], "verified_done")
             self.assertEqual(linear.actions[-1][1], "Done")
             self.assertEqual(linear.actions[-1][2], "verified")
+
+    def test_verified_claim_preserves_contract_and_records_event_when_linear_writeback_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FileBackedResetStore(temp_dir)
+            service = ResetVerificationService(
+                store=store,
+                linear_client=FailingLinearClient(),
+                verifier=FakeVerifier(("verified_done", "github proof verified")),
+                openclaw_client=FakeOpenClawClient(),
+            )
+            contract = ResetVerificationContract(
+                contract_id="contract-1",
+                linear_issue_id="KNO-999",
+                repository_owner="sfayka",
+                repository_name="Harness",
+                branch_ref="codex/reset-verifier-v1",
+            )
+            service.register_contract(contract)
+
+            result = service.submit_claim(
+                "contract-1",
+                ResetCompletionClaim(
+                    repository_owner="sfayka",
+                    repository_name="Harness",
+                    branch_name="codex/reset-verifier-v1",
+                    commit_sha="abc123",
+                    pull_request_number=42,
+                    pull_request_url="https://github.com/sfayka/Harness/pull/42",
+                ),
+            )
+            updated = service.get_contract("contract-1")
+
+            self.assertEqual(result["status"], "verified_done")
+            self.assertEqual(updated.harness_status, "verified")
+            self.assertEqual(updated.latest_verdict, "verified_done")
+            self.assertEqual(updated.event_log[-1].kind, "linear_writeback_failed")
+            self.assertIn("Linear issueUpdate did not succeed", updated.event_log[-1].message)
 
     def test_tick_escalates_to_review_after_retry_budget_is_spent(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_fastapi_backend.py
+++ b/tests/test_fastapi_backend.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from backend.server import create_app
 from modules.local_env import load_local_env_file, load_native_local_env
+from modules.reset.linear_client import LinearClientError
 from modules.reset.service import ResetVerificationService
 from modules.reset.store import FileBackedResetStore
 from modules.store import FileBackedHarnessStore
@@ -237,3 +238,66 @@ class FastApiBackendTests(unittest.TestCase):
         self.assertEqual(claimed.json()["status"], "needs_review")
         self.assertEqual(self.linear_actions[-1][1], "In Review")
         self.assertEqual(self.linear_actions[-1][2], "needs_review")
+
+    def test_reset_claim_verified_done_still_returns_success_when_linear_writeback_fails(self) -> None:
+        class _VerifiedVerifier:
+            def verify(inner_self, **_: object):
+                return type(
+                    "Verdict",
+                    (),
+                    {"status": "verified_done", "reason": "github proof verified", "details": None},
+                )()
+
+        class _FailingLinearClient:
+            def update_issue(
+                inner_self,
+                issue_id: str,
+                *,
+                state: str | None,
+                harness_status: str,
+                comment: str,
+            ) -> None:
+                raise LinearClientError("Linear issueUpdate did not succeed")
+
+        reset_service = ResetVerificationService(
+            store=FileBackedResetStore(self.temp_dir.name),
+            linear_client=_FailingLinearClient(),
+            verifier=_VerifiedVerifier(),
+            openclaw_client=type(
+                "_FakeOpenClawClient",
+                (),
+                {"request_repair": lambda inner_self, issue_id, *, reason, contract_id=None: None},
+            )(),
+        )
+        client = TestClient(create_app(store=self.store, reset_service=reset_service))
+
+        created = client.post(
+            "/reset/contracts",
+            json={
+                "contract_id": "contract-1",
+                "linear_issue_id": "KNO-999",
+                "repository_owner": "sfayka",
+                "repository_name": "Harness",
+                "branch_ref": "codex/reset-verifier-v1",
+            },
+        )
+        self.assertEqual(created.status_code, 201)
+
+        claimed = client.post(
+            "/reset/contracts/contract-1/claims",
+            json={
+                "repository_owner": "sfayka",
+                "repository_name": "Harness",
+                "branch_name": "codex/reset-verifier-v1",
+                "commit_sha": "abc123",
+                "pull_request_number": 42,
+                "pull_request_url": "https://github.com/sfayka/Harness/pull/42",
+            },
+        )
+
+        self.assertEqual(claimed.status_code, 200)
+        self.assertEqual(claimed.json()["status"], "verified_done")
+        self.assertEqual(
+            claimed.json()["contract"]["event_log"][-1]["kind"],
+            "linear_writeback_failed",
+        )


### PR DESCRIPTION
## Summary
- verify reset-slice Linear mutations actually succeed instead of trusting GraphQL 200s
- re-read Linear issue state after state transitions so silent writeback drift becomes explicit
- keep reset claim/register routes truthful by recording `linear_writeback_failed` on the contract instead of failing after canonical state has already changed

## Validation
- python3 -m unittest tests.reset.test_linear_client tests.reset.test_service tests.test_fastapi_backend
- production hosted failure-path check after PR #302 merge: bad claim now returns `needs_review` with canonical contract update, but real Linear issue KNO-222 stayed `In Progress`; this patch hardens the writeback path that allowed that silent mismatch
- direct live Linear writeback on KNO-222 confirmed the team state exists and manual transition to `In Review` succeeds

## Notes
- Vercel preview CLI deployments are still intermittently failing with an opaque `BUILD_ERROR` before logs are exposed. I did not treat that as evidence against this patch because the reset/adapter suites pass and the production repro for the writeback mismatch is concrete.
