### PR TITLE
Define trace budget and eval foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,20 @@ These proofs are specific to `missing_pr_after_execution`. They do not claim tha
 
 ## Planned Capabilities
 
-The repository also carries planning-only scaffolds for two future capabilities:
+The repository also carries planning-only scaffolds for future capabilities:
 
 - the Harness Evolution Engine (HEE), an advisory subsystem for diagnosing recurring failures and proposing reviewed improvements
 - a replaceable desktop-agent executor adapter, with the current concrete example documented in the OpenClaw-shaped adapter note below
+- trace continuity across replay, retry, resume, compaction, handoff, and review
+- execution budget governance for spend, runtime, retry, fan-out, and tool-use caps
+- a local eval harness for skills and delegated workflows
 
 See:
 
 - [`docs/architecture/harness-evolution-engine.md`](docs/architecture/harness-evolution-engine.md)
+- [`docs/architecture/trace-continuity.md`](docs/architecture/trace-continuity.md)
+- [`docs/architecture/execution-budget-model.md`](docs/architecture/execution-budget-model.md)
+- [`docs/architecture/local-eval-harness.md`](docs/architecture/local-eval-harness.md)
 - [`docs/architecture/openclaw-executor-adapter.md`](docs/architecture/openclaw-executor-adapter.md)
 - [`docs/architecture/completion-interception-and-artifact-validation-boundary.md`](docs/architecture/completion-interception-and-artifact-validation-boundary.md)
 

--- a/docs/architecture/artifact-and-completion-evidence.md
+++ b/docs/architecture/artifact-and-completion-evidence.md
@@ -259,8 +259,12 @@ For long-running artifacts, `metadata` should carry structured continuity detail
 - progress counters or checklist summaries for `progress_artifact`
 - plan scope, decomposition revision, or feature list identifiers for `plan_artifact`
 - previous session identifiers, next executor identifiers, or resume instructions for `handoff_artifact`
+- `trace_segment_id` and `continuity_group_id` when the artifact is part of replay, resume, compaction, handoff, or review lineage
+- explicit source references such as `compacted_from`, `handoff_from`, or `reviewed_from` when the artifact summarizes or supersedes earlier context
 
 Harness stores these as auditable task artifacts, but keeps the metadata executor-neutral and substrate-neutral.
+
+Continuity metadata improves inspection and review. It does not promote progress, plan, compacted-summary, or handoff artifacts into completion evidence unless a later explicit evidence policy says so.
 
 ## Completion Evidence
 

--- a/docs/architecture/canonical-vocabulary.md
+++ b/docs/architecture/canonical-vocabulary.md
@@ -10,7 +10,7 @@ Define the words Harness will use consistently so documentation and implementati
 
 The user-facing entry point that receives requests, asks clarifying questions, and hands validated work into Harness.
 
-For this architecture, OpenClaw is the ingress.
+For this architecture, a desktop agent client such as OpenClaw, Hermes, or a future equivalent may act as ingress. Harness should stay tied to the role, not to one client implementation.
 
 ### Harness
 
@@ -59,6 +59,26 @@ The decision that a specific executor type or executor instance owns a task.
 ### Execution Event
 
 A progress, result, failure, or heartbeat message emitted by an executor and consumed by Harness.
+
+### Trace Segment
+
+One contiguous execution-context span inside an attempt. A new segment usually starts after replay, retry, resume, compaction, handoff, or manual-review follow-up.
+
+### Trace Continuity
+
+The lineage model that preserves how trace segments, context snapshots, compacted summaries, handoff artifacts, attempts, and review decisions relate over time.
+
+Trace continuity is inspection truth, not completion truth.
+
+### Execution Budget
+
+The policy and ledger model that records authorized and consumed spend, runtime, retry count, fan-out, and tool-use limits for delegated execution.
+
+Budget governance controls continuation. It does not decide completion.
+
+### Local Eval Harness
+
+A local-first regression harness for skills and delegated workflows. It compares reproducible fixture runs against baselines and links results back to canonical Harness surfaces when present.
 
 ### Verification
 

