### PR TITLE
fix: retry reset linear confirmation

### DIFF
--- a/modules/reset/linear_client.py
+++ b/modules/reset/linear_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import ssl
+import time
 from typing import Any
 from urllib import error, request
 
@@ -22,10 +23,14 @@ class LinearResetClient:
         api_key: str | None = None,
         api_url: str = "https://api.linear.app/graphql",
         timeout_seconds: float = 10.0,
+        state_confirmation_attempts: int = 2,
+        state_confirmation_delay_seconds: float = 0.5,
     ) -> None:
         self.api_key = api_key or os.getenv("LINEAR_API_KEY")
         self.api_url = api_url
         self.timeout_seconds = timeout_seconds
+        self.state_confirmation_attempts = max(1, int(state_confirmation_attempts))
+        self.state_confirmation_delay_seconds = max(0.0, float(state_confirmation_delay_seconds))
         self.ssl_context = _build_ssl_context()
 
     def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
@@ -106,11 +111,17 @@ class LinearResetClient:
               }
             }
             """
-            update_result = self._graphql(update_mutation, {"id": issue_id, "input": {"stateId": state_id}})
-            self._require_mutation_success(update_result, "issueUpdate")
-            issue = self._get_issue_context(issue_id)
-            current_state_name = str(((issue.get("state") or {}).get("name")) or "")
-            if current_state_name.lower() != state.lower():
+            current_state_name = ""
+            for attempt_index in range(self.state_confirmation_attempts):
+                update_result = self._graphql(update_mutation, {"id": issue_id, "input": {"stateId": state_id}})
+                self._require_mutation_success(update_result, "issueUpdate")
+                issue = self._get_issue_context(issue_id)
+                current_state_name = str(((issue.get("state") or {}).get("name")) or "")
+                if current_state_name.lower() == state.lower():
+                    break
+                if attempt_index + 1 < self.state_confirmation_attempts:
+                    time.sleep(self.state_confirmation_delay_seconds)
+            else:
                 raise LinearClientError(
                     f"Linear issue state did not update to {state!r}; current state is {current_state_name!r}"
                 )

--- a/tests/reset/test_linear_client.py
+++ b/tests/reset/test_linear_client.py
@@ -20,6 +20,7 @@ class _LinearHandler(BaseHTTPRequestHandler):
     issue_update_success = True
     comment_create_success = True
     apply_state_change = True
+    issue_update_apply_sequence: list[bool] = []
     current_state_id = "state-in-progress"
     current_state_name = "In Progress"
     current_state_type = "started"
@@ -30,6 +31,7 @@ class _LinearHandler(BaseHTTPRequestHandler):
         cls.issue_update_success = True
         cls.comment_create_success = True
         cls.apply_state_change = True
+        cls.issue_update_apply_sequence = []
         cls.current_state_id = "state-in-progress"
         cls.current_state_name = "In Progress"
         cls.current_state_type = "started"
@@ -75,7 +77,12 @@ class _LinearHandler(BaseHTTPRequestHandler):
             }
         elif "mutation UpdateIssue" in query:
             state_id = payload["variables"]["input"]["stateId"]
-            if _LinearHandler.issue_update_success and _LinearHandler.apply_state_change:
+            should_apply_state = (
+                _LinearHandler.issue_update_apply_sequence.pop(0)
+                if _LinearHandler.issue_update_apply_sequence
+                else _LinearHandler.apply_state_change
+            )
+            if _LinearHandler.issue_update_success and should_apply_state:
                 state_lookup = {
                     "state-in-progress": ("state-in-progress", "In Progress", "started"),
                     "state-review": ("state-review", "In Review", "started"),
@@ -113,6 +120,8 @@ class LinearResetClientTests(unittest.TestCase):
         self.client = LinearResetClient(
             api_key="linear-test-token",
             api_url=f"http://127.0.0.1:{self.port}/graphql",
+            state_confirmation_attempts=2,
+            state_confirmation_delay_seconds=0,
         )
 
     def tearDown(self) -> None:
@@ -180,6 +189,20 @@ class LinearResetClientTests(unittest.TestCase):
                 harness_status="needs_review",
                 comment="state readback mismatch",
             )
+
+    def test_retries_state_transition_when_first_confirmation_misses(self) -> None:
+        _LinearHandler.issue_update_apply_sequence = [False, True]
+
+        result = self.client.update_issue(
+            "KNO-999",
+            state="In Review",
+            harness_status="needs_review",
+            comment="retry state transition",
+        )
+
+        self.assertEqual(result["state"], "In Review")
+        update_calls = [call for call in _LinearHandler.calls if "mutation UpdateIssue" in call["query"]]
+        self.assertEqual(len(update_calls), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retry reset-slice Linear state confirmation when the first mutation/readback cycle misses
- keep the stricter mutation success and readback verification added in #303
- target the live hosted failure mode where Harness persisted `needs_review` correctly but Linear sometimes remained in `In Progress` until a later manual retry

## Validation
- python3 -m unittest tests.reset.test_linear_client tests.reset.test_service tests.test_fastapi_backend
- live production repro after #303 merge showed KNO-223 staying in `In Progress` while Harness recorded `linear_writeback_failed`
- direct follow-up retry on KNO-223 moved it to `In Review` immediately, which is why this patch adds one bounded retry instead of changing the lifecycle semantics
