### PR TITLE
Package dashboard for local app runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ temp/
 *.log
 runs/
 .harness-dryruns/
+.harness-local-dashboard-build/
 .superpowers/
 
 # Node / frontend

--- a/README.md
+++ b/README.md
@@ -168,14 +168,15 @@ See:
 ### Frontend
 
 - Next.js 16 app in [`app/`](app) with shared dashboard components in [`components/`](components).
-- Root route redirects to `/tasks`.
+- Root route redirects to `/tasks` in normal Next mode. The static local-app export renders the tasks view at `/dashboard/` so the packaged dashboard has a working entrypoint.
 - Main working views:
   - `/tasks`
   - `/verification`
   - `/reconciliation`
   - `/reviews`
 - Frontend reads backend data through the Next proxy route at [`app/api/harness/[...path]/route.ts`](app/api/harness/[...path]/route.ts).
-- The frontend requires `HARNESS_API_BASE_URL` to point at a reachable backend. If it is missing or unreachable, the UI shows an error; it does not silently switch to fake live data.
+- Local app builds can also export the dashboard as static assets under `/dashboard` with [`scripts/build-local-dashboard.mjs`](scripts/build-local-dashboard.mjs). That packageable path serves the dashboard from the Python backend and calls the same-origin Harness API directly, so normal users do not need Node or `pnpm`.
+- The frontend requires a reachable backend, either through the hosted Next proxy or the local same-origin API. If the backend is missing or unreachable, the UI shows an error; it does not silently switch to fake live data.
 
 ### Backend
 
@@ -214,6 +215,7 @@ See:
 - SQLite storage is implemented in [`modules/store.py`](modules/store.py) and [`modules/reset/store.py`](modules/reset/store.py). Harness creates the local database and schema automatically.
 - The default hosted deployment target is Neon-backed Postgres attached through Vercel. Harness stores canonical task and evaluation payloads as JSONB in `tasks` and `evaluation_records`.
 - The local app runtime contract is implemented in [`modules/local_runtime.py`](modules/local_runtime.py) and documented in [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md).
+- Local dashboard packaging is documented in [`docs/architecture/local-dashboard-packaging.md`](docs/architecture/local-dashboard-packaging.md).
 
 ## Hosted Deployment Target
 
@@ -351,7 +353,15 @@ python3 -m modules.local_runtime --json doctor
 python3 -m modules.local_runtime stop
 ```
 
-Packaged builds should expose the same contract as `harness init`, `harness serve`, `harness status`, `harness doctor`, `harness open`, and `harness stop`. The runtime stores config, SQLite state, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
+Packaged builds should expose the same contract as `harness init`, `harness serve`, `harness status`, `harness doctor`, `harness open`, and `harness stop`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
+
+Build the packageable dashboard assets for the local app path:
+
+```bash
+pnpm build:dashboard:local
+```
+
+The output lives in `dist/local-dashboard/`. When `HARNESS_DASHBOARD_ASSETS_DIR` points at that directory, the Python backend serves the dashboard at `/dashboard` from the same process that serves the local API.
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 
@@ -451,6 +461,8 @@ Run frontend validation:
 ```bash
 pnpm lint
 pnpm build
