### PR TITLE
Expand local setup doctor contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ See:
 - The local app runtime contract is implemented in [`modules/local_runtime.py`](modules/local_runtime.py) and documented in [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md).
 - App-managed secret storage is implemented in [`modules/local_secrets.py`](modules/local_secrets.py) and documented in [`docs/architecture/app-managed-secrets.md`](docs/architecture/app-managed-secrets.md).
 - Local dashboard packaging is documented in [`docs/architecture/local-dashboard-packaging.md`](docs/architecture/local-dashboard-packaging.md).
+- Setup doctor output is documented in [`docs/architecture/setup-doctor.md`](docs/architecture/setup-doctor.md).
 
 ## Hosted Deployment Target
 

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -146,20 +146,32 @@ The backend exposes two app-shell-safe probes:
   "code": "sqlite",
   "status": "pass",
   "message": "SQLite database is ready.",
+  "impact": "Harness can persist local task and verifier state.",
   "next_action": "No action needed."
 }
 ```
 
-Initial checks cover:
+Current checks cover:
 
 - app data directory writability
 - log directory writability
 - config presence and validity
 - SQLite schema readiness
 - local API health
+- dashboard asset and route availability
+- GitHub credential setup state
+- Linear credential setup state
+- ingress/executor bridge setup state
+- notification permission state reported by the app shell
+- Launch at Login state reported by the app shell
+- selected workspace folder availability
 
 The local API check is a warning when the runtime is stopped.
 A stopped runtime is a valid setup state; it is not a corrupted install.
+Optional integrations also report warnings rather than failures when they are missing.
+Configured-but-broken setup, such as a missing selected workspace folder, reports `fail`.
+
+See [setup-doctor.md](setup-doctor.md).
 
 ## Exit Codes
 

--- a/docs/architecture/setup-doctor.md
+++ b/docs/architecture/setup-doctor.md
@@ -1,0 +1,92 @@
+# Setup Doctor Contract
+
+`harness doctor --json` is the local app setup report.
+The menu-bar app and onboarding flow should render this JSON directly instead of parsing logs or backend exception text.
+
+The doctor is intentionally broader than `/health`.
+`/health` reports whether the backend is alive.
+`doctor` explains whether the local app is set up well enough for normal users to understand what is missing and what to do next.
+
+## Check Shape
+
+Every check returns:
+
+```json
+{
+  "code": "sqlite",
+  "status": "pass",
+  "message": "SQLite database is ready at /path/to/harness.db.",
+  "impact": "Harness can persist local task and verifier state.",
+  "next_action": "No action needed.",
+  "details": {
+    "path": "/path/to/harness.db"
+  }
+}
+```
+
+Status values:
+
+- `pass`: the item is ready.
+- `warn`: the item is incomplete, optional, or currently stopped, but Harness can still run.
+- `fail`: the item is broken enough that setup or the selected workflow cannot be trusted.
+
+The top-level payload includes a summary count:
+
+```json
+{
+  "status": "ok",
+  "summary": {
+    "pass": 8,
+    "warn": 4,
+    "fail": 0
+  },
+  "checks": []
+}
+```
+
+The doctor exits with `0` unless at least one check is `fail`.
+Warnings are still important, but they should not block normal local runtime setup.
+
+## Current Checks
+
+The current doctor covers:
+
+- `app_data_dir`: app data directory writability.
+- `log_dir`: log directory writability.
+- `config`: app-managed config presence and readability.
+- `sqlite`: SQLite database availability and schema readiness.
+- `api_health`: local API availability.
+- `dashboard`: packaged dashboard asset availability and dashboard HTTP route reachability when the API is running.
+- `github_connection`: GitHub credential setup state.
+- `linear_connection`: Linear credential setup state.
+- `ingress_executor`: desktop-agent bridge setup state for the current OpenClaw-shaped adapter wiring, without making OpenClaw the product boundary.
+- `notification_permission`: notification permission state reported by the app shell.
+- `launch_at_login`: launch-at-login state reported by the app shell.
+- `workspace_folders`: configured local workspace folder availability.
+
+## App Shell Inputs
+
+Some checks depend on facts owned by the native app shell.
+Until the Swift app owns these directly, the CLI reads these environment variables:
+
+- `HARNESS_NOTIFICATION_PERMISSION`: `authorized`, `denied`, or `not_determined`.
+- `HARNESS_LAUNCH_AT_LOGIN`: `enabled` or `disabled`.
+- `HARNESS_WORKSPACE_FOLDERS`: `os.pathsep`-separated folder paths selected by the user.
+
+Current desktop-agent bridge checks read the existing adapter variables:
+
+- `OPENCLAW_CONFIG_PATH`
+- `OPENCLAW_STATE_DIR`
+- `OPENCLAW_BIN`
+- `OPENCLAW_BASE_URL`
+
+Those names are adapter wiring, not the product boundary.
+The UI should describe the setup item as a desktop-agent bridge for OpenClaw, Hermes, Codex, or a future equivalent.
+
+## Safety Rules
+
+- Do not return raw token values.
+- Do not include stack traces in normal-user output.
+- Do not mark optional integrations as `fail` just because they are not connected.
+- Do fail configured-but-broken items, such as a selected workspace folder that no longer exists.
+- Do not require notification permission or launch-at-login to use Harness.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -125,6 +125,14 @@ python3 -m modules.local_runtime --json secrets status
 Secret status output is redacted. Use `--require <secret-name>` when a selected workflow cannot run without that credential.
 Native developer mode can still use repo-root `.env.local`.
 
+Run setup doctor to get app-renderable setup status:
+
+```bash
+python3 -m modules.local_runtime --json doctor
+```
+
+Doctor checks report `status`, `impact`, and `next_action` for runtime health, SQLite, dashboard assets, GitHub and Linear credentials, desktop-agent bridge wiring, notifications, launch-at-login, and configured workspace folders. Warnings are actionable but do not block the local runtime. Failures indicate configured setup that cannot be trusted.
+
 To run the same backend against Postgres instead of the file-backed store:
 
 ```bash

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import os
 import platform
