### PR TITLE
docs: add Harness release documentation readiness plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ The repo now also carries a narrower reset-oriented path alongside the broader T
 
 That reset slice is the current fastest path to something operationally useful:
 
-- OpenClaw owns intake, PRD generation, decomposition, Linear issue creation, and Codex dispatch.
+- A desktop agent client such as OpenClaw, Hermes, or a future equivalent owns intake, PRD generation, decomposition, Linear issue creation, and Codex dispatch.
 - Harness owns verification contracts, GitHub proof validation, retry budgeting, and Linear truth updates.
 - Linear is the operator UI for V1.
 - GitHub is the proof source for code-bearing completion.
+
+The current repo still carries OpenClaw-shaped adapter names, routes, config templates, and environment variables for the repair path. Treat those names as the current concrete implementation, not as an architectural requirement.
 
 The reset routes live under:
 
@@ -32,23 +34,23 @@ In hosted Vercel runtimes, the reset slice is not allowed to take the whole back
 - A Python control-plane backend that evaluates canonical `TaskEnvelope` submissions.
 - A read-only Next.js dashboard over canonical inspection APIs.
 - A persistence layer for task snapshots and append-only evaluation history.
-- A thin integration boundary around Linear/manual/OpenClaw ingress and GitHub/Linear fact inputs.
+- A thin integration boundary around Linear/manual/client-specific ingress adapters and GitHub/Linear fact inputs.
 - An operational reconciliation path that can enter `reconciling`, repair missing PR artifacts, and then delegate back into canonical reevaluation.
 
 Harness is not a PM tool, an agent runtime, or a chatbot UI.
-OpenClaw ingress is also intentionally narrow. It can submit task intent, provenance, and planning-ready work into Harness, but it cannot declare `executing` or `completed`, inject executor runtime telemetry, or claim completion on initial handoff. If OpenClaw wants to hand work off as `planned`, it must provide explicit planning-grade objective fields plus a concrete `plan_summary`, and it cannot declare unresolved conditions at the same time. If OpenClaw also supplies parent/dependency/capability structure, that structure must be canonical and non-self-referential before Harness will persist it. If unresolved ambiguity still exists, Harness now converts that upstream signal into canonical clarification and blocks the task instead of letting vague work look ready. Execution and completion truth must still come back through executor/reporting paths that Harness can verify.
+Client-specific ingress adapters are also intentionally narrow. The repo currently includes an OpenClaw-shaped ingress translator, but the same restriction applies to Hermes or any future desktop agent client: it can submit task intent, provenance, and planning-ready work into Harness, but it cannot declare `executing` or `completed`, inject executor runtime telemetry, or claim completion on initial handoff. If a client wants to hand work off as `planned`, it must provide explicit planning-grade objective fields plus a concrete `plan_summary`, and it cannot declare unresolved conditions at the same time. If it also supplies parent/dependency/capability structure, that structure must be canonical and non-self-referential before Harness will persist it. If unresolved ambiguity still exists, Harness now converts that upstream signal into canonical clarification and blocks the task instead of letting vague work look ready. Execution and completion truth must still come back through executor/reporting paths that Harness can verify.
 
-On the inspection side, Harness now also exposes a canonical supervision queue at `GET /supervision/queue`. That queue is a read-only projection for OpenClaw-style supervisors: it surfaces tasks that currently need attention because they are in review, blocked on clarification, retryable, carrying invalid execution proof, waiting on canonical GitHub sync, or stale. It does not authorize actions on its own and it does not replace canonical reevaluation, dispatch, completion-claim, or GitHub sync paths.
+On the inspection side, Harness now also exposes a canonical supervision queue at `GET /supervision/queue`. That queue is a read-only projection for desktop-agent supervisors such as OpenClaw, Hermes, or a future equivalent. It surfaces tasks that currently need attention because they are in review, blocked on clarification, retryable, carrying invalid execution proof, waiting on canonical GitHub sync, or stale. It does not authorize actions on its own and it does not replace canonical reevaluation, dispatch, completion-claim, or GitHub sync paths.
 
 On the execution side, Harness now also contains a real Codex Cloud adapter boundary in addition to the stub dispatch path. That adapter projects canonical dispatch input into a Codex Cloud request shape and enforces the repo/bootstrap preflight contract before it will emit a successful advisory completion signal. Live runtime transport is still a separate integration step, but the proof gate is now encoded at the adapter boundary instead of left to convention.
 
 The same boundary now applies to manual and Linear ingress. Those adapters may submit task intent, coordination metadata, and clarification blockers, but they cannot claim completion, assert acceptance, inject runtime facts, or attach repository execution artifacts such as PRs, commits, branches, or changed-file proofs on initial handoff.
 
-If you are introducing a new ingress such as Hermes, target the canonical `POST /tasks` contract first. The `/ingress/manual`, `/ingress/linear`, and `/ingress/openclaw` routes are translator helpers for those specific payload families, not the universal ingress contract. The source-of-truth ingress shape, prohibited initial-submission fields, and a copyable planning-only example now live in [`docs/api/agent-api-usage.md`](docs/api/agent-api-usage.md) under `Ingress Client Contract`.
+If you are introducing or swapping a desktop agent client such as Hermes, OpenClaw, or a future equivalent, target the canonical `POST /tasks` contract first. The `/ingress/manual`, `/ingress/linear`, and `/ingress/openclaw` routes are translator helpers for those specific payload families, not the universal ingress contract. The source-of-truth ingress shape, prohibited initial-submission fields, and a copyable planning-only example now live in [`docs/api/agent-api-usage.md`](docs/api/agent-api-usage.md) under `Ingress Client Contract`.
 
 That same boundary now applies to the canonical `POST /tasks` and one-shot new-task `POST /evaluate` paths as well. A brand-new task may carry intent, planning state, support artifacts, and clarification blockers, but it may not arrive already carrying execution truth. If a caller tries to create a new task with claimed completion, runtime facts, prevalidated completion evidence, execution attempts, advisory completion claims, reconciliation history, assignment truth, or runtime/terminal lifecycle truth, Harness rejects the request as invalid input instead of storing a polluted task snapshot. Even when initial support artifacts are allowed, Harness strips any caller-submitted `verification_status=verified` before persisting the task so new work cannot begin with pre-certified artifact truth.
 