+pnpm build:dashboard:local
+pnpm test:frontend
 ```
 
 ## Unattended Dry-Run Runner
@@ -599,7 +611,7 @@ Current screenshot assets:
 ## Known Limitations
 
 - The dashboard is read-only. There is no mutation UI for submissions, reevaluation, or review actions.
-- The frontend depends on a reachable backend via `HARNESS_API_BASE_URL`; it does not provide an offline sample-data mode in the current code path.
+- The frontend depends on a reachable backend via the hosted proxy or local same-origin API; it does not provide an offline sample-data mode in the current code path.
 - Live Linear and GitHub synchronization are still thin integration layers rather than full background sync services.
 - Review-required handling exists in evaluation, reevaluation, and dashboard summaries, but the hosted backend is not guaranteed to keep a review-required example task seeded at all times.
 - Hosted example task IDs are operational data and may change independently of the local deterministic scenario pack.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,11 @@
 import { redirect } from "next/navigation";
 
+import { TaskBrowser } from "@/components/dashboard/task-browser";
+
 export default function HomePage() {
+  if (process.env.NEXT_PUBLIC_HARNESS_DASHBOARD_MODE === "local-static") {
+    return <TaskBrowser view="tasks" />;
+  }
+
   redirect("/tasks");
 }

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 from modules.api import HarnessApiService
 from modules.local_env import load_native_local_env
@@ -12,6 +15,8 @@ from modules.reset.service import ResetVerificationService
 from modules.store import HarnessStore
 
 load_native_local_env()
+
+DASHBOARD_ASSETS_DIR_ENV_VAR = "HARNESS_DASHBOARD_ASSETS_DIR"
 
 
 def _json_response(result: tuple[int, dict[str, Any]]) -> JSONResponse:
@@ -54,6 +59,27 @@ def _build_reset_service(store: HarnessStore | None) -> ResetVerificationService
         return ResetVerificationService.from_env(root_dir=root_dir)
     except (OSError, ValueError) as error:
         return _UnavailableResetService(str(error))
+
+
+def _resolve_dashboard_assets_dir() -> Path | None:
+    configured = os.environ.get(DASHBOARD_ASSETS_DIR_ENV_VAR)
+    if not configured or not configured.strip():
+        return None
+    assets_dir = Path(configured).expanduser()
+    if not (assets_dir / "index.html").is_file():
+        return None
+    return assets_dir
+
+
+def _mount_dashboard_assets(app: FastAPI) -> None:
+    assets_dir = _resolve_dashboard_assets_dir()
+    if assets_dir is None:
+        return
+    app.mount(
+        "/dashboard",
+        StaticFiles(directory=str(assets_dir), html=True),
+        name="dashboard",
+    )
 
 
 def create_app(
@@ -164,6 +190,8 @@ def create_app(
     @app.post("/reset/tick")
     def run_reset_tick() -> JSONResponse:
         return _json_response(reset_verifier.tick_http())
+
+    _mount_dashboard_assets(app)
 
     return app
 

--- a/docs/architecture/local-dashboard-packaging.md
+++ b/docs/architecture/local-dashboard-packaging.md
@@ -1,0 +1,101 @@
+# Local Dashboard Packaging
+
+The local Harness app should not ask normal users to install Node, `pnpm`, or a developer checkout just to inspect task progress.
+
+Harness packages the dashboard as static assets for local app builds and serves those assets from the local Python runtime at `/dashboard`.
+The dashboard still reads canonical Harness APIs. It does not get a separate local truth store and it does not fall back to sample data when the backend is unavailable.
+
+## Decision
+
+Use a prebuilt static dashboard bundle for the local app path.
+
+The local dashboard build:
+
+- runs with `HARNESS_DASHBOARD_OUTPUT=export`
+- sets the Next base path to `/dashboard`
+- removes the staged `app/api` routes before export
+- builds the existing read-only dashboard routes as static files
+- writes a manifest to `dist/local-dashboard/dashboard-manifest.json`
+
+The normal hosted and developer dashboard build remains a Next.js app. It keeps `app/api/harness/[...path]/route.ts` so hosted deployments can proxy dashboard reads through the web service.
+
+This split is intentional. The local app path does not need a Node server because it talks to the same-origin Python API. The hosted path still benefits from the Next proxy because Vercel owns the web/backend service boundary.
+
+## Build Artifact
+
+From a repo checkout:
+
+```bash
+pnpm build:dashboard:local
+```
+
+The output directory is:
+
+```text
+dist/local-dashboard/
+```
+
+The generated bundle expects to be served at:
+
+```text
+/dashboard
+```
+
+The generated JavaScript resolves API calls in this order:
+
+- `window.__HARNESS_DASHBOARD_CONFIG__.apiBaseUrl`, when an embedding shell provides it
+- `NEXT_PUBLIC_HARNESS_API_BASE_URL`, when an explicit public API URL is compiled in
+- same-origin paths, when `NEXT_PUBLIC_HARNESS_DASHBOARD_MODE=local-static`
+- `/api/harness`, for the normal hosted/developer Next proxy mode
+
+## Runtime Mount
+
+The Python backend mounts packaged assets when `HARNESS_DASHBOARD_ASSETS_DIR` points at a directory containing `index.html`.
+
+```bash
+HARNESS_DASHBOARD_ASSETS_DIR="$PWD/dist/local-dashboard" \
+python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8765
+```
+
+Expected local routes:
+
+- `GET /dashboard/`
+- `GET /dashboard/tasks/`
+- `GET /dashboard/verification/`
+- `GET /dashboard/reconciliation/`
+- `GET /dashboard/reviews/`
+
+The same process serves the canonical API routes such as `GET /tasks`, `GET /tasks/<task_id>/read-model`, and `GET /runtime/status`.
+
+## Packaged App Contract
+
+Packaged macOS and Linux shells should either:
+
+- place the prebuilt dashboard bundle at the configured `dashboard_assets_dir`
+- set `HARNESS_DASHBOARD_ASSETS_DIR` before starting the Harness runtime
+
+The app should open:
+
+```text
+http://127.0.0.1:<runtime-port>/dashboard
+```
+
+Closing the dashboard window must not stop the runtime. The menu-bar or tray shell remains responsible for process control.
+
+## Validation
+
+Run both build modes before changing packaging behavior:
+
+```bash
+pnpm build
+pnpm build:dashboard:local
+pnpm test:frontend
+```
+
+Run backend validation when changing the runtime mount:
+
+```bash
+python3 -m unittest tests.test_fastapi_backend tests.test_local_runtime -v
+```
+
+If the dashboard cannot reach the local API, the UI should show the backend error. It must not silently switch to demo or sample data.

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -29,6 +29,7 @@ Default macOS paths:
 - Data: `~/Library/Application Support/Harness/`
 - Config: `~/Library/Application Support/Harness/config.json`
 - SQLite: `~/Library/Application Support/Harness/harness.db`
+- Dashboard assets: `~/Library/Application Support/Harness/dashboard/`
 - PID: `~/Library/Application Support/Harness/runtime/harness.pid`
 - Logs: `~/Library/Logs/Harness/harness.log`
 
@@ -37,6 +38,7 @@ Default Linux paths:
 - Data: `$XDG_DATA_HOME/harness/`, or `~/.local/share/harness/`
 - Config: `<data-dir>/config.json`
 - SQLite: `<data-dir>/harness.db`
+- Dashboard assets: `<data-dir>/dashboard/`
 - PID: `<data-dir>/runtime/harness.pid`
 - Logs: `$XDG_STATE_HOME/harness/logs/harness.log`, or `~/.local/state/harness/logs/harness.log`
 
@@ -54,7 +56,7 @@ The first schema stores:
 
 - local API host and port
 - SQLite database path
-- data, runtime, PID, and log paths
+- data, dashboard asset, runtime, PID, and log paths
 
 `harness serve` applies the config to the backend process through environment variables before startup:
 
@@ -67,8 +69,32 @@ The first schema stores:
 - `HARNESS_RUNTIME_HOST=127.0.0.1`
 - `HARNESS_RUNTIME_PORT=8765`
 - `HARNESS_RUNTIME_BASE_URL=http://127.0.0.1:8765`
