### PR TITLE
Add guided local integration setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,11 +352,12 @@ python3 -m modules.local_runtime --json init
 python3 -m modules.local_runtime --json status
 python3 -m modules.local_runtime serve
 python3 -m modules.local_runtime --json doctor
+python3 -m modules.local_runtime --json setup status
 python3 -m modules.local_runtime --json secrets status
 python3 -m modules.local_runtime stop
 ```
 
-Packaged builds should expose the same contract as `harness init`, `harness serve`, `harness status`, `harness doctor`, `harness open`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
+Packaged builds should expose the same contract as `harness init`, `harness serve`, `harness status`, `harness doctor`, `harness setup status`, `harness open`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
 
 Build the packageable dashboard assets for the local app path:
 
@@ -375,6 +376,17 @@ python3 -m modules.local_runtime --json secrets status --require github_token
 ```
 
 The secrets command reports setup state without printing token values. Developer `.env.local` mode remains supported for native local development, but packaged app onboarding should use the secret store instead of asking users to edit env files.
+
+Use guided setup status for the onboarding flow:
+
+```bash
+python3 -m modules.local_runtime --json setup status
+python3 -m modules.local_runtime --json setup status --workflow github-proof
+python3 -m modules.local_runtime --json setup status --workflow linear-sync
+python3 -m modules.local_runtime --json setup status --workflow repair-dispatch
+```
+
+Default onboarding only requires a healthy local Harness runtime. GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the user selects a workflow that requires it. See [`docs/architecture/guided-integration-setup.md`](docs/architecture/guided-integration-setup.md).
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 

--- a/docs/architecture/guided-integration-setup.md
+++ b/docs/architecture/guided-integration-setup.md
@@ -1,0 +1,129 @@
+# Guided Integration Setup
+
+`harness setup status --json` is the local app onboarding contract.
+It turns the lower-level setup doctor into user-facing setup items that a normal desktop app can render directly.
+
+The setup contract is intentionally client-neutral.
+Harness can integrate with OpenClaw, Hermes, Codex, or a future desktop-agent client, but Harness must not become architecturally tied to one of them.
+
+## Command
+
+From a packaged app, expose:
+
+```bash
+harness setup status
+```
+
+From a repo checkout, use:
+
+```bash
+python3 -m modules.local_runtime --json setup status
+```
+
+The command exits with `0` when onboarding can finish.
+It exits with setup-required when a required item is missing for the selected workflow.
+
+## Default Onboarding
+
+Default onboarding only requires the local Harness runtime:
+
+- writable app data and log directories
+- app-managed runtime config
+- SQLite schema readiness
+- accessible selected workspace folders, if any were selected
+
+Missing GitHub, Linear, and ingress/executor setup appears as incomplete optional work.
+Those integrations become blockers only when the user selects a workflow that needs them.
+
+Warnings for API stopped, dashboard assets, notifications, or Launch at Login are actionable, but they do not block runtime-only onboarding.
+The app can start the API when live progress is needed, and notification/startup preferences remain user choices.
+
+## Workflow Requirements
+
+Use `--workflow` when a user selects a workflow that requires an external integration:
+
+```bash
+python3 -m modules.local_runtime --json setup status --workflow github-proof
+python3 -m modules.local_runtime --json setup status --workflow linear-sync
+python3 -m modules.local_runtime --json setup status --workflow repair-dispatch
+```
+
+Current workflow gates:
+
+- `github-proof` requires GitHub artifact verification.
+- `linear-sync` requires Linear coordination.
+- `repair-dispatch` requires an ingress/executor bridge.
+
+Multiple `--workflow` flags can be passed when the app needs to validate a combined workflow.
+
+## Setup Items
+
+Each item reports:
+
+- `id`
+- `title`
+- `category`
+- `required`
+- `status`
+- `blocks_onboarding`
+- `purpose`
+- `what_user_needs`
+- `how_harness_validates`
+- `next_action`
+- `setup_actions`
+- `validation`
+
+Item status values:
+
+- `complete`: the item is ready.
+- `incomplete`: the item is missing or optional until a selected workflow requires it.
+- `blocked`: the item is configured badly enough that the selected setup cannot be trusted.
+
+The top-level payload includes:
+
+- `status`: `ready` or `setup_required`
+- `onboarding_complete`
+- `runtime_ready`
+- `selected_workflows`
+- `available_workflows`
+- `required_blockers`
+- `optional_incomplete`
+- `optional_attention`
+- `doctor_summary`
+
+## Integration Boundaries
+
+GitHub and Linear credentials must be stored through the app-managed secret boundary.
+The setup contract names the secret to store and exposes the redacted validation status.
+It must not ask normal users to edit env files.
+
+Current secret names:
+
+- `github_token`
+- `linear_api_key`
+- `repair_callback_bearer_token`
+
+CLI fallback examples use stdin so tokens do not land in shell history:
+
+```bash
+printf '%s' "$TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin
+printf '%s' "$TOKEN" | python3 -m modules.local_runtime --json secrets set linear_api_key --value-stdin
+```
+
+The ingress/executor item must stay client-neutral in UI copy.
+It should describe the connection as a desktop-agent bridge for OpenClaw, Hermes, Codex, or a future equivalent.
+The current doctor still recognizes OpenClaw-shaped adapter variables because that is the existing bridge wiring, not the Harness product boundary.
+
+## Validation Source
+
+Guided setup does not create a second validation system.
+It consumes `harness doctor --json` and maps existing checks into onboarding items.
+
+Current mapping:
+
+- Local runtime: `app_data_dir`, `log_dir`, `config`, `sqlite`, `api_health`, `dashboard`, `notification_permission`, `launch_at_login`, `workspace_folders`
+- GitHub: `github_connection`
+- Linear: `linear_connection`
+- Ingress/executor: `ingress_executor`
+
+This keeps the app, CLI, and docs aligned around one diagnostic source.

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -17,6 +17,7 @@ Commands:
 - `harness serve`
 - `harness status`
 - `harness doctor`
