### PR TITLE
Add app-managed local secrets boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ See:
 - SQLite storage is implemented in [`modules/store.py`](modules/store.py) and [`modules/reset/store.py`](modules/reset/store.py). Harness creates the local database and schema automatically.
 - The default hosted deployment target is Neon-backed Postgres attached through Vercel. Harness stores canonical task and evaluation payloads as JSONB in `tasks` and `evaluation_records`.
 - The local app runtime contract is implemented in [`modules/local_runtime.py`](modules/local_runtime.py) and documented in [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md).
+- App-managed secret storage is implemented in [`modules/local_secrets.py`](modules/local_secrets.py) and documented in [`docs/architecture/app-managed-secrets.md`](docs/architecture/app-managed-secrets.md).
 - Local dashboard packaging is documented in [`docs/architecture/local-dashboard-packaging.md`](docs/architecture/local-dashboard-packaging.md).
 
 ## Hosted Deployment Target
@@ -350,10 +351,11 @@ python3 -m modules.local_runtime --json init
 python3 -m modules.local_runtime --json status
 python3 -m modules.local_runtime serve
 python3 -m modules.local_runtime --json doctor
+python3 -m modules.local_runtime --json secrets status
 python3 -m modules.local_runtime stop
 ```
 
-Packaged builds should expose the same contract as `harness init`, `harness serve`, `harness status`, `harness doctor`, `harness open`, and `harness stop`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
+Packaged builds should expose the same contract as `harness init`, `harness serve`, `harness status`, `harness doctor`, `harness open`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
 
 Build the packageable dashboard assets for the local app path:
 
@@ -362,6 +364,16 @@ pnpm build:dashboard:local
 ```
 
 The output lives in `dist/local-dashboard/`. When `HARNESS_DASHBOARD_ASSETS_DIR` points at that directory, the Python backend serves the dashboard at `/dashboard` from the same process that serves the local API.
+
+Store app-managed secrets for packaged local app usage:
+
+```bash
+printf '%s' "$GITHUB_TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin
+printf '%s' "$LINEAR_API_KEY" | python3 -m modules.local_runtime --json secrets set linear_api_key --value-stdin
+python3 -m modules.local_runtime --json secrets status --require github_token
+```
+
+The secrets command reports setup state without printing token values. Developer `.env.local` mode remains supported for native local development, but packaged app onboarding should use the secret store instead of asking users to edit env files.
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 

--- a/docs/architecture/app-managed-secrets.md
+++ b/docs/architecture/app-managed-secrets.md
@@ -1,0 +1,68 @@
+# App-Managed Secrets
+
+Harness local app builds must not ask normal users to edit `.env.local`.
+Non-secret runtime config lives in `config.json`; tokens and integration credentials live behind the app-managed secret provider.
+
+## Secret Provider
+
+macOS v1 uses Keychain through the Harness service namespace:
+
+```text
+com.knoxanalytics.harness.local-runtime
+```
+
+The runtime secret boundary is implemented in [`modules/local_secrets.py`](../../modules/local_secrets.py).
+It exposes named secrets, redacted status output, and provider operations without writing secret values to `config.json`, logs, or JSON status payloads.
+
+Current secret names:
+
+- `github_token`: maps to `GITHUB_TOKEN`
+- `linear_api_key`: maps to `LINEAR_API_KEY`
+- `repair_callback_bearer_token`: maps to `OPENCLAW_REPAIR_BEARER_TOKEN`
+
+The `OPENCLAW_REPAIR_BEARER_TOKEN` env name remains the current concrete repair-adapter variable. It is not the product boundary. The stable local-app boundary is the named Harness secret.
+
+## CLI Contract
+
+The packaged app can call the same command surface that developers can run from a checkout:
+
+```bash
+python3 -m modules.local_runtime --json secrets status
+python3 -m modules.local_runtime --json secrets status --require github_token
+printf '%s' "$GITHUB_TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin
+python3 -m modules.local_runtime --json secrets delete github_token
+```
+
+`secrets status` never prints secret values. When a workflow requires a credential, pass `--require <name>` so missing or unavailable credentials return a setup-required exit code instead of looking like a healthy state.
+
+`secrets set` intentionally requires `--value-stdin` so users and app shells do not put tokens in shell history.
+
+The future native macOS shell should prefer the Keychain APIs directly when storing user-entered tokens.
+Use the same service value above and the Harness secret name as the Keychain account.
+The Python CLI exists as a portable contract and developer fallback; the native app does not need to shell out to store secrets.
+
+## Runtime Behavior
+
+`harness serve` applies app-managed config, then loads available app-managed secrets into process environment variables before starting the backend.
+
+Existing environment variables win. This preserves developer mode:
+
+- repo-root `.env.local` remains valid for native local development
+- exported shell variables remain valid for CI and one-off debugging
+- app-managed Keychain secrets are the normal packaged-app path
+
+Missing secrets do not block the local API from starting because GitHub, Linear, and executor integrations are optional until a chosen workflow needs them.
+Workflows that need a credential should call `secrets status --require <name>` or surface the integration-specific setup error.
+
+## Security Rules
+
+- Do not write token values to `config.json`.
+- Do not write token values to logs.
+- Do not return token values from CLI JSON.
+- Do not teach packaged-app users to edit `.env.local`.
+- Do not couple the secret model to OpenClaw or Hermes. Use Harness secret names and map them to current env vars at the runtime boundary.
+
+## Linux Portability
+
+Linux support will use the same Harness secret names and CLI/status contract.
+The provider can later be Secret Service/libsecret or an encrypted local fallback, but it should not change the runtime env mapping or the onboarding contract.

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -19,6 +19,9 @@ Commands:
 - `harness doctor`
 - `harness open`
 - `harness stop`