--- a/docs/architecture/execution-budget-model.md
+++ b/docs/architecture/execution-budget-model.md
@@ -1,0 +1,215 @@
+# Execution Budget Model
+
+## Status
+
+Design/spec only. This document does not add budget accounting, billing integration, alert delivery, storage, or UI behavior.
+
+Addresses: [GitHub issue #312](https://github.com/sfayka/Harness/issues/312)
+
+## Purpose
+
+Define how Harness should model execution budgets for delegated workflows.
+
+Harness already enforces evidence and lifecycle correctness. That is not enough for production operators. A task can be evidence-backed and still be operationally unsafe if it burns far more time, money, retries, tool calls, or agent fan-out than authorized.
+
+Budget governance is part of operator trust.
+
+## Core Principle
+
+Budget exhaustion can affect orchestration, review, and continuation policy.
+
+Budget exhaustion does not assert completion truth.
+
+## Budget Dimensions
+
+### Model and token spend
+
+Tracks estimated or actual model usage.
+
+Minimum fields:
+
+- provider or model family when known
+- input units
+- output units
+- total cost estimate when available
+- source of cost data
+
+### Elapsed runtime
+
+Tracks wall-clock execution time.
+
+Minimum fields:
+
+- started_at
+- ended_at or last_observed_at
+- elapsed_seconds
+- active versus waiting time when the runtime can distinguish them
+
+### Attempts and redispatches
+
+Tracks execution count and repair/retry count.
+
+Minimum fields:
+
+- attempt_count
+- retry_count
+- redispatch_count
+- repair_dispatch_count
+- current attempt identifier
+
+### Subagent fan-out
+
+Tracks delegated child work or parallel agent count.
+
+Minimum fields:
+
+- delegated_work_count
+- active_subagent_count
+- max_concurrent_subagents
+- subagent identifiers when available
+
+### Tool and integration spend classes
+
+Tracks expensive or risky tool categories even when precise dollars are unavailable.
+
+Initial classes:
+
+- browser automation
+- long-running code execution
+- external API calls
+- repository mutation
+- hosted execution
+- file or object storage operations
+
+## Budget Scopes
+
+### Per task
+
+Total authorized budget for the canonical task.
+
+Use when the operator wants one cap for the whole outcome regardless of attempts.
+
+### Per attempt
+
+Budget for one execution attempt.
+
+Use when retry behavior should be bounded independently from the task total.
+
+### Per executor
+
+Budget for a specific executor or executor class.
+
+Use when different executor types have different risk or cost profiles.
+
+### Per project, queue, or policy profile
+
+Budget for a larger operating surface.
+
+Use when many tasks share an operator policy, project budget, or queue-level cap.
+
+This is optional for v1 design and should not block task-level budget semantics.
+
+## Threshold Semantics
+
+### Soft threshold
+
+A soft threshold means the system should warn, annotate, or require an explicit continuation policy.
+
+Allowed consequences:
+
+- append timeline annotation
+- record evaluation or runtime warning
+- notify operator
+- require continuation policy before further automatic retry
+- lower priority or restrict fan-out
+
+Soft threshold crossing must be visible, but it does not necessarily stop execution.
+
+### Hard cap
+
+A hard cap means automatic continuation is no longer allowed without explicit policy.
+
+Allowed consequences:
+
+- pause execution
+- block the task pending operator decision
+- escalate to manual review
+- cancel queued retry or redispatch
+- fail the attempt if policy marks cap violation terminal
+
+Hard cap crossing must not silently continue.
+
+## Control-Plane Outcomes
+
+Budget events should be projected into canonical surfaces as execution governance facts:
+
+- timeline annotations
+- read-model budget summary
+- execution attempt metadata
+- review request context when escalation occurs
+- HEE/local-eval input when analyzing workflow regressions
+
+Budget events should not be projected as verification success or failure by themselves.
+
+Examples:
+
+- token soft threshold crossed: annotate and alert
+- runtime hard cap crossed: pause and escalate to review
+- retry budget exhausted: stop automatic repair and require operator decision
+- tool class cap crossed: block further use of that tool class for the task
+
+## Inspection Surface Requirements
+
+Operators should be able to inspect:
+
+- active budget policy
+- consumed budget by dimension
+- remaining budget when measurable
+- top contributors by attempt, executor, and tool class
+- threshold crossings
+- actions taken because of each threshold
+- whether execution is allowed to continue automatically
+
+## Alerting Semantics
+
+Budget alerts should include:
+
+- task id
+- attempt id when applicable
+- threshold crossed
+- measured consumption
+- configured cap
+- consequence already taken
+- allowed operator choices
+
+Alerts should be explicit operational messages, not hidden evaluator notes.
+
+## Worked Scenario
+
+1. Task `task-456` is assigned to Codex Cloud.
+2. Budget policy allows two attempts, 30 minutes elapsed runtime, and one browser automation session.
+3. Attempt 1 starts and records model spend, runtime, and one browser tool event.
+4. Attempt 1 fails with missing PR evidence.
+5. Harness schedules one repair retry.
+6. Attempt 2 crosses the soft token threshold.
+7. Harness appends a budget warning and alerts the operator, but execution continues because policy allows one soft crossing.
+8. Attempt 2 crosses the hard runtime cap.
+9. Harness cancels further automatic retry and escalates the task to manual review.
+10. Manual review sees budget context alongside execution attempts, evidence state, and reconciliation results.
+11. Completion is still decided by verification/reconciliation or explicit review, not by the budget event itself.
+
+## Boundary Rules
+
+- Budget policy influences whether work may continue automatically.
+- Budget policy does not decide whether produced work is correct.
+- Budget warnings and cap violations must be auditable.
+- Budget data must preserve attempt and executor attribution when available.
+- Missing budget telemetry should be visible as unknown or unavailable, not treated as zero spend.
+
+## Related Documents
+
+- [Runtime Execution Contract](runtime-execution-contract.md)
+- [Operator And Manual Review](operator-and-manual-review.md)
+- [TaskEnvelope Contract](task-envelope.md)
+- [Codex Cloud Execution](codex-cloud-execution.md)
+- [`modules/evolution/contracts/execution-budget.contract.md`](../../modules/evolution/contracts/execution-budget.contract.md)

--- a/docs/architecture/harness-evolution-engine.md
+++ b/docs/architecture/harness-evolution-engine.md
@@ -58,6 +58,9 @@ HEE may consume only canonical records or explicit derived snapshots from:
 - verification, evidence, and reconciliation summaries
 - artifact metadata and completion-proof references
 - execution trace summaries
+- trace continuity records and compacted/handoff lineage
+- execution budget summaries and threshold events
+- local eval run summaries and regression classifications
 - manual review decisions and reviewer notes
 
 ### Required Input Semantics
@@ -111,6 +114,24 @@ Timeline remains canonical audit surface for task progression. HEE may reference
 Execution traces are descriptive evidence of what happened during attempts. HEE may use them for diagnosis but they never become authoritative completion proof by themselves.
 
 Trace minimum-field expectations for future HEE inputs are defined in `modules/evolution/contracts/execution-trace-requirements.contract.md`
+
+Trace continuity expectations for replay, retry, resume, compaction, handoff, and review linkage are defined in `docs/architecture/trace-continuity.md`.
+
+### Execution Budgets
+
+Execution budget records are governance facts about spend, runtime, retry, fan-out, and expensive tool use.
+
+HEE may use budget records to detect workflow regressions or runaway execution patterns, but budget records do not decide task correctness or completion.
+
+Budget planning expectations are defined in `docs/architecture/execution-budget-model.md` and `modules/evolution/contracts/execution-budget.contract.md`.
+
+### Local Eval Results
+
+Local eval results are quality and regression signals for skills and delegated workflows.
+
+HEE may compare local eval trends with historical Harness outcomes. Local eval verdicts remain advisory and must not mutate canonical task lifecycle.
+
+The local eval harness model is defined in `docs/architecture/local-eval-harness.md`.
 
 Failure diagnosis shape and taxonomy expectations are defined in:
 

--- a/docs/architecture/local-eval-harness.md
+++ b/docs/architecture/local-eval-harness.md
@@ -1,0 +1,285 @@
+# Local Eval Harness
+
+## Status
+
+Design/spec only. This document does not add an executable eval runner.
+
+Addresses: [GitHub issue #313](https://github.com/sfayka/Harness/issues/313)
+
+## Purpose
+
+Define a local eval harness model for skills and delegated workflows.
+
+Harness should help operators answer a practical question:
+
+Did this skill, agent workflow, or delegation path actually get better?
+
+The answer should be local-first, reproducible, understandable by operators, and linked back to canonical Harness inspection surfaces. It should not become a disconnected benchmark world.
+
+## Product Thesis
+
+Local evals should describe real operator workflows in plain English, run against stable fixtures, compare baseline and candidate behavior, and report regressions in operational terms.
+
+The primary user is an operator improving workflows, not an ML researcher tuning a benchmark.
+
+## Target Surfaces
+
+### Skill-level evals
+
+Evaluate whether a reusable skill or instruction package handles a known scenario correctly.
+
+Examples:
+
+- GitHub PR review skill finds actionable comments
+- spreadsheet skill preserves formulas and formatting
+- repair skill dispatches the correct follow-up prompt
+
+### Delegated workflow evals
+
+Evaluate a multi-step agent workflow.
+
+Examples:
+
+- planner produces executable tasks
+- supervisor notices stale work and requests repair
+- executor produces GitHub proof and Harness verifies it
+
+### Ingress-to-verification evals
+
+Evaluate the full path from task intake to Harness verification.
+
+Examples:
+
+- desktop agent creates Linear issue
+- Harness stores verification contract
+- completion claim is rejected
+- repair is requested
+- corrected claim is accepted
+
+## Eval Spec Shape
+
+A v1 eval spec should be plain-language first and structured second.
+
+Minimum fields:
+
+```text
+LocalEvalSpec
+  id: string
+  title: string
+  target_type: skill | delegated_workflow | ingress_to_verification
+  target_ref: string
+  scenario: string
+  fixture_refs: string[]
+  expected_outcomes: string[]
+  must_pass_checks: string[]
+  allowed_variance: string[]
+  expected_artifacts: string[]
+  expected_trace_properties: string[]
+  expected_budget_behavior: string[]
+  canonical_surface_refs: string[]
+  baseline_run_ref: string?
+```
+
+### Scenario
+
+Plain-English description of the operator workflow being evaluated.
+
+Good scenario text names:
+
+- the user-visible goal
+- the expected workflow shape
+- what evidence should exist
+- what failure modes should be caught
+
+### Fixtures
+
+Stable local input bundles.
+
+Fixtures may include:
+
+- task payloads
+- seeded Harness store snapshots
+- fake GitHub or Linear facts
+- expected artifact bundles
+- prior eval run outputs
+
+Fixture references must be stable enough for reruns. If the fixture depends on external live systems, the eval must say so explicitly.
+
+### Expected outcomes
+
+Operator-readable success conditions.
+
+Examples:
+
+- "Harness rejects missing PR proof."
+- "The workflow preserves handoff lineage after compaction."
+- "The budget hard cap escalates to review instead of silently retrying."
+
+### Must-pass checks
+
+Machine-checkable assertions derived from expected outcomes.
+
+Examples:
+
+- final verdict is `verified_done`
+- final state is `in_review`
+- trace continuity group contains all expected segments
+- budget hard cap event is present
+- read-model links to the expected artifact id
+
+### Allowed variance
+
+Explicit tolerance for non-deterministic outputs.
+
+Examples:
+
+- model wording may differ
+- runtime duration may vary within a threshold
+- generated branch suffix may differ
+- ordering may vary only where chronology is not meaningful
+
+## Run Model
+
+### Local reproducible run
+
+Each run should record:
+
+- `eval_id`
+- `run_id`
+- timestamp
+- git commit
+- target version
+- fixture digests
+- model/runtime configuration when known
+- environment summary without secrets
+- produced Harness task IDs
+- produced artifacts and trace references
+- budget observations when available
+
+### Baseline run
+
+A baseline is a prior accepted run for the same eval spec.
+
+Baseline records should be immutable for comparison. If the baseline itself is wrong, create a new baseline and preserve the old record.
+
+### Candidate run
+
+A candidate is the run being evaluated against the baseline.
+
+Candidate output should be compared against baseline using explicit categories.
+
+## Comparison Model
+
+Comparison output should classify changes into:
+
+- correctness
+- evidence quality
+- trace continuity
+- budget behavior
+- runtime anomalies
+- artifact completeness
+- operator readability
+
+Each category should support:
+
+- improved
+- unchanged
+- regressed
+- inconclusive
+- not_applicable
+
+The comparison should lead with a human-readable summary, then provide structured result data for automation.
+
+## Output Surface
+
+### Human-readable summary
+
+The first output should answer:
+
+- what was evaluated
+- whether it passed
+- what improved or regressed
+- what evidence supports the conclusion
+- what an operator should inspect next
+
+### Structured result
+
+Minimum shape:
+
+```text
+LocalEvalResult
+  eval_id: string
+  run_id: string
+  baseline_run_id: string?
+  candidate_run_id: string
+  verdict: pass | fail | review_required | inconclusive
+  category_results: CategoryResult[]
+  harness_refs: HarnessRef[]
+  artifact_refs: ArtifactRef[]
+  trace_refs: TraceRef[]
+  budget_refs: BudgetRef[]
+  summary: string
+```
+
+## Relationship To Harness Inspection Surfaces
+
+Local eval output must link back to canonical Harness inspection surfaces when present:
+
+- `GET /tasks`
+- `GET /tasks/<task_id>/read-model`
+- `GET /tasks/<task_id>/timeline`
+- `GET /tasks/<task_id>/evaluations`
+- `/reset/*` contract inspection routes for reset-slice evals
+
+Eval output may summarize those surfaces, but it must not replace them.
+
+## Boundary Rules
+
+- Local evals are quality and regression checks, not lifecycle authority.
+- Passing an eval does not accept a task as complete.
+- Failing an eval does not automatically fail a task.
+- Evals may use Harness truth, traces, artifacts, and budget records as inputs.
+- Evals must preserve the distinction between local deterministic proof and live external proof.
+
+## Worked Example: Repair Workflow Eval
+
+Scenario:
+
+- seeded task fixture expects GitHub PR proof
+- completion claim omits PR
+- Harness rejects the claim
+- repair workflow is triggered
+- corrected claim provides PR, branch, and commit
+- Harness accepts completion
+
+Expected checks:
+
+- first verdict is `retryable_invalid_proof`
+- repair request is recorded
+- final verdict is `verified_done`
+- trace continuity links invalid claim, repair request, and corrected claim
+- budget does not exceed configured retry cap
+
+## Worked Example: Skill-Level Eval
+
+Scenario:
+
+- a PR-review skill reads a fixture containing review comments
+- it must identify actionable feedback and ignore non-actionable commentary
+- it must produce a concise plan with file references
+
+Expected checks:
+
+- all blocking comments are classified as actionable
+- resolved or praise-only comments are not converted into work
+- output includes exact file paths when available
+- no completion claim is made
+
+## Related Documents
+
+- [Trace Continuity Model](trace-continuity.md)
+- [Execution Budget Model](execution-budget-model.md)
+- [Runtime Execution Contract](runtime-execution-contract.md)
+- [Verification And Completion Enforcement](verification-and-completion-enforcement.md)
+- [Agent API Usage](../api/agent-api-usage.md)
+- [Integrations Overview](../integrations/overview.md)

--- a/docs/architecture/operator-and-manual-review.md
+++ b/docs/architecture/operator-and-manual-review.md
@@ -44,6 +44,7 @@ Initial trigger classes include:
 - reconciliation reveals contradictory external facts
 - clarification is deadlocked or cannot be resolved automatically
 - runtime behavior is anomalous enough that automatic retry or reassignment is not obviously safe
+- execution budget thresholds make automatic continuation unsafe or no longer authorized
 - an authorized operator explicitly escalates the task
 
 ### Verification-Driven Review
@@ -78,6 +79,15 @@ Manual review is appropriate when:
 - capability mismatch or execution behavior suggests the current path is no longer trustworthy
 - automatic redispatch or failure would be too risky without human judgment
 
+### Budget Thresholds
+
+Manual review is appropriate when:
+
+- a hard execution budget cap has been crossed
+- retry, fan-out, runtime, or tool-use budget is exhausted
+- missing budget telemetry is itself policy-blocking
+- an operator must decide whether to authorize more spend, reduce scope, reroute execution, or stop the task
+
 ### Explicit Operator Escalation
 
 An authorized operator may escalate a task into manual review when:
@@ -96,6 +106,8 @@ At minimum, the reviewer should be presented with:
 - artifact and completion evidence state
 - reconciliation results and mismatch categories
 - runtime facts and attempt history
+- trace continuity and handoff context when relevant
+- active budget policy, consumed budget, threshold crossings, and allowed continuation choices
 - clarification state when relevant
 - prior review and override history
 
@@ -136,6 +148,25 @@ The reviewer should see:
 - stalls, timeouts, cancellations, and retries
 - relevant outputs or execution logs when needed
 
+### Trace Continuity
+
+The reviewer should see:
+
+- trace segments inspected by the review
+- continuity group for related replay, retry, resume, compaction, and handoff events
+- context snapshots or handoff artifacts used by the current executor
+- unresolved lineage or missing provenance when present
+
+### Budget State
+
+The reviewer should see:
+
+- active budget policy and scope
+- consumed budget by dimension
+- soft and hard threshold crossings
+- actions already taken because of those crossings
+- whether automatic continuation is still allowed
+
 ### Prior Review History
 
 The reviewer should see:
@@ -161,6 +192,7 @@ Initial allowed outcomes include:
 - authorize redispatch
 - authorize re-plan
 - authorize retry
+- authorize budget continuation when policy permits it
 - cancel the task when policy and operator authority allow it
 
 ### Accept Completion
@@ -231,6 +263,21 @@ Typical lifecycle consequence:
 
 These are authorization outcomes. The corresponding module still owns the actual transition mechanics.
 
+### Authorize Budget Continuation
+
+Allowed when:
+
+- policy permits human authorization after a budget threshold
+- the reviewer determines that continued execution is justified
+- the new limit, scope reduction, or execution constraint is recorded explicitly
+
+Typical lifecycle consequence:
+
+- remain in the current non-terminal lifecycle state
+- resume, retry, or redispatch only through the normal owning module
+
+Budget continuation does not accept completion. It only allows more work under an explicit policy decision.
+
 ## Disallowed Reviewer Actions
 
 Reviewers must not:
@@ -260,6 +307,7 @@ At minimum, a review record should include:
 - chosen outcome
 - reasoning summary
 - resulting authorized lifecycle consequence
+- budget continuation terms when the decision authorizes more spend, time, retry, or tool use
 - whether the decision supersedes an earlier review
 
 ### Reviewer Identity
@@ -348,6 +396,12 @@ Verification and manual review are related but distinct.
 
 Manual review should therefore be understood as an explicit escalation path from verification, reconciliation, clarification, runtime anomaly handling, or operator oversight.
 
+## Review Versus Budget Governance
+
+Budget governance controls whether automatic execution may continue.
+
+Manual review may authorize additional spend, runtime, retry, or tool use when policy allows it, but that decision does not decide completion. The task still needs normal verification, reconciliation, or explicit completion acceptance through review.
+
 ## Review Versus Operator Override
 
 Not every operator action is the same as a review outcome.
@@ -385,3 +439,9 @@ The goal is that a reviewer of the system can answer:
 - whether the intervention stayed within policy
 - what evidence or contradiction drove the decision
 - how the review changed the task's lifecycle
+
+## Related Documents
+
+- [Trace Continuity Model](trace-continuity.md)
+- [Execution Budget Model](execution-budget-model.md)
+- [Runtime Execution Contract](runtime-execution-contract.md)

--- a/docs/architecture/runtime-execution-contract.md
+++ b/docs/architecture/runtime-execution-contract.md
@@ -175,6 +175,21 @@ This distinction matters because:
 
 Runtime reporting should preserve attempt-scoped records without collapsing them into a single task-level story.
 
+## Trace Continuity
+
+The runtime should preserve trace continuity without turning trace data into completion authority.
+
+A task may span retries, resumes, compacted context, executor handoffs, and manual-review follow-up. Those events should remain reconstructable through stable trace segment and continuity identifiers rather than flattened into one success or failure log.
+
+Runtime reporting should preserve:
+
+- `trace_segment_id` for each contiguous execution context
+- `continuity_group_id` for related segments that an operator should inspect together
+- the context snapshot or handoff artifact the executor actually received
+- explicit relationships such as replay, retry, resume, compaction, handoff, and review follow-up
+
+Trace continuity answers what context was used and how it changed over time. Verification and reconciliation still answer whether the produced outcome is trustworthy enough to accept.
+
 ## Execution Event Semantics
 
 Runtime events must be explicit and reviewable.
@@ -453,6 +468,22 @@ Retry policy is not invented by the runtime.
 
 The runtime applies the policy given by Harness core or higher-level orchestration rules.
 
+## Budget Governance
+
+The runtime may observe budget consumption, but it does not invent budget policy.
+
+Budget facts should be attributed to the most specific scope available:
+
+- task
+- attempt
+- executor
+- trace segment
+- tool or integration class
+
+Soft threshold crossings should be reported as auditable warnings or alerts. Hard cap crossings should stop automatic continuation according to policy, for example by pausing execution, blocking retry, or escalating to manual review.
+
+Budget exhaustion is a continuation-governance fact. It does not prove the work is correct, incorrect, complete, or incomplete by itself.
+
 ## Stall And Timeout Semantics
 
 Stalls and timeouts must be treated as first-class runtime findings.
@@ -542,6 +573,8 @@ At minimum, the control plane should preserve:
 - execution start timestamp
 - last progress timestamp
 - emitted execution events
+- trace segment and continuity group references when available
+- budget threshold events when budget policy is active
 - attached outputs and artifacts
 - failure, stall, timeout, and retry records
 - the source that reported each significant execution fact
@@ -553,3 +586,9 @@ The goal is that a reviewer can answer:
 - whether the attempt stalled, failed, or succeeded
 - what outputs or artifacts were produced
 - why a retry or redispatch happened later
+
+## Related Documents
+
+- [Trace Continuity Model](trace-continuity.md)
+- [Execution Budget Model](execution-budget-model.md)
+- [Artifact And Completion Evidence](artifact-and-completion-evidence.md)

--- a/docs/architecture/trace-continuity.md
+++ b/docs/architecture/trace-continuity.md
@@ -1,0 +1,214 @@
+# Trace Continuity Model
+
+## Status
+
+Design/spec only. This document does not add storage, ingestion, runtime logging, or UI behavior.
+
+Addresses: [GitHub issue #311](https://github.com/sfayka/Harness/issues/311)
+
+## Purpose
+
+Define how Harness preserves execution lineage across replay, retry, resume, compaction, handoff, and manual review.
+
+Execution traces are not useful if they degrade into flat logs. Operators need to know which execution context an executor actually saw, which context was compacted or summarized, which attempt superseded another, and how handoff artifacts connect to the work lineage.
+
+Trace continuity is descriptive/auditable truth. It does not authorize completion.
+
+## Core Principle
+
+Harness must preserve the difference between:
+
+- what happened during execution
+- how execution context changed over time
+- which artifacts summarize or supersede prior context
+- whether the final result is trustworthy enough to accept
+
+The first three are lineage questions. The last remains verification and reconciliation policy.
+
+## Identifiers
+
+### `task_id`
+
+Canonical Harness task identity.
+
+All continuity records must link back to exactly one task.
+
+### `attempt_id`
+
+Concrete execution attempt identity.
+
+One task may have many attempts across retries, redispatches, executor handoffs, or manual-review follow-up.
+
+### `trace_segment_id`
+
+Stable identity for one contiguous segment of execution context.
+
+A segment usually starts when an executor receives a context bundle and ends when one of these happens:
+
+- attempt completes, fails, stalls, or times out
+- context is compacted or summarized
+- work is handed to another executor
+- manual review interrupts or redirects the attempt
+- execution resumes with a materially different context bundle
+
+### `continuity_group_id`
+
+Identity for a lineage chain that should be understood together.
+
+Segments inside the same continuity group may span retries, resumes, compactions, handoffs, and review intervention. Group membership does not imply success or consistency. It only says the segments are related enough that an operator should be able to reconstruct the chain.
+
+### Relationship fields
+
+Continuity records should support explicit relationships:
+
+- `derived_from`: source segment or artifact used to create this segment
+- `supersedes`: prior segment or artifact no longer used as the active context
+- `compacted_from`: source segments summarized into a compacted representation
+- `handoff_from`: prior executor/attempt context transferred into this segment
+- `reviewed_from`: segment or artifact reviewed by a human decision
+
+Relationships should point to stable record IDs. Missing references should be represented as unresolved provenance, not silently dropped.
+
+## Mutation Semantics
+
+### Replay
+
+A replay reruns work from an earlier input or fixture.
+
+Rules:
+
+- replay creates a new `attempt_id`
+- replay may share a `continuity_group_id` with the original attempt when the purpose is comparison or recovery
+- replay must record `derived_from` pointing to the original attempt or segment
+- replay must not overwrite the original attempt timeline
+
+### Retry
+
+A retry is a new execution attempt after a failed, stalled, or insufficient attempt.
+
+Rules:
+
+- retry creates a new `attempt_id`
+- retry may share a continuity group with prior attempts on the same task
+- retry must preserve prior failed and insufficient segments
+- retry success must not collapse prior failure into a false single-success story
+
+### Resume
+
+Resume continues an interrupted attempt or stalled workflow from preserved context.
+
+Rules:
+
+- resume may keep the same `attempt_id` only if the execution substrate treats it as the same concrete run
+- otherwise resume creates a new `attempt_id`
+- resume always creates a new `trace_segment_id`
+- resumed segments must reference the context bundle they resumed from
+
+### Summarize / Compact
+
+Compaction rewrites full-fidelity context into a shorter operational context.
+
+Rules:
+
+- compaction creates a new artifact or segment with `compacted_from` references
+- compacted summaries must preserve enough provenance to reconstruct source segments
+- compaction must distinguish dropped context from summarized context
+- compaction must not erase contradictory facts
+
+### Executor Handoff
+
+Handoff transfers work from one executor or session to another.
+
+Rules:
+
+- handoff creates a `handoff_artifact`
+- the new segment references the handoff artifact through `handoff_from`
+- the handoff artifact references the source segment and source attempt
+- handoff must record which context the receiving executor actually saw
+
+### Manual Review Intervention
+
+Manual review may inspect execution lineage and authorize a follow-up path.
+
+Rules:
+
+- review decisions reference the trace segments and artifacts inspected
+- review-created follow-up segments record `reviewed_from`
+- review does not mutate prior trace history
+- review may authorize retry, redispatch, replan, clarification, failure, or completion only through normal policy surfaces
+
+## Continuity-Preserving Artifacts
+
+### `progress_artifact`
+
+Use for structured progress state carried across execution cycles.
+
+Continuity expectations:
+
+- references the segment that produced it
+- identifies which checklist, milestone, or progress state it summarizes
+- does not imply completion by itself
+
+### `handoff_artifact`
+
+Use for session or executor transition context.
+
+Continuity expectations:
+
+- references source attempt and source segment
+- records receiving executor or intended receiver when known
+- records what context was handed off
+- records what was intentionally omitted or unresolved
+
+### Compacted summary artifact
+
+Use when a full context bundle is summarized before replay, resume, or handoff.
+
+Continuity expectations:
+
+- references all source segments compacted into the summary
+- records whether source detail remains available
+- records whether any facts were dropped, elided, or contradicted
+
+## Read And Query Requirements
+
+Harness should eventually be able to answer:
+
+- show the full lineage for a task
+- show all attempts inside a continuity group
+- show which context an executor actually saw
+- show which artifacts superseded or summarized earlier context
+- show what was dropped, compacted, or unresolved
+- show manual review decisions linked to inspected segments
+- show contradictory attempts without collapsing them into a single outcome
+
+These are inspection requirements, not storage-engine requirements.
+
+## Boundary Rules
+
+- Trace continuity is observable execution lineage, not completion truth.
+- A continuity group may contain failed, contradictory, stale, and successful segments.
+- A compacted or handoff artifact is support context, not verified completion evidence by default.
+- Continuity metadata may inform review, diagnosis, and local evals, but verification and reconciliation remain authoritative for completion.
+- Trace ingestion or continuity reconstruction failure must not bypass lifecycle enforcement.
+
+## Worked Example
+
+1. Attempt `attempt-a` starts for task `task-123`.
+2. Runtime records segment `seg-a1` in continuity group `cg-task-123-repair`.
+3. The executor produces a progress artifact `progress-a1`.
+4. Context is compacted into artifact `summary-a1`, with `compacted_from=["seg-a1"]`.
+5. Attempt `attempt-a` resumes with segment `seg-a2`, `derived_from=["summary-a1"]`.
+6. Work is handed to another executor with `handoff-1`, referencing `seg-a2`.
+7. New executor starts `attempt-b`, segment `seg-b1`, `handoff_from=["handoff-1"]`, same continuity group.
+8. Manual review inspects `seg-a2`, `handoff-1`, and `seg-b1`.
+9. Review authorizes retry. Harness creates `attempt-c`, segment `seg-c1`, `reviewed_from=["review-decision-1"]`.
+10. Completion still depends on GitHub/Linear evidence and Harness verification, not on the fact that the continuity chain exists.
+
+## Related Documents
+
+- [Runtime Execution Contract](runtime-execution-contract.md)
+- [Artifact And Completion Evidence](artifact-and-completion-evidence.md)
+- [Operator And Manual Review](operator-and-manual-review.md)
+- [Harness Evolution Engine](harness-evolution-engine.md)
+- [`modules/evolution/contracts/execution-trace-requirements.contract.md`](../../modules/evolution/contracts/execution-trace-requirements.contract.md)

--- a/docs/evals/README.md
+++ b/docs/evals/README.md
@@ -1,0 +1,18 @@
+# Local Eval Specs
+
+This directory holds planning-stage examples for the future local eval harness.
+
+These files are not executable test definitions yet. They define the operator-readable spec shape Harness should support when local evals become runnable.
+
+Local eval specs must stay tied to Harness inspection truth:
+
+- use stable local fixtures when possible
+- declare live external dependencies when unavoidable
+- compare baseline and candidate runs by explicit regression category
+- link results back to canonical task, read-model, timeline, evaluation, trace, artifact, and budget records when present
+- avoid treating an eval pass as task completion authority
+
+## Examples
+
+- [`examples/repair-workflow.eval.md`](examples/repair-workflow.eval.md)
+- [`examples/pr-review-skill.eval.md`](examples/pr-review-skill.eval.md)

--- a/docs/evals/examples/pr-review-skill.eval.md
+++ b/docs/evals/examples/pr-review-skill.eval.md
@@ -1,0 +1,63 @@
+# PR Review Skill Local Eval Example
+
+## Eval Spec
+
+```yaml
+id: eval-pr-review-skill-v1
+title: PR review skill actionable-comment classification
+target_type: skill
+target_ref: github:gh-address-comments
+scenario: >
+  A PR review workflow receives a fixture containing blocking comments,
+  resolved comments, praise-only comments, and ambiguous comments. The skill
+  must identify actionable work without converting non-actionable commentary
+  into tasks.
+fixture_refs:
+  - docs/evals/fixtures/pr-review-comments.v1.json
+expected_outcomes:
+  - blocking comments are classified as actionable
+  - resolved comments are ignored unless they reveal unresolved follow-up
+  - praise-only comments are not turned into work
+  - ambiguous comments are surfaced as questions or review-needed items
+must_pass_checks:
+  - all fixture comments with expected_classification=actionable are returned
+  - no fixture comments with expected_classification=non_actionable are returned as required work
+  - output includes file path and line references when fixture provides them
+  - output does not claim code changes were completed
+allowed_variance:
+  - wording of the human-readable plan may differ
+  - ordering may differ only within the same severity class
+  - ambiguous comments may be classified as questions or review-needed items
+expected_artifacts:
+  - human-readable action plan
+  - structured actionable-comment list
+expected_trace_properties:
+  - inspected comments and final classifications are linkable
+expected_budget_behavior:
+  - no browser or external mutation tool class is used
+canonical_surface_refs:
+  - GitHub PR review threads
+  - Harness task timeline when this eval is run through a Harness task
+```
+
+## Baseline Comparison
+
+Baseline and candidate runs should compare:
+
+- actionable recall
+- false positive count
+- file/line reference preservation
+- operator readability
+- tool usage class
+
+## Operator Summary Shape
+
+```text
+REVIEW REQUIRED: Candidate found all blocking comments but misclassified one praise-only comment as required work.
+
+Regression categories:
+- correctness: regressed
+- evidence quality: unchanged
+- trace continuity: not_available
+- budget behavior: unchanged
+```

--- a/docs/evals/examples/repair-workflow.eval.md
+++ b/docs/evals/examples/repair-workflow.eval.md
@@ -1,0 +1,68 @@
+# Repair Workflow Local Eval Example
+
+## Eval Spec
+
+```yaml
+id: eval-reset-repair-workflow-v1
+title: Reset verifier repair workflow
+target_type: ingress_to_verification
+target_ref: modules.reset_dryrun:success
+scenario: >
+  A task claims completion without acceptable pull-request proof. Harness rejects
+  the claim, records a repair request, then accepts a corrected claim with real
+  repository, branch, commit, and PR evidence.
+fixture_refs:
+  - modules.reset_dryrun:success
+expected_outcomes:
+  - first claim is rejected as retryable invalid proof
+  - repair request is recorded
+  - corrected claim is accepted as verified done
+  - final Linear-facing state would be Done
+must_pass_checks:
+  - initial_claim_verdict == retryable_invalid_proof
+  - repair_request_count >= 1
+  - final_claim_verdict == verified_done
+  - final_harness_status == verified
+allowed_variance:
+  - generated contract ids may differ
+  - timestamps may differ
+  - repair request transport may be local file bridge or remote callback when explicitly declared
+expected_artifacts:
+  - reset contract event history
+  - completion claim summary
+  - repair request record
+expected_trace_properties:
+  - invalid claim, repair request, and corrected claim are linkable in one continuity group
+expected_budget_behavior:
+  - retry count stays within configured retry budget
+canonical_surface_refs:
+  - POST /reset/contracts
+  - POST /reset/contracts/<contract_id>/claims
+  - GET /reset/contracts/<contract_id>
+```
+
+## Baseline Comparison
+
+Baseline and candidate runs should compare:
+
+- verdict sequence
+- repair request count
+- final Harness status
+- event history completeness
+- trace continuity when trace support exists
+- retry budget behavior when budget support exists
+
+## Operator Summary Shape
+
+```text
+PASS: Reset repair workflow still rejects bad proof and accepts corrected proof.
+
+Initial claim: retryable_invalid_proof
+Repair requests: 1
+Final claim: verified_done
+Regression categories:
+- correctness: unchanged
+- evidence quality: unchanged
+- trace continuity: not_available
+- budget behavior: not_available
+```

--- a/docs/planning/issues/2026-04-21-foundation-contract-issues.md
+++ b/docs/planning/issues/2026-04-21-foundation-contract-issues.md
@@ -1,0 +1,76 @@
+# Foundation Contract Issues Plan
+
+## Source Issues
+
+- [#311 Define trace continuity model for replay, compaction, and handoff](https://github.com/sfayka/Harness/issues/311)
+- [#312 Define execution budget model with spend caps and operator alerting](https://github.com/sfayka/Harness/issues/312)
+- [#313 Design a local eval harness for skills and delegated workflows](https://github.com/sfayka/Harness/issues/313)
+
+## Recommended Order
+
+1. Define trace continuity first.
+2. Define execution budget governance second.
+3. Define the local eval harness third.
+
+That order keeps the dependency chain clean. Budget records need attempt, executor, and trace attribution. Local evals need both continuity and budget semantics if they are going to compare delegated workflows instead of only checking final text output.
+
+## Implementation Plan
+
+### Issue #311: Trace continuity
+
+Add a planning architecture document that defines:
+
+- `trace_segment_id`
+- `continuity_group_id`
+- replay, retry, resume, compaction, handoff, and review relationships
+- continuity-preserving artifact expectations
+- read/query requirements for operators
+- boundary rules that keep trace lineage separate from completion truth
+
+Update the trace requirements contract so future runtime and HEE work has explicit fields to target.
+
+### Issue #312: Execution budget model
+
+Add a planning architecture document and evolution contract that define:
+
+- budget dimensions for model spend, tokens, runtime, attempts, retries, fan-out, and tool classes
+- task, attempt, executor, project, queue, and operator-policy scopes
+- soft threshold and hard cap semantics
+- alert content and control-plane consequences
+- review inputs when budget exhaustion blocks automatic continuation
+
+Budget governance should control whether work may continue automatically. It must not decide whether produced work is correct.
+
+### Issue #313: Local eval harness
+
+Add a planning architecture document and concrete eval examples that define:
+
+- plain-English eval specs with stable fixture references
+- baseline and candidate run records
+- regression categories for correctness, evidence quality, trace continuity, budget behavior, runtime anomalies, artifact completeness, and operator readability
+- output shape that leads with an operator summary and keeps structured results available for automation
+- links back to canonical Harness inspection surfaces
+
+Local evals are quality checks. They are not task lifecycle authority.
+
+## Deliverables In This PR
+
+- `docs/architecture/trace-continuity.md`
+- `docs/architecture/execution-budget-model.md`
+- `docs/architecture/local-eval-harness.md`
+- `modules/evolution/contracts/execution-trace-requirements.contract.md`
+- `modules/evolution/contracts/execution-budget.contract.md`
+- `docs/evals/README.md`
+- `docs/evals/examples/repair-workflow.eval.md`
+- `docs/evals/examples/pr-review-skill.eval.md`
+
+## Deferred Work
+
+- storage schema
+- ingestion APIs
+- runnable eval CLI
+- dashboard UI
+- alert delivery integrations
+- migration of existing trace or budget data
+
+Those should come after the contracts are reviewed and accepted.

--- a/modules/evolution/contracts/README.md
+++ b/modules/evolution/contracts/README.md
@@ -8,6 +8,7 @@ These contracts define:
 - what an evolution candidate must contain before a proposal is drafted
 - what an evolution proposal must contain for auditable human review and decision tracking
 - what execution trace records must contain for future diagnosis inputs
+- what execution budget records must contain for cost, retry, fan-out, and continuation governance
 - how taxonomy versioning and provenance back to task, trace, artifact, and review records are preserved
 
 Contracts here are non-executable and non-authoritative for runtime behavior until implemented through normal Harness review.
@@ -18,3 +19,4 @@ Contracts here are non-executable and non-authoritative for runtime behavior unt
 - `evolution-candidate.contract.md`
 - `evolution-proposal.contract.md`
 - `execution-trace-requirements.contract.md`
+- `execution-budget.contract.md`

--- a/modules/evolution/contracts/execution-budget.contract.md
+++ b/modules/evolution/contracts/execution-budget.contract.md
@@ -1,0 +1,187 @@
+# Execution Budget Contract
+
+Planning scaffold only. This contract is not executable code.
+
+## Purpose
+
+Define the minimum budget facts future runtime, review, local eval, and HEE surfaces need in order to reason about delegated workflow cost and runaway execution risk.
+
+Budget records are governance facts. They can influence whether execution continues automatically, but they do not decide whether work is complete.
+
+## Design Principles
+
+1. Budget consumption must be attributable to task, attempt, executor, and tool class when known.
+2. Soft and hard thresholds must have explicit control-plane consequences.
+3. Missing budget telemetry must be represented as unknown, not treated as zero.
+4. Budget exhaustion may escalate to review or block continuation, but verification remains completion authority.
+5. Budget records must preserve provenance to runtime events, traces, artifacts, or external billing sources.
+
+## Minimum Fields
+
+```text
+ExecutionBudgetPolicy
+  policy_id: string
+  scope_type: task | attempt | executor | project | queue | operator_policy
+  scope_id: string
+  dimensions: BudgetDimension[]
+  thresholds: BudgetThreshold[]
+  effective_at: timestamp
+  expires_at: timestamp?
+  source_system: string
+  source_record_id: string?
+  schema_version: string
+
+BudgetDimension
+  dimension_type: model_spend | token_usage | elapsed_runtime | attempt_count | retry_count | redispatch_count | subagent_fanout | tool_class_usage
+  unit: string
+  soft_limit: number?
+  hard_limit: number?
+  unknown_behavior: allow_with_annotation | require_review | block
+
+BudgetLedgerEntry
+  entry_id: string
+  policy_id: string
+  task_id: string
+  attempt_id: string?
+  executor_id: string?
+  trace_segment_id: string?
+  continuity_group_id: string?
+  dimension_type: string
+  unit: string
+  quantity: number?
+  quantity_status: measured | estimated | unknown
+  tool_class: string?
+  source_system: string
+  source_record_id: string
+  recorded_at: timestamp
+  schema_version: string
+
+BudgetThresholdEvent
+  event_id: string
+  policy_id: string
+  task_id: string
+  attempt_id: string?
+  threshold_type: soft | hard
+  dimension_type: string
+  consumed_quantity: number?
+  configured_limit: number?
+  action_taken: annotate | alert | pause | block | escalate_to_review | cancel_retry | fail_attempt
+  reason: string
+  recorded_at: timestamp
+  source_system: string
+  source_record_id: string?
+  schema_version: string
+
+BudgetAlertRecord
+  alert_id: string
+  threshold_event_id: string
+  task_id: string
+  attempt_id: string?
+  recipient_type: operator | reviewer | system_queue
+  channel: dashboard | timeline | webhook | email | chat | local_console
+  message: string
+  allowed_operator_choices: string[]
+  delivered_at: timestamp?
+  delivery_status: pending | delivered | failed | suppressed
+  schema_version: string
+```
+
+## Scope Requirements
+
+### Task-scoped budgets
+
+Task-scoped budgets must aggregate all attempts and retries for the task.
+
+They should answer:
+
+- how much total budget was authorized
+- how much has been consumed
+- whether automatic continuation is still allowed
+
+### Attempt-scoped budgets
+
+Attempt-scoped budgets must isolate one concrete execution run.
+
+They should answer:
+
+- whether the current attempt is still inside allowed limits
+- whether this attempt consumed disproportionate budget
+- whether follow-up retry is still allowed
+
+### Executor-scoped budgets
+
+Executor-scoped budgets must identify the executor or executor class that consumed budget.
+
+They should answer:
+
+- which executor spent the budget
+- whether one executor class is causing runaway cost
+- whether future dispatch should choose a different execution path
+
+## Threshold Requirements
+
+### Soft thresholds
+
+Soft threshold events must record:
+
+- threshold crossed
+- measured or estimated consumption
+- action taken
+- alert or annotation emitted when policy requires one
+- whether automatic continuation remains allowed
+
+### Hard caps
+
+Hard cap events must record:
+
+- cap crossed
+- action taken
+- whether the task is blocked, paused, or escalated
+- alert or review request emitted as the visible operator surface
+- what operator decision is required before continuation
+
+Hard cap violations must not silently continue.
+
+## Alert Requirements
+
+Budget alerts must be explicit operator-facing records when policy requires operator awareness or intervention.
+
+They should answer:
+
+- which threshold crossed
+- how much was consumed
+- what limit was configured
+- what action Harness already took
+- what choices remain available to the operator or reviewer
+- whether alert delivery succeeded or failed
+
+An alert delivery failure must be visible as an operational fact. It must not erase the threshold event or allow automatic continuation that policy already blocked.
+
+## Provenance And Linkage Requirements
+
+Budget records should link to:
+
+- `task_id`
+- `attempt_id` when known
+- `trace_segment_id` when spend is tied to a trace segment
+- `continuity_group_id` when spend spans replay/resume/handoff lineage
+- runtime events that observed the spend
+- external billing or provider records when available
+- review records if budget exhaustion triggered review
+
+Missing linkage should be explicit unresolved provenance.
+
+## Boundary Rules
+
+- Budget records are not completion evidence by themselves.
+- Budget exhaustion does not prove work failed; it proves automatic continuation is no longer allowed under policy.
+- Budget policy must not bypass verification, reconciliation, or manual review.
+- Budget telemetry failures must not be hidden.
+- Budget summaries may feed HEE/local eval analysis, but advisory outputs remain separate from lifecycle truth.
+
+## Related Documents
+
+- `docs/architecture/execution-budget-model.md`
+- `docs/architecture/runtime-execution-contract.md`
+- `docs/architecture/operator-and-manual-review.md`
+- `docs/architecture/local-eval-harness.md`

--- a/modules/evolution/contracts/execution-trace-requirements.contract.md
+++ b/modules/evolution/contracts/execution-trace-requirements.contract.md
@@ -21,6 +21,17 @@ ExecutionTraceRecord
   task_id: string
   attempt_id: string
   attempt_sequence: integer
+  trace_segment_id: string
+  continuity_group_id: string
+  segment_sequence: integer
+  segment_kind: execution | replay | retry | resume | compaction | handoff | review_annotation
+  derived_from: TraceContinuityRef[]
+  supersedes: TraceContinuityRef[]
+  compacted_from: TraceContinuityRef[]
+  handoff_from: TraceContinuityRef[]
+  reviewed_from: TraceContinuityRef[]
+  context_snapshot_ref: ContextSnapshotRef?
+  handoff_artifact_refs: ArtifactRef[]
   event_time: timestamp
   event_type: string
   event_status: started | checkpoint | completed | failed | cancelled | timed_out
@@ -37,6 +48,17 @@ ExecutionTraceRecord
   source_record_id: string
   ingest_time: timestamp
   schema_version: string
+
+TraceContinuityRef
+  ref_type: trace_segment | trace_record | artifact | attempt | review_decision
+  ref_id: string
+  relationship: derived_from | supersedes | compacted_from | handoff_from | reviewed_from
+
+ContextSnapshotRef
+  snapshot_id: string
+  source_system: string
+  source_record_id: string
+  captured_at: timestamp
 ```
 
 ## Scope Requirements
@@ -60,11 +82,28 @@ Task-scoped summaries may be derived from attempt traces, but must:
 - keep failed/cancelled/timed-out attempts visible
 - avoid collapsing contradictory attempt outcomes into a single success claim
 
+### Continuity Requirements (required)
+
+Trace records must preserve execution lineage across replay, retry, resume, compaction, handoff, and manual review.
+
+Continuity records must:
+
+- assign each contiguous execution context a stable `trace_segment_id`
+- group related segments with `continuity_group_id`
+- preserve segment order with `segment_sequence`
+- distinguish normal execution from replay, retry, resume, compaction, handoff, and review annotation
+- explicitly link source records through `derived_from`, `supersedes`, `compacted_from`, `handoff_from`, or `reviewed_from`
+- preserve the context snapshot or handoff artifact the executor actually received when available
+- represent missing lineage as unresolved provenance rather than dropping it
+
 ## Provenance And Linkage Requirements
 
 Trace records must remain linkable to canonical control-plane records:
 
 - `TaskEnvelope` identity (`task_id`)
+- execution attempts (`attempt_id`)
+- trace segments (`trace_segment_id`)
+- continuity groups (`continuity_group_id`)
 - evaluation history entries (by explicit reference)
 - timeline events (via `timeline_ref` when available)
 - artifact and evidence records used for verification
@@ -76,6 +115,8 @@ Missing linkage should be represented as explicit unresolved provenance, not sil
 
 - Trace events are descriptive execution facts, not completion decisions.
 - A terminal `completed` trace status does not authorize lifecycle transition by itself.
+- A complete continuity chain does not prove the task outcome is correct.
+- Compacted summaries and handoff artifacts are support context unless verification policy explicitly accepts them as evidence.
 - Verification/reconciliation outcomes remain the trusted completion authority.
 - Trace ingestion or analysis failures must not bypass policy enforcement.
 
@@ -91,3 +132,10 @@ Missing linkage should be represented as explicit unresolved provenance, not sil
 - whether `event_type` should be normalized by a shared enum in v1
 - whether actor identity should support structured resolver metadata beyond `actor_id`
 - what retention windows should apply for full-fidelity trace events versus compacted summaries
+- whether continuity groups should span only one task or support explicit cross-task lineage for future delegated workflows
+
+## Related Documents
+
+- `docs/architecture/trace-continuity.md`
+- `docs/architecture/runtime-execution-contract.md`
+- `docs/architecture/artifact-and-completion-evidence.md`


### PR DESCRIPTION
## Summary

- Adds planning architecture docs for trace continuity, execution budget governance, and the local eval harness.
- Extends evolution contracts with trace-continuity fields and a new execution-budget contract.
- Adds concrete local eval examples and a planning issue map for #311, #312, and #313.
- Updates cross-cutting docs so these capabilities stay client-neutral across OpenClaw, Hermes, or future desktop agent clients.

## Issues

- Addresses #311
- Addresses #312
- Addresses #313

## Validation

- `git diff --check`
- `python3` markdown relative-link check across 16 changed markdown files
- `gh issue list --repo sfayka/Harness --state open --search "created:>=2026-04-21" --json number,title,state,createdAt,url --limit 50`

Docs-only change; no runtime tests were required.