-That clarification rule also now applies across canonical submission, not just the OpenClaw adapter. If a caller submits unresolved conditions through `POST /tasks`, Harness records canonical clarification, moves the task to `blocked`, and preserves the caller's intended next lifecycle state as `clarification.resume_target_status` instead of pretending the task is already `planned` or `dispatch_ready`. When later reevaluation clears those required inputs, Harness now resumes the task back to that recorded lifecycle target. If the target is `dispatch_ready`, it immediately runs the same automatic-dispatch policy used after ingestion so “ready next” turns into a real execution attempt instead of a passive label. If the target is `assigned`, Harness restores the active assignment instead of leaving the task blocked behind a resolved clarification.
+That clarification rule also now applies across canonical submission, not just the current OpenClaw-named adapter. If a caller submits unresolved conditions through `POST /tasks`, Harness records canonical clarification, moves the task to `blocked`, and preserves the caller's intended next lifecycle state as `clarification.resume_target_status` instead of pretending the task is already `planned` or `dispatch_ready`. When later reevaluation clears those required inputs, Harness now resumes the task back to that recorded lifecycle target. If the target is `dispatch_ready`, it immediately runs the same automatic-dispatch policy used after ingestion so “ready next” turns into a real execution attempt instead of a passive label. If the target is `assigned`, Harness restores the active assignment instead of leaving the task blocked behind a resolved clarification.
 Harness also keeps new-task submission separate from persisted-task mutation. `POST /evaluate` may still evaluate a stored task, but it cannot mutate stored lifecycle, assignment, artifact, or completion-evidence truth through submission-style overlays. Existing tasks must use `POST /tasks/<task_id>/reevaluate` for persisted updates.
 That same fail-closed rule now applies to the persisted-task helpers themselves. `POST /tasks/<task_id>/reevaluate` and `POST /tasks/<task_id>/completion-claims` reject submission-style mutation fields such as `task_envelope`, `task_status`, `assigned_executor`, and `linked_artifacts` instead of silently ignoring them.
 Generic reevaluation is also no longer allowed to combine executor runtime telemetry with repository execution artifacts such as PRs, commits, branches, or changed-file proofs. If a caller is reporting executor-side execution evidence, it must use `POST /tasks/<task_id>/completion-claims`, where Harness records the execution attempt and applies executor-side contract validation before completion can proceed. Fact-only reevaluation can still attach externally synchronized repository artifacts without pretending they came from a fresh executor run.
@@ -147,7 +149,7 @@ These proofs are specific to `missing_pr_after_execution`. They do not claim tha
 The repository also carries planning-only scaffolds for two future capabilities:
 
 - the Harness Evolution Engine (HEE), an advisory subsystem for diagnosing recurring failures and proposing reviewed improvements
-- an OpenClaw executor adapter, a future execution boundary that would keep completion truth, verification, and lifecycle enforcement inside Harness
+- a replaceable desktop-agent executor adapter, with the current concrete example documented in the OpenClaw-shaped adapter note below
 
 See:
 
@@ -273,17 +275,19 @@ Reset-slice verifier environment variables:
 - `LINEAR_API_KEY`
   - Used by the reset verifier to move Linear issues and leave canonical Harness comments
 - `OPENCLAW_BASE_URL`
-  - Optional HTTP fallback used when the reset verifier requests OpenClaw repair through a remote callback endpoint
-  - In hosted Vercel runtimes this must be a remote-reachable OpenClaw receiver, not `127.0.0.1`, `localhost`, or another loopback/private-only address
+  - Optional HTTP fallback used when the reset verifier requests repair through the current OpenClaw-shaped remote callback adapter
+  - In hosted Vercel runtimes this must be a remote-reachable repair receiver, not `127.0.0.1`, `localhost`, or another loopback/private-only address
 - `OPENCLAW_REPAIR_ENDPOINT`
-  - Optional override for the OpenClaw repair callback path
+  - Optional override for the current OpenClaw-shaped repair callback path
 - `OPENCLAW_REPAIR_BEARER_TOKEN`
   - Optional bearer token for authenticated HTTP repair receivers
   - When set, Harness sends `Authorization: Bearer <token>` on hosted repair callbacks
 
 If the reset verifier rejects a claim and the repair callback itself cannot be delivered, Harness now preserves the failed claim, moves the contract into `needs_review`, and updates Linear to `In Review` instead of returning a transport-shaped false negative that leaves the contract looking untouched.
 
-For native local development, `backend.server` now auto-loads both repo-root `.env.local` and `config/openclaw/.env.local`. When the OpenClaw local config exports `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, Harness prefers a local `openclaw agent --local` repair dispatch over the HTTP callback path.
+The `OPENCLAW_*` variable names remain because the current repo-owned repair receiver adapter is OpenClaw-specific today. They should be treated as implementation details, not as the architectural boundary.
+
+For native local development, `backend.server` now auto-loads both repo-root `.env.local` and `config/openclaw/.env.local`. When the current repo-owned OpenClaw local config exports `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, Harness prefers a local `openclaw agent --local` repair dispatch over the HTTP callback path.
 
 Relevant supporting files:
 
@@ -310,7 +314,7 @@ Run the backend with the file store:
 python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
 
-`backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned OpenClaw config/state paths without manual shell export steps.
+`backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 
 Run the backend with Postgres:
 

--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -21,7 +21,7 @@ For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritativ
 - `GET /tasks/<task_id>/evaluations`: append-only evaluation history
 - `GET /tasks/<task_id>/read-model`: canonical current-truth projection for one task
 - `GET /tasks/<task_id>/timeline`: canonical ordered audit timeline for one task
-- `GET /supervision/queue`: canonical attention queue for autonomous supervisors such as OpenClaw
+- `GET /supervision/queue`: canonical attention queue for autonomous supervisors such as OpenClaw, Hermes, or a future desktop agent client
 
 `GET /supervision/queue` is projection-only. It does not create work, mutate task state, or authorize follow-up actions. It exists so an ingress-side supervisor can poll Harness for the tasks that currently need intervention without rebuilding policy client-side from raw task payloads.
 
@@ -34,9 +34,9 @@ Queue entries are derived from canonical read-model and timeline truth and curre
 - `retryable_failure`
 - `stale_active_task`
 
-OpenClaw or another supervisor may use those entries to decide what to inspect next, but the actual task mutation still has to go back through canonical submission, dispatch, completion-claim, or reevaluation paths.
+OpenClaw, Hermes, or another supervisor may use those entries to decide what to inspect next, but the actual task mutation still has to go back through canonical submission, dispatch, completion-claim, or reevaluation paths.
 
-The repository now includes a thin example supervisor loop in [`modules/connectors/openclaw_supervisor.py`](../../modules/connectors/openclaw_supervisor.py). That client does not mutate review, clarification, or proof decisions on its own. It only:
+The repository now includes a thin example supervisor loop in [`modules/connectors/openclaw_supervisor.py`](../../modules/connectors/openclaw_supervisor.py). That file is the current concrete OpenClaw-shaped example, not an architectural requirement. It does not mutate review, clarification, or proof decisions on its own. It only:
 
 - polls `GET /supervision/queue`
 - enriches queue entries with canonical inspection surfaces
@@ -51,7 +51,7 @@ Ingress adapters are intake/planning surfaces, not execution-reporting surfaces.
 
 ## Ingress Client Contract
 
-If you are building a new ingress client such as Hermes, do not start from `/ingress/manual` just because it is easy to hit. The `/ingress/*` routes are source-specific translators. They exist for callers that already have manual-, Linear-, or OpenClaw-shaped payloads.
+If you are building or swapping a direct ingress client such as Hermes, OpenClaw, or a future equivalent, do not start from `/ingress/manual` just because it is easy to hit. The `/ingress/*` routes are source-specific translators. They exist for callers that already have manual-, Linear-, or OpenClaw-shaped payloads.
 
 For a new ingress that wants to speak Harness directly, the stable contract is:
 
@@ -98,7 +98,7 @@ If the ingress needs to report completion, runtime telemetry, repository proof, 
 
 ### Planning-Only Example
 
