### PR TITLE
fix: recheck reset linear state after comment sync

### DIFF
--- a/modules/reset/linear_client.py
+++ b/modules/reset/linear_client.py
@@ -149,6 +149,8 @@ class LinearResetClient:
         if state:
             try:
                 issue = self._confirm_issue_state(issue_id, state)
+                time.sleep(self.state_confirmation_delay_seconds)
+                issue = self._confirm_issue_state(issue_id, state)
             except LinearClientError:
                 issue = self._set_state_with_confirmation(issue_id, state_id, state)
         return {

--- a/tests/reset/test_linear_client.py
+++ b/tests/reset/test_linear_client.py
@@ -22,6 +22,7 @@ class _LinearHandler(BaseHTTPRequestHandler):
     apply_state_change = True
     issue_update_apply_sequence: list[bool] = []
     comment_reset_state_to_in_progress = False
+    issue_context_state_sequence: list[tuple[str, str, str]] = []
     current_state_id = "state-in-progress"
     current_state_name = "In Progress"
     current_state_type = "started"
@@ -34,6 +35,7 @@ class _LinearHandler(BaseHTTPRequestHandler):
         cls.apply_state_change = True
         cls.issue_update_apply_sequence = []
         cls.comment_reset_state_to_in_progress = False
+        cls.issue_context_state_sequence = []
         cls.current_state_id = "state-in-progress"
         cls.current_state_name = "In Progress"
         cls.current_state_type = "started"
@@ -51,6 +53,12 @@ class _LinearHandler(BaseHTTPRequestHandler):
 
         query = payload["query"]
         if "query IssueContext" in query:
+            if _LinearHandler.issue_context_state_sequence:
+                (
+                    _LinearHandler.current_state_id,
+                    _LinearHandler.current_state_name,
+                    _LinearHandler.current_state_type,
+                ) = _LinearHandler.issue_context_state_sequence.pop(0)
             response = {
                 "data": {
                     "issue": {
@@ -145,8 +153,15 @@ class LinearResetClientTests(unittest.TestCase):
 
         self.assertEqual(result["issue_id"], "uuid-123")
         self.assertEqual(result["state"], "Done")
-        self.assertEqual(len(_LinearHandler.calls), 5)
-        issue_query, update_mutation, state_readback_query, comment_mutation, final_state_query = _LinearHandler.calls
+        self.assertEqual(len(_LinearHandler.calls), 6)
+        (
+            issue_query,
+            update_mutation,
+            state_readback_query,
+            comment_mutation,
+            final_state_query,
+            delayed_final_state_query,
+        ) = _LinearHandler.calls
         self.assertEqual(issue_query["headers"]["Authorization"], "linear-test-token")
         self.assertEqual(update_mutation["variables"]["id"], "uuid-123")
         self.assertEqual(update_mutation["variables"]["input"]["stateId"], "state-done")
@@ -154,6 +169,7 @@ class LinearResetClientTests(unittest.TestCase):
         self.assertEqual(comment_mutation["variables"]["input"]["issueId"], "uuid-123")
         self.assertIn("Harness status: verified", comment_mutation["variables"]["input"]["body"])
         self.assertIn("query IssueContext", final_state_query["query"])
+        self.assertIn("query IssueContext", delayed_final_state_query["query"])
 
     def test_raises_when_requested_state_is_missing(self) -> None:
         with self.assertRaises(LinearClientError):
@@ -219,6 +235,26 @@ class LinearResetClientTests(unittest.TestCase):
             state="In Review",
             harness_status="needs_review",
             comment="post-comment drift",
+        )
+
+        self.assertEqual(result["state"], "In Review")
+        update_calls = [call for call in _LinearHandler.calls if "mutation UpdateIssue" in call["query"]]
+        self.assertEqual(len(update_calls), 2)
+
+    def test_reapplies_state_when_delayed_post_comment_confirmation_detects_drift(self) -> None:
+        _LinearHandler.issue_context_state_sequence = [
+            ("state-in-progress", "In Progress", "started"),
+            ("state-review", "In Review", "started"),
+            ("state-review", "In Review", "started"),
+            ("state-in-progress", "In Progress", "started"),
+            ("state-review", "In Review", "started"),
+        ]
+
+        result = self.client.update_issue(
+            "KNO-999",
+            state="In Review",
+            harness_status="needs_review",
+            comment="delayed post-comment drift",
         )
 
         self.assertEqual(result["state"], "In Review")


### PR DESCRIPTION
## Summary
- add a second post-comment Linear state confirmation before trusting the writeback result
- reapply the desired state when delayed post-comment drift is detected
- extend reset Linear client tests to cover delayed drift and the extra confirmation readback

## Testing
- python3 -m unittest tests.reset.test_linear_client tests.reset.test_service tests.test_fastapi_backend
- python3 -m unittest discover -s tests