+- `harness secrets status`
+- `harness secrets set <name> --value-stdin`
+- `harness secrets delete <name>`
 
 The CLI supports `--json` for app-shell consumption. JSON output is the contract the macOS menu-bar app should use.
 
@@ -50,7 +53,7 @@ Normal app usage should rely on app-managed defaults.
 
 `harness init` writes non-secret config to `config.json` and initializes the SQLite schema.
 Secrets do not belong in this file.
-GitHub, Linear, and ingress/executor credentials should move through the app-managed secret store in later slices.
+GitHub, Linear, and ingress/executor credentials move through the app-managed secret store.
 
 The first schema stores:
 
@@ -70,8 +73,31 @@ The first schema stores:
 - `HARNESS_RUNTIME_PORT=8765`
 - `HARNESS_RUNTIME_BASE_URL=http://127.0.0.1:8765`
 - `HARNESS_DASHBOARD_ASSETS_DIR=<app-data>/dashboard`
+- app-managed secrets, when present, mapped to their backend environment variables
 
 This is what removes the need for Docker, Node, `pnpm`, or repo-local shell exports for the backend runtime.
+
+## Secret Store
+
+macOS v1 stores local app secrets in Keychain. The stable Harness secret names are:
+
+- `github_token`, mapped to `GITHUB_TOKEN`
+- `linear_api_key`, mapped to `LINEAR_API_KEY`
+- `repair_callback_bearer_token`, mapped to `OPENCLAW_REPAIR_BEARER_TOKEN`
+
+From a repo checkout, use:
+
+```bash
+python3 -m modules.local_runtime --json secrets status
+python3 -m modules.local_runtime --json secrets status --require github_token
+printf '%s' "$GITHUB_TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin
+python3 -m modules.local_runtime --json secrets delete github_token
+```
+
+Secret status output is redacted. It reports configured, missing, unavailable, and error states without returning token values.
+Existing environment variables win over Keychain values so native developer `.env.local` workflows still work.
+
+See [app-managed-secrets.md](app-managed-secrets.md).
 
 ## Dashboard Assets
 

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -100,6 +100,7 @@ python3 -m modules.local_runtime --json init
 python3 -m modules.local_runtime --json status
 python3 -m modules.local_runtime serve
 python3 -m modules.local_runtime --json doctor