-This is a canonical planning-only payload for a generic ingress client. Replace `{{now_iso}}` and `{{run_id}}` before sending.
+This is a canonical planning-only payload for a generic ingress client. It uses Hermes as the example name only. Replace `{{now_iso}}`, `{{run_id}}`, and the client-specific metadata before sending.
 
 ```json
 {

--- a/docs/architecture/openclaw-executor-adapter.md
+++ b/docs/architecture/openclaw-executor-adapter.md
@@ -1,40 +1,42 @@
-# OpenClaw Executor Adapter
+# Desktop Agent Executor Adapter (OpenClaw Example)
 
 ## Purpose
 
-Define the future adapter boundary that would allow Harness to use OpenClaw as an execution engine while keeping lifecycle truth, verification, and completion enforcement inside Harness.
+Define the future adapter boundary that would allow Harness to use a desktop agent client as an execution engine while keeping lifecycle truth, verification, and completion enforcement inside Harness.
 
-This document is planning-only. It does not add a working OpenClaw execution integration.
+This document is planning-only. It does not add a working execution integration.
+
+The file keeps its existing OpenClaw-oriented path because the current spike and local adapter work in this repo are OpenClaw-shaped. The architectural constraints here are meant to apply equally to Hermes or a future desktop agent client.
 
 ## Scope
 
 This architecture definition is limited to:
 
-- executor-side boundary definition for a future OpenClaw adapter
+- executor-side boundary definition for a future desktop-agent adapter, using OpenClaw as the current concrete example
 - separation between ingress/client behavior and executor behavior
 - explicit constraints that preserve Harness as lifecycle and completion authority
 
 ## Why It Exists
 
-The repository already contains an ingress-side OpenClaw spike proving that OpenClaw can act as a thin client against Harness's public API.
+The repository already contains an ingress-side OpenClaw spike proving that one desktop agent client can act as a thin client against Harness's public API.
 
 A future executor adapter is a different concern:
 
 - ingress answers how work enters Harness
-- executor adaptation answers how assigned work could later be executed by OpenClaw
+- executor adaptation answers how assigned work could later be executed by a desktop agent client
 
 Keeping those concerns separate protects the core design:
 
 - Harness remains the control plane
-- OpenClaw remains replaceable
+- the desktop agent client remains replaceable
 - completion remains evidence-backed instead of executor-declared
 
 ## Responsibilities
 
-The future OpenClaw executor adapter should own only execution-boundary concerns such as:
+The future desktop-agent executor adapter should own only execution-boundary concerns such as:
 
-- mapping canonical assigned-task data into an OpenClaw execution request
-- translating OpenClaw runtime events into canonical execution facts
+- mapping canonical assigned-task data into a client-specific execution request
+- translating client runtime events into canonical execution facts
 - normalizing produced artifacts, outputs, and trace references
 - returning completion claims to Harness for verification instead of accepting them directly
 - preserving provenance needed for audit and reevaluation
@@ -56,15 +58,15 @@ The adapter must not:
 This architecture definition explicitly does **not** include:
 
 - implementing OpenClaw API wiring
-- implementing a production-ready OpenClaw runtime integration
-- making OpenClaw the source of lifecycle truth, completion truth, or policy decisions
+- implementing a production-ready desktop-agent runtime integration
+- making any desktop agent client the source of lifecycle truth, completion truth, or policy decisions
 
 ## Inputs
 
 Expected adapter inputs:
 
 - canonical `TaskEnvelope` data for a task in an execution-ready state
-- assignment metadata identifying OpenClaw as the selected executor
+- assignment metadata identifying the selected client or executor
 - execution attempt context from Harness runtime or dispatch layers
 - constraints, acceptance criteria, artifact expectations, and provenance metadata
 
@@ -83,7 +85,7 @@ The adapter output is execution telemetry and artifact references, not trusted c
 
 ### TaskEnvelope
 
-`TaskEnvelope` remains canonical. The adapter may project a subset into an OpenClaw request, but OpenClaw-specific request shape must not become the source of truth.
+`TaskEnvelope` remains canonical. The adapter may project a subset into a client-specific request, but that request shape must not become the source of truth.
 
 ### Lifecycle States
 
@@ -95,7 +97,7 @@ The adapter is a likely producer of normalized execution-trace references. Those
 
 ### Artifacts And Proof Of Completion
 
-Artifacts produced through OpenClaw remain subject to Harness verification, reconciliation, and manual review rules. An OpenClaw success report is advisory only.
+Artifacts produced through a desktop agent client remain subject to Harness verification, reconciliation, and manual review rules. A client success report is advisory only.
 
 ## Relationship To The Existing OpenClaw Spike
 
@@ -108,21 +110,21 @@ This future adapter would be separate and executor-facing. It should not reuse t
 To preserve executor replaceability:
 
 - Harness-facing adapter APIs should remain executor-generic instead of OpenClaw-specific.
-- OpenClaw-specific request/response details should stay inside adapter translation code.
+- client-specific request/response details should stay inside adapter translation code.
 - Control-plane policies (evaluation outcomes, lifecycle transitions, review gates, reconciliation) must remain in Harness modules.
-- Any future executor can implement the same canonical adapter contract without changing TaskEnvelope semantics.
+- Any future desktop agent client or executor can implement the same canonical adapter contract without changing TaskEnvelope semantics.
 
 ## Future Implementation Notes
 
-- Define a stable executor-adapter contract before any OpenClaw API wiring.
+- Define a stable executor-adapter contract before any client-specific API wiring.
 - Intercept completion claims and route them through canonical Harness verification rather than accepting executor status as terminal truth.
-- Keep OpenClaw payload mapping explicit so executor-specific fields stay outside control-plane contracts.
+- Keep client-specific payload mapping explicit so executor-specific fields stay outside control-plane contracts.
 - Preserve replaceability by keeping the adapter contract generic enough for other executors.
 - Treat execution traces and artifact references as first-class outputs from the adapter boundary.
 
 ## Boundary Summary
 
-OpenClaw may become a future execution backend.
+A desktop agent client such as OpenClaw or Hermes may become a future execution backend.
 
 Harness still owns truth.
 

--- a/docs/architecture/system-context.md
+++ b/docs/architecture/system-context.md
@@ -8,7 +8,7 @@ Define the top-level system model before implementation so future modules do not
 
 Harness sits underneath the user-facing and agent-facing work surface as the system that enforces correctness.
 
-- OpenClaw is the ingress layer.
+- A desktop agent client such as OpenClaw, Hermes, or a future equivalent is the ingress layer.
 - Linear is the human-and-agent work surface and the source of truth for structured work.
 - Harness is the control plane and reliability layer beneath that work surface.
 - GitHub is the source of truth for code artifacts such as pull requests and commits.
@@ -28,7 +28,7 @@ An editable Excalidraw version also lives in [system-context.excalidraw](system-
 
 ```mermaid
 flowchart LR
-    U["User"] --> O["OpenClaw\nIngress and clarification"]
+    U["User"] --> O["Desktop Agent Client\nIngress and clarification"]
     O --> L["Linear\nWork surface and structured work source of truth"]
     L --> H["Harness\nControl plane and reliability layer"]
     H --> G["GitHub\nArtifact evidence source of truth"]
@@ -41,7 +41,7 @@ flowchart LR
 
 ## Responsibilities By System
 
-### OpenClaw
+### Desktop Agent Client
 
 - collects user intent
 - asks follow-up questions when intent is ambiguous
@@ -88,7 +88,7 @@ flowchart LR
 
 ## Boundary Rules
 
-- OpenClaw does not become the durable orchestrator.
+- Desktop agent clients do not become the durable orchestrator.
 - Harness does not become the user interface.
 - Linear owns work coordination and structured work records, not completion enforcement semantics.
 - GitHub owns artifact evidence records, not lifecycle policy.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -56,7 +56,7 @@ pnpm build
 python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
 