+import shutil
 import signal
 import socket
 import subprocess
@@ -21,6 +22,7 @@ from urllib.request import Request, urlopen
 from modules.local_secrets import (
     LocalSecretError,
     MacOSKeychainSecretStore,
+    SecretStatus,
     collect_secret_statuses,
     load_app_managed_secrets_into_environment,
     secret_status_payload,
@@ -48,6 +50,9 @@ ENV_RUNTIME_PORT = "HARNESS_RUNTIME_PORT"
 ENV_RUNTIME_BASE_URL = "HARNESS_RUNTIME_BASE_URL"
 ENV_DASHBOARD_ASSETS_DIR = "HARNESS_DASHBOARD_ASSETS_DIR"
 ENV_SECRET_PROVIDER = "HARNESS_SECRET_PROVIDER"
+ENV_NOTIFICATION_PERMISSION = "HARNESS_NOTIFICATION_PERMISSION"
+ENV_LAUNCH_AT_LOGIN = "HARNESS_LAUNCH_AT_LOGIN"
+ENV_WORKSPACE_FOLDERS = "HARNESS_WORKSPACE_FOLDERS"
 
 
 class LocalRuntimeError(ValueError):
@@ -164,7 +169,9 @@ class RuntimeCheck:
     code: str
     status: str
     message: str
+    impact: str
     next_action: str
+    details: dict[str, Any] | None = None
 
 
 def resolve_runtime_paths(
@@ -327,6 +334,22 @@ def fetch_runtime_health(
         return None, None, str(error)
 
 
+def fetch_http_status(
+    url: str,
+    *,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    accept: str = "text/html,application/json",
+) -> tuple[int | None, str | None]:
+    request = Request(url, headers={"Accept": accept})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return int(response.status), None
+    except HTTPError as error:
+        return int(error.code), str(error)
+    except (OSError, TimeoutError, URLError) as error:
+        return None, str(error)
+
+
 def read_pid(pid_path: Path) -> int | None:
     try:
         raw_pid = pid_path.read_text(encoding="utf-8").strip()
@@ -393,6 +416,7 @@ def uninitialized_status(paths: RuntimePaths) -> dict[str, Any]:
 def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
     checks: list[RuntimeCheck] = []
     config: RuntimeConfig | None = None
+    status_payload: dict[str, Any] | None = None
 
     checks.append(
         _check_writable_directory(
@@ -411,6 +435,7 @@ def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
                 code="config",
                 status="fail",
                 message=str(error),
+                impact="Harness cannot start reliably until app-managed config exists and is readable.",
                 next_action="Run `harness init` from the app bundle or CLI.",
             )
         )
@@ -420,6 +445,7 @@ def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
                 code="config",
                 status="pass",
                 message=f"Runtime config exists at {paths.config_path}.",
+                impact="Harness can read non-secret local runtime settings.",
                 next_action="No action needed.",
             )
         )
@@ -434,6 +460,7 @@ def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
                     code="sqlite",
                     status="fail",
                     message=str(error),
+                    impact="Harness cannot persist canonical task truth or reset verifier state.",
                     next_action=(
                         "Move the damaged database aside and rerun setup, "
                         "or restore a known-good backup."
@@ -448,6 +475,11 @@ def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
                     message=(
                         "SQLite database is "
                         f"{'ready' if sqlite_ready else 'not on the expected schema'} at {config.database_path}."
+                    ),
+                    impact=(
+                        "Harness can persist local task and verifier state."
+                        if sqlite_ready
+                        else "Harness storage exists but is not on the expected schema."
                     ),
                     next_action=(
                         "No action needed."
@@ -464,17 +496,67 @@ def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
                 code="api_health",
                 status="pass" if api_running else "warn",
                 message="Local API is healthy." if api_running else "Local API is not running.",
+                impact=(
+                    "The menu-bar app and dashboard can read Harness state."
+                    if api_running
+                    else "The app can still run setup checks, but live task status and the dashboard are unavailable."
+                ),
                 next_action=(
                     "No action needed."
                     if api_running
                     else "Start Harness from the app or run `harness serve`."
                 ),
+                details={
+                    "api_base_url": config.base_url,
+                    "health_http_status": status_payload.get("health_http_status"),
+                },
+            )
+        )
+        checks.append(_check_dashboard(config, status_payload=status_payload))
+    else:
+        checks.append(
+            RuntimeCheck(
+                code="sqlite",
+                status="fail",
+                message="SQLite database has not been initialized.",
+                impact="Harness cannot store local task truth until setup creates the database.",
+                next_action="Run `harness init` from the app bundle or CLI.",
+            )
+        )
+        checks.append(
+            RuntimeCheck(
+                code="api_health",
+                status="warn",
+                message="Local API cannot be checked before runtime initialization.",
+                impact="The app cannot report live task status until setup completes and the API starts.",
+                next_action="Run `harness init`, then start Harness.",
+            )
+        )
+        checks.append(
+            RuntimeCheck(
+                code="dashboard",
+                status="warn",
+                message="Dashboard assets cannot be checked before runtime initialization.",
+                impact="The dashboard window may not open until setup completes.",
+                next_action="Run `harness init`, then install packaged dashboard assets.",
             )
         )
 
+    checks.extend(_secret_doctor_checks())
+    checks.append(_check_ingress_executor())
+    checks.append(_check_notification_permission())
+    checks.append(_check_launch_at_login())
+    checks.append(_check_workspace_folders())
+
     exit_code = EXIT_RUNTIME_ERROR if any(check.status == "fail" for check in checks) else EXIT_OK
+    counts = {
+        "pass": sum(1 for check in checks if check.status == "pass"),
+        "warn": sum(1 for check in checks if check.status == "warn"),
+        "fail": sum(1 for check in checks if check.status == "fail"),
+    }
     return exit_code, {
         "status": "fail" if exit_code else "ok",
+        "summary": counts,
         "checks": [asdict(check) for check in checks],
     }
 
@@ -490,14 +572,274 @@ def _check_writable_directory(code: str, path: Path, impact: str) -> RuntimeChec
             code=code,
             status="fail",
             message=f"{impact} {path} is not writable: {error}",
+            impact=impact,
             next_action="Choose a writable app data location or fix directory permissions.",
+            details={"path": str(path)},
         )
     return RuntimeCheck(
         code=code,
         status="pass",
         message=f"{path} is writable.",
+        impact=impact,
         next_action="No action needed.",
+        details={"path": str(path)},
     )