+- `harness setup status`
 - `harness open`
 - `harness stop`
 - `harness secrets status`
@@ -98,6 +99,33 @@ Secret status output is redacted. It reports configured, missing, unavailable, a
 Existing environment variables win over Keychain values so native developer `.env.local` workflows still work.
 
 See [app-managed-secrets.md](app-managed-secrets.md).
+
+## Guided Setup
+
+`harness setup status --json` is the app-renderable onboarding contract.
+It converts `harness doctor --json` into setup items with purpose, requirements, validation status, and next actions.
+
+Default onboarding requires only the local Harness runtime.
+Missing GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the app selects a workflow that requires one of them:
+
+```bash
+python3 -m modules.local_runtime --json setup status
+python3 -m modules.local_runtime --json setup status --workflow github-proof
+python3 -m modules.local_runtime --json setup status --workflow linear-sync
+python3 -m modules.local_runtime --json setup status --workflow repair-dispatch
+```
+
+The current workflow gates are:
+
+- `github-proof`: requires GitHub artifact verification.
+- `linear-sync`: requires Linear coordination.
+- `repair-dispatch`: requires a desktop-agent ingress/executor bridge.
+
+Setup items use the app-managed secret boundary.
+The GitHub and Linear items tell the app which named secret to store and how Harness validates it; they do not ask normal users to edit env files.
+The ingress/executor item stays client-neutral and describes the bridge as compatible with OpenClaw, Hermes, Codex, or future desktop-agent clients.
+
+See [guided-integration-setup.md](guided-integration-setup.md).
 
 ## Dashboard Assets
 

--- a/docs/architecture/setup-doctor.md
+++ b/docs/architecture/setup-doctor.md
@@ -2,6 +2,7 @@
 
 `harness doctor --json` is the local app setup report.
 The menu-bar app and onboarding flow should render this JSON directly instead of parsing logs or backend exception text.
+For user-facing onboarding steps, prefer `harness setup status --json`, which maps these checks into guided setup items and workflow-specific blockers.
 
 The doctor is intentionally broader than `/health`.
 `/health` reports whether the backend is alive.
@@ -90,3 +91,16 @@ The UI should describe the setup item as a desktop-agent bridge for OpenClaw, He
 - Do not mark optional integrations as `fail` just because they are not connected.
 - Do fail configured-but-broken items, such as a selected workspace folder that no longer exists.
 - Do not require notification permission or launch-at-login to use Harness.
+
+## Guided Setup Mapping
+
+`harness setup status --json` consumes this doctor payload.
+It keeps default onboarding limited to the local runtime and marks GitHub, Linear, and ingress/executor setup as optional until a selected workflow requires them.
+
+Use workflow gates when needed:
+
+- `--workflow github-proof`
+- `--workflow linear-sync`
+- `--workflow repair-dispatch`
+
+See [guided-integration-setup.md](guided-integration-setup.md).

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -100,6 +100,7 @@ python3 -m modules.local_runtime --json init
 python3 -m modules.local_runtime --json status
 python3 -m modules.local_runtime serve
 python3 -m modules.local_runtime --json doctor
+python3 -m modules.local_runtime --json setup status
 python3 -m modules.local_runtime --json secrets status
 python3 -m modules.local_runtime stop
 ```
@@ -132,6 +133,17 @@ python3 -m modules.local_runtime --json doctor
 ```
 
 Doctor checks report `status`, `impact`, and `next_action` for runtime health, SQLite, dashboard assets, GitHub and Linear credentials, desktop-agent bridge wiring, notifications, launch-at-login, and configured workspace folders. Warnings are actionable but do not block the local runtime. Failures indicate configured setup that cannot be trusted.
