### PR TITLE
fix: reapply reset linear state after comment drift

### DIFF
--- a/modules/reset/linear_client.py
+++ b/modules/reset/linear_client.py
@@ -98,33 +98,43 @@ class LinearResetClient:
         if not isinstance(mutation, dict) or mutation.get("success") is not True:
             raise LinearClientError(f"Linear {mutation_name} did not succeed")
 
+    def _confirm_issue_state(self, issue_id: str, desired_state_name: str) -> dict[str, Any]:
+        issue = self._get_issue_context(issue_id)
+        current_state_name = str(((issue.get("state") or {}).get("name")) or "")
+        if current_state_name.lower() != desired_state_name.lower():
+            raise LinearClientError(
+                f"Linear issue state did not update to {desired_state_name!r}; current state is {current_state_name!r}"
+            )
+        return issue
+
+    def _set_state_with_confirmation(self, issue_id: str, state_id: str, desired_state_name: str) -> dict[str, Any]:
+        update_mutation = """
+        mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+          }
+        }
+        """
+        last_error: LinearClientError | None = None
+        for attempt_index in range(self.state_confirmation_attempts):
+            update_result = self._graphql(update_mutation, {"id": issue_id, "input": {"stateId": state_id}})
+            self._require_mutation_success(update_result, "issueUpdate")
+            try:
+                return self._confirm_issue_state(issue_id, desired_state_name)
+            except LinearClientError as error:
+                last_error = error
+                if attempt_index + 1 < self.state_confirmation_attempts:
+                    time.sleep(self.state_confirmation_delay_seconds)
+        assert last_error is not None
+        raise last_error
+
     def update_issue(self, issue_ref: str, *, state: str | None, harness_status: str, comment: str) -> dict[str, Any]:
         issue = self._get_issue_context(issue_ref)
         issue_id = str(issue["id"])
 
         if state:
             state_id = self._state_id_for_name(issue, state)
-            update_mutation = """
-            mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
-              issueUpdate(id: $id, input: $input) {
-                success
-              }
-            }
-            """
-            current_state_name = ""
-            for attempt_index in range(self.state_confirmation_attempts):
-                update_result = self._graphql(update_mutation, {"id": issue_id, "input": {"stateId": state_id}})
-                self._require_mutation_success(update_result, "issueUpdate")
-                issue = self._get_issue_context(issue_id)
-                current_state_name = str(((issue.get("state") or {}).get("name")) or "")
-                if current_state_name.lower() == state.lower():
-                    break
-                if attempt_index + 1 < self.state_confirmation_attempts:
-                    time.sleep(self.state_confirmation_delay_seconds)
-            else:
-                raise LinearClientError(
-                    f"Linear issue state did not update to {state!r}; current state is {current_state_name!r}"
-                )
+            issue = self._set_state_with_confirmation(issue_id, state_id, state)
 
         comment_body = f"Harness status: {harness_status}\n\n{comment}"
         comment_mutation = """
@@ -136,6 +146,11 @@ class LinearResetClient:
         """
         comment_result = self._graphql(comment_mutation, {"input": {"issueId": issue_id, "body": comment_body}})
         self._require_mutation_success(comment_result, "commentCreate")
