### PR TITLE
Embed dashboard in macOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,13 +388,13 @@ python3 -m modules.local_runtime --json setup status --workflow repair-dispatch
 
 Default onboarding only requires a healthy local Harness runtime. GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the user selects a workflow that requires it. See [`docs/architecture/guided-integration-setup.md`](docs/architecture/guided-integration-setup.md).
 
-The native macOS app shell starts under [`apps/macos/HarnessApp`](apps/macos/HarnessApp). It is a SwiftPM menu-bar app that reads runtime/task state through the local CLI and API contracts, not through direct SQLite access. Build and launch development builds with:
+The native macOS app shell starts under [`apps/macos/HarnessApp`](apps/macos/HarnessApp). It is a SwiftPM menu-bar app that reads runtime/task state through the local CLI and API contracts, not through direct SQLite access. It also opens the full local dashboard inside an app window while keeping browser/copy-URL fallbacks for debugging. Build and launch development builds with:
 
 ```bash
 ./script/build_and_run.sh
 ```
 
-See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md).
+See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md) and [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md).
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 

--- a/apps/macos/HarnessApp/README.md
+++ b/apps/macos/HarnessApp/README.md
@@ -1,7 +1,7 @@
 # Harness macOS App
 
 This is the native macOS shell for local Harness operation.
-The first slice is a menu-bar controller with runtime controls and summary counts.
+The first slices are a menu-bar controller with runtime controls and summary counts, plus an embedded dashboard window for full inspection.
 
 ## Targets
 