+
+Run guided setup for user-facing onboarding items:
+
+```bash
+python3 -m modules.local_runtime --json setup status
+python3 -m modules.local_runtime --json setup status --workflow github-proof
+python3 -m modules.local_runtime --json setup status --workflow linear-sync
+python3 -m modules.local_runtime --json setup status --workflow repair-dispatch
+```
+
+Default onboarding only requires the local runtime. GitHub, Linear, and ingress/executor setup appears as incomplete optional work until the selected workflow needs it. The ingress/executor setup copy should stay client-neutral: OpenClaw, Hermes, Codex, and future desktop-agent clients are all treated as compatible bridges, not Harness architecture dependencies.
 
 To run the same backend against Postgres instead of the file-backed store:
 

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -27,6 +27,11 @@ from modules.local_secrets import (
     load_app_managed_secrets_into_environment,
     secret_status_payload,
 )
+from modules.local_setup import (
+    LocalSetupError,
+    available_workflow_ids,
+    build_guided_setup_status,
+)
 from modules.store import SQLiteHarnessStore, StoreError
 
 
@@ -652,6 +657,7 @@ def _secret_doctor_checks() -> list[RuntimeCheck]:
 
 def _secret_status_to_check(code: str, status: SecretStatus) -> RuntimeCheck:
     configured = status.status == "configured"