+python3 -m modules.local_runtime --json secrets status
 python3 -m modules.local_runtime stop
 ```
 
@@ -112,6 +113,17 @@ Default macOS paths:
 - `~/Library/Application Support/Harness/dashboard/`
 - `~/Library/Application Support/Harness/runtime/harness.pid`
 - `~/Library/Logs/Harness/harness.log`
+
+Packaged app secrets use the app-managed secret store instead of `.env.local`:
+
+```bash
+printf '%s' "$GITHUB_TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin
+printf '%s' "$LINEAR_API_KEY" | python3 -m modules.local_runtime --json secrets set linear_api_key --value-stdin
+python3 -m modules.local_runtime --json secrets status
+```
+
+Secret status output is redacted. Use `--require <secret-name>` when a selected workflow cannot run without that credential.
+Native developer mode can still use repo-root `.env.local`.
 
 To run the same backend against Postgres instead of the file-backed store:
 

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -18,6 +18,13 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from modules.local_secrets import (
+    LocalSecretError,
+    MacOSKeychainSecretStore,
+    collect_secret_statuses,
+    load_app_managed_secrets_into_environment,
+    secret_status_payload,
+)
 from modules.store import SQLiteHarnessStore, StoreError
 
 
@@ -40,6 +47,7 @@ ENV_RUNTIME_HOST = "HARNESS_RUNTIME_HOST"
 ENV_RUNTIME_PORT = "HARNESS_RUNTIME_PORT"
 ENV_RUNTIME_BASE_URL = "HARNESS_RUNTIME_BASE_URL"
 ENV_DASHBOARD_ASSETS_DIR = "HARNESS_DASHBOARD_ASSETS_DIR"
+ENV_SECRET_PROVIDER = "HARNESS_SECRET_PROVIDER"
 
 
 class LocalRuntimeError(ValueError):
@@ -295,6 +303,8 @@ def apply_runtime_environment(config: RuntimeConfig, *, config_path: Path) -> No
     os.environ[ENV_RUNTIME_PORT] = str(config.port)
     os.environ[ENV_RUNTIME_BASE_URL] = config.base_url
     os.environ.setdefault(ENV_DASHBOARD_ASSETS_DIR, str(config.dashboard_assets_dir))
+    load_app_managed_secrets_into_environment(store=create_secret_store())
+    os.environ.setdefault(ENV_SECRET_PROVIDER, "macos-keychain")
 
 
 def fetch_runtime_health(
@@ -598,6 +608,7 @@ def build_runtime_status_payload(health_payload: dict[str, Any]) -> dict[str, An
     return {
         "status": "running" if health_payload.get("status") == "ok" else "degraded",
         "mode": os.environ.get(ENV_RUNTIME_MODE, "developer"),
+        "secret_provider": os.environ.get(ENV_SECRET_PROVIDER),
         "api_base_url": base_url,
         "store_backend": health_payload.get("store_backend"),
         "database_schema_ready": health_payload.get("database_schema_ready"),
@@ -667,7 +678,42 @@ def build_parser() -> argparse.ArgumentParser:
     stop_parser = subparsers.add_parser("stop", help="Gracefully stop the local Harness runtime")
     stop_parser.add_argument("--timeout", default=10.0, type=float, help="Shutdown timeout in seconds")
 
+    secrets_parser = subparsers.add_parser("secrets", help="Manage app-managed Harness secrets")
+    secrets_subparsers = secrets_parser.add_subparsers(dest="secret_command", required=True)
+
+    secrets_status_parser = secrets_subparsers.add_parser(
+        "status",
+        help="Report configured and missing app-managed secrets without printing values",
+    )
+    secrets_status_parser.add_argument(
+        "--require",
+        action="append",
+        default=[],
+        help="Treat the named secret as required for this status check",
+    )
+
+    secrets_set_parser = secrets_subparsers.add_parser(
+        "set",
+        help="Store a secret in the app-managed secret provider",
+    )
+    secrets_set_parser.add_argument("name", help="Secret name")
+    secrets_set_parser.add_argument(
+        "--value-stdin",
+        action="store_true",
+        help="Read the secret value from stdin",
+    )
+
+    secrets_delete_parser = secrets_subparsers.add_parser(
+        "delete",
+        help="Delete a stored app-managed secret",
+    )
+    secrets_delete_parser.add_argument("name", help="Secret name")
+
     return parser
+
+
+def create_secret_store() -> MacOSKeychainSecretStore:
+    return MacOSKeychainSecretStore()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -713,8 +759,12 @@ def main(argv: list[str] | None = None) -> int:
             config = load_runtime_config(paths)
             exit_code, payload = stop_runtime(config, timeout_seconds=args.timeout)
             return _emit(payload, as_json=args.as_json, exit_code=exit_code)
+        if args.command == "secrets":
+            return _handle_secrets_command(args, as_json=args.as_json)
     except LocalRuntimeError as error:
         return _emit({"status": "error", "error": str(error)}, as_json=args.as_json, exit_code=error.exit_code)
+    except LocalSecretError as error:
+        return _emit({"status": "error", "error": str(error)}, as_json=args.as_json, exit_code=EXIT_SETUP_REQUIRED)
     except Exception as error:
         return _emit(
             {"status": "error", "error": f"{type(error).__name__}: {error}"},
@@ -724,6 +774,43 @@ def main(argv: list[str] | None = None) -> int:
 
     parser.error(f"Unsupported command {args.command!r}")
     return EXIT_RUNTIME_ERROR
+
+
+def _handle_secrets_command(args: argparse.Namespace, *, as_json: bool) -> int:
+    store = create_secret_store()
+    if args.secret_command == "status":
+        statuses = collect_secret_statuses(store=store, required_names=args.require)
+        payload = secret_status_payload(statuses)
+        missing_required = bool(payload.get("missing_required"))
+        exit_code = EXIT_SETUP_REQUIRED if missing_required else EXIT_OK
+        return _emit(payload, as_json=as_json, exit_code=exit_code)
+    if args.secret_command == "set":
+        if not args.value_stdin:
+            raise LocalRuntimeError(
+                "Use `--value-stdin` so secrets are not stored in shell history.",
+                exit_code=EXIT_SETUP_REQUIRED,
+            )
+        value = sys.stdin.read().rstrip("\n")
+        store.set_secret(args.name, value)
+        return _emit(
+            {
+                "status": "stored",
+                "secret": args.name,
+                "message": "Secret stored in the app-managed secret provider.",
+            },
+            as_json=as_json,
+        )
+    if args.secret_command == "delete":
+        deleted = store.delete_secret(args.name)
+        return _emit(
+            {
+                "status": "deleted" if deleted else "missing",
+                "secret": args.name,
+                "message": "Secret deleted." if deleted else "Secret was not stored.",
+            },
+            as_json=as_json,
+        )
+    raise LocalRuntimeError(f"Unsupported secrets command {args.secret_command!r}.")
 
 
 def _emit(payload: dict[str, Any], *, as_json: bool, exit_code: int = EXIT_OK) -> int:
@@ -748,6 +835,12 @@ def _emit(payload: dict[str, Any], *, as_json: bool, exit_code: int = EXIT_OK) -
         for check in checks:
             if isinstance(check, dict):
                 print(f"- {check.get('code')}: {check.get('status')} - {check.get('message')}")
+    secrets = payload.get("secrets")
+    if isinstance(secrets, list):
+        print("secrets:")
+        for secret in secrets:
+            if isinstance(secret, dict):
+                print(f"- {secret.get('name')}: {secret.get('status')} - {secret.get('message')}")
     return exit_code
 
 

--- a/modules/local_secrets.py
+++ b/modules/local_secrets.py
@@ -1,0 +1,385 @@
+"""App-managed secret storage for the local Harness runtime."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from typing import Callable, Iterable, Protocol
+
+
+KEYCHAIN_SERVICE = "com.knoxanalytics.harness.local-runtime"
+
+
+class LocalSecretError(ValueError):
+    """Operator-readable local secret failure."""
+
+
+class SecretNotFoundError(LocalSecretError):
+    """Requested secret is not stored in the configured provider."""
+
+
+class SecretProviderUnavailableError(LocalSecretError):
+    """The configured secret provider cannot be used on this machine."""
+
+
+class SecretStore(Protocol):
+    def get_secret(self, name: str) -> str:
+        """Return a secret value or raise a LocalSecretError."""
+
+    def set_secret(self, name: str, value: str) -> None:
+        """Store a secret value."""
+
+    def delete_secret(self, name: str) -> bool:
+        """Delete a stored secret. Return False when it was already absent."""
+
+
+@dataclass(frozen=True)
+class SecretDefinition:
+    name: str
+    env_var: str
+    label: str
+    purpose: str
+    required_for: str
+
+
+@dataclass(frozen=True)
+class SecretStatus:
+    name: str
+    env_var: str
+    label: str
+    purpose: str
+    required_for: str
+    status: str
+    source: str | None
+    required: bool
+    message: str
+    next_action: str
+
+    def asdict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+SECRET_DEFINITIONS: tuple[SecretDefinition, ...] = (
+    SecretDefinition(
+        name="github_token",
+        env_var="GITHUB_TOKEN",
+        label="GitHub token",
+        purpose="Validates repository, branch, commit, pull-request, and changed-file proof.",
+        required_for="GitHub artifact verification and repair workflows.",
+    ),
+    SecretDefinition(
+        name="linear_api_key",
+        env_var="LINEAR_API_KEY",
+        label="Linear API key",
+        purpose="Reads and updates Linear work state when a workflow uses Linear coordination.",
+        required_for="Linear synchronization and write-back workflows.",
+    ),
+    SecretDefinition(
+        name="repair_callback_bearer_token",
+        env_var="OPENCLAW_REPAIR_BEARER_TOKEN",
+        label="Repair callback bearer token",
+        purpose="Authenticates HTTP repair callbacks for the current desktop-agent bridge.",
+        required_for="Bearer-protected repair callback workflows.",
+    ),
+)
+
+SECRET_DEFINITIONS_BY_NAME = {definition.name: definition for definition in SECRET_DEFINITIONS}
+
+CommandRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def get_secret_definition(name: str) -> SecretDefinition:
+    try:
+        return SECRET_DEFINITIONS_BY_NAME[name]
+    except KeyError as error:
+        names = ", ".join(sorted(SECRET_DEFINITIONS_BY_NAME))
+        raise LocalSecretError(f"Unknown Harness secret {name!r}. Expected one of: {names}.") from error
+
+
+class MacOSKeychainSecretStore:
+    """Store local app secrets in macOS Keychain through the `security` command."""
+
+    def __init__(
+        self,
+        *,
+        service: str = KEYCHAIN_SERVICE,
+        command_runner: CommandRunner | None = None,
+        platform_name: str | None = None,
+        security_bin: str | None = None,
+    ) -> None:
+        self.service = service
+        self._command_runner = command_runner or _run_command
+        self._platform_name = platform_name or platform.system()
+        self._security_bin = security_bin
+
+    @property
+    def provider_name(self) -> str:
+        return "macos-keychain"
+
+    def get_secret(self, name: str) -> str:
+        definition = get_secret_definition(name)
+        result = self._run_security(
+            [
+                "find-generic-password",
+                "-s",
+                self.service,
+                "-a",
+                definition.name,
+                "-w",
+            ]
+        )
+        if result.returncode == 0:
+            value = result.stdout.rstrip("\n")
+            if value:
+                return value
+            raise SecretNotFoundError(f"{definition.label} is empty in macOS Keychain.")
+        if _security_result_is_missing(result):
+            raise SecretNotFoundError(f"{definition.label} is not stored in macOS Keychain.")
+        raise LocalSecretError(_security_error_message(result, f"Could not read {definition.label}."))
+
+    def set_secret(self, name: str, value: str) -> None:
+        definition = get_secret_definition(name)
+        if not value:
+            raise LocalSecretError(f"{definition.label} cannot be empty.")
+        result = self._run_security(
+            [
+                "add-generic-password",
+                "-U",
+                "-s",
+                self.service,
+                "-a",
+                definition.name,
+                "-l",
+                definition.label,
+                "-w",
+                value,
+            ]
+        )
+        if result.returncode != 0:
+            raise LocalSecretError(_security_error_message(result, f"Could not store {definition.label}."))
+
+    def delete_secret(self, name: str) -> bool:
+        definition = get_secret_definition(name)
+        result = self._run_security(
+            [
+                "delete-generic-password",
+                "-s",
+                self.service,
+                "-a",
+                definition.name,
+            ]
+        )
+        if result.returncode == 0:
+            return True
+        if _security_result_is_missing(result):
+            return False
+        raise LocalSecretError(_security_error_message(result, f"Could not delete {definition.label}."))
+
+    def _run_security(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        security_bin = self._resolve_security_bin()
+        return self._command_runner([security_bin, *args])
+
+    def _resolve_security_bin(self) -> str:
+        if self._platform_name != "Darwin":
+            raise SecretProviderUnavailableError(
+                "macOS Keychain is unavailable on this platform. "
+                "Use developer env-file mode until the Linux secret provider is implemented."
+            )
+        if self._security_bin:
+            return self._security_bin
+        resolved = shutil.which("security")
+        if not resolved:
+            raise SecretProviderUnavailableError("The macOS `security` command was not found.")
+        return resolved
+
+
+class InMemorySecretStore:
+    """Small test and fixture secret store. Not used for persisted app secrets."""
+
+    provider_name = "memory"
+
+    def __init__(self, values: dict[str, str] | None = None) -> None:
+        self.values = dict(values or {})
+
+    def get_secret(self, name: str) -> str:
+        get_secret_definition(name)
+        value = self.values.get(name)
+        if not value:
+            raise SecretNotFoundError(f"{name} is not stored.")
+        return value
+
+    def set_secret(self, name: str, value: str) -> None:
+        get_secret_definition(name)
+        if not value:
+            raise LocalSecretError(f"{name} cannot be empty.")
+        self.values[name] = value
+
+    def delete_secret(self, name: str) -> bool:
+        get_secret_definition(name)
+        return self.values.pop(name, None) is not None
+
+
+def load_app_managed_secrets_into_environment(
+    *,
+    store: SecretStore | None = None,
+    overwrite: bool = False,
+) -> list[SecretStatus]:
+    """Populate missing runtime env vars from app-managed secrets.
+
+    Existing environment variables win by default so developer env-file mode and
+    explicitly exported variables keep working.
+    """
+
+    secret_store = store or MacOSKeychainSecretStore()
+    statuses: list[SecretStatus] = []
+    for definition in SECRET_DEFINITIONS:
+        current_value = os.environ.get(definition.env_var)
+        if current_value and not overwrite:
+            statuses.append(_configured_status(definition, source="environment", required=False))
+            continue
+        try:
+            value = secret_store.get_secret(definition.name)
+        except SecretNotFoundError:
+            statuses.append(_missing_status(definition, required=False))
+        except SecretProviderUnavailableError as error:
+            statuses.append(_unavailable_status(definition, str(error), required=False))
+        except LocalSecretError as error:
+            statuses.append(_error_status(definition, str(error), required=False))
+        else:
+            os.environ[definition.env_var] = value
+            statuses.append(_configured_status(definition, source=_provider_name(secret_store), required=False))
+    return statuses
+
+
+def collect_secret_statuses(
+    *,
+    store: SecretStore | None = None,
+    required_names: Iterable[str] = (),
+) -> list[SecretStatus]:
+    secret_store = store or MacOSKeychainSecretStore()
+    required = set(required_names)
+    for name in required:
+        get_secret_definition(name)
+
+    statuses: list[SecretStatus] = []
+    for definition in SECRET_DEFINITIONS:
+        is_required = definition.name in required
+        if os.environ.get(definition.env_var):
+            statuses.append(_configured_status(definition, source="environment", required=is_required))
+            continue
+        try:
+            secret_store.get_secret(definition.name)
+        except SecretNotFoundError:
+            statuses.append(_missing_status(definition, required=is_required))
+        except SecretProviderUnavailableError as error:
+            statuses.append(_unavailable_status(definition, str(error), required=is_required))
+        except LocalSecretError as error:
+            statuses.append(_error_status(definition, str(error), required=is_required))
+        else:
+            statuses.append(_configured_status(definition, source=_provider_name(secret_store), required=is_required))
+    return statuses
+
+
+def secret_status_payload(statuses: list[SecretStatus]) -> dict[str, object]:
+    missing_required = [
+        status.name for status in statuses if status.required and status.status != "configured"
+    ]
+    provider_errors = [status.name for status in statuses if status.status in {"error", "unavailable"}]
+    if missing_required:
+        status = "missing_required_secrets"
+    elif provider_errors:
+        status = "degraded"
+    else:
+        status = "ok"
+    return {
+        "status": status,
+        "provider": "app-managed-secret-store",
+        "missing_required": missing_required,
+        "secrets": [status_item.asdict() for status_item in statuses],
+    }
+
+
+def _configured_status(definition: SecretDefinition, *, source: str, required: bool) -> SecretStatus:
+    return SecretStatus(
+        name=definition.name,
+        env_var=definition.env_var,
+        label=definition.label,
+        purpose=definition.purpose,
+        required_for=definition.required_for,
+        status="configured",
+        source=source,
+        required=required,
+        message=f"{definition.label} is configured.",
+        next_action="No action needed.",
+    )
+
+
+def _missing_status(definition: SecretDefinition, *, required: bool) -> SecretStatus:
+    return SecretStatus(
+        name=definition.name,
+        env_var=definition.env_var,
+        label=definition.label,
+        purpose=definition.purpose,
+        required_for=definition.required_for,
+        status="missing",
+        source=None,
+        required=required,
+        message=f"{definition.label} is not configured.",
+        next_action=(
+            f"Connect {definition.label} during setup or run "
+            f"`harness secrets set {definition.name} --value-stdin`."
+        ),
+    )
+
+
+def _unavailable_status(definition: SecretDefinition, message: str, *, required: bool) -> SecretStatus:
+    return SecretStatus(
+        name=definition.name,
+        env_var=definition.env_var,
+        label=definition.label,
+        purpose=definition.purpose,
+        required_for=definition.required_for,
+        status="unavailable",
+        source=None,
+        required=required,
+        message=message,
+        next_action="Use developer env-file mode or install a supported local app secret provider.",
+    )
+
+
+def _error_status(definition: SecretDefinition, message: str, *, required: bool) -> SecretStatus:
+    return SecretStatus(
+        name=definition.name,
+        env_var=definition.env_var,
+        label=definition.label,
+        purpose=definition.purpose,
+        required_for=definition.required_for,
+        status="error",
+        source=None,
+        required=required,
+        message=message,
+        next_action="Open Harness setup and reconnect this integration.",
+    )
+
+
+def _provider_name(store: SecretStore) -> str:
+    return str(getattr(store, "provider_name", store.__class__.__name__))
+
+
+def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=False, capture_output=True, text=True)
+
+
+def _security_result_is_missing(result: subprocess.CompletedProcess[str]) -> bool:
+    stderr = (result.stderr or "").lower()
+    return result.returncode == 44 or "could not be found" in stderr or "not be found" in stderr
+
+
+def _security_error_message(result: subprocess.CompletedProcess[str], fallback: str) -> str:
+    stderr = (result.stderr or "").strip()
+    if not stderr:
+        return fallback
+    return f"{fallback} Keychain returned: {stderr}"

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -9,6 +9,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from modules.local_secrets import InMemorySecretStore
 from modules.local_runtime import (
     DEFAULT_API_PORT,
     EXIT_OK,
@@ -70,6 +71,8 @@ class LocalRuntimeCliTests(unittest.TestCase):
             config["paths"]["dashboard_assets_dir"],
             str(self.data_path / "dashboard"),
         )
+        self.assertNotIn("GITHUB_TOKEN", json.dumps(config))
+        self.assertNotIn("LINEAR_API_KEY", json.dumps(config))
 
     def test_status_before_init_returns_setup_required(self) -> None:
         exit_code, payload = self._run_cli("status")
@@ -115,6 +118,43 @@ class LocalRuntimeCliTests(unittest.TestCase):
         self.assertEqual(checks["api_health"]["status"], "warn")
         self.assertIn("harness serve", checks["api_health"]["next_action"])
 
+    def test_secrets_status_reports_required_missing_without_values(self) -> None:
+        store = InMemorySecretStore({"github_token": "ghp_secret"})
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("modules.local_runtime.create_secret_store", return_value=store),
+        ):
+            exit_code, payload = self._run_cli("secrets", "status", "--require", "linear_api_key")
+
+        self.assertEqual(exit_code, EXIT_SETUP_REQUIRED)
+        self.assertEqual(payload["status"], "missing_required_secrets")
+        self.assertEqual(payload["missing_required"], ["linear_api_key"])
+        self.assertNotIn("ghp_secret", json.dumps(payload))
+
+    def test_secrets_set_reads_value_from_stdin_without_echoing_value(self) -> None:
+        store = InMemorySecretStore()
+
+        with (
+            patch("modules.local_runtime.create_secret_store", return_value=store),
+            patch("sys.stdin", io.StringIO("ghp_secret\n")),
+        ):
+            exit_code, payload = self._run_cli("secrets", "set", "github_token", "--value-stdin")
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "stored")
+        self.assertEqual(store.values["github_token"], "ghp_secret")
+        self.assertNotIn("ghp_secret", json.dumps(payload))
+
+    def test_secrets_delete_reports_missing_without_error(self) -> None:
+        store = InMemorySecretStore()
+
+        with patch("modules.local_runtime.create_secret_store", return_value=store):
+            exit_code, payload = self._run_cli("secrets", "delete", "github_token")
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "missing")
+
 
 class LocalRuntimeProcessTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -135,11 +175,16 @@ class LocalRuntimeProcessTests(unittest.TestCase):
             observed["sqlite_path"] = os.environ.get("HARNESS_SQLITE_PATH")
             observed["runtime_mode"] = os.environ.get("HARNESS_RUNTIME_MODE")
             observed["dashboard_assets_dir"] = os.environ.get("HARNESS_DASHBOARD_ASSETS_DIR")
+            observed["github_token"] = os.environ.get("GITHUB_TOKEN")
             print("server-started")
 
         with (
-            patch.dict(os.environ, {}, clear=False),
+            patch.dict(os.environ, {}, clear=True),
             patch("modules.local_runtime._assert_port_available"),
+            patch(
+                "modules.local_runtime.create_secret_store",
+                return_value=InMemorySecretStore({"github_token": "ghp_secret"}),
+            ),
             patch(
                 "modules.local_runtime._run_uvicorn",
                 side_effect=fake_run_uvicorn,
@@ -153,8 +198,11 @@ class LocalRuntimeProcessTests(unittest.TestCase):
         self.assertEqual(observed["sqlite_path"], str(self.paths.database_path))
         self.assertEqual(observed["runtime_mode"], "local-app")
         self.assertEqual(observed["dashboard_assets_dir"], str(self.paths.dashboard_assets_dir))
+        self.assertEqual(observed["github_token"], "ghp_secret")
         self.assertFalse(self.paths.pid_path.exists())
-        self.assertIn("server-started", self.paths.log_path.read_text(encoding="utf-8"))
+        log_text = self.paths.log_path.read_text(encoding="utf-8")
+        self.assertIn("server-started", log_text)
+        self.assertNotIn("ghp_secret", log_text)
 
     def test_stop_treats_missing_or_stale_process_as_stopped(self) -> None:
         config, _ = init_runtime(self.paths)

--- a/tests/test_local_secrets.py
+++ b/tests/test_local_secrets.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from modules.local_secrets import (
+    InMemorySecretStore,
+    MacOSKeychainSecretStore,
+    SecretNotFoundError,
+    SecretProviderUnavailableError,
+    collect_secret_statuses,
+    load_app_managed_secrets_into_environment,
+    secret_status_payload,
+)
+
+
+class MacOSKeychainSecretStoreTests(unittest.TestCase):
+    def test_reads_secret_from_security_command(self) -> None:
+        calls: list[list[str]] = []
+
+        def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            calls.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="ghp_secret\n", stderr="")
+
+        store = MacOSKeychainSecretStore(
+            command_runner=runner,
+            platform_name="Darwin",
+            security_bin="/usr/bin/security",
+        )
+
+        value = store.get_secret("github_token")
+
+        self.assertEqual(value, "ghp_secret")
+        self.assertEqual(calls[0][:2], ["/usr/bin/security", "find-generic-password"])
+        self.assertIn("github_token", calls[0])
+
+    def test_missing_keychain_item_raises_not_found(self) -> None:
+        def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                command,
+                44,
+                stdout="",
+                stderr="security: SecKeychainSearchCopyNext: The specified item could not be found.",
+            )
+
+        store = MacOSKeychainSecretStore(
+            command_runner=runner,
+            platform_name="Darwin",
+            security_bin="/usr/bin/security",
+        )
+
+        with self.assertRaises(SecretNotFoundError):
+            store.get_secret("linear_api_key")
+
+    def test_non_macos_keychain_is_unavailable(self) -> None:
+        store = MacOSKeychainSecretStore(platform_name="Linux", security_bin="/usr/bin/security")
+
+        with self.assertRaises(SecretProviderUnavailableError):
+            store.get_secret("github_token")
+
+    def test_stores_and_deletes_secret_without_shell(self) -> None:
+        calls: list[list[str]] = []
+
+        def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            calls.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        store = MacOSKeychainSecretStore(
+            command_runner=runner,
+            platform_name="Darwin",
+            security_bin="/usr/bin/security",
+        )
+
+        store.set_secret("github_token", "ghp_secret")
+        deleted = store.delete_secret("github_token")
+
+        self.assertTrue(deleted)
+        self.assertEqual(calls[0][1], "add-generic-password")
+        self.assertEqual(calls[1][1], "delete-generic-password")
+        self.assertNotIn("shell=True", " ".join(calls[0]))
+
+
+class LocalSecretStatusTests(unittest.TestCase):
+    def test_loads_app_managed_secrets_into_missing_environment_vars(self) -> None:
+        store = InMemorySecretStore(
+            {
+                "github_token": "ghp_secret",
+                "linear_api_key": "lin_secret",
+            }
+        )
+
+        with patch.dict(os.environ, {}, clear=True):
+            statuses = load_app_managed_secrets_into_environment(store=store)
+
+            self.assertEqual(os.environ["GITHUB_TOKEN"], "ghp_secret")
+            self.assertEqual(os.environ["LINEAR_API_KEY"], "lin_secret")
+
+        status_by_name = {status.name: status for status in statuses}
+        self.assertEqual(status_by_name["github_token"].status, "configured")
+        self.assertEqual(status_by_name["github_token"].source, "memory")
+        self.assertEqual(status_by_name["repair_callback_bearer_token"].status, "missing")
+
+    def test_existing_environment_vars_win_over_app_managed_secrets(self) -> None:
+        store = InMemorySecretStore({"github_token": "keychain-secret"})
+
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "env-secret"}, clear=True):
+            load_app_managed_secrets_into_environment(store=store)
+
+            self.assertEqual(os.environ["GITHUB_TOKEN"], "env-secret")
+
+    def test_secret_status_payload_marks_required_missing_without_values(self) -> None:
+        store = InMemorySecretStore({"github_token": "ghp_secret"})
+
+        with patch.dict(os.environ, {}, clear=True):
+            statuses = collect_secret_statuses(store=store, required_names=["linear_api_key"])
+
+        payload = secret_status_payload(statuses)
+        serialized = str(payload)
+
+        self.assertEqual(payload["status"], "missing_required_secrets")
+        self.assertEqual(payload["missing_required"], ["linear_api_key"])
+        self.assertNotIn("ghp_secret", serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a local secret-provider boundary with Harness secret names mapped to the current backend env vars.
- Adds macOS Keychain support through the `security` command for runtime reads and CLI set/delete/status operations.
- Extends the local runtime CLI with `secrets status`, `secrets set --value-stdin`, and `secrets delete` without printing token values.
- Loads available app-managed secrets into the backend process environment during `harness serve`, while preserving existing env vars and `.env.local` developer mode.
- Documents the app-managed secret contract and updates local runtime/setup docs.

Closes #320.

## Validation

- `python3 -m unittest tests.test_local_secrets tests.test_local_runtime -v`
- `python3 -m py_compile modules/local_secrets.py modules/local_runtime.py`
- `python3 -m modules.local_runtime --data-dir .tmp/secret-status --log-dir .tmp/secret-logs --json secrets status --require github_token` returned the expected setup-required payload with no secret values
- `python3 -m unittest discover -s tests` (`820` tests, `17` skipped)
- `git diff --check`