+- `HARNESS_DASHBOARD_ASSETS_DIR=<app-data>/dashboard`
 
 This is what removes the need for Docker, Node, `pnpm`, or repo-local shell exports for the backend runtime.
+
+## Dashboard Assets
+
+The local app dashboard is a prebuilt static bundle served by the Python backend.
+It is not a second server process and it is not a Node runtime embedded in the app package.
+
+Developer builds produce the local bundle with:
+
+```bash
+pnpm build:dashboard:local
+```
+
+Packaged builds should copy that bundle into `dashboard_assets_dir`, or set `HARNESS_DASHBOARD_ASSETS_DIR` to the installed bundle path before starting `harness serve`.
+
+When the configured directory contains `index.html`, the backend mounts it at:
+
+- `GET /dashboard/`
+- `GET /dashboard/tasks/`
+- `GET /dashboard/verification/`
+- `GET /dashboard/reconciliation/`
+- `GET /dashboard/reviews/`
+
+The dashboard calls the same-origin local Harness API. If the backend is unavailable, it should display the API error rather than substituting sample data.
 
 ## Status And Health
 
@@ -127,3 +153,9 @@ and removes the PID file on clean exit.
 Missing or stale PID files are treated as already stopped because the desired state is satisfied.
 
 The local API binds to loopback by default. Network exposure is out of scope for the local app v1 contract.
