### PR TITLE
fix: trust repair callback tls chain

### DIFF
--- a/modules/reset/openclaw_client.py
+++ b/modules/reset/openclaw_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import ssl
 import subprocess
 from typing import Any
 from urllib import error, request
@@ -76,6 +77,7 @@ class OpenClawRepairClient:
         self.session_prefix = (session_prefix or os.getenv("OPENCLAW_REPAIR_SESSION_PREFIX") or "harness-repair").strip()
         self.timeout_seconds = timeout_seconds
         self.transport = transport or os.getenv("OPENCLAW_REPAIR_TRANSPORT") or self._default_transport()
+        self.ssl_context = _build_ssl_context()
 
     def request_repair(self, issue_id: str, *, reason: str, contract_id: str | None = None) -> dict[str, Any]:
         if self.transport == "cli":
@@ -104,7 +106,7 @@ class OpenClawRepairClient:
             method="POST",
         )
         try:
-            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+            with request.urlopen(req, timeout=self.timeout_seconds, context=self.ssl_context) as response:
                 raw_body = response.read().decode("utf-8")
                 return json.loads(raw_body) if raw_body else {"status": "ok"}
         except error.HTTPError as http_error:
@@ -162,6 +164,15 @@ class OpenClawRepairClient:
             detail = payloads[0].get("text") if payloads and isinstance(payloads[0], dict) else "agent run failed"
             raise OpenClawRepairClientError(f"OpenClaw CLI repair dispatch failed: {detail}")
         return payload
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    try:
+        import certifi  # type: ignore
+    except ImportError:
+        return context
+    return ssl.create_default_context(cafile=certifi.where())
 
 
 __all__ = ["OpenClawRepairClient", "OpenClawRepairClientError"]

--- a/tests/reset/test_openclaw_client.py
+++ b/tests/reset/test_openclaw_client.py
@@ -7,6 +7,7 @@ import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from unittest.mock import patch
 
 from modules.reset.openclaw_client import OpenClawRepairClient, OpenClawRepairClientError
 
@@ -99,6 +100,35 @@ class OpenClawRepairClientTests(unittest.TestCase):
             _OpenClawHandler.calls[0]["headers"].get("Authorization"),
             "Bearer repair-secret",
         )
+
+    def test_request_repair_uses_configured_ssl_context_for_https_callbacks(self) -> None:
+        client = OpenClawRepairClient(
+            transport="http",
+            base_url="https://example.com",
+            repair_endpoint="/repair",
+        )
+
+        class _Response:
+            status = 200
+
+            def read(self) -> bytes:
+                return b'{"status":"accepted"}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> None:
+                return None
+
+        with patch("modules.reset.openclaw_client.request.urlopen", return_value=_Response()) as mocked_urlopen:
+            response = client.request_repair(
+                "KNO-999",
+                reason="commit sha does not exist in the expected repository",
+                contract_id="contract-1",
+            )
+
+        self.assertEqual(response["status"], "accepted")
+        self.assertEqual(mocked_urlopen.call_args.kwargs["context"], client.ssl_context)
 
     def test_cli_transport_invokes_local_openclaw_agent(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- make hosted HTTP repair callbacks use the repo standard certifi-backed TLS context
- add regression coverage that asserts HTTPS repair callbacks pass the configured SSL context
- verify the Hermes bridge callback path now returns `retryable_invalid_proof` and `retrying` instead of TLS verification failure

## Testing
- python3 -m unittest tests.reset.test_openclaw_client tests.reset.test_service tests.test_fastapi_backend
- python3 -m unittest discover -s tests