-`backend.server` now auto-loads repo-root `.env.local` during native local startup. It also loads `config/openclaw/.env.local` when present so local OpenClaw config and state paths do not need to be duplicated into the shell environment.
+`backend.server` now auto-loads repo-root `.env.local` during native local startup. It also loads `config/openclaw/.env.local` when present so the current repo-owned desktop-agent config and state paths do not need to be duplicated into the shell environment.
 
 For the reset verifier slice, put these in repo-root `.env.local`:
 
@@ -67,9 +67,11 @@ For the reset verifier slice, put these in repo-root `.env.local`:
 - optional `OPENCLAW_REPAIR_BEARER_TOKEN`
 - optional `HARNESS_RESET_POLL_SECONDS`
 
-`HARNESS_RESET_POLL_SECONDS` controls how long Harness waits before `/reset/tick` asks OpenClaw to retry a contract already in `retrying`. The production default is `900` seconds. For deterministic local test loops, set it to `0`.
+The `OPENCLAW_*` names remain because the current repair receiver adapter in the repo is OpenClaw-shaped. They are operational names, not the architectural boundary.
 
-When `config/openclaw/.env.local` provides `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, the reset verifier prefers local OpenClaw CLI dispatch over the HTTP callback. `OPENCLAW_BASE_URL` and `OPENCLAW_REPAIR_ENDPOINT` remain the fallback for remote OpenClaw receivers.
+`HARNESS_RESET_POLL_SECONDS` controls how long Harness waits before `/reset/tick` asks the configured repair receiver to retry a contract already in `retrying`. The production default is `900` seconds. For deterministic local test loops, set it to `0`.
+
+When `config/openclaw/.env.local` provides `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, the reset verifier prefers the current repo-owned OpenClaw CLI dispatch over the HTTP callback. `OPENCLAW_BASE_URL` and `OPENCLAW_REPAIR_ENDPOINT` remain the fallback for remote repair receivers.
 
 If the remote repair receiver is bearer-protected, set `OPENCLAW_REPAIR_BEARER_TOKEN`. Harness will send it as `Authorization: Bearer <token>` on the HTTP repair callback path.
 
@@ -107,7 +109,7 @@ Use this path when you want Harness to:
 
 - register a Linear issue verification contract
 - verify GitHub proof for a claimed completion
-- trigger OpenClaw repair on invalid proof
+- trigger repair dispatch on invalid proof
 - escalate to `In Review` after the retry budget is exhausted
 
 ### Reset Verifier Dry Runs
@@ -122,7 +124,7 @@ python3 -m modules.reset_dryrun review
 These commands:
 
 - start a temporary local FastAPI app
-- hit the `/reset/*` routes through the thin OpenClaw-style HTTP client
+- hit the `/reset/*` routes through the current thin desktop-agent HTTP client implementation
 - avoid mutating real Linear or GitHub state
 - prove the two operator-critical paths:
   - retryable invalid proof that later verifies successfully
@@ -142,7 +144,21 @@ That live smoke:
 - creates real branches, commits, and pull requests in `sfayka/HARNESS-DRYRUN`
 - runs the happy path first
 - then runs real GitHub-backed unhappy paths for missing PR linkage and wrong SHA review escalation
-- keeps OpenClaw simulated so the only live systems are Harness, Linear, and GitHub
+- keeps the desktop-agent repair side simulated so the only live systems are Harness, Linear, and GitHub
+
+### Next Reset Verifier Test Steps
+
+The next staged test sequence is documented in:
+
+- [`docs/superpowers/plans/2026-04-18-reset-verifier-next-test-steps.md`](../superpowers/plans/2026-04-18-reset-verifier-next-test-steps.md)
+
+That plan moves in five stages:
+
+- deterministic local reset baseline
+- local live smoke against Linear and GitHub
+- hosted callback reachability proof
+- hosted end-to-end remote repair proof
+- generic desktop-agent contract smoke through canonical `/tasks` and `/supervision/queue`
 
 ### Run The Dashboard
 

--- a/docs/setup/openclaw-local.md
+++ b/docs/setup/openclaw-local.md
@@ -1,8 +1,10 @@
 # OpenClaw Local Bootstrap
 
+This document covers one concrete local client implementation. Harness is not architecturally tied to OpenClaw. Hermes or a future desktop agent client can fill the same ingress or supervision role as long as it speaks the canonical Harness boundaries. This file keeps the OpenClaw name because the current repo-owned scripts, config template, and local bootstrap path are OpenClaw-specific.
+
 This document defines a local-first, deterministic OpenClaw bring-up path for Harness.
 
-The goal is not broad Harness ↔ OpenClaw integration yet. The goal is a reproducible macOS-oriented install and config scaffold that avoids interactive onboarding, keeps config explicit, and gives future adapter work a stable base.
+The goal is not broad Harness ↔ OpenClaw integration yet. The goal is a reproducible macOS-oriented install and config scaffold for one current client implementation that avoids interactive onboarding, keeps config explicit, and gives future adapter work a stable base.
 
 ## Why Local-First
 

--- a/docs/setup/vercel-neon.md
+++ b/docs/setup/vercel-neon.md
@@ -65,9 +65,11 @@ psql "$POSTGRES_URL" -f sql/postgres/001_harness_store.sql
 
 The reset verifier now also bootstraps its own `reset_contracts` table on first Postgres access if that slice has not been migrated yet. That protects hosted `/backend/reset/*` routes from failing with opaque `500` errors when the canonical task schema exists but the reset slice has not been applied yet.
 
-For hosted repair dispatch, set `OPENCLAW_BASE_URL` to a real remote receiver that the Vercel runtime can reach. Do not reuse a local development value like `http://127.0.0.1:18789`, because that only points back at the serverless container itself.
+For hosted repair dispatch, set `OPENCLAW_BASE_URL` to the real remote repair receiver for the current desktop-agent client implementation. Do not reuse a local development value like `http://127.0.0.1:18789`, because that only points back at the serverless container itself.
 
 If that remote receiver requires bearer authentication, also set `OPENCLAW_REPAIR_BEARER_TOKEN`. Hosted Harness will include it as `Authorization: Bearer <token>` on the repair callback request.
+
+The variable names remain `OPENCLAW_*` because the current callback adapter is OpenClaw-shaped today. Treat those names as operational wiring, not as the architectural boundary.
 
 If Harness rejects a completion claim and the OpenClaw repair callback is unreachable, the reset verifier now records the failed claim, moves the contract to `needs_review`, and updates Linear to `In Review`. It no longer returns a transport-only `400` that leaves the contract looking idle.
 