+
+`harness open` should open the dashboard URL by default:
+
+```text
+http://127.0.0.1:<runtime-port>/dashboard
+```

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -5,7 +5,7 @@ This guide covers the practical local and container runbook for Harness.
 ## Prerequisites
 
 - Python 3
-- `pnpm`
+- `pnpm`, when developing or rebuilding the dashboard
 - Docker, if you want the containerized mode
 
 ## Native Local Development
@@ -48,6 +48,8 @@ Frontend validation:
 ```bash
 pnpm lint
 pnpm build
+pnpm build:dashboard:local
+pnpm test:frontend
 ```
 
 ### Run The API
@@ -101,12 +103,13 @@ python3 -m modules.local_runtime --json doctor
 python3 -m modules.local_runtime stop
 ```
 
-The runtime contract uses app-managed config, SQLite state, PID files, and logs. It does not require Docker, Node, `pnpm`, or repo-local shell exports.
+The runtime contract uses app-managed config, SQLite state, PID files, dashboard assets, and logs. A packaged app should not require Docker, Node, `pnpm`, or repo-local shell exports.
 
 Default macOS paths:
 
 - `~/Library/Application Support/Harness/config.json`
 - `~/Library/Application Support/Harness/harness.db`
+- `~/Library/Application Support/Harness/dashboard/`
 - `~/Library/Application Support/Harness/runtime/harness.pid`
 - `~/Library/Logs/Harness/harness.log`
 
@@ -204,6 +207,38 @@ The dashboard is read-only and depends on the canonical inspection APIs:
 - `GET /tasks`
 - `GET /tasks/<task_id>/read-model`
 - `GET /tasks/<task_id>/timeline`
+
+### Build The Packaged Local Dashboard
+
+For the self-contained local app path, build static dashboard assets instead of running a Node dashboard server:
+
+```bash
+pnpm build:dashboard:local
+```
+
+This writes:
+
+```text
+dist/local-dashboard/
+```
+
+The local bundle is served by the Python backend at `/dashboard` and calls the same-origin Harness API directly.
+It does not use the Next proxy route and it does not fall back to sample data.
+
+Smoke it from a checkout:
+
+```bash
+HARNESS_DASHBOARD_ASSETS_DIR="$PWD/dist/local-dashboard" \
+python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8765
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8765/dashboard/
+```
+
+The normal hosted/developer dashboard still uses `pnpm dev` or `pnpm build` and the Next proxy route.
 
 ### One-Command Demo Bootstrap
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import nextVitals from "eslint-config-next/core-web-vitals";
 const config = [
   ...nextVitals,
   {
-    ignores: [".next/**", "node_modules/**"],
+    ignores: [".harness-local-dashboard-build/**", ".next/**", "node_modules/**"],
   },
 ];
 

--- a/lib/harness-api.ts
+++ b/lib/harness-api.ts
@@ -8,6 +8,39 @@ import type {
 } from "@/lib/types";
 
 const proxyBasePath = "/api/harness";
+const localStaticApiBasePath = "";
+
+declare global {
+  interface Window {
+    __HARNESS_DASHBOARD_CONFIG__?: {
+      apiBaseUrl?: string;
+    };
+  }
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/$/, "");
+}
+
+export function resolveDashboardApiBasePath(): string {
+  if (typeof window !== "undefined") {
+    const runtimeBaseUrl = window.__HARNESS_DASHBOARD_CONFIG__?.apiBaseUrl?.trim();
+    if (runtimeBaseUrl) {
+      return stripTrailingSlash(runtimeBaseUrl);
+    }
+  }
+
+  const publicBaseUrl = process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL?.trim();
+  if (publicBaseUrl) {
+    return stripTrailingSlash(publicBaseUrl);
+  }
+
+  if (process.env.NEXT_PUBLIC_HARNESS_DASHBOARD_MODE === "local-static") {
+    return localStaticApiBasePath;
+  }
+
+  return proxyBasePath;
+}
 
 function mapVerificationStatus(summary: Record<string, unknown> | null): VerificationStatus | null {
   if (!summary) {
@@ -345,7 +378,7 @@ function mapTask(readModel: Record<string, unknown>, timelineOverride?: Timeline
 }
 
 async function fetchJson(path: string): Promise<unknown> {
-  const response = await fetch(`${proxyBasePath}${path}`, {
+  const response = await fetch(`${resolveDashboardApiBasePath()}${path}`, {
     headers: { Accept: "application/json" },
     cache: "no-store",
   });

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -39,6 +39,7 @@ ENV_RUNTIME_LOG_PATH = "HARNESS_RUNTIME_LOG_PATH"
 ENV_RUNTIME_HOST = "HARNESS_RUNTIME_HOST"
 ENV_RUNTIME_PORT = "HARNESS_RUNTIME_PORT"
 ENV_RUNTIME_BASE_URL = "HARNESS_RUNTIME_BASE_URL"
+ENV_DASHBOARD_ASSETS_DIR = "HARNESS_DASHBOARD_ASSETS_DIR"
 
 
 class LocalRuntimeError(ValueError):
@@ -56,6 +57,7 @@ class RuntimePaths:
     runtime_dir: Path
     config_path: Path
     database_path: Path
+    dashboard_assets_dir: Path
     pid_path: Path
     log_path: Path
 
@@ -66,6 +68,7 @@ class RuntimeConfig:
     host: str
     port: int
     database_path: Path
+    dashboard_assets_dir: Path
     data_dir: Path
     log_dir: Path
     runtime_dir: Path
@@ -90,6 +93,7 @@ class RuntimeConfig:
             },
             "paths": {
                 "data_dir": str(self.data_dir),
+                "dashboard_assets_dir": str(self.dashboard_assets_dir),
                 "log_dir": str(self.log_dir),
                 "runtime_dir": str(self.runtime_dir),
                 "pid_path": str(self.pid_path),
@@ -126,6 +130,9 @@ class RuntimeConfig:
             ) from error
         database_path = Path(str(storage.get("sqlite_path") or paths.database_path)).expanduser()
         data_dir = Path(str(stored_paths.get("data_dir") or paths.data_dir)).expanduser()
+        dashboard_assets_dir = Path(
+            str(stored_paths.get("dashboard_assets_dir") or paths.dashboard_assets_dir)
+        ).expanduser()
         log_dir = Path(str(stored_paths.get("log_dir") or paths.log_dir)).expanduser()
         runtime_dir = Path(str(stored_paths.get("runtime_dir") or paths.runtime_dir)).expanduser()
         pid_path = Path(str(stored_paths.get("pid_path") or paths.pid_path)).expanduser()
@@ -135,6 +142,7 @@ class RuntimeConfig:
             host=host,
             port=port,
             database_path=database_path,
+            dashboard_assets_dir=dashboard_assets_dir,
             data_dir=data_dir,
             log_dir=log_dir,
             runtime_dir=runtime_dir,
@@ -176,6 +184,7 @@ def resolve_runtime_paths(
         runtime_dir=runtime_dir,
         config_path=resolved_data_dir / "config.json",
         database_path=resolved_data_dir / "harness.db",
+        dashboard_assets_dir=resolved_data_dir / "dashboard",
         pid_path=runtime_dir / "harness.pid",
         log_path=resolved_log_dir / "harness.log",
     )
@@ -210,6 +219,7 @@ def create_default_config(
         host=host,
         port=port,
         database_path=paths.database_path,
+        dashboard_assets_dir=paths.dashboard_assets_dir,
         data_dir=paths.data_dir,
         log_dir=paths.log_dir,
         runtime_dir=paths.runtime_dir,
@@ -284,6 +294,7 @@ def apply_runtime_environment(config: RuntimeConfig, *, config_path: Path) -> No
     os.environ[ENV_RUNTIME_HOST] = config.host
     os.environ[ENV_RUNTIME_PORT] = str(config.port)
     os.environ[ENV_RUNTIME_BASE_URL] = config.base_url
+    os.environ.setdefault(ENV_DASHBOARD_ASSETS_DIR, str(config.dashboard_assets_dir))
 
 
 def fetch_runtime_health(
@@ -555,7 +566,7 @@ def stop_runtime(config: RuntimeConfig, *, timeout_seconds: float = 10.0) -> tup
 
 
 def open_runtime(config: RuntimeConfig, *, launch: bool = True) -> tuple[int, dict[str, Any]]:
-    url = os.environ.get("HARNESS_DASHBOARD_URL") or config.base_url
+    url = os.environ.get("HARNESS_DASHBOARD_URL") or f"{config.base_url}/dashboard"
     if launch:
         _open_url(url)
     return EXIT_OK, {
@@ -605,6 +616,7 @@ def _paths_payload(config: RuntimeConfig) -> dict[str, str]:
         "data_dir": str(config.data_dir),
         "log_dir": str(config.log_dir),
         "config_path": str(config.data_dir / "config.json"),
+        "dashboard_assets_dir": str(config.dashboard_assets_dir),
         "database_path": str(config.database_path),
         "runtime_dir": str(config.runtime_dir),
         "pid_path": str(config.pid_path),

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
 
+const isStaticDashboardExport = process.env.HARNESS_DASHBOARD_OUTPUT === "export";
+
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1", "localhost"],
+  basePath: isStaticDashboardExport ? "/dashboard" : undefined,
+  output: isStaticDashboardExport ? "export" : undefined,
+  trailingSlash: isStaticDashboardExport ? true : undefined,
   turbopack: {
     root: process.cwd(),
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "build:dashboard:local": "node scripts/build-local-dashboard.mjs",
     "start": "next start",
     "lint": "eslint .",
     "test:frontend": "tsx --test tests/frontend/**/*.test.ts"

--- a/scripts/build-local-dashboard.mjs
+++ b/scripts/build-local-dashboard.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { cp, mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(scriptPath), "..");
+const stageRoot = path.join(repoRoot, ".harness-local-dashboard-build");
+const stageSource = path.join(stageRoot, "source");
+const outputDir = path.join(repoRoot, "dist", "local-dashboard");
+const appSource = path.join(repoRoot, "app");
+const appTarget = path.join(stageSource, "app");
+
+async function copyIfExists(source, target) {
+  if (existsSync(source)) {
+    await cp(source, target, {
+      recursive: true,
+      force: true,
+      verbatimSymlinks: true,
+    });
+  }
+}
+
+async function prepareStage() {
+  await rm(stageRoot, { recursive: true, force: true });
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(stageSource, { recursive: true });
+
+  await copyIfExists(appSource, appTarget);
+  await rm(path.join(appTarget, "api"), { recursive: true, force: true });
+
+  for (const entry of [
+    "components",
+    "lib",
+    "public",
+    "next.config.ts",
+    "package.json",
+    "postcss.config.mjs",
+    "tsconfig.json",
+    "next-env.d.ts",
+  ]) {
+    await copyIfExists(path.join(repoRoot, entry), path.join(stageSource, entry));
+  }
+}
+
+function runNextBuild() {
+  const result = spawnSync("pnpm", ["exec", "next", "build", stageSource], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HARNESS_DASHBOARD_OUTPUT: "export",
+      NEXT_PUBLIC_HARNESS_DASHBOARD_MODE: "local-static",
+      NEXT_TELEMETRY_DISABLED: "1",
+    },
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+async function writeManifest() {
+  const manifest = {
+    format_version: 1,
+    mode: "local-static",
+    base_path: "/dashboard",
+    api_base: "same-origin",
+    entrypoints: [
+      "/dashboard/",
+      "/dashboard/tasks/",
+      "/dashboard/verification/",
+      "/dashboard/reconciliation/",
+      "/dashboard/reviews/",
+    ],
+  };
+  await writeFile(
+    path.join(outputDir, "dashboard-manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+async function main() {
+  await prepareStage();
+  runNextBuild();
+  await cp(path.join(stageSource, "out"), outputDir, {
+    recursive: true,
+    force: true,
+  });
+  await writeManifest();
+  console.log(`Built local dashboard assets at ${path.relative(repoRoot, outputDir)}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/tests/frontend/dashboard-api-base.test.ts
+++ b/tests/frontend/dashboard-api-base.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveDashboardApiBasePath } from "../../lib/harness-api";
+
+type TestWindow = {
+  __HARNESS_DASHBOARD_CONFIG__?: {
+    apiBaseUrl?: string;
+  };
+};
+
+function resetEnvironment() {
+  delete process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL;
+  delete process.env.NEXT_PUBLIC_HARNESS_DASHBOARD_MODE;
+  delete (globalThis as { window?: TestWindow }).window;
+}
+
+test.afterEach(() => {
+  resetEnvironment();
+});
+
+test("uses the Next proxy by default", () => {
+  resetEnvironment();
+
+  assert.equal(resolveDashboardApiBasePath(), "/api/harness");
+});
+
+test("uses same-origin API paths for local static dashboard builds", () => {
+  resetEnvironment();
+  process.env.NEXT_PUBLIC_HARNESS_DASHBOARD_MODE = "local-static";
+
+  assert.equal(resolveDashboardApiBasePath(), "");
+});
+
+test("uses explicit public API base URL when configured", () => {
+  resetEnvironment();
+  process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL = "http://127.0.0.1:8765/";
+
+  assert.equal(resolveDashboardApiBasePath(), "http://127.0.0.1:8765");
+});
+
+test("runtime dashboard config wins over build-time environment", () => {
+  resetEnvironment();
+  process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL = "http://build-time.example/";
+  (globalThis as { window?: TestWindow }).window = {
+    __HARNESS_DASHBOARD_CONFIG__: {
+      apiBaseUrl: "http://runtime.example/",
+    },
+  };
+
+  assert.equal(resolveDashboardApiBasePath(), "http://runtime.example");
+});