@@ -23,3 +23,16 @@ The repo-level launch path is:
 ```
 
 The app reads Harness through the local CLI and HTTP API contract. It must not read SQLite directly.
+
+## Dashboard
+
+The dashboard opens inside the app from the menu bar.
+It uses a narrow WebKit bridge to load the app-managed local dashboard routes:
+
+- `/dashboard/tasks/`
+- `/dashboard/verification/`
+- `/dashboard/reconciliation/`
+- `/dashboard/reviews/`
+
+Closing the dashboard window does not stop the local Harness runtime.
+Use "Open in Browser" or "Copy URL" from the dashboard toolbar for debugging.

--- a/apps/macos/HarnessApp/Sources/HarnessApp/DashboardWebView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/DashboardWebView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import WebKit
+
+struct DashboardWebView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.allowsBackForwardNavigationGestures = true
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        guard webView.url != url else {
+            return
+        }
+        webView.load(URLRequest(url: url))
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {}
+}

--- a/apps/macos/HarnessApp/Sources/HarnessApp/DashboardWindowView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/DashboardWindowView.swift
@@ -1,0 +1,103 @@
+import HarnessAppCore
+import SwiftUI
+
+struct DashboardWindowView: View {
+    @ObservedObject var model: HarnessMenuBarModel
+    @State private var selectedRoute: DashboardRoute = .tasks
+
+    var body: some View {
+        VStack(spacing: 0) {
+            DashboardToolbar(
+                selectedRoute: $selectedRoute,
+                routeURL: routeURL,
+                model: model
+            )
+
+            Divider()
+
+            if model.isPreparingDashboard {
+                DashboardUnavailableView(
+                    title: "Preparing Dashboard",
+                    message: model.dashboardMessage,
+                    actionTitle: nil,
+                    action: nil
+                )
+            } else if let routeURL {
+                DashboardWebView(url: routeURL)
+            } else {
+                DashboardUnavailableView(
+                    title: "Dashboard Unavailable",
+                    message: model.dashboardMessage,
+                    actionTitle: "Start Harness",
+                    action: {
+                        Task { await model.prepareDashboard() }
+                    }
+                )
+            }
+        }
+        .frame(minWidth: 880, minHeight: 620)
+        .task {
+            await model.prepareDashboard()
+        }
+    }
+
+    private var routeURL: URL? {
+        model.dashboardURL?.dashboardRoute(selectedRoute)
+    }
+}
+
+private struct DashboardToolbar: View {
+    @Binding var selectedRoute: DashboardRoute
+    let routeURL: URL?
+    @ObservedObject var model: HarnessMenuBarModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Picker("Dashboard Route", selection: $selectedRoute) {
+                ForEach(DashboardRoute.allCases) { route in
+                    Text(route.title).tag(route)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 520)
+
+            Spacer()
+
+            Button("Refresh") {
+                Task { await model.prepareDashboard() }
+            }
+
+            Button("Copy URL") {
+                model.copyDashboardURL(routeURL)
+            }
+            .disabled(routeURL == nil)
+
+            Button("Open in Browser") {
+                model.openDashboardInBrowser(routeURL: routeURL)
+            }
+            .disabled(routeURL == nil)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.bar)
+    }
+}
+
+private struct DashboardUnavailableView: View {
+    let title: String
+    let message: String
+    let actionTitle: String?
+    let action: (() -> Void)?
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(title, systemImage: "rectangle.connected.to.line.below")
+        } description: {
+            Text(message)
+        } actions: {
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+            }
+        }
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessApp.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessApp.swift
@@ -23,6 +23,11 @@ struct HarnessApp: App {
         }
         .menuBarExtraStyle(.menu)
 
+        Window("Harness Dashboard", id: "dashboard") {
+            DashboardWindowView(model: model)
+        }
+        .defaultSize(width: 1180, height: 820)
+
         Settings {
             SettingsView(model: model)
         }

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarModel.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarModel.swift
@@ -7,6 +7,9 @@ final class HarnessMenuBarModel: ObservableObject {
     @Published private(set) var snapshot: HarnessMenuSnapshot = .initial
     @Published private(set) var isBusy = false
     @Published private(set) var lastDoctorMessage: String?
+    @Published private(set) var dashboardURL: URL?
+    @Published private(set) var dashboardMessage = "Open the dashboard to inspect full Harness progress."
+    @Published private(set) var isPreparingDashboard = false
 
     private let runtime: HarnessRuntimeCommand
     private let apiClient: HarnessAPIClient
@@ -85,15 +88,44 @@ final class HarnessMenuBarModel: ObservableObject {
         }
     }
 
-    func openDashboard() async {
-        await runControlAction("Opening dashboard...") {
-            if snapshot.runtimeState != .running {
+    func prepareDashboard() async {
+        guard !isPreparingDashboard else {
+            return
+        }
+        isPreparingDashboard = true
+        dashboardMessage = "Preparing the local dashboard..."
+        do {
+            let status = try await runtime.runtimeStatus()
+            if status.status != "running" {
+                dashboardMessage = "Starting local Harness runtime..."
                 try await runtime.startRuntime()
                 try? await Task.sleep(for: .seconds(1))
             }
-            let url = try await runtime.dashboardURL()
-            NSWorkspace.shared.open(url)
+            dashboardURL = try await runtime.dashboardURL()
+            dashboardMessage = "Dashboard is connected to the local Harness runtime."
+            await refresh()
+        } catch {
+            dashboardURL = nil
+            dashboardMessage = "Dashboard is unavailable: \(error.localizedDescription)"
         }
+        isPreparingDashboard = false
+    }
+
+    func openDashboardInBrowser(routeURL: URL?) {
+        if let routeURL {
+            NSWorkspace.shared.open(routeURL)
+        } else if let dashboardURL {
+            NSWorkspace.shared.open(dashboardURL)
+        }
+    }
+
+    func copyDashboardURL(_ routeURL: URL?) {
+        let value = routeURL?.absoluteString ?? dashboardURL?.absoluteString
+        guard let value else {
+            return
+        }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
     }
 
     func openLogs() {

--- a/apps/macos/HarnessApp/Sources/HarnessApp/MenuBarContentView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/MenuBarContentView.swift
@@ -3,6 +3,7 @@ import HarnessAppCore
 import SwiftUI
 
 struct MenuBarContentView: View {
+    @Environment(\.openWindow) private var openWindow
     @ObservedObject var model: HarnessMenuBarModel
 
     var body: some View {
@@ -25,7 +26,8 @@ struct MenuBarContentView: View {
             Divider()
 
             Button("Open Dashboard") {
-                Task { await model.openDashboard() }
+                openWindow(id: "dashboard")
+                Task { await model.prepareDashboard() }
             }
             Button("Refresh Status") {
                 Task { await model.refresh() }

--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/DashboardRoute.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/DashboardRoute.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public enum DashboardRoute: String, CaseIterable, Identifiable, Sendable {
+    case tasks
+    case verification
+    case reconciliation
+    case reviews
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .tasks:
+            return "Tasks"
+        case .verification:
+            return "Verification"
+        case .reconciliation:
+            return "Reconciliation"
+        case .reviews:
+            return "Reviews"
+        }
+    }
+
+    public var path: String {
+        switch self {
+        case .tasks:
+            return "/dashboard/tasks/"
+        case .verification:
+            return "/dashboard/verification/"
+        case .reconciliation:
+            return "/dashboard/reconciliation/"
+        case .reviews:
+            return "/dashboard/reviews/"
+        }
+    }
+}
+
+public extension URL {
+    func dashboardRoute(_ route: DashboardRoute) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
+        components.path = route.path
+        components.query = nil
+        components.fragment = nil
+        return components.url ?? self
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
@@ -6,6 +6,7 @@ struct HarnessAppCoreCheck {
     static func main() throws {
         try checksRunningSummaryFromTaskListAndQueue()
         try checksStoppedRuntimeSummary()
+        try checksDashboardRoutes()
         print("HarnessAppCoreCheck passed")
     }
 
@@ -110,6 +111,27 @@ struct HarnessAppCoreCheck {
 
     private static func decode<T: Decodable>(_ type: T.Type, _ json: String) throws -> T {
         try JSONDecoder().decode(type, from: Data(json.utf8))
+    }
+
+    private static func checksDashboardRoutes() throws {
+        let baseURL = URL(string: "http://127.0.0.1:8765/dashboard?stale=true#old")!
+
+        try require(
+            baseURL.dashboardRoute(.tasks).absoluteString == "http://127.0.0.1:8765/dashboard/tasks/",
+            "tasks dashboard route"
+        )
+        try require(
+            baseURL.dashboardRoute(.verification).absoluteString == "http://127.0.0.1:8765/dashboard/verification/",
+            "verification dashboard route"
+        )
+        try require(
+            baseURL.dashboardRoute(.reconciliation).absoluteString == "http://127.0.0.1:8765/dashboard/reconciliation/",
+            "reconciliation dashboard route"
+        )
+        try require(
+            baseURL.dashboardRoute(.reviews).absoluteString == "http://127.0.0.1:8765/dashboard/reviews/",
+            "reviews dashboard route"
+        )
     }
 
     private static func require(_ condition: Bool, _ message: String) throws {

--- a/docs/architecture/macos-dashboard-window.md
+++ b/docs/architecture/macos-dashboard-window.md
@@ -1,0 +1,50 @@
+# macOS Dashboard Window
+
+The macOS dashboard window provides the full Harness inspection surface inside the native app.
+It is opened from the menu bar and embeds the same local dashboard served by the app-managed Harness runtime.
+
+## Boundary
+
+The dashboard window does not read SQLite and does not rebuild dashboard truth in Swift.
+It loads the canonical local dashboard over HTTP from the local runtime.
+
+The app shell uses:
+
+- `python3 -m modules.local_runtime --json status`
+- `python3 -m modules.local_runtime --json open --print-url`
+- the local dashboard routes under `/dashboard/`
+
+The embedded web view is a narrow `NSViewRepresentable` wrapper around `WKWebView`.
+SwiftUI owns window state, selected route, fallback controls, and runtime preparation.
+WebKit owns only page rendering and navigation.
+
+## Routes
+
+The window exposes the current dashboard routes as first-class toolbar choices:
+
+- `Tasks`: `/dashboard/tasks/`
+- `Verification`: `/dashboard/verification/`
+- `Reconciliation`: `/dashboard/reconciliation/`
+- `Reviews`: `/dashboard/reviews/`
+
+These are the same routes used by the packaged local dashboard.
+The app must not introduce a separate route model that contradicts the dashboard.
+
+## Runtime Behavior
+
+Opening the dashboard starts the local runtime when it is not already running.
+If runtime setup or startup fails, the window shows an actionable unavailable state instead of a blank web view.
+
+Closing the dashboard window does not stop Harness.
+Runtime lifecycle remains controlled by explicit Start, Stop, and Restart actions in the menu bar.
+
+## Debugging Fallback
+
+The dashboard toolbar includes:
+
+- `Refresh`
+- `Copy URL`
+- `Open in Browser`
+
+Those controls are for debugging route, asset, or backend availability issues.
+They do not replace the embedded dashboard as the normal app path.

--- a/docs/architecture/macos-menu-bar-controller.md
+++ b/docs/architecture/macos-menu-bar-controller.md
@@ -11,7 +11,7 @@ The v1 controller shows:
 - active task count
 - manual-review count
 - failed, stale, retryable, or repair-needed attention count
-- controls for start, stop, restart, refresh, doctor, dashboard, logs, settings, and quit
+- controls for start, stop, restart, refresh, doctor, embedded dashboard, logs, settings, and quit
 
 The dashboard remains the full detail surface.
 The menu bar is for operational awareness and safe controls, not for editing task truth.
@@ -53,7 +53,7 @@ It is a SwiftPM GUI app with:
 
 - `HarnessApp`: SwiftUI/AppKit menu-bar executable
 - `HarnessAppCore`: testable parsing and summary logic
-- `HarnessAppCoreTests`: Swift unit tests for menu-bar counts
+- `HarnessAppCoreCheck`: deterministic Swift validation executable for summary and route contracts
 
 The project-local run entrypoint is:
 
@@ -61,4 +61,21 @@ The project-local run entrypoint is:
 ./script/build_and_run.sh
 ```
 
