### PR TITLE
feat: add bearer auth for repair callbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ HARNESS_API_BASE_URL=http://127.0.0.1:8000
 # fallback for remote or gateway-exposed repair receivers.
 # OPENCLAW_BASE_URL=http://127.0.0.1:18789
 # OPENCLAW_REPAIR_ENDPOINT=/repair
+# OPENCLAW_REPAIR_BEARER_TOKEN=replace-with-shared-secret
 
 # Hosted Vercel deployments derive the backend route automatically from
 # VERCEL_URL and the /backend service prefix.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ Reset-slice verifier environment variables:
   - In hosted Vercel runtimes this must be a remote-reachable OpenClaw receiver, not `127.0.0.1`, `localhost`, or another loopback/private-only address
 - `OPENCLAW_REPAIR_ENDPOINT`
   - Optional override for the OpenClaw repair callback path
+- `OPENCLAW_REPAIR_BEARER_TOKEN`
+  - Optional bearer token for authenticated HTTP repair receivers
+  - When set, Harness sends `Authorization: Bearer <token>` on hosted repair callbacks
 
 If the reset verifier rejects a claim and the repair callback itself cannot be delivered, Harness now preserves the failed claim, moves the contract into `needs_review`, and updates Linear to `In Review` instead of returning a transport-shaped false negative that leaves the contract looking untouched.
 

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -64,11 +64,14 @@ For the reset verifier slice, put these in repo-root `.env.local`:
 - `LINEAR_API_KEY`
 - optional `OPENCLAW_BASE_URL`
 - optional `OPENCLAW_REPAIR_ENDPOINT`
+- optional `OPENCLAW_REPAIR_BEARER_TOKEN`
 - optional `HARNESS_RESET_POLL_SECONDS`
 
 `HARNESS_RESET_POLL_SECONDS` controls how long Harness waits before `/reset/tick` asks OpenClaw to retry a contract already in `retrying`. The production default is `900` seconds. For deterministic local test loops, set it to `0`.
 
 When `config/openclaw/.env.local` provides `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, the reset verifier prefers local OpenClaw CLI dispatch over the HTTP callback. `OPENCLAW_BASE_URL` and `OPENCLAW_REPAIR_ENDPOINT` remain the fallback for remote OpenClaw receivers.
+
+If the remote repair receiver is bearer-protected, set `OPENCLAW_REPAIR_BEARER_TOKEN`. Harness will send it as `Authorization: Bearer <token>` on the HTTP repair callback path.
 
 That loopback-style fallback is only appropriate for native local development. Do not copy `OPENCLAW_BASE_URL=http://127.0.0.1:...` into hosted Vercel environments, because the reset verifier will not be able to reach your laptop from a serverless runtime.
 

--- a/docs/setup/vercel-neon.md
+++ b/docs/setup/vercel-neon.md
@@ -67,6 +67,8 @@ The reset verifier now also bootstraps its own `reset_contracts` table on first 
 
 For hosted repair dispatch, set `OPENCLAW_BASE_URL` to a real remote receiver that the Vercel runtime can reach. Do not reuse a local development value like `http://127.0.0.1:18789`, because that only points back at the serverless container itself.
 
+If that remote receiver requires bearer authentication, also set `OPENCLAW_REPAIR_BEARER_TOKEN`. Hosted Harness will include it as `Authorization: Bearer <token>` on the repair callback request.
+
 If Harness rejects a completion claim and the OpenClaw repair callback is unreachable, the reset verifier now records the failed claim, moves the contract to `needs_review`, and updates Linear to `In Review`. It no longer returns a transport-only `400` that leaves the contract looking idle.
 
 The backend health endpoint remains:

--- a/modules/reset/openclaw_client.py
+++ b/modules/reset/openclaw_client.py
@@ -58,6 +58,7 @@ class OpenClawRepairClient:
         transport: str | None = None,
         base_url: str | None = None,
         repair_endpoint: str | None = None,
+        bearer_token: str | None = None,
         cli_bin: str | None = None,
         config_path: str | None = None,
         state_dir: str | None = None,
@@ -67,6 +68,7 @@ class OpenClawRepairClient:
     ) -> None:
         self.base_url = (base_url or os.getenv("OPENCLAW_BASE_URL") or "").rstrip("/")
         self.repair_endpoint = repair_endpoint or os.getenv("OPENCLAW_REPAIR_ENDPOINT") or "/repair"
+        self.bearer_token = bearer_token or os.getenv("OPENCLAW_REPAIR_BEARER_TOKEN")
         self.cli_bin = cli_bin or os.getenv("OPENCLAW_BIN") or "openclaw"
         self.config_path = config_path or os.getenv("OPENCLAW_CONFIG_PATH")
         self.state_dir = state_dir or os.getenv("OPENCLAW_STATE_DIR")
@@ -92,10 +94,13 @@ class OpenClawRepairClient:
             raise OpenClawRepairClientError("OPENCLAW_BASE_URL is required")
         url = f"{self.base_url}{self.repair_endpoint}"
         payload = {"linear_issue_id": issue_id, "reason": reason, "contract_id": contract_id}
+        headers = {"Content-Type": "application/json"}
+        if self.bearer_token:
+            headers["Authorization"] = f"Bearer {self.bearer_token}"
         req = request.Request(
             url,
             data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
+            headers=headers,
             method="POST",
         )
         try:

--- a/tests/reset/test_openclaw_client.py
+++ b/tests/reset/test_openclaw_client.py
@@ -23,7 +23,13 @@ class _OpenClawHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         body = self.rfile.read(int(self.headers.get("Content-Length", "0"))).decode("utf-8")
         payload = json.loads(body)
-        _OpenClawHandler.calls.append({"path": self.path, "payload": payload})
+        _OpenClawHandler.calls.append(
+            {
+                "path": self.path,
+                "payload": payload,
+                "headers": dict(self.headers.items()),
+            }
+        )
         encoded = json.dumps({"status": "accepted"}).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -70,6 +76,28 @@ class OpenClawRepairClientTests(unittest.TestCase):
                 "reason": "commit sha does not exist in the expected repository",
                 "contract_id": "contract-1",
             },
+        )
+        self.assertNotIn("Authorization", _OpenClawHandler.calls[0]["headers"])
+
+    def test_request_repair_sends_bearer_token_when_configured(self) -> None:
+        client = OpenClawRepairClient(
+            transport="http",
+            base_url=f"http://127.0.0.1:{self.port}",
+            repair_endpoint="/repair",
+            bearer_token="repair-secret",
+        )
+
+        response = client.request_repair(
+            "KNO-999",
+            reason="commit sha does not exist in the expected repository",
+            contract_id="contract-1",
+        )
+
+        self.assertEqual(response["status"], "accepted")
+        self.assertEqual(len(_OpenClawHandler.calls), 1)
+        self.assertEqual(
+            _OpenClawHandler.calls[0]["headers"].get("Authorization"),
+            "Bearer repair-secret",
         )
 
     def test_cli_transport_invokes_local_openclaw_agent(self) -> None:


### PR DESCRIPTION
## Summary
- add optional bearer-token support for hosted HTTP repair callbacks
- cover both unauthenticated and authenticated callback paths in the OpenClaw repair client tests
- document the new `OPENCLAW_REPAIR_BEARER_TOKEN` env var for local and Vercel setup

## Testing
- python3 -m unittest tests.reset.test_openclaw_client tests.reset.test_service tests.test_fastapi_backend
- python3 -m unittest discover -s tests