### PR TITLE
Add macOS onboarding setup assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,13 +388,13 @@ python3 -m modules.local_runtime --json setup status --workflow repair-dispatch
 
 Default onboarding only requires a healthy local Harness runtime. GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the user selects a workflow that requires it. See [`docs/architecture/guided-integration-setup.md`](docs/architecture/guided-integration-setup.md).
 
-The native macOS app shell starts under [`apps/macos/HarnessApp`](apps/macos/HarnessApp). It is a SwiftPM menu-bar app that reads runtime/task state through the local CLI and API contracts, not through direct SQLite access. It also opens the full local dashboard inside an app window while keeping browser/copy-URL fallbacks for debugging. Build and launch development builds with:
+The native macOS app shell starts under [`apps/macos/HarnessApp`](apps/macos/HarnessApp). It is a SwiftPM menu-bar app that reads runtime/task state through the local CLI and API contracts, not through direct SQLite access. It opens first-run onboarding automatically, exposes setup again from the menu bar, and opens the full local dashboard inside an app window while keeping browser/copy-URL fallbacks for debugging. Build and launch development builds with:
 
 ```bash
 ./script/build_and_run.sh
 ```
 
-See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md) and [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md).
+See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md), [`docs/architecture/macos-onboarding-assistant.md`](docs/architecture/macos-onboarding-assistant.md), and [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md).
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 

--- a/apps/macos/HarnessApp/README.md
+++ b/apps/macos/HarnessApp/README.md
@@ -1,7 +1,7 @@
 # Harness macOS App
 
 This is the native macOS shell for local Harness operation.
-The first slices are a menu-bar controller with runtime controls and summary counts, plus an embedded dashboard window for full inspection.
+The first slices are a menu-bar controller with runtime controls and summary counts, a first-run setup assistant, and an embedded dashboard window for full inspection.
 
 ## Targets
 