+
+
+def _check_dashboard(config: RuntimeConfig, *, status_payload: dict[str, Any]) -> RuntimeCheck:
+    assets_dir = Path(os.environ.get(ENV_DASHBOARD_ASSETS_DIR) or config.dashboard_assets_dir).expanduser()
+    dashboard_url = f"{config.base_url}/dashboard/"
+    assets_ready = (assets_dir / "index.html").is_file()
+    api_running = status_payload.get("status") == "running"
+    details: dict[str, Any] = {
+        "assets_dir": str(assets_dir),
+        "dashboard_url": dashboard_url,
+        "assets_ready": assets_ready,
+    }
+
+    if not assets_ready:
+        return RuntimeCheck(
+            code="dashboard",
+            status="warn",
+            message=f"Dashboard assets are missing at {assets_dir}.",
+            impact="The dashboard window cannot render until packaged assets are installed.",
+            next_action="Build or install the packaged dashboard assets, then set HARNESS_DASHBOARD_ASSETS_DIR if they are not in the default app data path.",
+            details=details,
+        )
+
+    if not api_running:
+        return RuntimeCheck(
+            code="dashboard",
+            status="warn",
+            message="Dashboard assets are present, but the local API is not running.",
+            impact="The dashboard window can be opened after Harness starts.",
+            next_action="Start Harness from the app or run `harness serve`.",
+            details=details,
+        )
+
+    http_status, error = fetch_http_status(dashboard_url)
+    details["http_status"] = http_status
+    if http_status == 200:
+        return RuntimeCheck(
+            code="dashboard",
+            status="pass",
+            message="Dashboard is reachable from the local Harness runtime.",
+            impact="The dashboard window can inspect live local Harness state.",
+            next_action="No action needed.",
+            details=details,
+        )
+    details["error"] = error
+    return RuntimeCheck(
+        code="dashboard",
+        status="warn",
+        message="Dashboard assets are present, but the dashboard route is not reachable.",
+        impact="The dashboard window may fail to open or may show a backend error.",
+        next_action="Restart Harness and rerun doctor. If the problem continues, reinstall the dashboard assets.",
+        details=details,
+    )
+
+
+def _secret_doctor_checks() -> list[RuntimeCheck]:
+    statuses = collect_secret_statuses(store=create_secret_store())
+    checks: list[RuntimeCheck] = []
+    for status in statuses:
+        if status.name == "github_token":
+            checks.append(_secret_status_to_check("github_connection", status))
+        elif status.name == "linear_api_key":
+            checks.append(_secret_status_to_check("linear_connection", status))
+    return checks
+
+
+def _secret_status_to_check(code: str, status: SecretStatus) -> RuntimeCheck:
+    configured = status.status == "configured"
+    return RuntimeCheck(
+        code=code,
+        status="pass" if configured else "warn",
+        message=(
+            f"{status.label} is configured."
+            if configured
+            else f"{status.label} is not ready: {status.message}"
+        ),
+        impact=(
+            status.required_for
+            if configured
+            else f"{status.required_for} will remain unavailable until this credential is connected."
+        ),
+        next_action=status.next_action,
+        details={
+            "secret": status.name,
+            "env_var": status.env_var,
+            "source": status.source,
+            "credential_status": status.status,
+        },
+    )
+
+
+def _check_ingress_executor() -> RuntimeCheck:
+    cli_config_path = _clean_env_value("OPENCLAW_CONFIG_PATH")
+    state_dir = _clean_env_value("OPENCLAW_STATE_DIR")
+    base_url = _clean_env_value("OPENCLAW_BASE_URL")
+    cli_bin = _clean_env_value("OPENCLAW_BIN") or "openclaw"
+
+    if cli_config_path or state_dir:
+        details = {
+            "mode": "local_cli",
+            "config_path": cli_config_path,
+            "state_dir": state_dir,
+            "cli_bin": cli_bin,
+        }
+        if cli_config_path and not Path(cli_config_path).expanduser().is_file():
+            return RuntimeCheck(
+                code="ingress_executor",
+                status="fail",
+                message=f"Desktop-agent CLI config is configured but missing at {cli_config_path}.",
+                impact="Harness repair dispatch cannot use the configured local desktop-agent bridge.",
+                next_action="Fix OPENCLAW_CONFIG_PATH or rerun the desktop-agent setup flow.",
+                details=details,
+            )
+        if shutil.which(cli_bin) is None:
+            return RuntimeCheck(
+                code="ingress_executor",
+                status="warn",
+                message=f"Desktop-agent CLI config is present, but `{cli_bin}` is not on PATH.",
+                impact="Harness may not be able to dispatch repair work through the local bridge.",
+                next_action="Install the configured desktop-agent CLI or set OPENCLAW_BIN to the executable path.",
+                details=details,
+            )
+        return RuntimeCheck(
+            code="ingress_executor",
+            status="pass",
+            message="Desktop-agent local CLI bridge is configured.",
+            impact="Harness can request repair work through the configured local bridge when a workflow needs it.",
+            next_action="No action needed.",
+            details=details,
+        )
+
+    if base_url:
+        return RuntimeCheck(
+            code="ingress_executor",
+            status="pass",
+            message="Desktop-agent HTTP repair bridge is configured.",
+            impact="Harness can request repair work through the configured HTTP bridge when a workflow needs it.",
+            next_action="No action needed.",
+            details={"mode": "http", "base_url": base_url},
+        )
+
+    return RuntimeCheck(
+        code="ingress_executor",
+        status="warn",
+        message="No desktop-agent ingress/executor bridge is configured.",
+        impact="Harness can run locally, but repair dispatch and executor-backed workflows are incomplete.",
+        next_action="Connect OpenClaw, Hermes, Codex, or another compatible desktop-agent bridge during setup.",
+        details={"mode": "unconfigured"},
+    )
+
+
+def _check_notification_permission() -> RuntimeCheck:
+    permission = (_clean_env_value(ENV_NOTIFICATION_PERMISSION) or "unknown").lower()
+    if permission in {"authorized", "granted", "enabled"}:
+        return RuntimeCheck(
+            code="notification_permission",
+            status="pass",
+            message="Notification permission is authorized.",
+            impact="Harness can surface attention events through local notifications.",
+            next_action="No action needed.",
+            details={"permission": permission},
+        )
+    if permission in {"denied", "disabled"}:
+        return RuntimeCheck(
+            code="notification_permission",
+            status="warn",
+            message="Notification permission is denied.",
+            impact="Harness can still run, but attention events will not appear as local notifications.",
+            next_action="Enable Harness notifications in system settings if you want attention alerts.",
+            details={"permission": permission},
+        )
+    return RuntimeCheck(
+        code="notification_permission",
+        status="warn",
+        message="Notification permission has not been reported by the app shell.",
+        impact="Harness can run, but the app has not confirmed whether attention alerts can be delivered.",
+        next_action="Open the Harness app and complete the notifications setup step.",
+        details={"permission": permission},
+    )
+
+
+def _check_launch_at_login() -> RuntimeCheck:
+    state = (_clean_env_value(ENV_LAUNCH_AT_LOGIN) or "unknown").lower()
+    if state in {"enabled", "true", "1", "yes"}:
+        return RuntimeCheck(
+            code="launch_at_login",
+            status="pass",
+            message="Launch at Login is enabled.",
+            impact="Harness can start automatically after login.",
+            next_action="No action needed.",
+            details={"state": state},
+        )
+    if state in {"disabled", "false", "0", "no"}:
+        return RuntimeCheck(
+            code="launch_at_login",
+            status="warn",
+            message="Launch at Login is disabled.",
+            impact="Harness will only run after the user starts it manually.",
+            next_action="Enable Launch at Login from the Harness app if you want background supervision after login.",
+            details={"state": state},
+        )
+    return RuntimeCheck(
+        code="launch_at_login",
+        status="warn",
+        message="Launch at Login state has not been reported by the app shell.",
+        impact="Harness can run, but automatic startup has not been confirmed.",
+        next_action="Open the Harness app and complete the Launch at Login setup step.",
+        details={"state": state},
+    )
+
+
+def _check_workspace_folders() -> RuntimeCheck:
+    raw_folders = _clean_env_value(ENV_WORKSPACE_FOLDERS)
+    if not raw_folders:
+        return RuntimeCheck(
+            code="workspace_folders",
+            status="pass",
+            message="No workspace folders are configured.",
+            impact="No external folder access is required until a workflow needs local repo or artifact inspection.",
+            next_action="No action needed.",
+            details={"folders": []},
+        )
+
+    folders = [Path(value).expanduser() for value in raw_folders.split(os.pathsep) if value.strip()]
+    missing = [str(path) for path in folders if not path.exists()]
+    unreadable = [str(path) for path in folders if path.exists() and not os.access(path, os.R_OK)]
+    details = {
+        "folders": [str(path) for path in folders],
+        "missing": missing,
+        "unreadable": unreadable,
+    }
+    if missing or unreadable:
+        return RuntimeCheck(
+            code="workspace_folders",
+            status="fail",
+            message="One or more configured workspace folders are unavailable.",
+            impact="Workflows that need local repository or artifact inspection may fail.",
+            next_action="Reconnect the missing folders from the Harness app or remove stale workspace folder entries.",
+            details=details,
+        )
+    return RuntimeCheck(
+        code="workspace_folders",
+        status="pass",
+        message="Configured workspace folders are accessible.",
+        impact="Harness can use the configured local workspace folders when a workflow needs them.",
+        next_action="No action needed.",
+        details=details,
+    )
+
+
+def _clean_env_value(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
 
 
 def serve_runtime(paths: RuntimePaths, *, host: str | None = None, port: int | None = None) -> int:
@@ -835,6 +1177,10 @@ def _emit(payload: dict[str, Any], *, as_json: bool, exit_code: int = EXIT_OK) -
         for check in checks:
             if isinstance(check, dict):
                 print(f"- {check.get('code')}: {check.get('status')} - {check.get('message')}")
+                if check.get("impact"):
+                    print(f"  impact: {check.get('impact')}")
+                if check.get("next_action"):
+                    print(f"  next_action: {check.get('next_action')}")
     secrets = payload.get("secrets")
     if isinstance(secrets, list):
         print("secrets:")

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -13,6 +13,7 @@ from modules.local_secrets import InMemorySecretStore
 from modules.local_runtime import (
     DEFAULT_API_PORT,
     EXIT_OK,
+    EXIT_RUNTIME_ERROR,
     EXIT_SETUP_REQUIRED,
     EXIT_UNHEALTHY,
     build_runtime_status_payload,
@@ -105,18 +106,94 @@ class LocalRuntimeCliTests(unittest.TestCase):
 
     def test_doctor_reports_setup_passes_and_api_warning_when_stopped(self) -> None:
         self._run_cli("init")
+        dashboard_dir = self.data_path / "dashboard"
+        dashboard_dir.mkdir()
+        (dashboard_dir / "index.html").write_text("<h1>Harness</h1>", encoding="utf-8")
+        workspace_dir = self.data_path / "workspace"
+        workspace_dir.mkdir()
 
-        exit_code, payload = self._run_cli("doctor")
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "HARNESS_DASHBOARD_ASSETS_DIR": str(dashboard_dir),
+                    "OPENCLAW_BASE_URL": "http://127.0.0.1:18789",
+                    "HARNESS_NOTIFICATION_PERMISSION": "authorized",
+                    "HARNESS_LAUNCH_AT_LOGIN": "enabled",
+                    "HARNESS_WORKSPACE_FOLDERS": str(workspace_dir),
+                },
+                clear=True,
+            ),
+            patch(
+                "modules.local_runtime.create_secret_store",
+                return_value=InMemorySecretStore(
+                    {
+                        "github_token": "ghp_secret",
+                        "linear_api_key": "lin_secret",
+                    }
+                ),
+            ),
+        ):
+            exit_code, payload = self._run_cli("doctor")
         checks = {check["code"]: check for check in payload["checks"]}
 
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["summary"]["fail"], 0)
         self.assertEqual(checks["app_data_dir"]["status"], "pass")
         self.assertEqual(checks["log_dir"]["status"], "pass")
         self.assertEqual(checks["config"]["status"], "pass")
         self.assertEqual(checks["sqlite"]["status"], "pass")
         self.assertEqual(checks["api_health"]["status"], "warn")