--- a/tests/test_fastapi_backend.py
+++ b/tests/test_fastapi_backend.py
@@ -138,6 +138,23 @@ class FastApiBackendTests(unittest.TestCase):
         self.assertEqual(payload["paths"]["config_path"], "/tmp/harness/config.json")
         self.assertNotIn("TOKEN", json.dumps(payload))
 
+    def test_mounts_packaged_dashboard_assets_when_configured(self) -> None:
+        dashboard_dir = Path(self.temp_dir.name) / "dashboard"
+        (dashboard_dir / "tasks").mkdir(parents=True)
+        (dashboard_dir / "index.html").write_text("<h1>Dashboard Home</h1>", encoding="utf-8")
+        (dashboard_dir / "tasks" / "index.html").write_text("<h1>Tasks</h1>", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HARNESS_DASHBOARD_ASSETS_DIR": str(dashboard_dir)}, clear=False):
+            client = TestClient(create_app(store=self.store, reset_service=self.reset_service))
+
+        home = client.get("/dashboard/")
+        tasks = client.get("/dashboard/tasks/")
+
+        self.assertEqual(home.status_code, 200)
+        self.assertIn("Dashboard Home", home.text)
+        self.assertEqual(tasks.status_code, 200)
+        self.assertIn("Tasks", tasks.text)
+
     def test_backend_stays_healthy_when_reset_startup_is_unavailable(self) -> None:
         with patch("backend.server.ResetVerificationService.from_env", side_effect=OSError("read-only file system")):
             client = TestClient(create_app(store=self.store))

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -66,6 +66,10 @@ class LocalRuntimeCliTests(unittest.TestCase):
         self.assertEqual(config["storage"]["backend"], "sqlite")
         self.assertEqual(config["storage"]["sqlite_path"], str(database_path))
         self.assertEqual(config["api"]["port"], DEFAULT_API_PORT)
+        self.assertEqual(
+            config["paths"]["dashboard_assets_dir"],
+            str(self.data_path / "dashboard"),
+        )
 
     def test_status_before_init_returns_setup_required(self) -> None:
         exit_code, payload = self._run_cli("status")
@@ -130,6 +134,7 @@ class LocalRuntimeProcessTests(unittest.TestCase):
             observed["store_backend"] = os.environ.get("HARNESS_STORE_BACKEND")
             observed["sqlite_path"] = os.environ.get("HARNESS_SQLITE_PATH")
             observed["runtime_mode"] = os.environ.get("HARNESS_RUNTIME_MODE")
+            observed["dashboard_assets_dir"] = os.environ.get("HARNESS_DASHBOARD_ASSETS_DIR")
             print("server-started")
 
         with (
@@ -147,6 +152,7 @@ class LocalRuntimeProcessTests(unittest.TestCase):
         self.assertEqual(observed["store_backend"], "sqlite")
         self.assertEqual(observed["sqlite_path"], str(self.paths.database_path))
         self.assertEqual(observed["runtime_mode"], "local-app")
+        self.assertEqual(observed["dashboard_assets_dir"], str(self.paths.dashboard_assets_dir))
         self.assertFalse(self.paths.pid_path.exists())
         self.assertIn("server-started", self.paths.log_path.read_text(encoding="utf-8"))
 
@@ -170,6 +176,7 @@ class LocalRuntimeContractTests(unittest.TestCase):
         self.assertEqual(paths.log_dir, Path("/Users/sean/Library/Logs/Harness"))
         self.assertEqual(paths.config_path, paths.data_dir / "config.json")
         self.assertEqual(paths.database_path, paths.data_dir / "harness.db")
+        self.assertEqual(paths.dashboard_assets_dir, paths.data_dir / "dashboard")
 
     def test_resolves_linux_app_managed_paths(self) -> None:
         with patch.dict(
@@ -182,6 +189,7 @@ class LocalRuntimeContractTests(unittest.TestCase):
         self.assertEqual(paths.data_dir, Path("/tmp/xdg-data/harness"))
         self.assertEqual(paths.log_dir, Path("/tmp/xdg-state/harness/logs"))
         self.assertEqual(paths.database_path, Path("/tmp/xdg-data/harness/harness.db"))
+        self.assertEqual(paths.dashboard_assets_dir, Path("/tmp/xdg-data/harness/dashboard"))
 
     def test_backend_runtime_status_payload_uses_runtime_environment_without_secrets(self) -> None:
         with patch.dict(


### PR DESCRIPTION
## Summary

- Adds a local static dashboard export path that builds the existing read-only dashboard under `/dashboard` without bundling a Node runtime.
- Mounts packaged dashboard assets from `HARNESS_DASHBOARD_ASSETS_DIR` in the Python backend and threads that path through the local runtime contract.
- Keeps hosted/developer Next mode intact with the existing `/api/harness` proxy while local static mode uses same-origin API calls.
- Documents the local dashboard packaging contract, setup steps, and validation commands.

Closes #319.

## Validation

- `pnpm test:frontend`
- `python3 -m unittest tests.test_fastapi_backend tests.test_local_runtime -v`
- `python3 -m py_compile modules/local_runtime.py backend/server.py`
- `pnpm lint`
- `pnpm build`
- `pnpm build:dashboard:local`
- Static mount smoke: `GET /dashboard/`, `GET /dashboard/tasks/`, `GET /runtime/status`, and `GET /tasks` from one FastAPI process
- `python3 -m unittest discover -s tests` (`810` tests, `17` skipped)
- `git diff --check`