@@ -23,6 +23,21 @@ The repo-level launch path is:
 ```
 
 The app reads Harness through the local CLI and HTTP API contract. It must not read SQLite directly.
+
+## Onboarding
+
+First launch opens the setup assistant.
+It initializes app-managed config, logs, and SQLite state; asks for optional Launch at Login and notification permission; lets users select workspace folders; shows optional GitHub, Linear, and ingress/executor setup items; runs doctor; and opens the embedded dashboard.
+
+The assistant renders `harness setup status --json` through `GuidedSetupStatusPayload`.
+It reports app-owned facts back to the CLI with:
+
+- `HARNESS_NOTIFICATION_PERMISSION`
+- `HARNESS_LAUNCH_AT_LOGIN`
+- `HARNESS_WORKSPACE_FOLDERS`
+
+GitHub, Linear, and repair callback tokens entered in the assistant are saved through the app-managed secret boundary with stdin.
+They are not persisted in Swift preferences.
 
 ## Dashboard
 

--- a/apps/macos/HarnessApp/Sources/HarnessApp/AppPreferenceKeys.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/AppPreferenceKeys.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum AppPreferenceKeys {
+    static let onboardingCompleted = "com.knoxanalytics.harness.onboarding.completed"
+    static let workspaceFolders = "com.knoxanalytics.harness.workspaceFolders"
+}

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessApp.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessApp.swift
@@ -16,12 +16,14 @@ struct HarnessApp: App {
         MenuBarExtra {
             MenuBarContentView(model: model)
         } label: {
-            Label(model.snapshot.menuTitle, systemImage: model.snapshot.runtimeState.systemImage)
-                .task {
-                    model.startPolling()
-                }
+            HarnessMenuBarLabel(model: model)
         }
         .menuBarExtraStyle(.menu)
+
+        Window("Harness Setup", id: "onboarding") {
+            OnboardingWindowView(model: model)
+        }
+        .defaultSize(width: 1040, height: 720)
 
         Window("Harness Dashboard", id: "dashboard") {
             DashboardWindowView(model: model)

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarLabel.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarLabel.swift
@@ -1,0 +1,25 @@
+import AppKit
+import SwiftUI
+
+struct HarnessMenuBarLabel: View {
+    @Environment(\.openWindow) private var openWindow
+    @ObservedObject var model: HarnessMenuBarModel
+    @AppStorage(AppPreferenceKeys.onboardingCompleted) private var onboardingCompleted = false
+    @State private var didRunLaunchTask = false
+
+    var body: some View {
+        Label(model.snapshot.menuTitle, systemImage: model.snapshot.runtimeState.systemImage)
+            .task {
+                guard !didRunLaunchTask else {
+                    return
+                }
+                didRunLaunchTask = true
+                model.startPolling()
+                await model.refreshSetupStatus()
+                if !onboardingCompleted {
+                    openWindow(id: "onboarding")
+                    NSApp.activate(ignoringOtherApps: true)
+                }
+            }
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarModel.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarModel.swift
@@ -10,8 +10,11 @@ final class HarnessMenuBarModel: ObservableObject {
     @Published private(set) var dashboardURL: URL?
     @Published private(set) var dashboardMessage = "Open the dashboard to inspect full Harness progress."
     @Published private(set) var isPreparingDashboard = false
+    @Published private(set) var setupStatus: GuidedSetupStatusPayload?
+    @Published private(set) var setupMessage = "Setup has not been checked yet."
+    @Published private(set) var isCheckingSetup = false
 
-    private let runtime: HarnessRuntimeCommand
+    private var runtime: HarnessRuntimeCommand
     private let apiClient: HarnessAPIClient
     private var pollingTask: Task<Void, Never>?
 
@@ -60,9 +63,54 @@ final class HarnessMenuBarModel: ObservableObject {
         }
     }
 
+    func updateAppEnvironment(_ environment: [String: String]) {
+        runtime = runtime.withEnvironment(environment)
+    }
+
+    func refreshSetupStatus(workflows: [String] = []) async {
+        guard !isCheckingSetup else {
+            return
+        }
+        isCheckingSetup = true
+        setupMessage = "Checking setup..."
+        do {
+            let status = try await runtime.guidedSetupStatus(workflows: workflows)
+            setupStatus = status
+            setupMessage = status.onboardingComplete
+                ? "Core local setup is ready."
+                : "Setup needs attention before onboarding can finish."
+        } catch {
+            setupStatus = nil
+            setupMessage = "Setup could not be checked: \(error.localizedDescription)"
+        }
+        isCheckingSetup = false
+    }
+
+    func initializeAndValidateRuntime() async {
+        await runControlAction("Initializing Harness...") {
+            _ = try await runtime.initializeRuntime()
+            setupStatus = try await runtime.guidedSetupStatus()
+            setupMessage = setupStatus?.onboardingComplete == true
+                ? "Core local setup is ready."
+                : "Runtime initialized. Review remaining setup items."
+        }
+    }
+
+    func saveSecretAndValidate(name: String, value: String) async {
+        await runControlAction("Saving setup secret...") {
+            _ = try await runtime.setSecret(name: name, value: value)
+            setupStatus = try await runtime.guidedSetupStatus()
+            setupMessage = "Saved \(name) and refreshed setup validation."
+        }
+    }
+
     func startRuntime() async {
         await runControlAction("Starting Harness...") {
             try await runtime.startRuntime()
+            setupStatus = try await runtime.guidedSetupStatus()
+            setupMessage = setupStatus?.onboardingComplete == true
+                ? "Core local setup is ready."
+                : "Runtime started. Review remaining setup items."
         }
     }
 
@@ -85,6 +133,8 @@ final class HarnessMenuBarModel: ObservableObject {
             let warnCount = result.summary?["warn"] ?? 0
             let failCount = result.summary?["fail"] ?? 0
             lastDoctorMessage = "Doctor \(result.status): \(passCount) pass, \(warnCount) warn, \(failCount) fail"
+            setupStatus = try await runtime.guidedSetupStatus()
+            setupMessage = "Doctor \(result.status): \(passCount) pass, \(warnCount) warn, \(failCount) fail"
         }
     }
 
@@ -156,6 +206,7 @@ final class HarnessMenuBarModel: ObservableObject {
             await refresh()
         } catch {
             snapshot = HarnessMenuSummaryBuilder.errorSnapshot(error.localizedDescription)
+            setupMessage = error.localizedDescription
         }
         isBusy = false
     }

--- a/apps/macos/HarnessApp/Sources/HarnessApp/MacOSSetupState.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/MacOSSetupState.swift
@@ -1,0 +1,146 @@
+import Foundation
+import ServiceManagement
+import UserNotifications
+
+enum NotificationPermissionState: String {
+    case authorized
+    case denied
+    case notDetermined
+    case unknown
+
+    var environmentValue: String {
+        switch self {
+        case .authorized:
+            return "authorized"
+        case .denied:
+            return "denied"
+        case .notDetermined:
+            return "not_determined"
+        case .unknown:
+            return "unknown"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .authorized:
+            return "Authorized"
+        case .denied:
+            return "Denied"
+        case .notDetermined:
+            return "Not Asked"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+}
+enum LaunchAtLoginState: String {
+    case enabled
+    case disabled
+    case requiresApproval
+    case unavailable
+    case unknown
+
+    var environmentValue: String {
+        switch self {
+        case .enabled:
+            return "enabled"
+        case .disabled, .requiresApproval, .unavailable:
+            return "disabled"
+        case .unknown:
+            return "unknown"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .enabled:
+            return "Enabled"
+        case .disabled:
+            return "Disabled"
+        case .requiresApproval:
+            return "Needs Approval"
+        case .unavailable:
+            return "Unavailable"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+}
+
+struct AppSetupEnvironment {
+    let notificationPermission: NotificationPermissionState
+    let launchAtLogin: LaunchAtLoginState
+    let workspaceFolders: [String]
+
+    var dictionary: [String: String] {
+        var values: [String: String] = [
+            "HARNESS_NOTIFICATION_PERMISSION": notificationPermission.environmentValue,
+            "HARNESS_LAUNCH_AT_LOGIN": launchAtLogin.environmentValue
+        ]
+        if !workspaceFolders.isEmpty {
+            values["HARNESS_WORKSPACE_FOLDERS"] = workspaceFolders.joined(separator: ":")
+        }
+        return values
+    }
+}
+
+enum MacOSSetupState {
+    static func notificationPermissionState() async -> NotificationPermissionState {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return .authorized
+        case .denied:
+            return .denied
+        case .notDetermined:
+            return .notDetermined
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    static func requestNotificationPermission() async -> NotificationPermissionState {
+        do {
+            let granted = try await UNUserNotificationCenter.current().requestAuthorization(
+                options: [.alert, .sound, .badge]
+            )
+            if granted {
+                return await notificationPermissionState()
+            }
+            return .denied
+        } catch {
+            return await notificationPermissionState()
+        }
+    }
+
+    @MainActor
+    static func launchAtLoginState() -> LaunchAtLoginState {
+        switch SMAppService.mainApp.status {
+        case .enabled:
+            return .enabled
+        case .notRegistered:
+            return .disabled
+        case .requiresApproval:
+            return .requiresApproval
+        case .notFound:
+            return .unavailable
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    @MainActor
+    static func setLaunchAtLogin(enabled: Bool) -> (state: LaunchAtLoginState, message: String?) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+            return (launchAtLoginState(), nil)
+        } catch {
+            return (launchAtLoginState(), error.localizedDescription)
+        }
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessApp/MenuBarContentView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/MenuBarContentView.swift
@@ -29,6 +29,10 @@ struct MenuBarContentView: View {
                 openWindow(id: "dashboard")
                 Task { await model.prepareDashboard() }
             }
+            Button("Setup Assistant") {
+                openWindow(id: "onboarding")
+                Task { await model.refreshSetupStatus() }
+            }
             Button("Refresh Status") {
                 Task { await model.refresh() }
             }

--- a/apps/macos/HarnessApp/Sources/HarnessApp/OnboardingComponents.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/OnboardingComponents.swift
@@ -1,0 +1,344 @@
+import HarnessAppCore
+import SwiftUI
+
+enum OnboardingStep: String, CaseIterable, Identifiable, Hashable {
+    case welcome
+    case runtime
+    case permissions
+    case folders
+    case integrations
+    case doctor
+    case dashboard
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .welcome:
+            return "Welcome"
+        case .runtime:
+            return "Runtime"
+        case .permissions:
+            return "Permissions"
+        case .folders:
+            return "Folders"
+        case .integrations:
+            return "Integrations"
+        case .doctor:
+            return "Doctor"
+        case .dashboard:
+            return "Dashboard"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .welcome:
+            return "hand.wave"
+        case .runtime:
+            return "internaldrive"
+        case .permissions:
+            return "checkmark.shield"
+        case .folders:
+            return "folder"
+        case .integrations:
+            return "point.3.connected.trianglepath.dotted"
+        case .doctor:
+            return "stethoscope"
+        case .dashboard:
+            return "rectangle.3.group"
+        }
+    }
+}
+
+struct SectionIntro: View {
+    let title: String
+    let text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.title2.weight(.semibold))
+            Text(text)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+struct FactRow: View {
+    let title: String
+    let text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.headline)
+            Text(text)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+struct PermissionRow<Actions: View>: View {
+    let title: String
+    let value: String
+    let description: String
+    @ViewBuilder let actions: Actions
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(title)
+                        .font(.headline)
+                    Text(value)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(.quaternary, in: Capsule())
+                }
+                Text(description)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+            actions
+        }
+    }
+}
+
+struct SetupStatusBadge: View {
+    let status: String
+    let requiredBlockers: Int
+
+    var body: some View {
+        Label(title, systemImage: image)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(color.opacity(0.12), in: Capsule())
+    }
+
+    private var title: String {
+        if status == "ready" {
+            return "Ready"
+        }
+        return "\(requiredBlockers) blocker\(requiredBlockers == 1 ? "" : "s")"
+    }
+
+    private var image: String {
+        status == "ready" ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+    }
+
+    private var color: Color {
+        status == "ready" ? .green : .orange
+    }
+}
+
+struct SetupItemCard: View {
+    let item: GuidedSetupItem
+    let hidesTerminalNextActions: Bool
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(item.title)
+                        .font(.headline)
+                    Spacer()
+                    ItemStatusBadge(item: item)
+                }
+                Text(item.purpose)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if !displayNextAction.isEmpty {
+                    Text(displayNextAction)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if !item.compatibleClients.isEmpty {
+                    Text("Compatible clients: \(item.compatibleClients.joined(separator: ", "))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(4)
+        }
+    }
+
+    private var displayNextAction: String {
+        if hidesTerminalNextActions && item.nextAction.contains("`") {
+            switch item.id {
+            case "local_runtime":
+                return "Use the buttons in this setup assistant to initialize and validate the local runtime."
+            case "github":
+                return "Optional. Connect GitHub here or later when artifact verification is needed."
+            case "linear":
+                return "Optional. Connect Linear here or later when coordination sync is needed."
+            case "ingress_executor":
+                return "Optional. Connect a desktop-agent bridge later when repair dispatch is needed."
+            default:
+                return ""
+            }
+        }
+        return item.nextAction
+    }
+}
+
+struct CredentialEntryCard: View {
+    let item: GuidedSetupItem
+    let secretName: String
+    @Binding var value: String
+    let isBusy: Bool
+    var note: String?
+    let onSave: () -> Void
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(item.title)
+                            .font(.headline)
+                        Text(note ?? "Paste the token here. Harness stores it through the app-managed secret provider and never displays it again.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    ItemStatusBadge(item: item)
+                }
+
+                HStack {
+                    SecureField(secretName, text: $value)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Save & Validate") {
+                        onSave()
+                    }
+                    .disabled(isBusy || value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .padding(4)
+        }
+    }
+}
+
+struct SetupCheckList: View {
+    let checks: [GuidedSetupCheck]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(checks) { check in
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: image(for: check.status))
+                        .foregroundStyle(color(for: check.status))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(check.message)
+                        Text(check.impact)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func image(for status: String) -> String {
+        switch status {
+        case "pass":
+            return "checkmark.circle.fill"
+        case "fail":
+            return "xmark.octagon.fill"
+        default:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func color(for status: String) -> Color {
+        switch status {
+        case "pass":
+            return .green
+        case "fail":
+            return .red
+        default:
+            return .orange
+        }
+    }
+}
+
+struct ItemStatusBadge: View {
+    let item: GuidedSetupItem
+
+    var body: some View {
+        Label(title, systemImage: image)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(color)
+    }
+
+    private var title: String {
+        switch item.status {
+        case "complete":
+            return "Complete"
+        case "blocked":
+            return item.required ? "Blocked" : "Attention"
+        default:
+            return item.required ? "Required" : "Optional"
+        }
+    }
+
+    private var image: String {
+        switch item.status {
+        case "complete":
+            return "checkmark.circle.fill"
+        case "blocked":
+            return "xmark.octagon.fill"
+        default:
+            return "circle.dashed"
+        }
+    }
+
+    private var color: Color {
+        switch item.status {
+        case "complete":
+            return .green
+        case "blocked":
+            return .red
+        default:
+            return .secondary
+        }
+    }
+}
+
+struct SummaryPill: View {
+    let title: String
+    let value: Int
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(title)
+            Text(value, format: .number)
+                .font(.system(.body, design: .monospaced).weight(.semibold))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(color.opacity(0.12), in: Capsule())
+        .foregroundStyle(color)
+    }
+}
+
+func encodeWorkspaceFolders(_ folders: [String]) -> String {
+    folders.joined(separator: "\n")
+}
+
+func decodeWorkspaceFolders(_ rawValue: String) -> [String] {
+    rawValue
+        .split(whereSeparator: \.isNewline)
+        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessApp/OnboardingWindowView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/OnboardingWindowView.swift
@@ -1,0 +1,520 @@
+import AppKit
+import HarnessAppCore
+import SwiftUI
+
+struct OnboardingWindowView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
+    @ObservedObject var model: HarnessMenuBarModel
+
+    @AppStorage(AppPreferenceKeys.onboardingCompleted) private var onboardingCompleted = false
+    @AppStorage(AppPreferenceKeys.workspaceFolders) private var storedWorkspaceFolders = ""
+
+    @State private var selectedStep: OnboardingStep? = .welcome
+    @State private var didLoad = false
+    @State private var notificationPermission: NotificationPermissionState = .unknown
+    @State private var launchAtLogin: LaunchAtLoginState = .unknown
+    @State private var platformMessage: String?
+    @State private var isUpdatingPlatform = false
+    @State private var githubToken = ""
+    @State private var linearToken = ""
+    @State private var callbackToken = ""
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selectedStep) {
+                ForEach(OnboardingStep.allCases) { step in
+                    Label(step.title, systemImage: step.systemImage)
+                        .tag(step as OnboardingStep?)
+                }
+            }
+            .listStyle(.sidebar)
+            .navigationTitle("Setup")
+        } detail: {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    setupHeader
+                    detailView
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .safeAreaInset(edge: .bottom) {
+                footer
+            }
+        }
+        .task {
+            guard !didLoad else {
+                return
+            }
+            didLoad = true
+            await refreshPlatformStateAndSetup()
+        }
+    }
+
+    private var workspaceFolders: [String] {
+        decodeWorkspaceFolders(storedWorkspaceFolders)
+    }
+
+    private var setupHeader: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: "shield.checkered")
+                .font(.system(size: 34, weight: .semibold))
+                .foregroundStyle(.blue)
+                .frame(width: 44, height: 44)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Harness Setup Assistant")
+                    .font(.largeTitle.weight(.semibold))
+                Text("Set up local Harness without terminal commands. Core setup stays local: app-managed config, SQLite task truth, local logs, and the embedded dashboard.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            if let setupStatus = model.setupStatus {
+                SetupStatusBadge(status: setupStatus.status, requiredBlockers: setupStatus.requiredBlockers.count)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var detailView: some View {
+        switch selectedStep ?? .welcome {
+        case .welcome:
+            welcomeStep
+        case .runtime:
+            runtimeStep
+        case .permissions:
+            permissionsStep
+        case .folders:
+            foldersStep
+        case .integrations:
+            integrationsStep
+        case .doctor:
+            doctorStep
+        case .dashboard:
+            dashboardStep
+        }
+    }
+
+    private var welcomeStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SectionIntro(
+                title: "What Harness Does",
+                text: "Harness is the local control plane that checks whether AI-assisted work is actually complete, evidence-backed, reconciled with external systems, and safe to accept."
+            )
+            GroupBox {
+                VStack(alignment: .leading, spacing: 12) {
+                    FactRow(
+                        title: "Runs locally",
+                        text: "The app initializes local config, SQLite storage, and logs under app-managed folders."
+                    )
+                    FactRow(
+                        title: "Keeps truth out of the UI",
+                        text: "The dashboard and menu bar read canonical Harness APIs. They do not read SQLite directly."
+                    )
+                    FactRow(
+                        title: "Integrations are optional",
+                        text: "GitHub, Linear, and an ingress/executor bridge can be connected later. Core onboarding only requires the local runtime."
+                    )
+                }
+                .padding(4)
+            }
+        }
+    }
+
+    private var runtimeStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SectionIntro(
+                title: "Local Runtime And SQLite",
+                text: "Initialize the local runtime before using Harness. This creates app-managed config, logs, and the SQLite database."
+            )
+
+            if let item = model.setupStatus?.item(id: "local_runtime") {
+                SetupItemCard(item: item, hidesTerminalNextActions: true)
+            }
+
+            HStack(spacing: 10) {
+                Button("Initialize & Validate") {
+                    Task { await initializeRuntime() }
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("Start Harness") {
+                    Task { await startRuntime() }
+                }
+
+                Button("Check Again") {
+                    Task { await validateCurrentSetup() }
+                }
+            }
+            .disabled(model.isBusy || model.isCheckingSetup)
+        }
+    }
+
+    private var permissionsStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SectionIntro(
+                title: "Mac Permissions",
+                text: "These are optional but recommended. Harness can run without them, but they make the app behave like reliable local infrastructure."
+            )
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: 14) {
+                    PermissionRow(
+                        title: "Launch at Login",
+                        value: launchAtLogin.displayName,
+                        description: "Start Harness when you sign in so supervision and the menu-bar summary are ready without opening a terminal."
+                    ) {
+                        HStack {
+                            Button(launchAtLogin == .enabled ? "Disable" : "Enable") {
+                                Task { await configureLaunchAtLogin(enabled: launchAtLogin != .enabled) }
+                            }
+                            Button("Refresh") {
+                                Task { await refreshPlatformStateAndSetup() }
+                            }
+                        }
+                    }
+
+                    Divider()
+
+                    PermissionRow(
+                        title: "Notifications",
+                        value: notificationPermission.displayName,
+                        description: "Allow Harness to alert you when a task needs review or another attention event is detected."
+                    ) {
+                        HStack {
+                            Button("Request Permission") {
+                                Task { await requestNotifications() }
+                            }
+                            Button("Refresh") {
+                                Task { await refreshPlatformStateAndSetup() }
+                            }
+                        }
+                    }
+
+                    if let platformMessage {
+                        Text(platformMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(4)
+            }
+            .disabled(isUpdatingPlatform)
+
+            if let item = model.setupStatus?.item(id: "local_runtime") {
+                SetupCheckList(checks: item.validation.checks.filter { check in
+                    check.code == "notification_permission" || check.code == "launch_at_login"
+                })
+            }
+        }
+    }
+
+    private var foldersStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SectionIntro(
+                title: "Workspace Folders",
+                text: "Folder access is optional. Add only the local repos or artifact folders Harness should inspect for workflows that need local evidence."
+            )
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: 12) {
+                    if workspaceFolders.isEmpty {
+                        Text("No workspace folders selected. That is fine until a workflow needs local repo or artifact inspection.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(workspaceFolders, id: \.self) { folder in
+                            HStack {
+                                Image(systemName: "folder")
+                                    .foregroundStyle(.secondary)
+                                Text(folder)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                Spacer()
+                                Button("Remove") {
+                                    removeWorkspaceFolder(folder)
+                                }
+                            }
+                        }
+                    }
+
+                    HStack {
+                        Button("Choose Folders") {
+                            chooseWorkspaceFolders()
+                        }
+                        Button("Validate Folders") {
+                            Task { await validateCurrentSetup() }
+                        }
+                    }
+                }
+                .padding(4)
+            }
+
+            if let item = model.setupStatus?.item(id: "local_runtime") {
+                SetupCheckList(checks: item.validation.checks.filter { $0.code == "workspace_folders" })
+            }
+        }
+    }
+
+    private var integrationsStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SectionIntro(
+                title: "Optional Integrations",
+                text: "You can finish onboarding without these. Connect them when you want Harness to verify GitHub artifacts, reconcile Linear work, or dispatch repair/executor work through a desktop-agent bridge."
+            )
+
+            if let github = model.setupStatus?.item(id: "github") {
+                CredentialEntryCard(
+                    item: github,
+                    secretName: "github_token",
+                    value: $githubToken,
+                    isBusy: model.isBusy
+                ) {
+                    let token = githubToken
+                    githubToken = ""
+                    Task { await saveSecret(name: "github_token", value: token) }
+                }
+            }
+
+            if let linear = model.setupStatus?.item(id: "linear") {
+                CredentialEntryCard(
+                    item: linear,
+                    secretName: "linear_api_key",
+                    value: $linearToken,
+                    isBusy: model.isBusy
+                ) {
+                    let token = linearToken
+                    linearToken = ""
+                    Task { await saveSecret(name: "linear_api_key", value: token) }
+                }
+            }
+
+            if let ingress = model.setupStatus?.item(id: "ingress_executor") {
+                SetupItemCard(item: ingress, hidesTerminalNextActions: true)
+                CredentialEntryCard(
+                    item: ingress,
+                    secretName: "repair_callback_bearer_token",
+                    value: $callbackToken,
+                    isBusy: model.isBusy,
+                    note: "Only needed when your selected desktop-agent bridge uses bearer-protected callbacks."
+                ) {
+                    let token = callbackToken
+                    callbackToken = ""
+                    Task { await saveSecret(name: "repair_callback_bearer_token", value: token) }
+                }
+            }
+        }
+    }
+
+    private var doctorStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SectionIntro(
+                title: "Doctor Check",
+                text: "Run doctor before finishing setup. It validates app folders, SQLite, dashboard/API readiness, permissions, selected folders, and optional integration state."
+            )
+
+            HStack {
+                Button("Run Doctor") {
+                    Task { await runDoctor() }
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("Refresh Setup") {
+                    Task { await validateCurrentSetup() }
+                }
+            }
+            .disabled(model.isBusy || model.isCheckingSetup)
+
+            if let message = model.lastDoctorMessage {
+                Text(message)
+                    .font(.headline)
+            }
+
+            if let summary = model.setupStatus?.doctorSummary {
+                HStack(spacing: 10) {
+                    SummaryPill(title: "Pass", value: summary["pass"] ?? 0, color: .green)
+                    SummaryPill(title: "Warn", value: summary["warn"] ?? 0, color: .orange)
+                    SummaryPill(title: "Fail", value: summary["fail"] ?? 0, color: .red)
+                }
+            }
+
+            if let setupStatus = model.setupStatus {
+                ForEach(setupStatus.items) { item in
+                    SetupItemCard(item: item, hidesTerminalNextActions: true)
+                }
+            }
+        }
+    }
+
+    private var dashboardStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            SectionIntro(
+                title: "Open Dashboard",
+                text: "The dashboard is the full inspection surface. Opening it starts the local runtime if needed and loads the canonical local dashboard routes inside the app."
+            )
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(model.setupStatus?.onboardingComplete == true ? "Core setup is ready." : "Core setup still needs attention.")
+                        .font(.headline)
+                    Text(model.setupMessage)
+                        .foregroundStyle(.secondary)
+                    HStack {
+                        Button("Open Dashboard") {
+                            finishAndOpenDashboard()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(model.setupStatus?.onboardingComplete != true)
+
+                        Button("Check Setup") {
+                            Task { await validateCurrentSetup() }
+                        }
+                    }
+                }
+                .padding(4)
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Text(model.isCheckingSetup || model.isBusy ? "Working..." : model.setupMessage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Spacer()
+            Button("Skip Optional Items") {
+                selectedStep = .dashboard
+            }
+            Button("Finish & Open Dashboard") {
+                finishAndOpenDashboard()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(model.setupStatus?.onboardingComplete != true)
+        }
+        .padding(12)
+        .background(.regularMaterial)
+    }
+
+    @MainActor
+    private func initializeRuntime() async {
+        applyEnvironment()
+        await model.initializeAndValidateRuntime()
+    }
+
+    @MainActor
+    private func startRuntime() async {
+        applyEnvironment()
+        await model.startRuntime()
+        await model.refreshSetupStatus()
+    }
+
+    @MainActor
+    private func runDoctor() async {
+        applyEnvironment()
+        await model.runDoctor()
+    }
+
+    @MainActor
+    private func validateCurrentSetup() async {
+        applyEnvironment()
+        await model.refreshSetupStatus()
+    }
+
+    @MainActor
+    private func saveSecret(name: String, value: String) async {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return
+        }
+        applyEnvironment()
+        await model.saveSecretAndValidate(name: name, value: trimmed)
+    }
+
+    @MainActor
+    private func requestNotifications() async {
+        isUpdatingPlatform = true
+        notificationPermission = await MacOSSetupState.requestNotificationPermission()
+        platformMessage = notificationPermission == .authorized
+            ? "Notifications are authorized."
+            : "Notifications are optional. Harness can run without them."
+        applyEnvironment()
+        await model.refreshSetupStatus()
+        isUpdatingPlatform = false
+    }
+
+    @MainActor
+    private func configureLaunchAtLogin(enabled: Bool) async {
+        isUpdatingPlatform = true
+        let result = MacOSSetupState.setLaunchAtLogin(enabled: enabled)
+        launchAtLogin = result.state
+        if let message = result.message {
+            platformMessage = "Launch at Login could not be updated: \(message)"
+        } else if launchAtLogin == .requiresApproval {
+            platformMessage = "macOS needs approval in System Settings before Launch at Login is active."
+        } else {
+            platformMessage = "Launch at Login is \(launchAtLogin.displayName.lowercased())."
+        }
+        applyEnvironment()
+        await model.refreshSetupStatus()
+        isUpdatingPlatform = false
+    }
+
+    @MainActor
+    private func refreshPlatformStateAndSetup() async {
+        isUpdatingPlatform = true
+        notificationPermission = await MacOSSetupState.notificationPermissionState()
+        launchAtLogin = MacOSSetupState.launchAtLoginState()
+        applyEnvironment()
+        await model.refreshSetupStatus()
+        isUpdatingPlatform = false
+    }
+
+    @MainActor
+    private func applyEnvironment() {
+        let environment = AppSetupEnvironment(
+            notificationPermission: notificationPermission,
+            launchAtLogin: launchAtLogin,
+            workspaceFolders: workspaceFolders
+        )
+        model.updateAppEnvironment(environment.dictionary)
+    }
+
+    @MainActor
+    private func chooseWorkspaceFolders() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose Harness Workspace Folders"
+        panel.message = "Select only the repos or artifact folders Harness should be allowed to inspect."
+        panel.prompt = "Choose"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = true
+        panel.canCreateDirectories = false
+
+        if panel.runModal() == .OK {
+            let merged = Array(Set(workspaceFolders + panel.urls.map(\.path))).sorted()
+            storedWorkspaceFolders = encodeWorkspaceFolders(merged)
+            applyEnvironment()
+            Task { await model.refreshSetupStatus() }
+        }
+    }
+
+    @MainActor
+    private func removeWorkspaceFolder(_ folder: String) {
+        storedWorkspaceFolders = encodeWorkspaceFolders(workspaceFolders.filter { $0 != folder })
+        applyEnvironment()
+        Task { await model.refreshSetupStatus() }
+    }
+
+    @MainActor
+    private func finishAndOpenDashboard() {
+        onboardingCompleted = true
+        openWindow(id: "dashboard")
+        Task { await model.prepareDashboard() }
+        dismiss()
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/GuidedSetupStatus.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/GuidedSetupStatus.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+public struct GuidedSetupStatusPayload: Decodable, Equatable, Sendable {
+    public let status: String
+    public let onboardingComplete: Bool
+    public let runtimeReady: Bool
+    public let selectedWorkflows: [GuidedSetupWorkflow]
+    public let availableWorkflows: [GuidedSetupWorkflow]
+    public let requiredBlockers: [String]
+    public let optionalIncomplete: [String]
+    public let optionalAttention: [String]
+    public let items: [GuidedSetupItem]
+    public let doctorSummary: [String: Int]?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case onboardingComplete = "onboarding_complete"
+        case runtimeReady = "runtime_ready"
+        case selectedWorkflows = "selected_workflows"
+        case availableWorkflows = "available_workflows"
+        case requiredBlockers = "required_blockers"
+        case optionalIncomplete = "optional_incomplete"
+        case optionalAttention = "optional_attention"
+        case items
+        case doctorSummary = "doctor_summary"
+    }
+
+    public func item(id: String) -> GuidedSetupItem? {
+        items.first { $0.id == id }
+    }
+}
+
+public struct GuidedSetupWorkflow: Decodable, Equatable, Sendable, Identifiable {
+    public let id: String
+    public let label: String
+    public let description: String
+    public let requiredItems: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case label
+        case description
+        case requiredItems = "required_items"
+    }
+}
+
+public struct GuidedSetupItem: Decodable, Equatable, Sendable, Identifiable {
+    public let id: String
+    public let title: String
+    public let category: String
+    public let required: Bool
+    public let status: String
+    public let blocksOnboarding: Bool
+    public let purpose: String
+    public let whatUserNeeds: [String]
+    public let howHarnessValidates: String
+    public let nextAction: String
+    public let doctorCheckCodes: [String]
+    public let secretNames: [String]
+    public let compatibleClients: [String]
+    public let setupActions: [GuidedSetupAction]
+    public let notes: [String]
+    public let validation: GuidedSetupValidation
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case category
+        case required
+        case status
+        case blocksOnboarding = "blocks_onboarding"
+        case purpose
+        case whatUserNeeds = "what_user_needs"
+        case howHarnessValidates = "how_harness_validates"
+        case nextAction = "next_action"
+        case doctorCheckCodes = "doctor_check_codes"
+        case secretNames = "secret_names"
+        case compatibleClients = "compatible_clients"
+        case setupActions = "setup_actions"
+        case notes
+        case validation
+    }
+
+    public var isComplete: Bool {
+        status == "complete"
+    }
+
+    public var isBlocked: Bool {
+        status == "blocked"
+    }
+}
+
+public struct GuidedSetupAction: Decodable, Equatable, Sendable, Identifiable {
+    public let kind: String
+    public let label: String
+    public let description: String
+    public let command: String?
+    public let secretName: String?
+    public let storesSecret: Bool
+
+    public var id: String {
+        [kind, label, secretName ?? ""].joined(separator: ":")
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case label
+        case description
+        case command
+        case secretName = "secret_name"
+        case storesSecret = "stores_secret"
+    }
+}
+
+public struct GuidedSetupValidation: Decodable, Equatable, Sendable {
+    public let status: String
+    public let checks: [GuidedSetupCheck]
+    public let missingCheckCodes: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case checks
+        case missingCheckCodes = "missing_check_codes"
+    }
+}
+
+public struct GuidedSetupCheck: Decodable, Equatable, Sendable, Identifiable {
+    public let code: String
+    public let status: String
+    public let message: String
+    public let impact: String
+    public let nextAction: String
+
+    public var id: String {
+        code
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case status
+        case message
+        case impact
+        case nextAction = "next_action"
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessRuntimeCommand.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessRuntimeCommand.swift
@@ -3,13 +3,16 @@ import Foundation
 public struct HarnessRuntimeCommand: Sendable {
     public let repoRoot: URL
     public let pythonExecutable: String
+    public let environment: [String: String]
 
     public init(
         repoRoot: URL = HarnessRuntimeCommand.defaultRepoRoot(),
-        pythonExecutable: String = ProcessInfo.processInfo.environment["HARNESS_PYTHON"] ?? "python3"
+        pythonExecutable: String = ProcessInfo.processInfo.environment["HARNESS_PYTHON"] ?? "python3",
+        environment: [String: String] = [:]
     ) {
         self.repoRoot = repoRoot
         self.pythonExecutable = pythonExecutable
+        self.environment = environment
     }
 
     public static func defaultRepoRoot() -> URL {
@@ -34,6 +37,14 @@ public struct HarnessRuntimeCommand: Sendable {
         return try JSONDecoder().decode(RuntimeStatusPayload.self, from: Data(result.stdout.utf8))
     }
 
+    public func withEnvironment(_ environment: [String: String]) -> HarnessRuntimeCommand {
+        HarnessRuntimeCommand(
+            repoRoot: repoRoot,
+            pythonExecutable: pythonExecutable,
+            environment: environment
+        )
+    }
+
     @discardableResult
     public func initializeRuntime() async throws -> CommandResult {
         try await runJSONCommand(["init"], allowNonZeroExit: false)
@@ -46,6 +57,7 @@ public struct HarnessRuntimeCommand: Sendable {
             process.currentDirectoryURL = repoRoot
             process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
             process.arguments = [pythonExecutable, "-m", "modules.local_runtime", "serve"]
+            process.environment = mergedProcessEnvironment(environment)
             try process.run()
         }.value
     }
@@ -74,15 +86,33 @@ public struct HarnessRuntimeCommand: Sendable {
         return try JSONDecoder().decode(DoctorSummary.self, from: Data(result.stdout.utf8))
     }
 
+    @discardableResult
+    public func setSecret(name: String, value: String) async throws -> CommandResult {
+        try await runJSONCommand(
+            ["secrets", "set", name, "--value-stdin"],
+            allowNonZeroExit: false,
+            stdin: value
+        )
+    }
+
+    public func guidedSetupStatus(workflows: [String] = []) async throws -> GuidedSetupStatusPayload {
+        let workflowArgs = workflows.flatMap { ["--workflow", $0] }
+        let result = try await runJSONCommand(["setup", "status"] + workflowArgs, allowNonZeroExit: true)
+        return try JSONDecoder().decode(GuidedSetupStatusPayload.self, from: Data(result.stdout.utf8))
+    }
+
     public func runJSONCommand(
         _ args: [String],
-        allowNonZeroExit: Bool
+        allowNonZeroExit: Bool,
+        stdin: String? = nil
     ) async throws -> CommandResult {
         try await Task.detached(priority: .userInitiated) {
             try runProcess(
                 repoRoot: repoRoot,
                 pythonExecutable: pythonExecutable,
                 args: ["-m", "modules.local_runtime", "--json"] + args,
+                environment: environment,
+                stdin: stdin,
                 allowNonZeroExit: allowNonZeroExit
             )
         }.value
@@ -125,18 +155,30 @@ private func runProcess(
     repoRoot: URL,
     pythonExecutable: String,
     args: [String],
+    environment: [String: String],
+    stdin: String?,
     allowNonZeroExit: Bool
 ) throws -> CommandResult {
     let process = Process()
     let stdoutPipe = Pipe()
     let stderrPipe = Pipe()
+    let stdinPipe = stdin == nil ? nil : Pipe()
     process.currentDirectoryURL = repoRoot
     process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
     process.arguments = [pythonExecutable] + args
+    process.environment = mergedProcessEnvironment(environment)
     process.standardOutput = stdoutPipe
     process.standardError = stderrPipe
+    if let stdinPipe {
+        process.standardInput = stdinPipe
+    }
     do {
         try process.run()
+        if let stdin, let stdinPipe {
+            let data = Data(stdin.utf8)
+            stdinPipe.fileHandleForWriting.write(data)
+            stdinPipe.fileHandleForWriting.closeFile()
+        }
     } catch {
         throw HarnessRuntimeCommandError.launchFailed(error.localizedDescription)
     }
@@ -149,4 +191,8 @@ private func runProcess(
         throw HarnessRuntimeCommandError.commandFailed(exitCode: process.terminationStatus, stderr: stderr)
     }
     return result
+}
+
+private func mergedProcessEnvironment(_ environment: [String: String]) -> [String: String] {
+    ProcessInfo.processInfo.environment.merging(environment) { _, appValue in appValue }
 }

--- a/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
@@ -7,6 +7,7 @@ struct HarnessAppCoreCheck {
         try checksRunningSummaryFromTaskListAndQueue()
         try checksStoppedRuntimeSummary()
         try checksDashboardRoutes()
+        try checksGuidedSetupPayloadDecoding()
         print("HarnessAppCoreCheck passed")
     }
 
@@ -132,6 +133,71 @@ struct HarnessAppCoreCheck {
             baseURL.dashboardRoute(.reviews).absoluteString == "http://127.0.0.1:8765/dashboard/reviews/",
             "reviews dashboard route"
         )
+    }
+
+    private static func checksGuidedSetupPayloadDecoding() throws {
+        let payload = try decode(
+            GuidedSetupStatusPayload.self,
+            """
+            {
+              "status": "ready",
+              "onboarding_complete": true,
+              "runtime_ready": true,
+              "selected_workflows": [],
+              "available_workflows": [
+                {
+                  "id": "github-proof",
+                  "label": "GitHub artifact verification",
+                  "description": "Require GitHub proof.",
+                  "required_items": ["github"]
+                }
+              ],
+              "required_blockers": [],
+              "optional_incomplete": ["github"],
+              "optional_attention": [],
+              "doctor_summary": {"pass": 5, "warn": 3, "fail": 0},
+              "items": [
+                {
+                  "id": "local_runtime",
+                  "title": "Local Harness runtime",
+                  "category": "core",
+                  "required": true,
+                  "status": "complete",
+                  "blocks_onboarding": false,
+                  "purpose": "Runs Harness locally.",
+                  "what_user_needs": ["Writable folders."],
+                  "how_harness_validates": "Harness checks setup.",
+                  "next_action": "No setup action is required.",
+                  "doctor_check_codes": ["config"],
+                  "secret_names": [],
+                  "compatible_clients": [],
+                  "setup_actions": [],
+                  "notes": [],
+                  "validation": {
+                    "status": "pass",
+                    "checks": [
+                      {
+                        "code": "config",
+                        "status": "pass",
+                        "message": "Config is ready.",
+                        "impact": "Harness can start.",
+                        "next_action": "No action needed."
+                      }
+                    ],
+                    "missing_check_codes": []
+                  }
+                }
+              ]
+            }
+            """
+        )
+
+        try require(payload.onboardingComplete, "onboarding complete")
+        try require(payload.runtimeReady, "runtime ready")
+        try require(payload.availableWorkflows.first?.requiredItems == ["github"], "workflow required items")
+        try require(payload.item(id: "local_runtime")?.isComplete == true, "setup item complete")
+        try require(payload.item(id: "github") == nil, "missing item lookup")
+        try require(payload.doctorSummary?["pass"] == 5, "doctor summary")
     }
 
     private static func require(_ condition: Bool, _ message: String) throws {

--- a/docs/architecture/macos-menu-bar-controller.md
+++ b/docs/architecture/macos-menu-bar-controller.md
@@ -11,10 +11,11 @@ The v1 controller shows:
 - active task count
 - manual-review count
 - failed, stale, retryable, or repair-needed attention count
-- controls for start, stop, restart, refresh, doctor, embedded dashboard, logs, settings, and quit
+- controls for setup assistant, start, stop, restart, refresh, doctor, embedded dashboard, logs, settings, and quit
 
 The dashboard remains the full detail surface.
 The menu bar is for operational awareness and safe controls, not for editing task truth.
+The setup assistant is the first-run path for local runtime initialization and optional app setup.
 
 ## Data Boundary
 
@@ -23,6 +24,7 @@ It uses the same public local contract as any other app shell:
 
 - `python3 -m modules.local_runtime --json status`
 - `python3 -m modules.local_runtime --json doctor`
+- `python3 -m modules.local_runtime --json setup status`
 - `python3 -m modules.local_runtime --json open --print-url`
 - `GET /tasks`
 - `GET /supervision/queue`
@@ -79,3 +81,22 @@ Closing the dashboard window does not stop the runtime.
 The menu bar remains useful without the dashboard window open.
 
 Browser fallback and copy-URL controls exist for debugging local route or asset problems without changing the app/runtime boundary.
+
+## Setup Assistant
+
+The setup assistant is a singleton app scene opened automatically on first launch and manually from the menu bar.
+It keeps normal-user setup inside the app:
+
+- initialize app-managed local runtime and SQLite
+- request optional Launch at Login
+- request optional notifications
+- choose optional workspace folders through `NSOpenPanel`
+- store optional GitHub, Linear, and repair callback secrets through the app-managed secret boundary
+- run doctor and refresh guided setup status
+- open the embedded dashboard when core onboarding is complete
+
+The assistant reports app-owned facts to the setup doctor through environment overlays on the runtime command.
+It does not change Harness task truth, read SQLite, or bypass canonical API/read-model/timeline surfaces.
+
+Issue #326 still owns the full daemon lifecycle and crash/stale-process recovery model.
+Issue #327 still owns actionable notification delivery.

--- a/docs/architecture/macos-onboarding-assistant.md
+++ b/docs/architecture/macos-onboarding-assistant.md
@@ -1,0 +1,117 @@
+# macOS Onboarding Assistant
+
+The macOS onboarding assistant is the first-run path for normal users.
+It exists so a user can get to a healthy local Harness runtime without terminal commands, Docker, Python setup, Node, `pnpm`, repo cloning, or env-file editing.
+
+## Scope
+
+The assistant covers:
+
+- what Harness does
+- app-managed local runtime initialization
+- SQLite readiness
+- Launch at Login prompt
+- notification permission prompt
+- optional workspace folder selection
+- optional GitHub, Linear, and ingress/executor setup items
+- setup doctor validation
+- opening the embedded dashboard
+
+The menu bar can reopen the assistant at any time through `Setup Assistant`.
+First launch opens it automatically until the user finishes core local setup and opens the dashboard.
+
+## Source Of Truth
+
+The assistant does not create a second setup system.
+It renders the same guided setup contract used by CLI and docs:
+
+```bash
+python3 -m modules.local_runtime --json setup status
+```
+
+The Swift app decodes that payload through `GuidedSetupStatusPayload`.
+The payload maps doctor checks into setup items and keeps the default onboarding rule explicit: only the local runtime blocks first-run completion.
+GitHub, Linear, and ingress/executor setup remain optional until a selected workflow requires them.
+
+## Runtime Boundary
+
+The assistant initializes and validates runtime through the local runtime CLI:
+
+- `init` creates app-managed config, logs, and SQLite state.
+- `serve` starts the local API when the user wants live status or the dashboard.
+- `doctor` provides the diagnostic summary.
+- `setup status` drives setup item rendering.
+
+The Swift app does not read SQLite directly and does not reconstruct Harness task truth.
+The embedded dashboard remains the full inspection surface.
+
+## App-Owned Setup Facts
+
+Some doctor checks depend on state owned by the native app shell.
+The assistant reports those facts to the runtime command environment before validation:
+
+- `HARNESS_NOTIFICATION_PERMISSION`
+- `HARNESS_LAUNCH_AT_LOGIN`
+- `HARNESS_WORKSPACE_FOLDERS`
+
+Notification state comes from `UserNotifications`.
+Launch at Login state comes from `SMAppService`.
+Workspace folders come from the standard macOS folder picker.
+
+Warnings for notifications and Launch at Login do not block core onboarding.
+Selected workspace folders are different: if the user configured a folder and it later disappears or is unreadable, setup blocks because Harness can no longer trust workflows that depend on that folder.
+
+## Permissions
+
+Launch at Login and notifications are optional but recommended.
+
+Launch at Login is requested through the native login-item API.
+Issue #326 still owns the fuller daemon lifecycle model: recovery from crashed or stale backend processes, port conflicts, and final startup behavior after login.
+
+Notifications are requested through the native notification authorization prompt.
+Issue #327 still owns attention-event delivery: manual-review alerts, repair-dispatch failures, stalled executors, budget thresholds, and credential-expiry notifications.
+
+The assistant records and validates permission state, but it does not pretend these follow-on event and lifecycle behaviors are finished.
+
+## Integrations
+
+Optional integrations are shown as setup items, not blockers.
+
+- GitHub verifies artifact proof such as repos, branches, commits, PRs, and changed files.
+- Linear coordinates structured work state when a workflow needs it.
+- Ingress/executor connects OpenClaw, Hermes, Codex, or a future desktop-agent bridge without making Harness depend on one agentic desktop solution.
+
+GitHub and Linear tokens entered in the assistant are stored through the app-managed secret boundary by piping the value into `harness secrets set ... --value-stdin`.
+The token remains in view state only long enough to save it.
+The UI never writes the token to config files or logs and never displays terminal fallback commands to normal users.
+
+## Validation Rules
+
+After each configured item, the assistant refreshes `setup status`.
+That applies after:
+
+- runtime initialization
+- runtime start
+- notification permission request
+- Launch at Login changes
+- workspace folder selection or removal
+- secret save
+- doctor run
+
+The user can finish onboarding when `onboarding_complete=true`.
+In the default path, that means the local runtime, SQLite state, and selected workspace folders are healthy.
+
+## Development Validation
+
+Use the SwiftPM app checks plus the backend setup/runtime tests:
+
+```bash
+cd apps/macos/HarnessApp
+swift build
+swift run HarnessAppCoreCheck
+cd ../../..
+python3 -m unittest tests.test_local_runtime tests.test_local_setup -v
+./script/build_and_run.sh --verify
+```
+
+`HarnessAppCoreCheck` decodes the setup payload, verifies menu summary logic, and verifies dashboard route mapping in environments where SwiftPM test frameworks are unavailable.


### PR DESCRIPTION
## Summary

- add a first-run Harness Setup Assistant window and menu-bar entry
- initialize and validate the local runtime through the existing CLI/setup-status contract
- add native macOS setup reporters for notifications, Launch at Login, and selected workspace folders
- let optional GitHub/Linear/repair callback secrets be saved through the app-managed stdin secret boundary
- document the onboarding assistant boundary and validation flow

Closes #325

## Validation

- `swift build`
- `swift run HarnessAppCoreCheck`
- `python3 -m unittest tests.test_local_runtime tests.test_local_setup -v`
- `git diff --check`
- `./script/build_and_run.sh --verify`