+        if state:
+            try:
+                issue = self._confirm_issue_state(issue_id, state)
+            except LinearClientError:
+                issue = self._set_state_with_confirmation(issue_id, state_id, state)
         return {
             "issue_id": issue_id,
             "issue_identifier": issue["identifier"],

--- a/tests/reset/test_linear_client.py
+++ b/tests/reset/test_linear_client.py
@@ -21,6 +21,7 @@ class _LinearHandler(BaseHTTPRequestHandler):
     comment_create_success = True
     apply_state_change = True
     issue_update_apply_sequence: list[bool] = []
+    comment_reset_state_to_in_progress = False
     current_state_id = "state-in-progress"
     current_state_name = "In Progress"
     current_state_type = "started"
@@ -32,6 +33,7 @@ class _LinearHandler(BaseHTTPRequestHandler):
         cls.comment_create_success = True
         cls.apply_state_change = True
         cls.issue_update_apply_sequence = []
+        cls.comment_reset_state_to_in_progress = False
         cls.current_state_id = "state-in-progress"
         cls.current_state_name = "In Progress"
         cls.current_state_type = "started"
@@ -95,6 +97,10 @@ class _LinearHandler(BaseHTTPRequestHandler):
                 ) = state_lookup[state_id]
             response = {"data": {"issueUpdate": {"success": _LinearHandler.issue_update_success}}}
         elif "mutation CreateComment" in query:
+            if _LinearHandler.comment_create_success and _LinearHandler.comment_reset_state_to_in_progress:
+                _LinearHandler.current_state_id = "state-in-progress"
+                _LinearHandler.current_state_name = "In Progress"
+                _LinearHandler.current_state_type = "started"
             response = {"data": {"commentCreate": {"success": _LinearHandler.comment_create_success}}}
         else:
             response = {"errors": [{"message": "unexpected query"}]}
@@ -139,14 +145,15 @@ class LinearResetClientTests(unittest.TestCase):
 
         self.assertEqual(result["issue_id"], "uuid-123")
         self.assertEqual(result["state"], "Done")
-        self.assertEqual(len(_LinearHandler.calls), 4)
-        issue_query, update_mutation, state_readback_query, comment_mutation = _LinearHandler.calls
+        self.assertEqual(len(_LinearHandler.calls), 5)
+        issue_query, update_mutation, state_readback_query, comment_mutation, final_state_query = _LinearHandler.calls
         self.assertEqual(issue_query["headers"]["Authorization"], "linear-test-token")
         self.assertEqual(update_mutation["variables"]["id"], "uuid-123")
         self.assertEqual(update_mutation["variables"]["input"]["stateId"], "state-done")
         self.assertIn("query IssueContext", state_readback_query["query"])
         self.assertEqual(comment_mutation["variables"]["input"]["issueId"], "uuid-123")
         self.assertIn("Harness status: verified", comment_mutation["variables"]["input"]["body"])
+        self.assertIn("query IssueContext", final_state_query["query"])
 
     def test_raises_when_requested_state_is_missing(self) -> None:
         with self.assertRaises(LinearClientError):
@@ -198,6 +205,20 @@ class LinearResetClientTests(unittest.TestCase):
             state="In Review",
             harness_status="needs_review",
             comment="retry state transition",
+        )
+
+        self.assertEqual(result["state"], "In Review")
+        update_calls = [call for call in _LinearHandler.calls if "mutation UpdateIssue" in call["query"]]
+        self.assertEqual(len(update_calls), 2)
+
+    def test_reapplies_state_when_post_comment_verification_detects_drift(self) -> None:
+        _LinearHandler.comment_reset_state_to_in_progress = True
+
+        result = self.client.update_issue(
+            "KNO-999",
+            state="In Review",
+            harness_status="needs_review",
+            comment="post-comment drift",
         )
 
         self.assertEqual(result["state"], "In Review")


### PR DESCRIPTION
## Summary
- verify reset Linear state again after posting the Harness comment
- if the issue drifted back after comment write, reapply and reconfirm the desired state instead of silently accepting the mismatch
- target the live production behavior seen on KNO-225, where Harness persisted `needs_review` correctly but Linear still remained `In Progress` without logging a writeback failure

## Validation
- python3 -m unittest tests.reset.test_linear_client tests.reset.test_service tests.test_fastapi_backend
- live production repro after #304 merge: hosted reset claim returned `needs_review`, contract was correct, but KNO-225 still stayed `In Progress`
- Linear-side evidence showed the `needs_review` comment existed on KNO-225, which narrowed the failure to post-comment state drift rather than the review comment path itself
