### PR TITLE
Add local runtime CLI contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ See:
   - `GET /tasks/<task_id>/read-model`
   - `GET /tasks/<task_id>/timeline`
   - `GET /supervision/queue`
+  - `GET /runtime/status`
 - Canonical mutation surfaces:
 - `POST /tasks`
 - `POST /tasks/<task_id>/reevaluate`
@@ -212,6 +213,7 @@ See:
 - Postgres storage is implemented in [`modules/store.py`](modules/store.py) and bootstrapped with [`sql/postgres/001_harness_store.sql`](sql/postgres/001_harness_store.sql).
 - SQLite storage is implemented in [`modules/store.py`](modules/store.py) and [`modules/reset/store.py`](modules/reset/store.py). Harness creates the local database and schema automatically.
 - The default hosted deployment target is Neon-backed Postgres attached through Vercel. Harness stores canonical task and evaluation payloads as JSONB in `tasks` and `evaluation_records`.
+- The local app runtime contract is implemented in [`modules/local_runtime.py`](modules/local_runtime.py) and documented in [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md).
 
 ## Hosted Deployment Target
 
@@ -245,6 +247,7 @@ Backend inspection routes:
 - `GET /tasks/<task_id>/read-model`: canonical detail surface for current task truth.
 - `GET /tasks/<task_id>/timeline`: canonical audit timeline.
 - `GET /supervision/queue`: canonical autonomous-supervision triage surface.
+- `GET /runtime/status`: local app runtime status envelope for menu-bar polling.
 
 For triage surfaces, `review_required` stays distinct from terminal failure. If a task is in `in_review`, the projected `failure_summary.state` and `execution_summary.failure_state` remain `review_required` rather than collapsing into `failed`.
 
@@ -337,6 +340,18 @@ python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
 
 SQLite mode creates the database and schema automatically, enables WAL mode and foreign keys, and stores canonical tasks, evaluation records, and reset verifier contracts in the local database. This is the intended persistence base for the self-contained local app.
+
+Run the local app runtime contract from a repo checkout:
+
+```bash
+python3 -m modules.local_runtime --json init
+python3 -m modules.local_runtime --json status
+python3 -m modules.local_runtime serve
+python3 -m modules.local_runtime --json doctor
+python3 -m modules.local_runtime stop
+```
+
+Packaged builds should expose the same contract as `harness init`, `harness serve`, `harness status`, `harness doctor`, `harness open`, and `harness stop`. The runtime stores config, SQLite state, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 
 from modules.api import HarnessApiService
 from modules.local_env import load_native_local_env
+from modules.local_runtime import build_runtime_status_payload
 from modules.reset.service import ResetVerificationService
 from modules.store import HarnessStore
 