--- a/docs/superpowers/plans/2026-04-18-harness-release-documentation-readiness.md
+++ b/docs/superpowers/plans/2026-04-18-harness-release-documentation-readiness.md
@@ -1,0 +1,573 @@
+# Harness Release Documentation Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring Harness documentation to release-readiness by making it current, accurate, readable, screenshot-backed, and complete across setup, configuration, testing, operation, and validation.
+
+**Architecture:** Treat the docs as a product surface, not as a loose collection of notes. First run a reality audit against the current code and local runtime, then rebuild the reader-facing flow around a small how-to set, then capture deterministic screenshots from real local runs, and finally run a strict release QA pass so no command, route, screenshot, or file path drifts from the code. Preserve the current OpenClaw-shaped implementation details where the code still uses them, but explain them as replaceable client adapters rather than product truth.
+
+**Tech Stack:** Markdown docs, Python `unittest`, FastAPI, local `uvicorn`, Next.js dashboard, deterministic demo walkthroughs, reset dry runs, live reset smoke, canonical Harness `/tasks`, `/reset/*`, `/sync/github`, and `/supervision/queue` routes, screenshot assets checked into the repo
+
+---
+
+## File Map
+
+- `README.md`
+  Reframe the top-level product story, docs map, screenshot references, and release-facing quick links.
+
+- `docs/setup/local-development.md`
+  Keep as the operator runbook for local setup, local testing, and local reset flows.
+
+- `docs/setup/vercel-neon.md`
+  Keep as the hosted deployment and hosted verification runbook.
+
+- `docs/setup/openclaw-local.md`
+  Keep as the current concrete bootstrap doc for one local client implementation while making the architecture brand-agnostic.
+
+- `docs/api/agent-api-usage.md`
+  Keep as the source-of-truth API boundary doc for ingress, reevaluation, sync, dispatch, and supervision.
+
+- `docs/architecture/system-context.md`
+  Keep as the source-of-truth architecture framing doc.
+
+- `docs/demo/operator-walkthrough.md`
+  Keep as the deterministic seeded-flow operator walkthrough for dashboard screenshots and demo narration.
+
+- `docs/howto/index.md`
+  Create as the reader-facing documentation index for release use.
+
+- `docs/howto/local-quickstart.md`
+  Create as the shortest credible start-here guide for first-time local users.
+
+- `docs/howto/configure-harness.md`
+  Create as the configuration guide covering required env vars, optional overrides, storage selection, and current repair-receiver wiring.
+
+- `docs/howto/test-and-validate.md`
+  Create as the end-to-end testing and validation guide, including dry runs, local live smoke, hosted callback smoke, and what counts as proof.
+
+- `docs/howto/use-harness.md`
+  Create as the how-to for day-one use: submit work, inspect task truth, use the reset verifier, read the supervision queue, and judge whether Harness is actually working.
+
+- `docs/howto/troubleshoot.md`
+  Create as the operator troubleshooting guide for startup failures, env mistakes, hosted reset issues, unreachable repair callbacks, and bad-proof loops.
+
+- `docs/howto/images/local-dashboard-tasks.png`
+- `docs/howto/images/local-dashboard-task-detail.png`
+- `docs/howto/images/local-dashboard-reviews.png`
+- `docs/howto/images/reset-dryrun-verified.png`
+- `docs/howto/images/reset-dryrun-review.png`
+- `docs/howto/images/health-check-response.png`
+  Create as screenshot assets referenced directly by the new how-to docs.
+
+- `docs/release/documentation-readiness-checklist.md`
+  Create as the final ship gate for docs completeness and verification evidence.
+
+### Task 1: Run The Documentation Reality Audit Against The Current Product
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/setup/local-development.md`
+- Modify: `docs/setup/vercel-neon.md`
+- Modify: `docs/api/agent-api-usage.md`
+- Modify: `docs/architecture/system-context.md`
+- Reference: `backend/server.py`
+- Reference: `modules/reset/service.py`
+- Reference: `modules/reset_live_smoke.py`
+- Reference: `docs/demo/operator-walkthrough.md`
+
+- [ ] **Step 1: Start from a clean install and verify the documented local commands still work**
+
+Run:
+
+```bash
+python3 -m pip install -r requirements.txt
+pnpm install --frozen-lockfile
+python3 -m unittest tests.test_fastapi_backend tests.test_reset_dryrun tests.test_autonomous_dryrun tests.test_unattended_dryruns -v
+pnpm lint
+pnpm build
+```
+
+Expected:
+- backend validation passes
+- frontend lint and build pass
+- any command drift is found before doc rewriting starts
+
+- [ ] **Step 2: Run the documented local API and dashboard startup exactly as written**
+
+Run in one terminal:
+
+```bash
+python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
+```
+
+Run in another terminal:
+
+```bash
+pnpm dev
+```
+
+Expected:
+- backend responds on `http://127.0.0.1:8000/health`
+- dashboard responds on `http://127.0.0.1:3000`
+- no undocumented env prerequisite blocks startup
+
+- [ ] **Step 3: Verify the current docs against the running product and write down every mismatch before editing prose**
+
+Check:
+- `README.md`
+- `docs/setup/local-development.md`
+- `docs/setup/vercel-neon.md`
+- `docs/api/agent-api-usage.md`
+- `docs/architecture/system-context.md`
+
+Expected:
+- a concrete mismatch list with exact file paths, commands, or route names
+- no vague note like "docs feel stale"
+
+- [ ] **Step 4: Commit the audit-driven corrections before broader restructuring**
+
+```bash
+git add README.md docs/setup/local-development.md docs/setup/vercel-neon.md docs/api/agent-api-usage.md docs/architecture/system-context.md
+git commit -m "docs: correct release-facing command and boundary drift"
+```
+
+### Task 2: Build The Reader-Facing Documentation Information Architecture
+
+**Files:**
+- Create: `docs/howto/index.md`
+- Modify: `README.md`
+- Modify: `docs/setup/local-development.md`
+- Modify: `docs/setup/vercel-neon.md`
+- Modify: `docs/demo/operator-walkthrough.md`
+
+- [ ] **Step 1: Create the new reader-facing documentation index**
+
+Create:
+
+````markdown
+# Harness How-To Index
+
+Start here if you want to run, verify, and trust Harness without reading the full architecture set first.
+
+## Start Here
+
+- [Local Quickstart](./local-quickstart.md)
+- [Configure Harness](./configure-harness.md)
+- [Use Harness](./use-harness.md)
+- [Test And Validate](./test-and-validate.md)
+- [Troubleshoot](./troubleshoot.md)
+
+## Source-Of-Truth References
+
+- [Agent API Usage](../api/agent-api-usage.md)
+- [System Context](../architecture/system-context.md)
+- [Local Development](../setup/local-development.md)
+- [Vercel + Neon Deployment](../setup/vercel-neon.md)
+- [Operator Demo Walkthrough](../demo/operator-walkthrough.md)
+````
+
+- [ ] **Step 2: Update the top-level README docs section so release readers land in the how-to flow first**
+
+Modify the docs map in `README.md` so it leads with:
+
+````markdown
+## Docs And Screenshots
+
+Start here:
+
+- [`docs/howto/index.md`](docs/howto/index.md)
+- [`docs/howto/local-quickstart.md`](docs/howto/local-quickstart.md)
+- [`docs/howto/test-and-validate.md`](docs/howto/test-and-validate.md)
+
+Source-of-truth references:
+
+- [`docs/api/agent-api-usage.md`](docs/api/agent-api-usage.md)
+- [`docs/architecture/system-context.md`](docs/architecture/system-context.md)
+- [`docs/setup/local-development.md`](docs/setup/local-development.md)
+- [`docs/setup/vercel-neon.md`](docs/setup/vercel-neon.md)
+- [`docs/demo/operator-walkthrough.md`](docs/demo/operator-walkthrough.md)
+````
+
+- [ ] **Step 3: Remove duplicated navigation detours from the setup docs**
+
+Update:
+- `docs/setup/local-development.md`
+- `docs/setup/vercel-neon.md`
+
+Expected:
+- those docs stay focused on execution details
+- they do not compete with the new how-to index for orientation
+
+- [ ] **Step 4: Commit the doc IA changes**
+
+```bash
+git add README.md docs/howto/index.md docs/setup/local-development.md docs/setup/vercel-neon.md docs/demo/operator-walkthrough.md
+git commit -m "docs: add release-facing how-to index"
+```
+
+### Task 3: Write The Setup And Configuration Guides That Real Users Can Follow
+
+**Files:**
+- Create: `docs/howto/local-quickstart.md`
+- Create: `docs/howto/configure-harness.md`
+- Modify: `docs/setup/local-development.md`
+- Modify: `docs/setup/vercel-neon.md`
+- Modify: `docs/setup/openclaw-local.md`
+
+- [ ] **Step 1: Write the local quickstart as the shortest credible path from clone to running system**
+
+Create:
+
+````markdown
+# Local Quickstart
+
+## Goal
+
+Get Harness running locally with a healthy backend, a working dashboard, and one proof that the system is behaving correctly.
+
+## 1. Install dependencies
+
+```bash
+python3 -m pip install -r requirements.txt
+pnpm install --frozen-lockfile
+```
+
+## 2. Set local environment
+
+Create repo-root `.env.local` with:
+
+```bash
+GITHUB_TOKEN=...
+LINEAR_API_KEY=...
+HARNESS_API_BASE_URL=http://127.0.0.1:8000
+```
+
+## 3. Start the backend
+
+```bash
+python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
+```
+
+## 4. Start the dashboard
+
+```bash
+pnpm dev
+```
+
+## 5. Verify the backend is healthy
+
+```bash
+curl -sS http://127.0.0.1:8000/health
+```
+
+## 6. Run one deterministic reset proof
+
+```bash
+python3 -m modules.reset_dryrun success
+```
+````
+
+- [ ] **Step 2: Write the configuration guide with exact required and optional variables**
+
+Create:
+
+````markdown
+# Configure Harness
+
+## Required for reset verifier work
+
+- `GITHUB_TOKEN`
+- `LINEAR_API_KEY`
+
+## Storage selection
+
+- `HARNESS_STORE_BACKEND=file`
+- `HARNESS_STORE_BACKEND=postgres`
+- `DATABASE_URL`
+- `POSTGRES_URL`
+
+## Current repair receiver wiring
+
+- `OPENCLAW_BASE_URL`
+- `OPENCLAW_REPAIR_ENDPOINT`
+- `OPENCLAW_REPAIR_BEARER_TOKEN`
+- `OPENCLAW_CONFIG_PATH`
+- `OPENCLAW_STATE_DIR`
+
+The `OPENCLAW_*` names remain because the current concrete repair receiver adapter is OpenClaw-shaped today. They are not the product boundary.
+````
+
+- [ ] **Step 3: Tighten the setup docs so they agree with the new guides instead of partially overlapping them**
+
+Modify:
+- `docs/setup/local-development.md`
+- `docs/setup/vercel-neon.md`
+- `docs/setup/openclaw-local.md`
+
+Expected:
+- setup docs hold operational detail
+- the new how-to docs hold the reader-first narrative
+
+- [ ] **Step 4: Commit the setup and configuration guides**
+
+```bash
+git add docs/howto/local-quickstart.md docs/howto/configure-harness.md docs/setup/local-development.md docs/setup/vercel-neon.md docs/setup/openclaw-local.md
+git commit -m "docs: add setup and configuration guides"
+```
+
+### Task 4: Write The Testing, Validation, And Troubleshooting Guides
+
+**Files:**
+- Create: `docs/howto/test-and-validate.md`
+- Create: `docs/howto/troubleshoot.md`
+- Modify: `docs/superpowers/plans/2026-04-18-reset-verifier-next-test-steps.md`
+- Modify: `docs/api/agent-api-usage.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write the testing and validation guide with staged commands**
+
+Create:
+
+````markdown
+# Test And Validate Harness
+
+## Fast local baseline
+
+```bash
+python3 -m unittest tests.test_fastapi_backend tests.test_reset_dryrun tests.test_autonomous_dryrun tests.test_unattended_dryruns -v
+```
+
+## Deterministic reset verifier proofs
+
+```bash
+python3 -m modules.reset_dryrun success
+python3 -m modules.reset_dryrun review
+```
+
+## Local live smoke
+
+```bash
+HARNESS_RUN_LIVE_RESET_TESTS=1 python3 -m unittest tests.test_reset_live_smoke -v
+```
+
+## What counts as proof
+
+- healthy `/health` response
+- deterministic dry-run verdicts
+- live Linear issue identifiers
+- live GitHub branch, commit, and PR artifacts
+- canonical read-model or reset contract state that matches the external artifacts
+````
+
+- [ ] **Step 2: Write the troubleshooting guide around real failure modes already present in the repo**
+
+Create:
+
+````markdown
+# Troubleshoot Harness
+
+## Backend starts but `/reset/*` is unavailable
+- check database configuration
+- check reset temp store fallback
+- check startup logs for reset service initialization errors
+
+## Dashboard loads but shows no real data
+- verify `HARNESS_API_BASE_URL`
+- verify backend reachability
+- verify the dashboard is not pointing at a stale hosted backend
+
+## Reset verifier cannot dispatch repair
+- verify `OPENCLAW_BASE_URL`
+- verify the remote receiver is reachable from the runtime
+- verify bearer token configuration
+- verify local `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` when using the local CLI path
+
+## Claim says complete but Harness does not accept it
+- verify repository
+- verify branch
+- verify commit SHA
+- verify PR URL or PR number
+- verify current-run proof instead of historical or unrelated branch reuse
+````
+
+- [ ] **Step 3: Align the how-to with the existing staged reset-test plan**
+
+Modify:
+- `docs/superpowers/plans/2026-04-18-reset-verifier-next-test-steps.md`
+
+Expected:
+- the narrow reset verifier plan and the reader-facing validation guide do not contradict each other
+
+- [ ] **Step 4: Commit the testing and troubleshooting guides**
+
+```bash
+git add docs/howto/test-and-validate.md docs/howto/troubleshoot.md docs/superpowers/plans/2026-04-18-reset-verifier-next-test-steps.md docs/api/agent-api-usage.md README.md
+git commit -m "docs: add testing, validation, and troubleshooting guides"
+```
+
+### Task 5: Run Harness Locally And Capture Deterministic Screenshot Assets
+
+**Files:**
+- Create: `docs/howto/images/local-dashboard-tasks.png`
+- Create: `docs/howto/images/local-dashboard-task-detail.png`
+- Create: `docs/howto/images/local-dashboard-reviews.png`
+- Create: `docs/howto/images/reset-dryrun-verified.png`
+- Create: `docs/howto/images/reset-dryrun-review.png`
+- Create: `docs/howto/images/health-check-response.png`
+- Modify: `docs/howto/use-harness.md`
+- Modify: `docs/demo/operator-walkthrough.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Seed deterministic dashboard state before taking any screenshots**
+
+Run:
+
+```bash
+python3 -m modules.demo_walkthrough reset --store-root .demo-store --output-dir demo-output/walkthrough
+HARNESS_STORE_ROOT=.demo-store python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
+pnpm dev
+python3 -m modules.demo_walkthrough seed \
+  --base-url http://127.0.0.1:8000 \
+  --dashboard-url http://127.0.0.1:3000 \
+  --output-dir demo-output/walkthrough
+```
+
+Expected:
+- seeded tasks exist at deterministic local URLs
+- screenshots are taken from stable state instead of ad hoc live data
+
+- [ ] **Step 2: Capture the health and reset-verifier screenshots from real local runs**
+
+Run:
+
+```bash
+curl -sS http://127.0.0.1:8000/health > /tmp/harness-health.json
+python3 -m modules.reset_dryrun success
+python3 -m modules.reset_dryrun review
+```
+
+Save screenshots as:
+- `docs/howto/images/health-check-response.png`
+- `docs/howto/images/reset-dryrun-verified.png`
+- `docs/howto/images/reset-dryrun-review.png`
+
+Expected:
+- every screenshot reflects a real local run in the current repo
+
+- [ ] **Step 3: Capture the dashboard screenshots from the seeded walkthrough**
+
+Save screenshots as:
+- `docs/howto/images/local-dashboard-tasks.png`
+- `docs/howto/images/local-dashboard-task-detail.png`
+- `docs/howto/images/local-dashboard-reviews.png`
+
+Expected:
+- task list, task detail, and review surfaces are visible and readable
+- no stale screenshots from older product states remain referenced
+
+- [ ] **Step 4: Write the usage guide around those exact screenshots**
+
+Create:
+
+````markdown
+# Use Harness
+
+## 1. Check backend health
+
+See `docs/howto/images/health-check-response.png`.
+
+## 2. Open the dashboard
+
+See `docs/howto/images/local-dashboard-tasks.png`.
+
+## 3. Inspect one task's canonical truth
+
+See `docs/howto/images/local-dashboard-task-detail.png`.
+
+## 4. Understand review and intervention surfaces
+
+See `docs/howto/images/local-dashboard-reviews.png`.
+
+## 5. Validate the reset verifier loop
+
+See `docs/howto/images/reset-dryrun-verified.png` and `docs/howto/images/reset-dryrun-review.png`.
+````
+
+- [ ] **Step 5: Commit the screenshot-backed how-to**
+
+```bash
+git add docs/howto/use-harness.md docs/howto/images docs/demo/operator-walkthrough.md README.md
+git commit -m "docs: add screenshot-backed usage guide"
+```
+
+### Task 6: Run The Final Release Documentation QA Pass
+
+**Files:**
+- Create: `docs/release/documentation-readiness-checklist.md`
+- Modify: `README.md`
+- Modify: `docs/howto/index.md`
+- Modify: `docs/howto/local-quickstart.md`
+- Modify: `docs/howto/configure-harness.md`
+- Modify: `docs/howto/test-and-validate.md`
+- Modify: `docs/howto/use-harness.md`
+- Modify: `docs/howto/troubleshoot.md`
+
+- [ ] **Step 1: Create the final release checklist**
+
+Create:
+
+````markdown
+# Documentation Readiness Checklist
+
+- [ ] every command in the reader-facing docs was run in this repo
+- [ ] every route name matches the current backend
+- [ ] every env var name matches the current code
+- [ ] every screenshot comes from the current product state
+- [ ] every screenshot is referenced from at least one doc
+- [ ] quickstart works from clone to health check
+- [ ] test guide works from deterministic dry runs through live smoke
+- [ ] setup docs explain current OpenClaw-shaped env names without making the architecture vendor-specific
+- [ ] README points readers to the right first doc
+- [ ] no doc still describes an older product than the code
+````
+
+- [ ] **Step 2: Run the final documentation verification commands**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests
+pnpm lint
+pnpm build
+git diff --check
+rg -n "TODO|TBD|coming soon|placeholder" README.md docs
+```
+
+Expected:
+- tests pass
+- frontend validation passes
+- no whitespace issues
+- no release-facing placeholder language remains
+
+- [ ] **Step 3: Spot-check all new and modified doc links and screenshot references**
+
+Check:
+- `README.md`
+- `docs/howto/index.md`
+- `docs/howto/local-quickstart.md`
+- `docs/howto/configure-harness.md`
+- `docs/howto/test-and-validate.md`
+- `docs/howto/use-harness.md`
+- `docs/howto/troubleshoot.md`
+- `docs/release/documentation-readiness-checklist.md`
+
+Expected:
+- all internal links resolve
+- all screenshot paths exist
+
+- [ ] **Step 4: Commit the release QA pass**
+
+```bash
+git add README.md docs/howto docs/release/documentation-readiness-checklist.md
+git commit -m "docs: add release-readiness documentation checklist"
+```

--- a/docs/superpowers/plans/2026-04-18-reset-verifier-next-test-steps.md
+++ b/docs/superpowers/plans/2026-04-18-reset-verifier-next-test-steps.md
@@ -1,0 +1,230 @@
+# Reset Verifier Next Test Steps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the reset verifier loop across local and hosted environments without tying the product to OpenClaw, Hermes, or any single desktop agent client.
+
+**Architecture:** Run the next test sequence in layers. Start with deterministic local proof, then add live Linear and GitHub, then prove hosted repair reachability, then prove hosted end-to-end repair, and finally prove that a non-OpenClaw client can still use the canonical Harness boundaries. Keep the current `OPENCLAW_*` env names where the code requires them, but treat them as adapter wiring rather than product truth.
+
+**Tech Stack:** Python `unittest`, FastAPI, local `uvicorn`, GitHub REST, Linear GraphQL, Vercel-hosted FastAPI service, current OpenClaw-shaped repair callback adapter, canonical Harness `/tasks`, `/reset/*`, `/sync/github`, and `/supervision/queue` routes
+
+---
+
+### Task 1: Reconfirm The Deterministic Local Reset Baseline
+
+**Files:**
+- Reference: `docs/setup/local-development.md`
+- Test: `tests/test_reset_dryrun.py`
+- Test: `tests/reset/test_service.py`
+- Test: `tests/reset/test_scenarios.py`
+- Test: `tests/reset/test_openclaw_client.py`
+
+- [ ] **Step 1: Run the deterministic reset dry runs**
+
+Run:
+
+```bash
+python3 -m modules.reset_dryrun success
+python3 -m modules.reset_dryrun review
+```
+
+Expected:
+- the success path ends in `verified_done`
+- the review path ends in `needs_review`
+
+- [ ] **Step 2: Run the focused reset verifier unit tests**
+
+Run:
+
+```bash
+python3 -m unittest \
+  tests.test_reset_dryrun \
+  tests.reset.test_service \
+  tests.reset.test_scenarios \
+  tests.reset.test_openclaw_client -v
+```
+
+Expected:
+- PASS across the reset dry-run, service, scenario, and repair-client tests
+
+- [ ] **Step 3: Record any command drift immediately in the local-development doc**
+
+Modify if needed:
+- `docs/setup/local-development.md`
+
+Change only if one of the commands above is wrong, stale, or missing a prerequisite.
+
+### Task 2: Reconfirm The Local Live Smoke Against Linear And GitHub
+
+**Files:**
+- Reference: `docs/setup/local-development.md`
+- Test: `tests/test_reset_live_smoke.py`
+- Reference: `modules/reset_live_smoke.py`
+
+- [ ] **Step 1: Prepare the required local environment**
+
+Confirm these env vars exist in repo-root `.env.local`:
+
+```bash
+GITHUB_TOKEN=...
+LINEAR_API_KEY=...
+HARNESS_RESET_POLL_SECONDS=0
+```
+
+Expected:
+- `GITHUB_TOKEN` and `LINEAR_API_KEY` are present
+- `HARNESS_RESET_POLL_SECONDS=0` keeps the retry loop deterministic
+
+- [ ] **Step 2: Run the gated live smoke**
+
+Run:
+
+```bash
+HARNESS_RUN_LIVE_RESET_TESTS=1 python3 -m unittest tests.test_reset_live_smoke -v
+```
+
+Expected:
+- happy path returns `verified_done`
+- missing PR path returns `retryable_invalid_proof`
+- wrong SHA path escalates to `needs_review`
+
+- [ ] **Step 3: Capture the concrete external artifacts from the run**
+
+Record:
+- Linear issue identifiers
+- GitHub branch names
+- commit SHAs
+- PR URLs
+
+Expected:
+- every live scenario has external proof, not just a test summary
+
+### Task 3: Prove Hosted Repair Callback Reachability
+
+**Files:**
+- Reference: `docs/setup/vercel-neon.md`
+- Reference: `modules/reset/openclaw_client.py`
+- Test: `tests/test_fastapi_backend.py`
+
+- [ ] **Step 1: Deploy or identify a Vercel preview with the reset slice enabled**
+
+Confirm:
+
+```bash
+curl -sS https://<preview-host>/backend/health
+```
+
+Expected:
+- `status` is healthy
+- `store_backend` is `postgres` in the intended hosted path
+
+- [ ] **Step 2: Point the hosted env at a real remote repair receiver**
+
+Confirm these hosted env vars:
+
+```bash
+OPENCLAW_BASE_URL=https://<remote-repair-receiver>
+OPENCLAW_REPAIR_ENDPOINT=/repair
+OPENCLAW_REPAIR_BEARER_TOKEN=<token-if-required>
+```
+
+Expected:
+- the receiver is remote-reachable from Vercel
+- no loopback or laptop-only URL is used
+
+- [ ] **Step 3: Submit an invalid hosted completion claim and verify the callback is attempted**
+
+Use the hosted reset routes to create a contract and submit obviously invalid proof:
+
+```bash
+curl -sS -X POST https://<preview-host>/backend/reset/contracts \
+  -H 'content-type: application/json' \
+  -d '{"contract_id":"hosted-reset-callback-smoke","linear_issue_id":"KNO-TEST","repository_owner":"sfayka","repository_name":"HARNESS-DRYRUN","branch_ref":"codex/hosted-reset-callback-smoke"}'
+```
+
+Then submit a bad claim:
+
+```bash
+curl -sS -X POST https://<preview-host>/backend/reset/contracts/hosted-reset-callback-smoke/claims \
+  -H 'content-type: application/json' \
+  -d '{"repository_owner":"sfayka","repository_name":"HARNESS-DRYRUN","branch_name":"codex/hosted-reset-callback-smoke","commit_sha":"deadbeef","pull_request_number":999999,"pull_request_url":"https://github.com/sfayka/HARNESS-DRYRUN/pull/999999"}'
+```
+
+Expected:
+- Harness does not silently idle
+- the contract moves to `retrying` or `needs_review`
+- the remote receiver logs one repair callback attempt
+
+### Task 4: Prove Hosted End-To-End Remote Repair
+
+**Files:**
+- Reference: `docs/setup/vercel-neon.md`
+- Reference: `modules/reset/service.py`
+- Reference: `modules/reset_live_smoke.py`
+
+- [ ] **Step 1: Run one hosted scenario that starts invalid and ends valid**
+
+Sequence:
+1. create a hosted reset contract
+2. submit invalid proof
+3. let the remote repair receiver trigger fresh work
+4. submit or sync the corrected GitHub proof
+
+Expected:
+- first verdict is `retryable_invalid_proof`
+- final verdict is `verified_done`
+- Linear moves from `In Progress` to `Done`
+
+- [ ] **Step 2: Preserve operator proof from the hosted run**
+
+Record:
+- hosted deployment URL
+- Linear issue identifier
+- final branch
+- final commit SHA
+- final PR URL
+
+Expected:
+- the hosted proof can be inspected later without rerunning the scenario
+
+### Task 5: Prove The Canonical Client Boundary Is Brand-Agnostic
+
+**Files:**
+- Reference: `docs/api/agent-api-usage.md`
+- Reference: `docs/architecture/system-context.md`
+- Reference: `modules/connectors/openclaw_supervisor.py`
+
+- [ ] **Step 1: Submit a planning-only task through the canonical task API using a non-OpenClaw client identity**
+
+Use the canonical task contract with a Hermes-style origin:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8000/tasks \
+  -H 'content-type: application/json' \
+  -d '{"request":{"acceptance_criteria_satisfied":false,"claimed_completion":false,"external_facts":{},"task_envelope":{"id":"task-hermes-boundary-smoke","title":"Hermes boundary smoke","description":"Validate brand-agnostic ingress through the canonical Harness boundary.","origin":{"source_system":"hermes","source_type":"ingress_request","source_id":"telegram:test:hermes-boundary-smoke","ingress_id":"hermes-boundary-smoke","ingress_name":"Hermes","requested_by":"Sean Fay via Hermes"},"status":"planned","timestamps":{"created_at":"2026-04-18T00:00:00Z","updated_at":"2026-04-18T00:00:00Z","completed_at":null},"status_history":[],"objective":{"summary":"Prove that a non-OpenClaw client can submit planning-only work through the canonical Harness API.","deliverable_type":"planning_validation","success_signal":"Harness persists the task with Hermes provenance and no OpenClaw-specific requirement."},"constraints":[{"type":"mode","description":"Planning-only ingress validation.","required":true}],"acceptance_criteria":[{"id":"ac-1","description":"Task is accepted through POST /tasks.","required":true}],"parent_task_id":null,"child_task_ids":[],"dependencies":[],"assigned_executor":null,"required_capabilities":[],"priority":"normal","artifacts":{"completion_evidence":{"notes":null,"policy":"deferred","required_artifact_types":[],"status":"deferred","validated_artifact_ids":[],"validated_at":null,"validation_method":"deferred","validator":null},"items":[]},"observability":{"errors":[],"execution_metadata":{},"retries":{"attempt_count":0,"last_retry_at":null,"max_attempts":0}},"extensions":{"hermes":{"agent_id":"hermes","platform":"telegram","channel":"dm","conversation_id":"hermes-boundary-smoke","message_id":"hermes-boundary-smoke","user_id":"telegram:test","submitted_at":"2026-04-18T00:00:00Z","purpose":"boundary smoke"}}}}}'
+```
+
+Expected:
+- Harness accepts the task
+- provenance is stored under `origin` and `extensions.hermes`
+- no OpenClaw-specific route is required
+
+- [ ] **Step 2: Poll the canonical inspection surfaces**
+
+Run:
+
+```bash
+curl -sS http://127.0.0.1:8000/tasks/task-hermes-boundary-smoke/read-model
+curl -sS http://127.0.0.1:8000/tasks/task-hermes-boundary-smoke/timeline
+curl -sS http://127.0.0.1:8000/supervision/queue
+```
+
+Expected:
+- read-model and timeline show canonical task truth
+- the supervision queue remains the same generic surface regardless of client brand
+
+- [ ] **Step 3: Write down any remaining OpenClaw-only assumptions that still block a Hermes or future-client swap**
+
+Expected:
+- a short list of actual code-level coupling, if any remains
+- no vague architecture complaint without a concrete file or env var name


### PR DESCRIPTION
## Summary
- clarify the current docs around client-agnostic desktop agent boundaries
- add a staged reset verifier next-test plan
- add a release-readiness documentation plan covering local run, screenshots, setup, configuration, testing, use, and validation

## Validation
- python3 -m unittest tests.test_fastapi_backend tests.test_reset_dryrun tests.test_autonomous_dryrun tests.test_unattended_dryruns -v
- git diff --check