+        self.assertEqual(checks["dashboard"]["status"], "warn")
+        self.assertEqual(checks["github_connection"]["status"], "pass")
+        self.assertEqual(checks["linear_connection"]["status"], "pass")
+        self.assertEqual(checks["ingress_executor"]["status"], "pass")
+        self.assertEqual(checks["notification_permission"]["status"], "pass")
+        self.assertEqual(checks["launch_at_login"]["status"], "pass")
+        self.assertEqual(checks["workspace_folders"]["status"], "pass")
         self.assertIn("harness serve", checks["api_health"]["next_action"])
+        self.assertTrue(all(check.get("impact") for check in payload["checks"]))
+        self.assertTrue(all(check.get("next_action") for check in payload["checks"]))
+
+    def test_doctor_fails_when_configured_workspace_folder_is_missing(self) -> None:
+        self._run_cli("init")
+
+        with (
+            patch.dict(
+                os.environ,
+                {"HARNESS_WORKSPACE_FOLDERS": str(self.data_path / "missing-workspace")},
+                clear=True,
+            ),
+            patch("modules.local_runtime.create_secret_store", return_value=InMemorySecretStore()),
+        ):
+            exit_code, payload = self._run_cli("doctor")
+        checks = {check["code"]: check for check in payload["checks"]}
+
+        self.assertEqual(exit_code, EXIT_RUNTIME_ERROR)
+        self.assertEqual(payload["status"], "fail")
+        self.assertEqual(checks["workspace_folders"]["status"], "fail")
+        self.assertIn("Reconnect", checks["workspace_folders"]["next_action"])
+        self.assertNotIn("Traceback", json.dumps(payload))
+
+    def test_doctor_fails_when_configured_executor_config_is_missing(self) -> None:
+        self._run_cli("init")
+
+        with (
+            patch.dict(
+                os.environ,
+                {"OPENCLAW_CONFIG_PATH": str(self.data_path / "missing-openclaw.json5")},
+                clear=True,
+            ),
+            patch("modules.local_runtime.create_secret_store", return_value=InMemorySecretStore()),
+        ):
+            exit_code, payload = self._run_cli("doctor")
+        checks = {check["code"]: check for check in payload["checks"]}
+
+        self.assertEqual(exit_code, EXIT_RUNTIME_ERROR)
+        self.assertEqual(payload["status"], "fail")
+        self.assertEqual(checks["ingress_executor"]["status"], "fail")
+        self.assertIn("OPENCLAW_CONFIG_PATH", checks["ingress_executor"]["next_action"])
 
     def test_secrets_status_reports_required_missing_without_values(self) -> None:
         store = InMemorySecretStore({"github_token": "ghp_secret"})


### PR DESCRIPTION
## Summary

- Expands `harness doctor --json` into an app-renderable setup report with `status`, `impact`, `next_action`, and structured `details` on every check.
- Adds doctor coverage for dashboard assets/route availability, GitHub and Linear credential state, desktop-agent bridge wiring, notification permission, launch-at-login state, and configured workspace folders.
- Keeps optional incomplete setup as warnings while failing configured-but-broken items such as missing workspace folders or missing configured desktop-agent config files.
- Documents the setup doctor contract for the future menu-bar/onboarding UI.

Closes #322.

## Validation

- `python3 -m unittest tests.test_local_runtime tests.test_local_secrets -v`
- `python3 -m py_compile modules/local_runtime.py modules/local_secrets.py`
- Doctor CLI smoke with temp app data, dashboard assets, env-provided GitHub/Linear credentials, desktop-agent bridge URL, notification state, launch-at-login state, and workspace folder. The payload returned 12 structured checks and did not print token values.
- `python3 -m unittest discover -s tests` (`822` tests, `17` skipped)
- `git diff --check`