-The script builds the SwiftPM app, stages a local `.app` bundle under ignored `dist/macos/`, and launches it with `HARNESS_REPO_ROOT` pointed at the repo checkout so development builds can run the existing Python runtime module.
+The script builds the SwiftPM app, stages a local `.app` bundle under ignored `dist/macos/`, and writes the repo root into the development bundle metadata so local builds can run the existing Python runtime module.
+
+## Dashboard Window
+
+The dashboard window is a singleton app scene opened from the menu bar.
+It starts the local runtime when needed, then embeds the packaged dashboard through a small WebKit bridge.
+
+The window preserves the canonical local dashboard routes:
+
+- `/dashboard/tasks/`
+- `/dashboard/verification/`
+- `/dashboard/reconciliation/`
+- `/dashboard/reviews/`
+
+Closing the dashboard window does not stop the runtime.
+The menu bar remains useful without the dashboard window open.
+
+Browser fallback and copy-URL controls exist for debugging local route or asset problems without changing the app/runtime boundary.

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -43,6 +43,11 @@ cat >"$INFO_PLIST" <<PLIST
   <string>$MIN_SYSTEM_VERSION</string>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+  </dict>
   <key>HarnessRepoRoot</key>
   <string>$ROOT_DIR</string>
 </dict>


### PR DESCRIPTION
## Summary

- add a singleton native dashboard window opened from the menu bar
- embed the local Harness dashboard with a small WebKit bridge
- preserve task, verification, reconciliation, and review dashboard routes in the app toolbar
- start the local runtime when the dashboard opens and show actionable unavailable state on failure
- keep browser fallback and copy-URL controls for debugging
- document the dashboard window boundary and no-direct-SQLite rule

Closes #324

## Validation

- `swift build` from `apps/macos/HarnessApp`
- `swift run HarnessAppCoreCheck` from `apps/macos/HarnessApp`
- `./script/build_and_run.sh --verify`
- `python3 -m unittest tests.test_local_runtime tests.test_local_setup -v`
- `git diff --check`