+    required_for = status.required_for.rstrip(".")
     return RuntimeCheck(
         code=code,
         status="pass" if configured else "warn",
@@ -663,7 +669,7 @@ def _secret_status_to_check(code: str, status: SecretStatus) -> RuntimeCheck:
         impact=(
             status.required_for
             if configured
-            else f"{status.required_for} will remain unavailable until this credential is connected."
+            else f"{required_for} will remain unavailable until this credential is connected."
         ),
         next_action=status.next_action,
         details={
@@ -1020,6 +1026,21 @@ def build_parser() -> argparse.ArgumentParser:
     stop_parser = subparsers.add_parser("stop", help="Gracefully stop the local Harness runtime")
     stop_parser.add_argument("--timeout", default=10.0, type=float, help="Shutdown timeout in seconds")
 
+    setup_parser = subparsers.add_parser("setup", help="Guide local onboarding and optional integration setup")
+    setup_subparsers = setup_parser.add_subparsers(dest="setup_command", required=True)
+
+    setup_status_parser = setup_subparsers.add_parser(
+        "status",
+        help="Report guided setup state for the local app onboarding flow",
+    )
+    setup_status_parser.add_argument(
+        "--workflow",
+        action="append",
+        choices=available_workflow_ids(),
+        default=[],
+        help="Treat integrations for the selected workflow as required",
+    )
+
     secrets_parser = subparsers.add_parser("secrets", help="Manage app-managed Harness secrets")
     secrets_subparsers = secrets_parser.add_subparsers(dest="secret_command", required=True)
 
@@ -1101,10 +1122,14 @@ def main(argv: list[str] | None = None) -> int:
             config = load_runtime_config(paths)
             exit_code, payload = stop_runtime(config, timeout_seconds=args.timeout)
             return _emit(payload, as_json=args.as_json, exit_code=exit_code)
+        if args.command == "setup":
+            return _handle_setup_command(paths, args, as_json=args.as_json)
         if args.command == "secrets":
             return _handle_secrets_command(args, as_json=args.as_json)
     except LocalRuntimeError as error:
         return _emit({"status": "error", "error": str(error)}, as_json=args.as_json, exit_code=error.exit_code)
+    except LocalSetupError as error:
+        return _emit({"status": "error", "error": str(error)}, as_json=args.as_json, exit_code=EXIT_SETUP_REQUIRED)
     except LocalSecretError as error:
         return _emit({"status": "error", "error": str(error)}, as_json=args.as_json, exit_code=EXIT_SETUP_REQUIRED)
     except Exception as error:
@@ -1116,6 +1141,15 @@ def main(argv: list[str] | None = None) -> int:
 
     parser.error(f"Unsupported command {args.command!r}")
     return EXIT_RUNTIME_ERROR
+
+
+def _handle_setup_command(paths: RuntimePaths, args: argparse.Namespace, *, as_json: bool) -> int:
+    if args.setup_command == "status":
+        _, doctor_payload = run_doctor(paths)
+        payload = build_guided_setup_status(doctor_payload, selected_workflows=args.workflow)
+        exit_code = EXIT_SETUP_REQUIRED if payload.get("required_blockers") else EXIT_OK
+        return _emit(payload, as_json=as_json, exit_code=exit_code)
+    raise LocalRuntimeError(f"Unsupported setup command {args.setup_command!r}.")
 
 
 def _handle_secrets_command(args: argparse.Namespace, *, as_json: bool) -> int:
@@ -1187,6 +1221,15 @@ def _emit(payload: dict[str, Any], *, as_json: bool, exit_code: int = EXIT_OK) -
         for secret in secrets:
             if isinstance(secret, dict):
                 print(f"- {secret.get('name')}: {secret.get('status')} - {secret.get('message')}")
+    items = payload.get("items")
+    if isinstance(items, list):
+        print("setup_items:")
+        for item in items:
+            if isinstance(item, dict):
+                marker = "required" if item.get("required") else "optional"
+                print(f"- {item.get('id')}: {item.get('status')} ({marker})")
+                if item.get("next_action"):
+                    print(f"  next_action: {item.get('next_action')}")
     return exit_code
 
 

--- a/modules/local_setup.py
+++ b/modules/local_setup.py
@@ -1,0 +1,438 @@
+"""Guided setup contract for the local Harness app."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable
+
+
+class LocalSetupError(ValueError):
+    """Operator-readable guided setup failure."""
+
+
+@dataclass(frozen=True)
+class SetupAction:
+    kind: str
+    label: str
+    description: str
+    command: str | None = None
+    secret_name: str | None = None
+    stores_secret: bool = False
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SetupWorkflow:
+    id: str
+    label: str
+    description: str
+    required_items: tuple[str, ...]
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SetupItemDefinition:
+    id: str
+    title: str
+    category: str
+    purpose: str
+    what_user_needs: tuple[str, ...]
+    how_harness_validates: str
+    doctor_check_codes: tuple[str, ...]
+    completion_check_codes: tuple[str, ...]
+    setup_actions: tuple[SetupAction, ...] = ()
+    secret_names: tuple[str, ...] = ()
+    compatible_clients: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+
+WORKFLOW_DEFINITIONS: tuple[SetupWorkflow, ...] = (
+    SetupWorkflow(
+        id="github-proof",
+        label="GitHub artifact verification",
+        description="Require GitHub before accepting repository, branch, commit, pull-request, or changed-file proof.",
+        required_items=("github",),
+    ),
+    SetupWorkflow(
+        id="linear-sync",
+        label="Linear coordination",
+        description="Require Linear before reading or writing coordinated work state.",
+        required_items=("linear",),
+    ),
+    SetupWorkflow(
+        id="repair-dispatch",
+        label="Executor repair dispatch",
+        description="Require a desktop-agent bridge before Harness can request repair or executor-backed work.",
+        required_items=("ingress_executor",),
+    ),
+)
+WORKFLOW_DEFINITIONS_BY_ID = {workflow.id: workflow for workflow in WORKFLOW_DEFINITIONS}
+
+
+SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
+    SetupItemDefinition(
+        id="local_runtime",
+        title="Local Harness runtime",
+        category="core",
+        purpose=(
+            "Runs Harness locally with app-managed config, SQLite persistence, local logs, "
+            "and the dashboard/API served from the local backend."
+        ),
+        what_user_needs=(
+            "Writable app data and log folders.",
+            "Initialized app-managed config and SQLite database.",
+            "A running local API when the menu-bar summary or dashboard needs live progress.",
+        ),
+        how_harness_validates=(
+            "Harness checks writable app folders, config readability, SQLite schema readiness, "
+            "API health, dashboard assets, app-reported permissions, and selected workspace folders."
+        ),
+        doctor_check_codes=(
+            "app_data_dir",
+            "log_dir",
+            "config",
+            "sqlite",
+            "api_health",
+            "dashboard",
+            "notification_permission",
+            "launch_at_login",
+            "workspace_folders",
+        ),
+        completion_check_codes=("app_data_dir", "log_dir", "config", "sqlite", "workspace_folders"),
+        setup_actions=(
+            SetupAction(
+                kind="runtime",
+                label="Initialize local runtime",
+                description="Create app-managed config, logs, and the SQLite database.",
+                command="harness init",
+            ),
+            SetupAction(
+                kind="runtime",
+                label="Start Harness",
+                description="Start the local API when live status or the dashboard should be available.",
+                command="harness serve",
+            ),
+        ),
+        notes=(
+            "API and dashboard warnings do not block onboarding; the app can start the runtime when needed.",
+            "Notifications and Launch at Login are encouraged app-shell choices, not hard requirements.",
+        ),
+    ),
+    SetupItemDefinition(
+        id="github",
+        title="GitHub artifact verification",
+        category="integration",
+        purpose=(
+            "Lets Harness verify external execution proof such as repositories, branches, commits, "
+            "pull requests, and changed files instead of trusting an agent summary."
+        ),
+        what_user_needs=(
+            "A GitHub account or token with access to the repositories Harness should verify.",
+            "The packaged app should store the credential through its app-managed secret provider.",
+        ),
+        how_harness_validates=(
+            "Harness checks the redacted status of the app-managed `github_token` secret through the setup doctor."
+        ),
+        doctor_check_codes=("github_connection",),
+        completion_check_codes=("github_connection",),
+        setup_actions=(
+            SetupAction(
+                kind="secret",
+                label="Connect GitHub",
+                description="Store the GitHub credential through the app-managed secret boundary.",
+                command="harness secrets set github_token --value-stdin",
+                secret_name="github_token",
+                stores_secret=True,
+            ),
+        ),
+        secret_names=("github_token",),
+    ),
+    SetupItemDefinition(
+        id="linear",
+        title="Linear coordination",
+        category="integration",
+        purpose=(
+            "Lets Harness read and update Linear work state when a workflow uses Linear for coordination "
+            "or reconciliation."
+        ),
+        what_user_needs=(
+            "A Linear API key or app authorization for the workspace Harness should coordinate with.",
+            "The packaged app should store the credential through its app-managed secret provider.",
+        ),
+        how_harness_validates=(
+            "Harness checks the redacted status of the app-managed `linear_api_key` secret through the setup doctor."
+        ),
+        doctor_check_codes=("linear_connection",),
+        completion_check_codes=("linear_connection",),
+        setup_actions=(
+            SetupAction(
+                kind="secret",
+                label="Connect Linear",
+                description="Store the Linear credential through the app-managed secret boundary.",
+                command="harness secrets set linear_api_key --value-stdin",
+                secret_name="linear_api_key",
+                stores_secret=True,
+            ),
+        ),
+        secret_names=("linear_api_key",),
+    ),
+    SetupItemDefinition(
+        id="ingress_executor",
+        title="Ingress/executor bridge",
+        category="integration",
+        purpose=(
+            "Lets external clients submit work to Harness and lets Harness request repair or executor-backed "
+            "work when policy says more work is needed."
+        ),
+        what_user_needs=(
+            "A compatible desktop-agent bridge such as OpenClaw, Hermes, Codex, or a future equivalent.",
+            "Either a local CLI bridge configuration or an HTTP repair bridge reachable by the local runtime.",
+            "A callback bearer secret only when the selected bridge requires bearer-protected callbacks.",
+        ),
+        how_harness_validates=(
+            "Harness checks the configured desktop-agent bridge mode through the setup doctor. "
+            "Current adapter validation accepts a local CLI config/state pair or an HTTP bridge URL, "
+            "but the setup item remains client-neutral."
+        ),
+        doctor_check_codes=("ingress_executor",),
+        completion_check_codes=("ingress_executor",),
+        setup_actions=(
+            SetupAction(
+                kind="connection",
+                label="Connect desktop-agent bridge",
+                description=(
+                    "Connect OpenClaw, Hermes, Codex, or another compatible client through the app setup flow."
+                ),
+            ),
+            SetupAction(
+                kind="secret",
+                label="Store callback bearer token",
+                description="Only needed for bearer-protected repair callback workflows.",
+                command="harness secrets set repair_callback_bearer_token --value-stdin",
+                secret_name="repair_callback_bearer_token",
+                stores_secret=True,
+            ),
+        ),
+        secret_names=("repair_callback_bearer_token",),
+        compatible_clients=("OpenClaw", "Hermes", "Codex", "future desktop-agent clients"),
+        notes=(
+            "This setup item is client-neutral; OpenClaw-shaped environment variable names are adapter wiring, not Harness product boundaries.",
+        ),
+    ),
+)
+SETUP_ITEM_DEFINITIONS_BY_ID = {definition.id: definition for definition in SETUP_ITEM_DEFINITIONS}
+
+
+def available_workflow_ids() -> list[str]:
+    return sorted(WORKFLOW_DEFINITIONS_BY_ID)
+
+
+def build_guided_setup_status(
+    doctor_payload: dict[str, Any],
+    *,
+    selected_workflows: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Build the app-renderable guided onboarding status from doctor output."""
+
+    workflows = _normalize_workflows(selected_workflows)
+    required_item_ids = {"local_runtime"}
+    for workflow in workflows:
+        required_item_ids.update(workflow.required_items)
+
+    checks_by_code = _checks_by_code(doctor_payload)
+    items = [
+        _build_setup_item(definition, required=definition.id in required_item_ids, checks_by_code=checks_by_code)
+        for definition in SETUP_ITEM_DEFINITIONS
+    ]
+    required_blockers = [
+        item["id"] for item in items if item["required"] and item["status"] != "complete"
+    ]
+    optional_incomplete = [
+        item["id"] for item in items if not item["required"] and item["status"] != "complete"
+    ]
+    optional_attention = [
+        item["id"] for item in items if not item["required"] and item["status"] == "blocked"
+    ]
+    onboarding_complete = not required_blockers
+
+    return {
+        "status": "ready" if onboarding_complete else "setup_required",
+        "onboarding_complete": onboarding_complete,
+        "runtime_ready": _item_by_id(items, "local_runtime")["status"] == "complete",
+        "selected_workflows": [workflow.asdict() for workflow in workflows],
+        "available_workflows": [workflow.asdict() for workflow in WORKFLOW_DEFINITIONS],
+        "required_blockers": required_blockers,
+        "optional_incomplete": optional_incomplete,
+        "optional_attention": optional_attention,
+        "items": items,
+        "doctor_summary": doctor_payload.get("summary"),
+    }
+
+
+def _normalize_workflows(selected_workflows: Iterable[str]) -> list[SetupWorkflow]:
+    workflows: list[SetupWorkflow] = []
+    seen: set[str] = set()
+    for raw_workflow in selected_workflows:
+        workflow_id = str(raw_workflow).strip()
+        if not workflow_id or workflow_id in seen:
+            continue
+        try:
+            workflows.append(WORKFLOW_DEFINITIONS_BY_ID[workflow_id])
+        except KeyError as error:
+            choices = ", ".join(available_workflow_ids())
+            raise LocalSetupError(f"Unknown setup workflow {workflow_id!r}. Expected one of: {choices}.") from error
+        seen.add(workflow_id)
+    return workflows
+
+
+def _checks_by_code(doctor_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    checks = doctor_payload.get("checks")
+    if not isinstance(checks, list):
+        return {}
+    checks_by_code: dict[str, dict[str, Any]] = {}
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        code = check.get("code")
+        if code:
+            checks_by_code[str(code)] = check
+    return checks_by_code
+
+
+def _build_setup_item(
+    definition: SetupItemDefinition,
+    *,
+    required: bool,
+    checks_by_code: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    relevant_checks = [
+        checks_by_code[code]
+        for code in definition.doctor_check_codes
+        if code in checks_by_code
+    ]
+    completion_checks = [
+        checks_by_code[code]
+        for code in definition.completion_check_codes
+        if code in checks_by_code
+    ]
+    missing_completion_checks = [
+        code for code in definition.completion_check_codes if code not in checks_by_code
+    ]
+    status = _item_status(
+        definition,
+        completion_checks=completion_checks,
+        missing_completion_checks=missing_completion_checks,
+    )
+    blocks_onboarding = required and status != "complete"
+    return {
+        "id": definition.id,
+        "title": definition.title,
+        "category": definition.category,
+        "required": required,
+        "status": status,
+        "blocks_onboarding": blocks_onboarding,
+        "purpose": definition.purpose,
+        "what_user_needs": list(definition.what_user_needs),
+        "how_harness_validates": definition.how_harness_validates,
+        "next_action": _next_action(definition, status=status, checks=relevant_checks, required=required),
+        "doctor_check_codes": list(definition.doctor_check_codes),
+        "secret_names": list(definition.secret_names),
+        "compatible_clients": list(definition.compatible_clients),
+        "setup_actions": [action.asdict() for action in definition.setup_actions],
+        "notes": list(definition.notes),
+        "validation": {
+            "status": _validation_status(relevant_checks, missing_completion_checks=missing_completion_checks),
+            "checks": [_summarize_check(check) for check in relevant_checks],
+            "missing_check_codes": missing_completion_checks,
+        },
+    }
+
+
+def _item_status(
+    definition: SetupItemDefinition,
+    *,
+    completion_checks: list[dict[str, Any]],
+    missing_completion_checks: list[str],
+) -> str:
+    if missing_completion_checks:
+        return "blocked" if definition.id == "local_runtime" else "incomplete"
+    statuses = {str(check.get("status")) for check in completion_checks}
+    if "fail" in statuses:
+        return "blocked"
+    if definition.id == "local_runtime":
+        return "complete"
+    if statuses == {"pass"}:
+        return "complete"
+    return "incomplete"
+
+
+def _validation_status(
+    checks: list[dict[str, Any]],
+    *,
+    missing_completion_checks: list[str],
+) -> str:
+    if missing_completion_checks:
+        return "unknown"
+    statuses = {str(check.get("status")) for check in checks}
+    if "fail" in statuses:
+        return "fail"
+    if "warn" in statuses:
+        return "warn"
+    if statuses == {"pass"}:
+        return "pass"
+    return "unknown"
+
+
+def _next_action(
+    definition: SetupItemDefinition,
+    *,
+    status: str,
+    checks: list[dict[str, Any]],
+    required: bool,
+) -> str:
+    if status == "complete":
+        if definition.id == "local_runtime":
+            return "No setup action is required to finish onboarding. Start Harness when live progress is needed."
+        return "No action needed."
+
+    failing_check = next((check for check in checks if check.get("status") == "fail"), None)
+    if failing_check and failing_check.get("next_action"):
+        return str(failing_check["next_action"])
+
+    warning_check = next((check for check in checks if check.get("status") == "warn"), None)
+    if warning_check and warning_check.get("next_action"):
+        if required:
+            return str(warning_check["next_action"])
+        return f"Optional until a selected workflow requires it. {warning_check['next_action']}"
+
+    if definition.setup_actions:
+        action = definition.setup_actions[0]
+        if action.command:
+            return f"Run `{action.command}` or complete the equivalent app setup step."
+        return action.description
+    return "Open Harness setup and complete this item."
+
+
+def _summarize_check(check: dict[str, Any]) -> dict[str, Any]:
+    summary = {
+        "code": check.get("code"),
+        "status": check.get("status"),
+        "message": check.get("message"),
+        "impact": check.get("impact"),
+        "next_action": check.get("next_action"),
+    }
+    details = check.get("details")
+    if isinstance(details, dict):
+        summary["details"] = details
+    return summary
+
+
+def _item_by_id(items: list[dict[str, Any]], item_id: str) -> dict[str, Any]:
+    for item in items:
+        if item.get("id") == item_id:
+            return item
+    raise LocalSetupError(f"Missing setup item {item_id!r}.")

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -232,6 +232,45 @@ class LocalRuntimeCliTests(unittest.TestCase):
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(payload["status"], "missing")
 
+    def test_setup_status_allows_runtime_only_onboarding(self) -> None:
+        self._run_cli("init")
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("modules.local_runtime.create_secret_store", return_value=InMemorySecretStore()),
+        ):
+            exit_code, payload = self._run_cli("setup", "status")
+        items = {item["id"]: item for item in payload["items"]}
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "ready")
+        self.assertTrue(payload["onboarding_complete"])
+        self.assertEqual(payload["required_blockers"], [])
+        self.assertEqual(items["local_runtime"]["status"], "complete")
+        self.assertEqual(items["github"]["status"], "incomplete")
+        self.assertEqual(items["linear"]["status"], "incomplete")
+        self.assertEqual(items["ingress_executor"]["status"], "incomplete")
+        self.assertFalse(items["github"]["required"])
+        self.assertFalse(items["linear"]["required"])
+        self.assertFalse(items["ingress_executor"]["required"])
+
+    def test_setup_status_selected_workflow_requires_missing_integration(self) -> None:
+        self._run_cli("init")
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("modules.local_runtime.create_secret_store", return_value=InMemorySecretStore()),
+        ):
+            exit_code, payload = self._run_cli("setup", "status", "--workflow", "github-proof")
+        items = {item["id"]: item for item in payload["items"]}
+
+        self.assertEqual(exit_code, EXIT_SETUP_REQUIRED)
+        self.assertEqual(payload["status"], "setup_required")
+        self.assertEqual(payload["required_blockers"], ["github"])
+        self.assertTrue(items["github"]["required"])
+        self.assertEqual(items["github"]["secret_names"], ["github_token"])
+        self.assertNotIn("ghp_secret", json.dumps(payload))
+
 
 class LocalRuntimeProcessTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_local_setup.py
+++ b/tests/test_local_setup.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import unittest
+
+from modules.local_setup import (
+    LocalSetupError,
+    build_guided_setup_status,
+)
+
+
+def healthy_runtime_doctor_payload(
+    *,
+    github_status: str = "warn",
+    linear_status: str = "warn",
+    executor_status: str = "warn",
+) -> dict[str, object]:
+    checks = [
+        check("app_data_dir", "pass"),
+        check("log_dir", "pass"),
+        check("config", "pass"),
+        check("sqlite", "pass"),
+        check("api_health", "warn", next_action="Start Harness from the app or run `harness serve`."),
+        check("dashboard", "warn", next_action="Install packaged dashboard assets."),
+        check("notification_permission", "warn", next_action="Complete the notifications setup step."),
+        check("launch_at_login", "warn", next_action="Complete the Launch at Login setup step."),
+        check("workspace_folders", "pass"),
+        check(
+            "github_connection",
+            github_status,
+            next_action="Connect GitHub token during setup or run `harness secrets set github_token --value-stdin`.",
+        ),
+        check(
+            "linear_connection",
+            linear_status,
+            next_action="Connect Linear API key during setup or run `harness secrets set linear_api_key --value-stdin`.",
+        ),
+        check(
+            "ingress_executor",
+            executor_status,
+            next_action="Connect OpenClaw, Hermes, Codex, or another compatible desktop-agent bridge during setup.",
+        ),
+    ]
+    return {
+        "status": "ok",
+        "summary": {
+            "pass": sum(1 for item in checks if item["status"] == "pass"),
+            "warn": sum(1 for item in checks if item["status"] == "warn"),
+            "fail": sum(1 for item in checks if item["status"] == "fail"),
+        },
+        "checks": checks,
+    }
+
+
+def check(code: str, status: str, *, next_action: str = "No action needed.") -> dict[str, object]:
+    return {
+        "code": code,
+        "status": status,
+        "message": f"{code} is {status}.",
+        "impact": f"{code} impact.",
+        "next_action": next_action,
+    }
+
+
+class GuidedSetupStatusTests(unittest.TestCase):
+    def test_runtime_only_onboarding_can_complete_with_missing_optional_integrations(self) -> None:
+        payload = build_guided_setup_status(healthy_runtime_doctor_payload())
+        items = {item["id"]: item for item in payload["items"]}
+
+        self.assertEqual(payload["status"], "ready")
+        self.assertTrue(payload["onboarding_complete"])
+        self.assertTrue(payload["runtime_ready"])
+        self.assertEqual(payload["required_blockers"], [])
+        self.assertEqual(items["local_runtime"]["status"], "complete")
+        self.assertTrue(items["local_runtime"]["required"])
+        self.assertEqual(items["github"]["status"], "incomplete")
+        self.assertEqual(items["linear"]["status"], "incomplete")
+        self.assertEqual(items["ingress_executor"]["status"], "incomplete")
+        self.assertFalse(items["github"]["required"])
+        self.assertFalse(items["linear"]["required"])
+        self.assertFalse(items["ingress_executor"]["required"])
+
+    def test_selected_workflow_makes_integration_setup_required(self) -> None:
+        payload = build_guided_setup_status(
+            healthy_runtime_doctor_payload(),
+            selected_workflows=["github-proof"],
+        )
+        items = {item["id"]: item for item in payload["items"]}
+
+        self.assertEqual(payload["status"], "setup_required")
+        self.assertFalse(payload["onboarding_complete"])
+        self.assertEqual(payload["required_blockers"], ["github"])
+        self.assertTrue(items["github"]["required"])
+        self.assertTrue(items["github"]["blocks_onboarding"])
+        self.assertEqual(items["github"]["secret_names"], ["github_token"])
+        self.assertIn("harness secrets set github_token --value-stdin", items["github"]["next_action"])
+        self.assertNotIn("GITHUB_TOKEN=", str(items["github"]))
+
+    def test_configured_integration_completes_required_workflow(self) -> None:
+        payload = build_guided_setup_status(
+            healthy_runtime_doctor_payload(github_status="pass"),
+            selected_workflows=["github-proof"],
+        )
+        items = {item["id"]: item for item in payload["items"]}
+
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(payload["required_blockers"], [])
+        self.assertEqual(items["github"]["status"], "complete")
+        self.assertTrue(items["github"]["required"])
+
+    def test_repair_dispatch_requires_client_neutral_executor_bridge(self) -> None:
+        payload = build_guided_setup_status(
+            healthy_runtime_doctor_payload(),
+            selected_workflows=["repair-dispatch"],
+        )
+        items = {item["id"]: item for item in payload["items"]}
+        executor = items["ingress_executor"]
+
+        self.assertEqual(payload["status"], "setup_required")
+        self.assertEqual(payload["required_blockers"], ["ingress_executor"])
+        self.assertEqual(executor["status"], "incomplete")
+        self.assertTrue(executor["required"])
+        self.assertIn("OpenClaw", executor["compatible_clients"])
+        self.assertIn("Hermes", executor["compatible_clients"])
+        self.assertIn("Codex", executor["compatible_clients"])
+        self.assertIn("future desktop-agent clients", executor["compatible_clients"])
+        self.assertIn("client-neutral", " ".join(executor["notes"]))
+
+    def test_configured_broken_runtime_blocks_onboarding(self) -> None:
+        payload = healthy_runtime_doctor_payload()
+        for item in payload["checks"]:
+            if item["code"] == "workspace_folders":
+                item["status"] = "fail"
+                item["next_action"] = "Reconnect the missing folders."
+
+        setup_payload = build_guided_setup_status(payload)
+        items = {item["id"]: item for item in setup_payload["items"]}
+
+        self.assertEqual(setup_payload["status"], "setup_required")
+        self.assertEqual(setup_payload["required_blockers"], ["local_runtime"])
+        self.assertEqual(items["local_runtime"]["status"], "blocked")
+        self.assertIn("Reconnect", items["local_runtime"]["next_action"])
+
+    def test_unknown_workflow_raises_operator_readable_error(self) -> None:
+        with self.assertRaisesRegex(LocalSetupError, "Unknown setup workflow"):
+            build_guided_setup_status(healthy_runtime_doctor_payload(), selected_workflows=["unknown"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `harness setup status` as the guided local onboarding contract
- map doctor checks into required/optional setup items for runtime, GitHub, Linear, and ingress/executor
- add workflow gates so GitHub, Linear, and executor setup only block when selected
- document the app-facing setup contract and client-neutral desktop-agent bridge boundary

Closes #321

## Validation

- `python3 -m py_compile modules/local_setup.py modules/local_runtime.py modules/local_secrets.py`
- `python3 -m unittest tests.test_local_setup tests.test_local_runtime tests.test_local_secrets -v`
- `python3 -m unittest discover -s tests`
- `git diff --check`
- `python3 -m modules.local_runtime --data-dir /tmp/harness-setup-smoke-data.USPQts --log-dir /tmp/harness-setup-smoke-logs.QVYhVs --json init`
- `python3 -m modules.local_runtime --data-dir /tmp/harness-setup-smoke-data.USPQts --log-dir /tmp/harness-setup-smoke-logs.QVYhVs --json setup status`
- `python3 -m modules.local_runtime --data-dir /tmp/harness-setup-smoke-data.USPQts --log-dir /tmp/harness-setup-smoke-logs.QVYhVs --json setup status --workflow github-proof`