@@ -67,6 +68,11 @@ def create_app(
     @app.get("/health")
     def health() -> JSONResponse:
         return _json_response(service.health())
+
+    @app.get("/runtime/status")
+    def runtime_status() -> JSONResponse:
+        _, health_payload = service.health()
+        return JSONResponse(status_code=200, content=build_runtime_status_payload(health_payload))
 
     @app.get("/tasks")
     def list_tasks() -> JSONResponse:

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -1,0 +1,129 @@
+# Local Runtime Contract
+
+Harness local app builds control the Python backend through a stable runtime contract.
+The app shell should not import backend internals, write SQLite directly, or depend on repo-local shell exports.
+
+## Command Surface
+
+Packaged builds should expose these commands as `harness`. In a repo checkout, run the same contract with:
+
+```bash
+python3 -m modules.local_runtime <command>
+```
+
+Commands:
+
+- `harness init`
+- `harness serve`
+- `harness status`
+- `harness doctor`
+- `harness open`
+- `harness stop`
+
+The CLI supports `--json` for app-shell consumption. JSON output is the contract the macOS menu-bar app should use.
+
+## App-Managed Paths
+
+Default macOS paths:
+
+- Data: `~/Library/Application Support/Harness/`
+- Config: `~/Library/Application Support/Harness/config.json`
+- SQLite: `~/Library/Application Support/Harness/harness.db`
+- PID: `~/Library/Application Support/Harness/runtime/harness.pid`
+- Logs: `~/Library/Logs/Harness/harness.log`
+
+Default Linux paths:
+
+- Data: `$XDG_DATA_HOME/harness/`, or `~/.local/share/harness/`
+- Config: `<data-dir>/config.json`
+- SQLite: `<data-dir>/harness.db`
+- PID: `<data-dir>/runtime/harness.pid`
+- Logs: `$XDG_STATE_HOME/harness/logs/harness.log`, or `~/.local/state/harness/logs/harness.log`
+
+Developer and test runs may override paths with `--data-dir`, `--log-dir`, `HARNESS_APP_DATA_DIR`,
+or `HARNESS_APP_LOG_DIR`.
+Normal app usage should rely on app-managed defaults.
+
+## Runtime Config
+
+`harness init` writes non-secret config to `config.json` and initializes the SQLite schema.
+Secrets do not belong in this file.
+GitHub, Linear, and ingress/executor credentials should move through the app-managed secret store in later slices.
+
+The first schema stores:
+
+- local API host and port
+- SQLite database path
+- data, runtime, PID, and log paths
+
+`harness serve` applies the config to the backend process through environment variables before startup:
+
+- `HARNESS_STORE_BACKEND=sqlite`
+- `HARNESS_SQLITE_PATH=<app-data>/harness.db`
+- `HARNESS_RUNTIME_MODE=local-app`
+- `HARNESS_RUNTIME_CONFIG_PATH=<app-data>/config.json`
+- `HARNESS_RUNTIME_DATA_DIR=<app-data>`
+- `HARNESS_RUNTIME_LOG_PATH=<logs>/harness.log`
+- `HARNESS_RUNTIME_HOST=127.0.0.1`
+- `HARNESS_RUNTIME_PORT=8765`
+- `HARNESS_RUNTIME_BASE_URL=http://127.0.0.1:8765`
+
+This is what removes the need for Docker, Node, `pnpm`, or repo-local shell exports for the backend runtime.
+
+## Status And Health
+
+The backend exposes two app-shell-safe probes:
+
+- `GET /health`: canonical backend and storage health.
+- `GET /runtime/status`: local app runtime status envelope that includes mode, API base URL,
+  store backend, schema readiness, and app-managed paths.
+
+`harness status --json` calls the local health endpoint and returns:
+
+- `status=running` when the local API is healthy.
+- `status=stopped` when no health endpoint responds.
+- `status=uninitialized` when config has not been created.
+- `status=degraded` when the API responds but reports degraded health.
+
+## Doctor Checks
+
+`harness doctor --json` returns checks with this shape:
+
+```json
+{
+  "code": "sqlite",
+  "status": "pass",
+  "message": "SQLite database is ready.",
+  "next_action": "No action needed."
+}
+```
+
+Initial checks cover:
+
+- app data directory writability
+- log directory writability
+- config presence and validity
+- SQLite schema readiness
+- local API health
+
+The local API check is a warning when the runtime is stopped.
+A stopped runtime is a valid setup state; it is not a corrupted install.
+
+## Exit Codes
+
+- `0`: command succeeded or desired state is already true.
+- `1`: runtime is initialized but not currently healthy.
+- `2`: setup is missing or config is unreadable.
+- `3`: runtime error that requires remediation.
+
+All CLI failures should produce operator-readable messages. Stack traces are not part of the user-facing contract.
+
+## Process Lifecycle
+
+`harness serve` runs the backend in the foreground, writes a PID file, appends runtime output to `harness.log`,
+and removes the PID file on clean exit.
+
+`harness stop` reads the PID file and sends `SIGTERM`.
+Missing or stale PID files are treated as already stopped because the desired state is satisfied.
+
+The local API binds to loopback by default. Network exposure is out of scope for the local app v1 contract.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -89,6 +89,27 @@ SQLite mode is the intended persistence base for the self-contained local app. I
 
 If `HARNESS_SQLITE_PATH` is unset, Harness uses the platform local-data default: `~/Library/Application Support/Harness/harness.db` on macOS, `$XDG_DATA_HOME/harness/harness.db` on Linux, or `~/.local/share/harness/harness.db` when `XDG_DATA_HOME` is unset.
 
+### Run The Local App Runtime Contract
+
+The packaged app will expose this contract as `harness`. From a repo checkout, use the module entry point:
+
+```bash
+python3 -m modules.local_runtime --json init
+python3 -m modules.local_runtime --json status
+python3 -m modules.local_runtime serve
+python3 -m modules.local_runtime --json doctor
+python3 -m modules.local_runtime stop
+```
+
+The runtime contract uses app-managed config, SQLite state, PID files, and logs. It does not require Docker, Node, `pnpm`, or repo-local shell exports.
+
+Default macOS paths:
+
+- `~/Library/Application Support/Harness/config.json`
+- `~/Library/Application Support/Harness/harness.db`
+- `~/Library/Application Support/Harness/runtime/harness.pid`
+- `~/Library/Logs/Harness/harness.log`
+
 To run the same backend against Postgres instead of the file-backed store:
 
 ```bash

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -1,0 +1,743 @@
+"""Local app runtime CLI and process contract for Harness."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import platform
+import signal
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from modules.store import SQLiteHarnessStore, StoreError
+
+
+APP_NAME = "Harness"
+CONFIG_SCHEMA_VERSION = 1
+DEFAULT_API_HOST = "127.0.0.1"
+DEFAULT_API_PORT = 8765
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 2.0
+
+EXIT_OK = 0
+EXIT_UNHEALTHY = 1
+EXIT_SETUP_REQUIRED = 2
+EXIT_RUNTIME_ERROR = 3
+
+ENV_RUNTIME_MODE = "HARNESS_RUNTIME_MODE"
+ENV_RUNTIME_CONFIG_PATH = "HARNESS_RUNTIME_CONFIG_PATH"
+ENV_RUNTIME_DATA_DIR = "HARNESS_RUNTIME_DATA_DIR"
+ENV_RUNTIME_LOG_PATH = "HARNESS_RUNTIME_LOG_PATH"
+ENV_RUNTIME_HOST = "HARNESS_RUNTIME_HOST"
+ENV_RUNTIME_PORT = "HARNESS_RUNTIME_PORT"
+ENV_RUNTIME_BASE_URL = "HARNESS_RUNTIME_BASE_URL"
+
+
+class LocalRuntimeError(ValueError):
+    """Operator-readable local runtime failure."""
+
+    def __init__(self, message: str, *, exit_code: int = EXIT_RUNTIME_ERROR) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    data_dir: Path
+    log_dir: Path
+    runtime_dir: Path
+    config_path: Path
+    database_path: Path
+    pid_path: Path
+    log_path: Path
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    schema_version: int
+    host: str
+    port: int
+    database_path: Path
+    data_dir: Path
+    log_dir: Path
+    runtime_dir: Path
+    pid_path: Path
+    log_path: Path
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def asdict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "api": {
+                "host": self.host,
+                "port": self.port,
+                "base_url": self.base_url,
+            },
+            "storage": {
+                "backend": "sqlite",
+                "sqlite_path": str(self.database_path),
+            },
+            "paths": {
+                "data_dir": str(self.data_dir),
+                "log_dir": str(self.log_dir),
+                "runtime_dir": str(self.runtime_dir),
+                "pid_path": str(self.pid_path),
+                "log_path": str(self.log_path),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any], *, paths: RuntimePaths) -> "RuntimeConfig":
+        api = payload.get("api") if isinstance(payload.get("api"), dict) else {}
+        storage = payload.get("storage") if isinstance(payload.get("storage"), dict) else {}
+        stored_paths = payload.get("paths") if isinstance(payload.get("paths"), dict) else {}
+        try:
+            schema_version = int(payload.get("schema_version") or CONFIG_SCHEMA_VERSION)
+        except (TypeError, ValueError) as error:
+            raise LocalRuntimeError(
+                "Harness runtime config has an invalid schema_version.",
+                exit_code=EXIT_SETUP_REQUIRED,
+            ) from error
+        if schema_version != CONFIG_SCHEMA_VERSION:
+            raise LocalRuntimeError(
+                f"Unsupported Harness runtime config schema_version={schema_version}. "
+                f"Expected {CONFIG_SCHEMA_VERSION}.",
+                exit_code=EXIT_SETUP_REQUIRED,
+            )
+
+        host = str(api.get("host") or DEFAULT_API_HOST)
+        try:
+            port = int(api.get("port") or DEFAULT_API_PORT)
+        except (TypeError, ValueError) as error:
+            raise LocalRuntimeError(
+                "Harness runtime config has an invalid api.port.",
+                exit_code=EXIT_SETUP_REQUIRED,
+            ) from error
+        database_path = Path(str(storage.get("sqlite_path") or paths.database_path)).expanduser()
+        data_dir = Path(str(stored_paths.get("data_dir") or paths.data_dir)).expanduser()
+        log_dir = Path(str(stored_paths.get("log_dir") or paths.log_dir)).expanduser()
+        runtime_dir = Path(str(stored_paths.get("runtime_dir") or paths.runtime_dir)).expanduser()
+        pid_path = Path(str(stored_paths.get("pid_path") or paths.pid_path)).expanduser()
+        log_path = Path(str(stored_paths.get("log_path") or paths.log_path)).expanduser()
+        return cls(
+            schema_version=schema_version,
+            host=host,
+            port=port,
+            database_path=database_path,
+            data_dir=data_dir,
+            log_dir=log_dir,
+            runtime_dir=runtime_dir,
+            pid_path=pid_path,
+            log_path=log_path,
+        )
+
+
+@dataclass(frozen=True)
+class RuntimeCheck:
+    code: str
+    status: str
+    message: str
+    next_action: str
+
+
+def resolve_runtime_paths(
+    *,
+    data_dir: str | Path | None = None,
+    log_dir: str | Path | None = None,
+    platform_name: str | None = None,
+    home: str | Path | None = None,
+) -> RuntimePaths:
+    """Resolve app-managed local runtime paths."""
+
+    current_platform = platform_name or sys.platform
+    home_path = Path(home).expanduser() if home is not None else Path.home()
+
+    resolved_data_dir = Path(
+        data_dir or os.environ.get("HARNESS_APP_DATA_DIR") or _default_data_dir(current_platform, home_path)
+    ).expanduser()
+    resolved_log_dir = Path(
+        log_dir or os.environ.get("HARNESS_APP_LOG_DIR") or _default_log_dir(current_platform, home_path)
+    ).expanduser()
+    runtime_dir = resolved_data_dir / "runtime"
+    return RuntimePaths(
+        data_dir=resolved_data_dir,
+        log_dir=resolved_log_dir,
+        runtime_dir=runtime_dir,
+        config_path=resolved_data_dir / "config.json",
+        database_path=resolved_data_dir / "harness.db",
+        pid_path=runtime_dir / "harness.pid",
+        log_path=resolved_log_dir / "harness.log",
+    )
+
+
+def _default_data_dir(platform_name: str, home_path: Path) -> Path:
+    if platform_name == "darwin":
+        return home_path / "Library" / "Application Support" / APP_NAME
+    xdg_data_home = os.environ.get("XDG_DATA_HOME")
+    if xdg_data_home:
+        return Path(xdg_data_home).expanduser() / "harness"
+    return home_path / ".local" / "share" / "harness"
+
+
+def _default_log_dir(platform_name: str, home_path: Path) -> Path:
+    if platform_name == "darwin":
+        return home_path / "Library" / "Logs" / APP_NAME
+    xdg_state_home = os.environ.get("XDG_STATE_HOME")
+    if xdg_state_home:
+        return Path(xdg_state_home).expanduser() / "harness" / "logs"
+    return home_path / ".local" / "state" / "harness" / "logs"
+
+
+def create_default_config(
+    paths: RuntimePaths,
+    *,
+    host: str = DEFAULT_API_HOST,
+    port: int = DEFAULT_API_PORT,
+) -> RuntimeConfig:
+    return RuntimeConfig(
+        schema_version=CONFIG_SCHEMA_VERSION,
+        host=host,
+        port=port,
+        database_path=paths.database_path,
+        data_dir=paths.data_dir,
+        log_dir=paths.log_dir,
+        runtime_dir=paths.runtime_dir,
+        pid_path=paths.pid_path,
+        log_path=paths.log_path,
+    )
+
+
+def load_runtime_config(paths: RuntimePaths) -> RuntimeConfig:
+    if not paths.config_path.exists():
+        raise LocalRuntimeError(
+            f"Harness local runtime is not initialized at {paths.config_path}. Run `harness init` first.",
+            exit_code=EXIT_SETUP_REQUIRED,
+        )
+    try:
+        payload = json.loads(paths.config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise LocalRuntimeError(
+            f"Harness runtime config at {paths.config_path} could not be read: {error}",
+            exit_code=EXIT_SETUP_REQUIRED,
+        ) from error
+    if not isinstance(payload, dict):
+        raise LocalRuntimeError(
+            f"Harness runtime config at {paths.config_path} must contain a JSON object.",
+            exit_code=EXIT_SETUP_REQUIRED,
+        )
+    return RuntimeConfig.from_dict(payload, paths=paths)
+
+
+def init_runtime(
+    paths: RuntimePaths,
+    *,
+    host: str = DEFAULT_API_HOST,
+    port: int = DEFAULT_API_PORT,
+    force: bool = False,
+) -> tuple[RuntimeConfig, bool]:
+    """Create app-managed runtime directories, config, log file, and SQLite schema."""
+
+    paths.data_dir.mkdir(parents=True, exist_ok=True)
+    paths.log_dir.mkdir(parents=True, exist_ok=True)
+    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+
+    created = False
+    if paths.config_path.exists() and not force:
+        config = load_runtime_config(paths)
+    else:
+        config = create_default_config(paths, host=host, port=port)
+        paths.config_path.write_text(
+            json.dumps(config.asdict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        created = True
+
+    try:
+        SQLiteHarnessStore(config.database_path)
+    except StoreError as error:
+        raise LocalRuntimeError(str(error), exit_code=EXIT_SETUP_REQUIRED) from error
+    config.log_path.parent.mkdir(parents=True, exist_ok=True)
+    config.log_path.touch(exist_ok=True)
+    return config, created
+
+
+def apply_runtime_environment(config: RuntimeConfig, *, config_path: Path) -> None:
+    """Apply app-managed runtime environment for backend startup."""
+
+    os.environ["HARNESS_STORE_BACKEND"] = "sqlite"
+    os.environ["HARNESS_SQLITE_PATH"] = str(config.database_path)
+    os.environ[ENV_RUNTIME_MODE] = "local-app"
+    os.environ[ENV_RUNTIME_CONFIG_PATH] = str(config_path)
+    os.environ[ENV_RUNTIME_DATA_DIR] = str(config.data_dir)
+    os.environ[ENV_RUNTIME_LOG_PATH] = str(config.log_path)
+    os.environ[ENV_RUNTIME_HOST] = config.host
+    os.environ[ENV_RUNTIME_PORT] = str(config.port)
+    os.environ[ENV_RUNTIME_BASE_URL] = config.base_url
+
+
+def fetch_runtime_health(
+    config: RuntimeConfig,
+    *,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+) -> tuple[int | None, dict[str, Any] | None, str | None]:
+    request = Request(f"{config.base_url}/health", headers={"Accept": "application/json"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            return int(response.status), payload if isinstance(payload, dict) else None, None
+    except HTTPError as error:
+        try:
+            payload = json.loads(error.read().decode("utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload = None
+        return int(error.code), payload if isinstance(payload, dict) else None, str(error)
+    except (OSError, TimeoutError, URLError) as error:
+        return None, None, str(error)
+
+
+def read_pid(pid_path: Path) -> int | None:
+    try:
+        raw_pid = pid_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not raw_pid:
+        return None
+    try:
+        return int(raw_pid)
+    except ValueError:
+        return None
+
+
+def process_is_running(pid: int | None) -> bool:
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def runtime_status(
+    config: RuntimeConfig,
+    *,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+) -> tuple[int, dict[str, Any]]:
+    pid = read_pid(config.pid_path)
+    process_running = process_is_running(pid)
+    http_status, health, error = fetch_runtime_health(config, timeout=timeout)
+    healthy = http_status == 200 and bool(health and health.get("status") == "ok")
+    status = "running" if healthy else "degraded" if http_status is not None else "stopped"
+    exit_code = EXIT_OK if healthy else EXIT_UNHEALTHY
+    return exit_code, {
+        "status": status,
+        "api_base_url": config.base_url,
+        "pid": pid,
+        "process_running": process_running,
+        "health_http_status": http_status,
+        "health": health,
+        "error": None if healthy else error,
+        "paths": _paths_payload(config),
+    }
+
+
+def uninitialized_status(paths: RuntimePaths) -> dict[str, Any]:
+    return {
+        "status": "uninitialized",
+        "error": f"Harness local runtime is not initialized at {paths.config_path}.",
+        "next_action": "Run `harness init`.",
+        "paths": {
+            "data_dir": str(paths.data_dir),
+            "log_dir": str(paths.log_dir),
+            "config_path": str(paths.config_path),
+        },
+    }
+
+
+def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
+    checks: list[RuntimeCheck] = []
+    config: RuntimeConfig | None = None
+
+    checks.append(
+        _check_writable_directory(
+            "app_data_dir",
+            paths.data_dir,
+            "Harness needs a writable app data directory.",
+        )
+    )
+    checks.append(_check_writable_directory("log_dir", paths.log_dir, "Harness needs a writable log directory."))
+
+    try:
+        config = load_runtime_config(paths)
+    except LocalRuntimeError as error:
+        checks.append(
+            RuntimeCheck(
+                code="config",
+                status="fail",
+                message=str(error),
+                next_action="Run `harness init` from the app bundle or CLI.",
+            )
+        )
+    else:
+        checks.append(
+            RuntimeCheck(
+                code="config",
+                status="pass",
+                message=f"Runtime config exists at {paths.config_path}.",
+                next_action="No action needed.",
+            )
+        )
+
+    if config is not None:
+        try:
+            store = SQLiteHarnessStore(config.database_path)
+            sqlite_ready = store.schema_ready()
+        except StoreError as error:
+            checks.append(
+                RuntimeCheck(
+                    code="sqlite",
+                    status="fail",
+                    message=str(error),
+                    next_action=(
+                        "Move the damaged database aside and rerun setup, "
+                        "or restore a known-good backup."
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                RuntimeCheck(
+                    code="sqlite",
+                    status="pass" if sqlite_ready else "fail",
+                    message=(
+                        "SQLite database is "
+                        f"{'ready' if sqlite_ready else 'not on the expected schema'} at {config.database_path}."
+                    ),
+                    next_action=(
+                        "No action needed."
+                        if sqlite_ready
+                        else "Restart Harness after rerunning `harness init`."
+                    ),
+                )
+            )
+
+        _, status_payload = runtime_status(config)
+        api_running = status_payload["status"] == "running"
+        checks.append(
+            RuntimeCheck(
+                code="api_health",
+                status="pass" if api_running else "warn",
+                message="Local API is healthy." if api_running else "Local API is not running.",
+                next_action=(
+                    "No action needed."
+                    if api_running
+                    else "Start Harness from the app or run `harness serve`."
+                ),
+            )
+        )
+
+    exit_code = EXIT_RUNTIME_ERROR if any(check.status == "fail" for check in checks) else EXIT_OK
+    return exit_code, {
+        "status": "fail" if exit_code else "ok",
+        "checks": [asdict(check) for check in checks],
+    }
+
+
+def _check_writable_directory(code: str, path: Path, impact: str) -> RuntimeCheck:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / ".harness-write-test"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+    except OSError as error:
+        return RuntimeCheck(
+            code=code,
+            status="fail",
+            message=f"{impact} {path} is not writable: {error}",
+            next_action="Choose a writable app data location or fix directory permissions.",
+        )
+    return RuntimeCheck(
+        code=code,
+        status="pass",
+        message=f"{path} is writable.",
+        next_action="No action needed.",
+    )
+
+
+def serve_runtime(paths: RuntimePaths, *, host: str | None = None, port: int | None = None) -> int:
+    config, _ = init_runtime(paths, host=host or DEFAULT_API_HOST, port=port or DEFAULT_API_PORT)
+    if host or port:
+        config = RuntimeConfig.from_dict(
+            {**config.asdict(), "api": {"host": host or config.host, "port": port or config.port}},
+            paths=paths,
+        )
+    apply_runtime_environment(config, config_path=paths.config_path)
+    _assert_port_available(config.host, config.port)
+    config.pid_path.parent.mkdir(parents=True, exist_ok=True)
+    config.pid_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    try:
+        with config.log_path.open("a", encoding="utf-8") as log_file:
+            log_file.write(f"[local-runtime] starting Harness API at {config.base_url}\n")
+            log_file.flush()
+            with contextlib.redirect_stdout(log_file), contextlib.redirect_stderr(log_file):
+                _run_uvicorn(config)
+    finally:
+        with contextlib.suppress(OSError):
+            config.pid_path.unlink()
+    return EXIT_OK
+
+
+def _assert_port_available(host: str, port: int) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, port))
+        except OSError as error:
+            raise LocalRuntimeError(
+                f"Harness runtime cannot bind {host}:{port}: {error}. "
+                "Stop the existing process or choose a different port.",
+                exit_code=EXIT_RUNTIME_ERROR,
+            ) from error
+
+
+def _run_uvicorn(config: RuntimeConfig) -> None:
+    import uvicorn
+
+    uvicorn.run("backend.server:app", host=config.host, port=config.port, log_level="info")
+
+
+def stop_runtime(config: RuntimeConfig, *, timeout_seconds: float = 10.0) -> tuple[int, dict[str, Any]]:
+    pid = read_pid(config.pid_path)
+    if not process_is_running(pid):
+        with contextlib.suppress(OSError):
+            config.pid_path.unlink()
+        return EXIT_OK, {
+            "status": "stopped",
+            "message": "Harness runtime is not running.",
+            "pid": pid,
+            "paths": _paths_payload(config),
+        }
+    assert pid is not None
+    os.kill(pid, signal.SIGTERM)
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not process_is_running(pid):
+            with contextlib.suppress(OSError):
+                config.pid_path.unlink()
+            return EXIT_OK, {
+                "status": "stopped",
+                "message": "Harness runtime stopped.",
+                "pid": pid,
+                "paths": _paths_payload(config),
+            }
+        time.sleep(0.1)
+    return EXIT_RUNTIME_ERROR, {
+        "status": "failed",
+        "message": f"Harness runtime pid {pid} did not stop within {timeout_seconds:g} seconds.",
+        "pid": pid,
+        "paths": _paths_payload(config),
+    }
+
+
+def open_runtime(config: RuntimeConfig, *, launch: bool = True) -> tuple[int, dict[str, Any]]:
+    url = os.environ.get("HARNESS_DASHBOARD_URL") or config.base_url
+    if launch:
+        _open_url(url)
+    return EXIT_OK, {
+        "status": "opened" if launch else "ready",
+        "url": url,
+    }
+
+
+def _open_url(url: str) -> None:
+    system_name = platform.system()
+    if system_name not in {"Darwin", "Linux"}:
+        raise LocalRuntimeError(f"Opening URLs is not supported on {system_name}. Use this URL: {url}")
+    command = "open" if system_name == "Darwin" else "xdg-open"
+    try:
+        subprocess.run([command, url], check=False)
+    except OSError as error:
+        raise LocalRuntimeError(f"Could not open {url}: {error}. Use the URL directly.") from error
+
+
+def build_runtime_status_payload(health_payload: dict[str, Any]) -> dict[str, Any]:
+    """Build the stable backend endpoint payload used by the app shell."""
+
+    base_url = os.environ.get(ENV_RUNTIME_BASE_URL)
+    if not base_url:
+        host = os.environ.get(ENV_RUNTIME_HOST, DEFAULT_API_HOST)
+        port = os.environ.get(ENV_RUNTIME_PORT, str(DEFAULT_API_PORT))
+        base_url = f"http://{host}:{port}"
+
+    return {
+        "status": "running" if health_payload.get("status") == "ok" else "degraded",
+        "mode": os.environ.get(ENV_RUNTIME_MODE, "developer"),
+        "api_base_url": base_url,
+        "store_backend": health_payload.get("store_backend"),
+        "database_schema_ready": health_payload.get("database_schema_ready"),
+        "paths": {
+            "config_path": os.environ.get(ENV_RUNTIME_CONFIG_PATH),
+            "data_dir": os.environ.get(ENV_RUNTIME_DATA_DIR),
+            "database_path": health_payload.get("database_path"),
+            "log_path": os.environ.get(ENV_RUNTIME_LOG_PATH),
+        },
+        "health": health_payload,
+    }
+
+
+def _paths_payload(config: RuntimeConfig) -> dict[str, str]:
+    return {
+        "data_dir": str(config.data_dir),
+        "log_dir": str(config.log_dir),
+        "config_path": str(config.data_dir / "config.json"),
+        "database_path": str(config.database_path),
+        "runtime_dir": str(config.runtime_dir),
+        "pid_path": str(config.pid_path),
+        "log_path": str(config.log_path),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="harness",
+        description="Control the local Harness runtime.",
+    )
+    parser.add_argument("--data-dir", help="Override the app-managed data directory")
+    parser.add_argument("--log-dir", help="Override the app-managed log directory")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON output")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser(
+        "init",
+        help="Create local runtime config, directories, logs, and SQLite schema",
+    )
+    init_parser.add_argument("--host", default=DEFAULT_API_HOST, help="Loopback host for the local API")
+    init_parser.add_argument("--port", default=DEFAULT_API_PORT, type=int, help="Port for the local API")
+    init_parser.add_argument("--force", action="store_true", help="Rewrite config with the supplied defaults")
+
+    serve_parser = subparsers.add_parser("serve", help="Run the local Harness API in the foreground")
+    serve_parser.add_argument("--host", help="Temporary host override for this process")
+    serve_parser.add_argument("--port", type=int, help="Temporary port override for this process")
+
+    status_parser = subparsers.add_parser("status", help="Check whether the local Harness runtime is healthy")
+    status_parser.add_argument(
+        "--timeout",
+        default=DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        type=float,
+        help="Health request timeout in seconds",
+    )
+
+    doctor_parser = subparsers.add_parser("doctor", help="Run local setup checks with remediation hints")
+    doctor_parser.set_defaults(command="doctor")
+
+    open_parser = subparsers.add_parser("open", help="Open the local Harness dashboard or API URL")
+    open_parser.add_argument(
+        "--print-url",
+        action="store_true",
+        help="Print the URL without launching a browser",
+    )
+
+    stop_parser = subparsers.add_parser("stop", help="Gracefully stop the local Harness runtime")
+    stop_parser.add_argument("--timeout", default=10.0, type=float, help="Shutdown timeout in seconds")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    paths = resolve_runtime_paths(data_dir=args.data_dir, log_dir=args.log_dir)
+
+    try:
+        if args.command == "init":
+            config, created = init_runtime(paths, host=args.host, port=args.port, force=args.force)
+            return _emit(
+                {
+                    "status": "initialized",
+                    "created": created,
+                    "api_base_url": config.base_url,
+                    "paths": _paths_payload(config),
+                },
+                as_json=args.as_json,
+            )
+        if args.command == "serve":
+            return serve_runtime(paths, host=args.host, port=args.port)
+        if args.command == "status":
+            try:
+                config = load_runtime_config(paths)
+            except LocalRuntimeError as error:
+                if paths.config_path.exists():
+                    return _emit(
+                        {"status": "error", "error": str(error)},
+                        as_json=args.as_json,
+                        exit_code=error.exit_code,
+                    )
+                return _emit(uninitialized_status(paths), as_json=args.as_json, exit_code=EXIT_SETUP_REQUIRED)
+            exit_code, payload = runtime_status(config, timeout=args.timeout)
+            return _emit(payload, as_json=args.as_json, exit_code=exit_code)
+        if args.command == "doctor":
+            exit_code, payload = run_doctor(paths)
+            return _emit(payload, as_json=args.as_json, exit_code=exit_code)
+        if args.command == "open":
+            config = load_runtime_config(paths)
+            exit_code, payload = open_runtime(config, launch=not args.print_url)
+            return _emit(payload, as_json=args.as_json, exit_code=exit_code)
+        if args.command == "stop":
+            config = load_runtime_config(paths)
+            exit_code, payload = stop_runtime(config, timeout_seconds=args.timeout)
+            return _emit(payload, as_json=args.as_json, exit_code=exit_code)
+    except LocalRuntimeError as error:
+        return _emit({"status": "error", "error": str(error)}, as_json=args.as_json, exit_code=error.exit_code)
+    except Exception as error:
+        return _emit(
+            {"status": "error", "error": f"{type(error).__name__}: {error}"},
+            as_json=args.as_json,
+            exit_code=EXIT_RUNTIME_ERROR,
+        )
+
+    parser.error(f"Unsupported command {args.command!r}")
+    return EXIT_RUNTIME_ERROR
+
+
+def _emit(payload: dict[str, Any], *, as_json: bool, exit_code: int = EXIT_OK) -> int:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return exit_code
+
+    status = payload.get("status", "unknown")
+    print(f"status: {status}")
+    for key in ("message", "error", "next_action", "api_base_url", "url"):
+        value = payload.get(key)
+        if value:
+            print(f"{key}: {value}")
+    paths = payload.get("paths")
+    if isinstance(paths, dict):
+        print("paths:")
+        for key, value in paths.items():
+            print(f"- {key}: {value}")
+    checks = payload.get("checks")
+    if isinstance(checks, list):
+        print("checks:")
+        for check in checks:
+            if isinstance(check, dict):
+                print(f"- {check.get('code')}: {check.get('status')} - {check.get('message')}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fastapi_backend.py
+++ b/tests/test_fastapi_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import json
 import tempfile
 import unittest
 from copy import deepcopy
@@ -113,6 +114,29 @@ class FastApiBackendTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("store_backend", response.json())
+
+    def test_runtime_status_route_returns_app_shell_contract(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "HARNESS_RUNTIME_MODE": "local-app",
+                "HARNESS_RUNTIME_BASE_URL": "http://127.0.0.1:8765",
+                "HARNESS_RUNTIME_CONFIG_PATH": "/tmp/harness/config.json",
+                "HARNESS_RUNTIME_DATA_DIR": "/tmp/harness",
+                "HARNESS_RUNTIME_LOG_PATH": "/tmp/harness.log",
+            },
+            clear=False,
+        ):
+            client = TestClient(create_app(store=self.store, reset_service=self.reset_service))
+            response = client.get("/runtime/status")
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(payload["mode"], "local-app")
+        self.assertEqual(payload["api_base_url"], "http://127.0.0.1:8765")
+        self.assertEqual(payload["store_backend"], "file")
+        self.assertEqual(payload["paths"]["config_path"], "/tmp/harness/config.json")
+        self.assertNotIn("TOKEN", json.dumps(payload))
 
     def test_backend_stays_healthy_when_reset_startup_is_unavailable(self) -> None:
         with patch("backend.server.ResetVerificationService.from_env", side_effect=OSError("read-only file system")):

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.local_runtime import (
+    DEFAULT_API_PORT,
+    EXIT_OK,
+    EXIT_SETUP_REQUIRED,
+    EXIT_UNHEALTHY,
+    build_runtime_status_payload,
+    init_runtime,
+    main,
+    resolve_runtime_paths,
+    serve_runtime,
+    stop_runtime,
+)
+
+
+class LocalRuntimeCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.log_dir = tempfile.TemporaryDirectory()
+        self.data_path = Path(self.temp_dir.name)
+        self.log_path = Path(self.log_dir.name)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+        self.log_dir.cleanup()
+
+    def _run_cli(self, *args: str) -> tuple[int, dict[str, object]]:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = main(
+                [
+                    "--data-dir",
+                    str(self.data_path),
+                    "--log-dir",
+                    str(self.log_path),
+                    "--json",
+                    *args,
+                ]
+            )
+        return exit_code, json.loads(stdout.getvalue())
+
+    def test_init_creates_app_managed_config_sqlite_database_and_log(self) -> None:
+        exit_code, payload = self._run_cli("init")
+
+        config_path = self.data_path / "config.json"
+        database_path = self.data_path / "harness.db"
+        runtime_log_path = self.log_path / "harness.log"
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "initialized")
+        self.assertTrue(config_path.exists())
+        self.assertTrue(database_path.exists())
+        self.assertTrue(runtime_log_path.exists())
+
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(config["storage"]["backend"], "sqlite")
+        self.assertEqual(config["storage"]["sqlite_path"], str(database_path))
+        self.assertEqual(config["api"]["port"], DEFAULT_API_PORT)
+
+    def test_status_before_init_returns_setup_required(self) -> None:
+        exit_code, payload = self._run_cli("status")
+
+        self.assertEqual(exit_code, EXIT_SETUP_REQUIRED)
+        self.assertEqual(payload["status"], "uninitialized")
+        self.assertIn("harness init", payload["next_action"])
+
+    def test_status_reports_stopped_when_health_is_unreachable(self) -> None:
+        self._run_cli("init")
+
+        exit_code, payload = self._run_cli("status", "--timeout", "0.01")
+
+        self.assertEqual(exit_code, EXIT_UNHEALTHY)
+        self.assertEqual(payload["status"], "stopped")
+        self.assertFalse(payload["process_running"])
+
+    def test_invalid_config_returns_readable_setup_error(self) -> None:
+        self.data_path.mkdir(parents=True, exist_ok=True)
+        (self.data_path / "config.json").write_text(
+            json.dumps({"schema_version": 1, "api": {"port": "not-a-port"}}),
+            encoding="utf-8",
+        )
+
+        exit_code, payload = self._run_cli("status")
+
+        self.assertEqual(exit_code, EXIT_SETUP_REQUIRED)
+        self.assertEqual(payload["status"], "error")
+        self.assertIn("invalid api.port", payload["error"])
+
+    def test_doctor_reports_setup_passes_and_api_warning_when_stopped(self) -> None:
+        self._run_cli("init")
+
+        exit_code, payload = self._run_cli("doctor")
+        checks = {check["code"]: check for check in payload["checks"]}
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(checks["app_data_dir"]["status"], "pass")
+        self.assertEqual(checks["log_dir"]["status"], "pass")
+        self.assertEqual(checks["config"]["status"], "pass")
+        self.assertEqual(checks["sqlite"]["status"], "pass")
+        self.assertEqual(checks["api_health"]["status"], "warn")
+        self.assertIn("harness serve", checks["api_health"]["next_action"])
+
+
+class LocalRuntimeProcessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.log_dir = tempfile.TemporaryDirectory()
+        self.paths = resolve_runtime_paths(data_dir=self.temp_dir.name, log_dir=self.log_dir.name)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+        self.log_dir.cleanup()
+
+    def test_serve_applies_runtime_environment_and_cleans_pid_file(self) -> None:
+        observed: dict[str, object] = {}
+
+        def fake_run_uvicorn(config) -> None:  # noqa: ANN001
+            observed["pid_exists_during_run"] = config.pid_path.exists()
+            observed["store_backend"] = os.environ.get("HARNESS_STORE_BACKEND")
+            observed["sqlite_path"] = os.environ.get("HARNESS_SQLITE_PATH")
+            observed["runtime_mode"] = os.environ.get("HARNESS_RUNTIME_MODE")
+            print("server-started")
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("modules.local_runtime._assert_port_available"),
+            patch(
+                "modules.local_runtime._run_uvicorn",
+                side_effect=fake_run_uvicorn,
+            ),
+        ):
+            exit_code = serve_runtime(self.paths)
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertTrue(observed["pid_exists_during_run"])
+        self.assertEqual(observed["store_backend"], "sqlite")
+        self.assertEqual(observed["sqlite_path"], str(self.paths.database_path))
+        self.assertEqual(observed["runtime_mode"], "local-app")
+        self.assertFalse(self.paths.pid_path.exists())
+        self.assertIn("server-started", self.paths.log_path.read_text(encoding="utf-8"))
+
+    def test_stop_treats_missing_or_stale_process_as_stopped(self) -> None:
+        config, _ = init_runtime(self.paths)
+        config.pid_path.write_text("999999\n", encoding="utf-8")
+
+        with patch("modules.local_runtime.process_is_running", return_value=False):
+            exit_code, payload = stop_runtime(config)
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "stopped")
+        self.assertFalse(config.pid_path.exists())
+
+
+class LocalRuntimeContractTests(unittest.TestCase):
+    def test_resolves_macos_app_managed_paths(self) -> None:
+        paths = resolve_runtime_paths(platform_name="darwin", home="/Users/sean")
+
+        self.assertEqual(paths.data_dir, Path("/Users/sean/Library/Application Support/Harness"))
+        self.assertEqual(paths.log_dir, Path("/Users/sean/Library/Logs/Harness"))
+        self.assertEqual(paths.config_path, paths.data_dir / "config.json")
+        self.assertEqual(paths.database_path, paths.data_dir / "harness.db")
+
+    def test_resolves_linux_app_managed_paths(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"XDG_DATA_HOME": "/tmp/xdg-data", "XDG_STATE_HOME": "/tmp/xdg-state"},
+            clear=True,
+        ):
+            paths = resolve_runtime_paths(platform_name="linux", home="/Users/sean")
+
+        self.assertEqual(paths.data_dir, Path("/tmp/xdg-data/harness"))
+        self.assertEqual(paths.log_dir, Path("/tmp/xdg-state/harness/logs"))
+        self.assertEqual(paths.database_path, Path("/tmp/xdg-data/harness/harness.db"))
+
+    def test_backend_runtime_status_payload_uses_runtime_environment_without_secrets(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "HARNESS_RUNTIME_MODE": "local-app",
+                "HARNESS_RUNTIME_BASE_URL": "http://127.0.0.1:8765",
+                "HARNESS_RUNTIME_CONFIG_PATH": "/tmp/harness/config.json",
+                "HARNESS_RUNTIME_DATA_DIR": "/tmp/harness",
+                "HARNESS_RUNTIME_LOG_PATH": "/tmp/harness.log",
+            },
+            clear=True,
+        ):
+            payload = build_runtime_status_payload(
+                {
+                    "status": "ok",
+                    "store_backend": "sqlite",
+                    "database_path": "/tmp/harness/harness.db",
+                    "database_schema_ready": True,
+                }
+            )
+
+        self.assertEqual(payload["status"], "running")
+        self.assertEqual(payload["mode"], "local-app")
+        self.assertEqual(payload["api_base_url"], "http://127.0.0.1:8765")
+        self.assertEqual(payload["store_backend"], "sqlite")
+        self.assertEqual(payload["paths"]["database_path"], "/tmp/harness/harness.db")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a local runtime CLI contract for `init`, `serve`, `status`, `doctor`, `open`, and `stop` with app-managed config, SQLite, PID, and log paths.
- Adds `/runtime/status` for menu-bar/app-shell polling without requiring DB access or backend internals.
- Documents the runtime contract, exit codes, default macOS/Linux paths, and repo-checkout usage.

## Validation
- `python3 -m unittest tests.test_local_runtime tests.test_fastapi_backend tests.test_simulator -v`
- `python3 -m py_compile modules/local_runtime.py backend/server.py tests/test_local_runtime.py tests/test_fastapi_backend.py`
- `git diff --check`
- Local runtime smoke: temp app-data/log dirs, `init`, foreground `serve`, `/runtime/status`, `status`, `doctor`, `stop`
- `python3 -m unittest discover -s tests` (`809` tests, `17` skipped)

Closes #318