### PR TITLE
Add macOS daemon lifecycle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,15 +349,17 @@ Run the local app runtime contract from a repo checkout:
 
 ```bash
 python3 -m modules.local_runtime --json init
+python3 -m modules.local_runtime --json start
 python3 -m modules.local_runtime --json status
 python3 -m modules.local_runtime serve
 python3 -m modules.local_runtime --json doctor
 python3 -m modules.local_runtime --json setup status
 python3 -m modules.local_runtime --json secrets status
-python3 -m modules.local_runtime stop
+python3 -m modules.local_runtime --json recover
+python3 -m modules.local_runtime --json stop
 ```
 
-Packaged builds should expose the same contract as `harness init`, `harness serve`, `harness status`, `harness doctor`, `harness setup status`, `harness open`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
+Packaged builds should expose the same contract as `harness init`, `harness start`, `harness serve`, `harness status`, `harness doctor`, `harness setup status`, `harness open`, `harness recover`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
 
 Build the packageable dashboard assets for the local app path:
 
@@ -388,13 +390,13 @@ python3 -m modules.local_runtime --json setup status --workflow repair-dispatch
 
 Default onboarding only requires a healthy local Harness runtime. GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the user selects a workflow that requires it. See [`docs/architecture/guided-integration-setup.md`](docs/architecture/guided-integration-setup.md).
 
-The native macOS app shell starts under [`apps/macos/HarnessApp`](apps/macos/HarnessApp). It is a SwiftPM menu-bar app that reads runtime/task state through the local CLI and API contracts, not through direct SQLite access. It opens first-run onboarding automatically, exposes setup again from the menu bar, and opens the full local dashboard inside an app window while keeping browser/copy-URL fallbacks for debugging. Build and launch development builds with:
+The native macOS app shell starts under [`apps/macos/HarnessApp`](apps/macos/HarnessApp). It is a SwiftPM menu-bar app that reads runtime/task state through the local CLI and API contracts, not through direct SQLite access. It opens first-run onboarding automatically, exposes setup again from the menu bar, controls Launch at Login through `SMAppService`, supervises the backend through app-managed `start`/`stop`/`recover` commands, and opens the full local dashboard inside an app window while keeping browser/copy-URL fallbacks for debugging. Build and launch development builds with:
 
 ```bash
 ./script/build_and_run.sh
 ```
 
-See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md), [`docs/architecture/macos-onboarding-assistant.md`](docs/architecture/macos-onboarding-assistant.md), and [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md).
+See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md), [`docs/architecture/macos-onboarding-assistant.md`](docs/architecture/macos-onboarding-assistant.md), [`docs/architecture/macos-daemon-lifecycle.md`](docs/architecture/macos-daemon-lifecycle.md), and [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md).
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 

--- a/apps/macos/HarnessApp/README.md
+++ b/apps/macos/HarnessApp/README.md
@@ -24,6 +24,18 @@ The repo-level launch path is:
 
 The app reads Harness through the local CLI and HTTP API contract. It must not read SQLite directly.
 
+## Runtime Lifecycle
+
+The app uses the local runtime CLI as the process boundary:
+
+- `harness start`: start the backend as an app-managed process and wait for health.
+- `harness stop`: stop the PID-backed backend process.
+- `harness recover`: clear stale state, stop unhealthy PID-backed processes, handle port conflicts, and restart.
+
+Launch at Login is controlled through `SMAppService`.
+When enabled, macOS launches the app after login; the app then starts the local runtime if onboarding has been completed.
+The backend is not installed as a separate LaunchAgent in this slice.
+
 ## Onboarding
 
 First launch opens the setup assistant.

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarLabel.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarLabel.swift
@@ -5,6 +5,7 @@ struct HarnessMenuBarLabel: View {
     @Environment(\.openWindow) private var openWindow
     @ObservedObject var model: HarnessMenuBarModel
     @AppStorage(AppPreferenceKeys.onboardingCompleted) private var onboardingCompleted = false
+    @AppStorage(AppPreferenceKeys.workspaceFolders) private var storedWorkspaceFolders = ""
     @State private var didRunLaunchTask = false
 
     var body: some View {
@@ -15,7 +16,24 @@ struct HarnessMenuBarLabel: View {
                 }
                 didRunLaunchTask = true
                 model.startPolling()
-                await model.refreshSetupStatus()
+                let launchState = MacOSSetupState.launchAtLoginState()
+                let notificationState = await MacOSSetupState.notificationPermissionState()
+                model.updateAppEnvironment(
+                    AppSetupEnvironment(
+                        notificationPermission: notificationState,
+                        launchAtLogin: launchState,
+                        workspaceFolders: decodeWorkspaceFolders(storedWorkspaceFolders)
+                    ).dictionary
+                )
+                if onboardingCompleted {
+                    if launchState == .enabled {
+                        await model.startRuntimeAfterLogin()
+                    } else {
+                        await model.refreshSetupStatus()
+                    }
+                } else {
+                    await model.refreshSetupStatus()
+                }
                 if !onboardingCompleted {
                     openWindow(id: "onboarding")
                     NSApp.activate(ignoringOtherApps: true)

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarModel.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarModel.swift
@@ -106,23 +106,40 @@ final class HarnessMenuBarModel: ObservableObject {
 
     func startRuntime() async {
         await runControlAction("Starting Harness...") {
-            try await runtime.startRuntime()
+            let result = try await runtime.startRuntime()
             setupStatus = try await runtime.guidedSetupStatus()
-            setupMessage = setupStatus?.onboardingComplete == true
-                ? "Core local setup is ready."
-                : "Runtime started. Review remaining setup items."
+            setupMessage = result.message ?? "Runtime started."
         }
     }
 
     func stopRuntime() async {
         await runControlAction("Stopping Harness...") {
-            _ = try await runtime.stopRuntime()
+            let result = try await runtime.stopRuntime()
+            setupMessage = result.message ?? "Runtime stopped."
         }
     }
 
     func restartRuntime() async {
         await runControlAction("Restarting Harness...") {
-            try await runtime.restartRuntime()
+            let result = try await runtime.restartRuntime()
+            setupStatus = try await runtime.guidedSetupStatus()
+            setupMessage = result.message ?? "Runtime restarted."
+        }
+    }
+
+    func recoverRuntime() async {
+        await runControlAction("Recovering Harness...") {
+            let result = try await runtime.recoverRuntime()
+            setupStatus = try await runtime.guidedSetupStatus()
+            setupMessage = result.message ?? "Runtime recovered."
+        }
+    }
+
+    func startRuntimeAfterLogin() async {
+        await runControlAction("Starting Harness after login...") {
+            let result = try await runtime.startRuntime()
+            setupStatus = try await runtime.guidedSetupStatus()
+            setupMessage = result.message ?? "Runtime started after login."
         }
     }
 
@@ -148,7 +165,7 @@ final class HarnessMenuBarModel: ObservableObject {
             let status = try await runtime.runtimeStatus()
             if status.status != "running" {
                 dashboardMessage = "Starting local Harness runtime..."
-                try await runtime.startRuntime()
+                _ = try await runtime.startRuntime()
                 try? await Task.sleep(for: .seconds(1))
             }
             dashboardURL = try await runtime.dashboardURL()

--- a/apps/macos/HarnessApp/Sources/HarnessApp/MenuBarContentView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/MenuBarContentView.swift
@@ -51,6 +51,9 @@ struct MenuBarContentView: View {
             Button("Restart") {
                 Task { await model.restartRuntime() }
             }
+            Button("Recover Runtime") {
+                Task { await model.recoverRuntime() }
+            }
 
             Divider()
 

--- a/apps/macos/HarnessApp/Sources/HarnessApp/SettingsView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/SettingsView.swift
@@ -3,6 +3,11 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var model: HarnessMenuBarModel
+    @AppStorage(AppPreferenceKeys.workspaceFolders) private var storedWorkspaceFolders = ""
+    @State private var launchAtLogin: LaunchAtLoginState = .unknown
+    @State private var notificationPermission: NotificationPermissionState = .unknown
+    @State private var platformMessage: String?
+    @State private var isUpdatingLaunchAtLogin = false
 
     var body: some View {
         Form {
@@ -10,16 +15,56 @@ struct SettingsView: View {
                 LabeledContent("State", value: model.snapshot.runtimeState.displayName)
                 LabeledContent("API", value: model.snapshot.apiBaseURL ?? "Not running")
                 LabeledContent("Logs", value: model.snapshot.logDirectory ?? defaultLogDirectory)
+                HStack {
+                    Button("Start") {
+                        Task { await model.startRuntime() }
+                    }
+                    Button("Stop") {
+                        Task { await model.stopRuntime() }
+                    }
+                    Button("Restart") {
+                        Task { await model.restartRuntime() }
+                    }
+                    Button("Recover") {
+                        Task { await model.recoverRuntime() }
+                    }
+                }
+                .disabled(model.isBusy)
+            }
+
+            Section("Launch at Login") {
+                LabeledContent("State", value: launchAtLogin.displayName)
+                Text("When enabled, macOS launches the Harness app after login and the app starts the local runtime if onboarding has been completed.")
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Button(launchAtLogin == .enabled ? "Disable" : "Enable") {
+                        Task { await setLaunchAtLogin(enabled: launchAtLogin != .enabled) }
+                    }
+                    Button("Refresh") {
+                        Task { await refreshPlatformState() }
+                    }
+                }
+                .disabled(isUpdatingLaunchAtLogin)
+
+                if let platformMessage {
+                    Text(platformMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Section("Operation") {
-                Text("The menu bar reads local runtime status and task counts through the Harness CLI and HTTP API. It does not read SQLite directly.")
+                Text("The menu bar reads local runtime status and task counts through the Harness CLI and HTTP API. It does not read SQLite directly. Launch at Login starts the app; the app supervises the backend as an app-managed child process.")
                     .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)
         .padding()
-        .frame(width: 520)
+        .frame(width: 620)
+        .task {
+            await refreshPlatformState()
+        }
     }
 
     private var defaultLogDirectory: String {
@@ -28,5 +73,39 @@ struct SettingsView: View {
             .appendingPathComponent("Logs")
             .appendingPathComponent("Harness")
             .path
+    }
+
+    @MainActor
+    private func setLaunchAtLogin(enabled: Bool) async {
+        isUpdatingLaunchAtLogin = true
+        let result = MacOSSetupState.setLaunchAtLogin(enabled: enabled)
+        launchAtLogin = result.state
+        if let message = result.message {
+            platformMessage = "Launch at Login could not be updated: \(message)"
+        } else if launchAtLogin == .requiresApproval {
+            platformMessage = "macOS needs approval in System Settings before Launch at Login is active."
+        } else {
+            platformMessage = "Launch at Login is \(launchAtLogin.displayName.lowercased())."
+        }
+        await applySetupEnvironment()
+        await model.refreshSetupStatus()
+        isUpdatingLaunchAtLogin = false
+    }
+
+    @MainActor
+    private func refreshPlatformState() async {
+        launchAtLogin = MacOSSetupState.launchAtLoginState()
+        notificationPermission = await MacOSSetupState.notificationPermissionState()
+        await applySetupEnvironment()
+    }
+
+    @MainActor
+    private func applySetupEnvironment() async {
+        let environment = AppSetupEnvironment(
+            notificationPermission: notificationPermission,
+            launchAtLogin: launchAtLogin,
+            workspaceFolders: decodeWorkspaceFolders(storedWorkspaceFolders)
+        )
+        model.updateAppEnvironment(environment.dictionary)
     }
 }

--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessRuntimeCommand.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessRuntimeCommand.swift
@@ -50,26 +50,25 @@ public struct HarnessRuntimeCommand: Sendable {
         try await runJSONCommand(["init"], allowNonZeroExit: false)
     }
 
-    public func startRuntime() async throws {
-        _ = try await initializeRuntime()
-        try await Task.detached(priority: .userInitiated) {
-            let process = Process()
-            process.currentDirectoryURL = repoRoot
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [pythonExecutable, "-m", "modules.local_runtime", "serve"]
-            process.environment = mergedProcessEnvironment(environment)
-            try process.run()
-        }.value
+    public func startRuntime() async throws -> RuntimeControlPayload {
+        let result = try await runJSONCommand(["start"], allowNonZeroExit: false)
+        return try JSONDecoder().decode(RuntimeControlPayload.self, from: Data(result.stdout.utf8))
     }
 
     @discardableResult
-    public func stopRuntime() async throws -> CommandResult {
-        try await runJSONCommand(["stop"], allowNonZeroExit: false)
+    public func stopRuntime() async throws -> RuntimeControlPayload {
+        let result = try await runJSONCommand(["stop"], allowNonZeroExit: false)
+        return try JSONDecoder().decode(RuntimeControlPayload.self, from: Data(result.stdout.utf8))
     }
 
-    public func restartRuntime() async throws {
+    public func restartRuntime() async throws -> RuntimeControlPayload {
         _ = try? await stopRuntime()
-        try await startRuntime()
+        return try await startRuntime()
+    }
+
+    public func recoverRuntime() async throws -> RuntimeControlPayload {
+        let result = try await runJSONCommand(["recover"], allowNonZeroExit: false)
+        return try JSONDecoder().decode(RuntimeControlPayload.self, from: Data(result.stdout.utf8))
     }
 
     public func dashboardURL() async throws -> URL {
@@ -130,21 +129,41 @@ public struct DoctorSummary: Decodable, Equatable, Sendable {
     public let summary: [String: Int]?
 }
 
+public struct RuntimeControlPayload: Decodable, Equatable, Sendable {
+    public let status: String
+    public let message: String?
+    public let nextAction: String?
+    public let apiBaseURL: String?
+    public let pid: Int?
+    public let recovered: Bool?
+    public let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case message
+        case nextAction = "next_action"
+        case apiBaseURL = "api_base_url"
+        case pid
+        case recovered
+        case error
+    }
+}
+
 private struct OpenPayload: Decodable {
     let url: String
 }
 
 public enum HarnessRuntimeCommandError: Error, LocalizedError, Equatable {
     case launchFailed(String)
-    case commandFailed(exitCode: Int32, stderr: String)
+    case commandFailed(exitCode: Int32, message: String)
     case invalidURL(String)
 
     public var errorDescription: String? {
         switch self {
         case .launchFailed(let message):
             return message
-        case .commandFailed(let exitCode, let stderr):
-            return "Harness runtime command failed with exit \(exitCode): \(stderr)"
+        case .commandFailed(let exitCode, let message):
+            return "Harness runtime command failed with exit \(exitCode): \(message)"
         case .invalidURL(let value):
             return "Harness returned an invalid dashboard URL: \(value)"
         }
@@ -188,11 +207,34 @@ private func runProcess(
     let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
     let result = CommandResult(exitCode: process.terminationStatus, stdout: stdout, stderr: stderr)
     if !allowNonZeroExit && process.terminationStatus != 0 {
-        throw HarnessRuntimeCommandError.commandFailed(exitCode: process.terminationStatus, stderr: stderr)
+        throw HarnessRuntimeCommandError.commandFailed(
+            exitCode: process.terminationStatus,
+            message: commandFailureMessage(stdout: stdout, stderr: stderr)
+        )
     }
     return result
 }
 
 private func mergedProcessEnvironment(_ environment: [String: String]) -> [String: String] {
     ProcessInfo.processInfo.environment.merging(environment) { _, appValue in appValue }
+}
+
+private func commandFailureMessage(stdout: String, stderr: String) -> String {
+    if let data = stdout.data(using: .utf8),
+       let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        let message = payload["message"] as? String ?? payload["error"] as? String
+        let nextAction = payload["next_action"] as? String
+        if let message, let nextAction {
+            return "\(message) \(nextAction)"
+        }
+        if let message {
+            return message
+        }
+    }
+    let trimmedStderr = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmedStderr.isEmpty {
+        return trimmedStderr
+    }
+    let trimmedStdout = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmedStdout.isEmpty ? "No error output was returned." : trimmedStdout
 }

--- a/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
@@ -8,6 +8,7 @@ struct HarnessAppCoreCheck {
         try checksStoppedRuntimeSummary()
         try checksDashboardRoutes()
         try checksGuidedSetupPayloadDecoding()
+        try checksRuntimeControlPayloadDecoding()
         print("HarnessAppCoreCheck passed")
     }
 
@@ -198,6 +199,29 @@ struct HarnessAppCoreCheck {
         try require(payload.item(id: "local_runtime")?.isComplete == true, "setup item complete")
         try require(payload.item(id: "github") == nil, "missing item lookup")
         try require(payload.doctorSummary?["pass"] == 5, "doctor summary")
+    }
+
+    private static func checksRuntimeControlPayloadDecoding() throws {
+        let payload = try decode(
+            RuntimeControlPayload.self,
+            """
+            {
+              "status": "running",
+              "message": "Harness runtime started.",
+              "next_action": "No action needed.",
+              "api_base_url": "http://127.0.0.1:8765",
+              "pid": 4242,
+              "recovered": true
+            }
+            """
+        )
+
+        try require(payload.status == "running", "runtime control status")
+        try require(payload.message == "Harness runtime started.", "runtime control message")
+        try require(payload.nextAction == "No action needed.", "runtime control next action")
+        try require(payload.apiBaseURL == "http://127.0.0.1:8765", "runtime control api")
+        try require(payload.pid == 4242, "runtime control pid")
+        try require(payload.recovered == true, "runtime control recovered")
     }
 
     private static func require(_ condition: Bool, _ message: String) throws {

--- a/docs/architecture/app-managed-secrets.md
+++ b/docs/architecture/app-managed-secrets.md
@@ -43,7 +43,7 @@ The Python CLI exists as a portable contract and developer fallback; the native 
 
 ## Runtime Behavior
 
-`harness serve` applies app-managed config, then loads available app-managed secrets into process environment variables before starting the backend.
+`harness start` and `harness serve` apply app-managed config, then load available app-managed secrets into process environment variables before starting the backend.
 
 Existing environment variables win. This preserves developer mode:
 

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -14,12 +14,14 @@ python3 -m modules.local_runtime <command>
 Commands:
 
 - `harness init`
+- `harness start`
 - `harness serve`
 - `harness status`
 - `harness doctor`
 - `harness setup status`
 - `harness open`
 - `harness stop`
+- `harness recover`
 - `harness secrets status`
 - `harness secrets set <name> --value-stdin`
 - `harness secrets delete <name>`
@@ -62,7 +64,7 @@ The first schema stores:
 - SQLite database path
 - data, dashboard asset, runtime, PID, and log paths
 
-`harness serve` applies the config to the backend process through environment variables before startup:
+`harness start` and `harness serve` apply the config to the backend process through environment variables before startup:
 
 - `HARNESS_STORE_BACKEND=sqlite`
 - `HARNESS_SQLITE_PATH=<app-data>/harness.db`
@@ -212,11 +214,20 @@ All CLI failures should produce operator-readable messages. Stack traces are not
 
 ## Process Lifecycle
 
-`harness serve` runs the backend in the foreground, writes a PID file, appends runtime output to `harness.log`,
-and removes the PID file on clean exit.
+`harness start` is the app-facing lifecycle command.
+It initializes the runtime if needed, starts `harness serve` as an app-managed background process, waits for `/health`, and then returns JSON the app can render.
+If the runtime is already healthy, `start` exits successfully without launching a duplicate process.
+If the PID file is stale, `start` removes it and starts a fresh runtime.
+If the configured port is already owned by a non-Harness process, `start` fails with `status=port_conflict` and an explicit next action.
+
+`harness serve` runs the backend in the foreground, writes a PID file, appends runtime output to `harness.log`, and removes the PID file on clean exit.
+It is still useful for foreground debugging and for the background process launched by `harness start`.
 
 `harness stop` reads the PID file and sends `SIGTERM`.
 Missing or stale PID files are treated as already stopped because the desired state is satisfied.
+
+`harness recover` is the app-facing repair action for crashed, stale, or degraded runtime state.
+It stops an unhealthy PID-backed process when possible, clears stale PID files, starts a fresh runtime, waits for health, and reports the same user-facing JSON shape as `start`.
 
 The local API binds to loopback by default. Network exposure is out of scope for the local app v1 contract.
 

--- a/docs/architecture/macos-daemon-lifecycle.md
+++ b/docs/architecture/macos-daemon-lifecycle.md
@@ -1,0 +1,67 @@
+# macOS Daemon Lifecycle
+
+Harness v1 uses an app-managed lifecycle, not a standalone LaunchAgent.
+
+The decision is deliberate.
+The first normal-user app needs reversible startup behavior, clear recovery actions, and observable failures.
+Installing a second daemon manager before packaging and notarization would add operational friction without solving a current correctness problem.
+
+## V1 Model
+
+The macOS app owns the user-facing process lifecycle:
+
+- `SMAppService.mainApp` registers or unregisters Launch at Login.
+- macOS launches the Harness app after login when enabled.
+- After launch, the app starts the backend with `harness start` if onboarding has been completed.
+- The backend runs as an app-managed child process created by the local runtime CLI.
+- The menu bar and Settings expose Start, Stop, Restart, Recover, Doctor, Logs, and Dashboard.
+
+This gives users explicit control while still making Harness behave like local infrastructure after login.
+
+## Runtime Commands
+
+The app uses the local runtime contract instead of launching Python directly:
+
+- `harness start`: initialize if needed, start `harness serve` in the background, wait for health, and return app-renderable JSON.
+- `harness stop`: terminate the PID-backed backend process.
+- `harness recover`: stop unhealthy PID-backed processes, clear stale PID files, detect port conflicts, start a fresh runtime, and wait for health.
+- `harness status`: read health and PID state without mutating runtime state.
+- `harness doctor`: report setup and remediation checks.
+
+`harness serve` remains the foreground backend process used by `harness start`.
+It is also useful for debugging.
+Normal app controls should use `start`, `stop`, and `recover`.
+
+## Startup After Login
+
+Launch at Login starts the app, not the backend directly.
+That matters because the app owns:
+
+- onboarding completion state
+- user-visible status
+- recovery and logs
+- optional permissions and workspace folder facts
+- dashboard launch
+
+If Launch at Login is enabled but onboarding is not complete, the app opens setup instead of starting a half-configured backend.
+If onboarding is complete, the app calls `harness start`.
+If the backend is already healthy, `start` exits successfully and the app avoids duplicate processes.
+
+## Recovery Semantics
+
+Recovery handles the common local failure cases:
+
+- stale PID file: remove it and start fresh
+- PID-backed process is alive but unhealthy: stop it, then start fresh
+- configured port is already used by non-Harness process: fail with `status=port_conflict`
+- backend exits before health: fail with `status=start_failed` and point the user to logs
+
+The app should show the returned `message` and `next_action` rather than replacing it with a generic failure.
+
+## Boundaries
+
+The app-managed lifecycle does not change Harness truth boundaries.
+The app supervises a local process; it does not read SQLite, mutate task truth, or bypass canonical APIs.
+
+Future packaging work may revisit whether a helper, LaunchAgent, or privileged service is justified.
+That should be decided only if the app-managed model fails a concrete release requirement such as restart after app crash while the user intentionally keeps the menu-bar app closed.

--- a/docs/architecture/macos-menu-bar-controller.md
+++ b/docs/architecture/macos-menu-bar-controller.md
@@ -11,7 +11,7 @@ The v1 controller shows:
 - active task count
 - manual-review count
 - failed, stale, retryable, or repair-needed attention count
-- controls for setup assistant, start, stop, restart, refresh, doctor, embedded dashboard, logs, settings, and quit
+- controls for setup assistant, start, stop, restart, recover, refresh, doctor, embedded dashboard, logs, settings, and quit
 
 The dashboard remains the full detail surface.
 The menu bar is for operational awareness and safe controls, not for editing task truth.
@@ -34,14 +34,16 @@ Attention counts use `GET /supervision/queue` so stale, retryable, invalid-proof
 
 ## Runtime Controls
 
-Start, stop, and restart call the existing local runtime CLI:
+Start, stop, restart, and recover call the existing local runtime CLI:
 
-- start initializes local runtime state and launches `harness serve`
+- start initializes local runtime state, launches `harness serve` as an app-managed child process, and waits for health
 - stop calls `harness stop`
 - restart stops, then starts
+- recover stops unhealthy PID-backed processes, clears stale PID files, handles port conflicts explicitly, and starts a fresh runtime
 
-Issue #326 will own the final daemon/Launch-at-Login model.
-This first controller intentionally keeps lifecycle control thin and delegates process semantics to the runtime contract already used by docs and tests.
+The v1 daemon decision is intentionally small: macOS launches the Harness app with `SMAppService`, and the app supervises the backend through the app-managed CLI lifecycle.
+Harness does not install a LaunchAgent in this slice.
+That keeps the user-facing toggle reversible from Settings and avoids adding a second process manager before packaging/notarization work is finished.
 
 ## Project Shape
 
@@ -98,5 +100,5 @@ It keeps normal-user setup inside the app:
 The assistant reports app-owned facts to the setup doctor through environment overlays on the runtime command.
 It does not change Harness task truth, read SQLite, or bypass canonical API/read-model/timeline surfaces.
 
-Issue #326 still owns the full daemon lifecycle and crash/stale-process recovery model.
+Launch at Login and crash/stale-process recovery are implemented through the app-managed lifecycle contract.
 Issue #327 still owns actionable notification delivery.

--- a/docs/architecture/macos-onboarding-assistant.md
+++ b/docs/architecture/macos-onboarding-assistant.md
@@ -66,12 +66,15 @@ Selected workspace folders are different: if the user configured a folder and it
 Launch at Login and notifications are optional but recommended.
 
 Launch at Login is requested through the native login-item API.
-Issue #326 still owns the fuller daemon lifecycle model: recovery from crashed or stale backend processes, port conflicts, and final startup behavior after login.
+When enabled, macOS starts the Harness app after login.
+If onboarding has been completed, the app then starts the local runtime through `harness start`.
+The backend remains an app-managed child process, not a separate LaunchAgent.
 
 Notifications are requested through the native notification authorization prompt.
 Issue #327 still owns attention-event delivery: manual-review alerts, repair-dispatch failures, stalled executors, budget thresholds, and credential-expiry notifications.
 
-The assistant records and validates permission state, but it does not pretend these follow-on event and lifecycle behaviors are finished.
+The assistant records and validates permission state.
+Notification event delivery remains separate from permission capture.
 
 ## Integrations
 

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -98,14 +98,18 @@ The packaged app will expose this contract as `harness`. From a repo checkout, u
 ```bash
 python3 -m modules.local_runtime --json init
 python3 -m modules.local_runtime --json status
+python3 -m modules.local_runtime --json start
 python3 -m modules.local_runtime serve
 python3 -m modules.local_runtime --json doctor
 python3 -m modules.local_runtime --json setup status
 python3 -m modules.local_runtime --json secrets status
-python3 -m modules.local_runtime stop
+python3 -m modules.local_runtime --json recover
+python3 -m modules.local_runtime --json stop
 ```
 
 The runtime contract uses app-managed config, SQLite state, PID files, dashboard assets, and logs. A packaged app should not require Docker, Node, `pnpm`, or repo-local shell exports.
+Use `start` and `recover` for app-style background lifecycle control.
+Use `serve` only when you intentionally want a foreground backend for debugging.
 
 Default macOS paths:
 

--- a/docs/superpowers/specs/2026-04-21-harness-local-app-design.md
+++ b/docs/superpowers/specs/2026-04-21-harness-local-app-design.md
@@ -137,11 +137,13 @@ The app should control a stable runtime contract, not internal Python modules.
 The target runtime commands are:
 
 - `harness init`
+- `harness start`
 - `harness serve`
 - `harness status`
 - `harness doctor`
 - `harness open`
 - `harness stop`
+- `harness recover`
 
 The app may call an internal executable or bundled launcher rather than a user-installed shell command, but the behavior should match the same contract. A CLI shim can be installed later for power users.
 
@@ -470,7 +472,7 @@ macOS shell:
 - first-run onboarding completes with no integrations configured
 - SQLite DB is created in Application Support
 - runtime starts and survives dashboard window close
-- menu bar can start, stop, restart, and run doctor
+- menu bar can start, stop, restart, recover, and run doctor
 - dashboard opens inside the app
 - Launch at Login can be enabled and disabled
 - notifications permission denial does not block app use

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -405,6 +405,126 @@ def runtime_status(
     }
 
 
+def start_runtime(
+    paths: RuntimePaths,
+    *,
+    host: str | None = None,
+    port: int | None = None,
+    timeout_seconds: float = 10.0,
+    force_restart: bool = False,
+) -> tuple[int, dict[str, Any]]:
+    """Start the local runtime as an app-managed background process."""
+
+    config, _ = init_runtime(paths, host=host or DEFAULT_API_HOST, port=port or DEFAULT_API_PORT)
+    if host or port:
+        config = RuntimeConfig.from_dict(
+            {**config.asdict(), "api": {"host": host or config.host, "port": port or config.port}},
+            paths=paths,
+        )
+
+    _, status_payload = runtime_status(config)
+    if status_payload["status"] == "running" and not force_restart:
+        return EXIT_OK, {
+            "status": "running",
+            "message": "Harness runtime is already running.",
+            "api_base_url": config.base_url,
+            "pid": status_payload.get("pid"),
+            "recovered": False,
+            "paths": _paths_payload(config),
+        }
+
+    recovered = False
+    if status_payload.get("pid") and status_payload.get("process_running"):
+        stop_exit_code, stop_payload = stop_runtime(config, timeout_seconds=min(timeout_seconds, 10.0))
+        if stop_exit_code != EXIT_OK:
+            stop_payload["next_action"] = (
+                "Quit the stuck Harness process from Activity Monitor, then choose Recover Runtime again."
+            )
+            return stop_exit_code, stop_payload
+        recovered = True
+    elif status_payload.get("pid"):
+        with contextlib.suppress(OSError):
+            config.pid_path.unlink()
+        recovered = True
+
+    available, port_error = _port_available(config.host, config.port)
+    if not available:
+        return EXIT_RUNTIME_ERROR, {
+            "status": "port_conflict",
+            "message": f"Harness cannot start because {config.host}:{config.port} is already in use.",
+            "error": port_error,
+            "next_action": (
+                "Stop the process using that port, then choose Recover Runtime. "
+                "If another app owns the port permanently, reinitialize Harness with a different local port."
+            ),
+            "api_base_url": config.base_url,
+            "paths": _paths_payload(config),
+        }
+
+    command = [
+        sys.executable,
+        "-m",
+        "modules.local_runtime",
+        "--data-dir",
+        str(paths.data_dir),
+        "--log-dir",
+        str(paths.log_dir),
+        "serve",
+    ]
+    if host:
+        command.extend(["--host", host])
+    if port:
+        command.extend(["--port", str(port)])
+
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=Path.cwd(),
+            start_new_session=True,
+            close_fds=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as error:
+        raise LocalRuntimeError(
+            f"Harness runtime could not be started: {error}",
+            exit_code=EXIT_RUNTIME_ERROR,
+        ) from error
+
+    healthy = _wait_for_runtime_health(config, timeout_seconds=timeout_seconds)
+    if healthy:
+        return EXIT_OK, {
+            "status": "running",
+            "message": "Harness runtime started.",
+            "api_base_url": config.base_url,
+            "pid": read_pid(config.pid_path) or process.pid,
+            "recovered": recovered,
+            "paths": _paths_payload(config),
+        }
+
+    if process.poll() is not None:
+        message = "Harness runtime exited before it became healthy."
+    else:
+        message = f"Harness runtime did not become healthy within {timeout_seconds:g} seconds."
+    return EXIT_RUNTIME_ERROR, {
+        "status": "start_failed",
+        "message": message,
+        "pid": read_pid(config.pid_path) or process.pid,
+        "next_action": "Open Harness logs, fix the reported startup problem, then choose Recover Runtime.",
+        "paths": _paths_payload(config),
+    }
+
+
+def recover_runtime(
+    paths: RuntimePaths,
+    *,
+    timeout_seconds: float = 10.0,
+) -> tuple[int, dict[str, Any]]:
+    """Recover the app-managed runtime after stale PID, crash, or degraded health."""
+
+    return start_runtime(paths, timeout_seconds=timeout_seconds, force_restart=True)
+
+
 def uninitialized_status(paths: RuntimePaths) -> dict[str, Any]:
     return {
         "status": "uninitialized",
@@ -872,16 +992,33 @@ def serve_runtime(paths: RuntimePaths, *, host: str | None = None, port: int | N
 
 
 def _assert_port_available(host: str, port: int) -> None:
+    available, error = _port_available(host, port)
+    if not available:
+        raise LocalRuntimeError(
+            f"Harness runtime cannot bind {host}:{port}: {error}. "
+            "Stop the existing process or choose a different port.",
+            exit_code=EXIT_RUNTIME_ERROR,
+        )
+
+
+def _port_available(host: str, port: int) -> tuple[bool, str | None]:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind((host, port))
         except OSError as error:
-            raise LocalRuntimeError(
-                f"Harness runtime cannot bind {host}:{port}: {error}. "
-                "Stop the existing process or choose a different port.",
-                exit_code=EXIT_RUNTIME_ERROR,
-            ) from error
+            return False, str(error)
+    return True, None
+
+
+def _wait_for_runtime_health(config: RuntimeConfig, *, timeout_seconds: float) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        http_status, health, _ = fetch_runtime_health(config, timeout=0.5)
+        if http_status == 200 and bool(health and health.get("status") == "ok"):
+            return True
+        time.sleep(0.2)
+    return False
 
 
 def _run_uvicorn(config: RuntimeConfig) -> None:
@@ -1005,6 +1142,11 @@ def build_parser() -> argparse.ArgumentParser:
     serve_parser.add_argument("--host", help="Temporary host override for this process")
     serve_parser.add_argument("--port", type=int, help="Temporary port override for this process")
 
+    start_parser = subparsers.add_parser("start", help="Start the local Harness API as an app-managed process")
+    start_parser.add_argument("--host", help="Temporary host override for this process")
+    start_parser.add_argument("--port", type=int, help="Temporary port override for this process")
+    start_parser.add_argument("--timeout", default=10.0, type=float, help="Startup timeout in seconds")
+
     status_parser = subparsers.add_parser("status", help="Check whether the local Harness runtime is healthy")
     status_parser.add_argument(
         "--timeout",
@@ -1025,6 +1167,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     stop_parser = subparsers.add_parser("stop", help="Gracefully stop the local Harness runtime")
     stop_parser.add_argument("--timeout", default=10.0, type=float, help="Shutdown timeout in seconds")
+
+    recover_parser = subparsers.add_parser("recover", help="Recover a stale, crashed, or degraded local runtime")
+    recover_parser.add_argument("--timeout", default=10.0, type=float, help="Recovery startup timeout in seconds")
 
     setup_parser = subparsers.add_parser("setup", help="Guide local onboarding and optional integration setup")
     setup_subparsers = setup_parser.add_subparsers(dest="setup_command", required=True)
@@ -1098,6 +1243,14 @@ def main(argv: list[str] | None = None) -> int:
             )
         if args.command == "serve":
             return serve_runtime(paths, host=args.host, port=args.port)
+        if args.command == "start":
+            exit_code, payload = start_runtime(
+                paths,
+                host=args.host,
+                port=args.port,
+                timeout_seconds=args.timeout,
+            )
+            return _emit(payload, as_json=args.as_json, exit_code=exit_code)
         if args.command == "status":
             try:
                 config = load_runtime_config(paths)
@@ -1121,6 +1274,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "stop":
             config = load_runtime_config(paths)
             exit_code, payload = stop_runtime(config, timeout_seconds=args.timeout)
+            return _emit(payload, as_json=args.as_json, exit_code=exit_code)
+        if args.command == "recover":
+            exit_code, payload = recover_runtime(paths, timeout_seconds=args.timeout)
             return _emit(payload, as_json=args.as_json, exit_code=exit_code)
         if args.command == "setup":
             return _handle_setup_command(paths, args, as_json=args.as_json)

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -19,8 +19,10 @@ from modules.local_runtime import (
     build_runtime_status_payload,
     init_runtime,
     main,
+    recover_runtime,
     resolve_runtime_paths,
     serve_runtime,
+    start_runtime,
     stop_runtime,
 )
 
@@ -330,6 +332,94 @@ class LocalRuntimeProcessTests(unittest.TestCase):
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(payload["status"], "stopped")
         self.assertFalse(config.pid_path.exists())
+
+    def test_start_launches_background_runtime_and_waits_for_health(self) -> None:
+        class FakeProcess:
+            pid = 4242
+
+            def poll(self) -> None:
+                return None
+
+        with (
+            patch("modules.local_runtime.fetch_runtime_health", return_value=(None, None, "not running")),
+            patch("modules.local_runtime._port_available", return_value=(True, None)),
+            patch("modules.local_runtime._wait_for_runtime_health", return_value=True),
+            patch("modules.local_runtime.subprocess.Popen", return_value=FakeProcess()) as popen,
+        ):
+            exit_code, payload = start_runtime(self.paths)
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "running")
+        self.assertEqual(payload["pid"], 4242)
+        self.assertFalse(payload["recovered"])
+        popen.assert_called_once()
+        self.assertIn("serve", popen.call_args.args[0])
+        self.assertTrue(popen.call_args.kwargs["start_new_session"])
+
+    def test_start_removes_stale_pid_before_launch(self) -> None:
+        class FakeProcess:
+            pid = 5252
+
+            def poll(self) -> None:
+                return None
+
+        config, _ = init_runtime(self.paths)
+        config.pid_path.write_text("999999\n", encoding="utf-8")
+
+        with (
+            patch("modules.local_runtime.fetch_runtime_health", return_value=(None, None, "not running")),
+            patch("modules.local_runtime.process_is_running", return_value=False),
+            patch("modules.local_runtime._port_available", return_value=(True, None)),
+            patch("modules.local_runtime._wait_for_runtime_health", return_value=True),
+            patch("modules.local_runtime.subprocess.Popen", return_value=FakeProcess()),
+        ):
+            exit_code, payload = start_runtime(self.paths)
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "running")
+        self.assertTrue(payload["recovered"])
+        self.assertFalse(config.pid_path.exists())
+
+    def test_start_reports_port_conflict_without_launching_child(self) -> None:
+        with (
+            patch("modules.local_runtime.fetch_runtime_health", return_value=(None, None, "not running")),
+            patch("modules.local_runtime._port_available", return_value=(False, "address already in use")),
+            patch("modules.local_runtime.subprocess.Popen") as popen,
+        ):
+            exit_code, payload = start_runtime(self.paths)
+
+        self.assertEqual(exit_code, EXIT_RUNTIME_ERROR)
+        self.assertEqual(payload["status"], "port_conflict")
+        self.assertIn("already in use", payload["message"])
+        self.assertIn("Recover Runtime", payload["next_action"])
+        popen.assert_not_called()
+
+    def test_recover_stops_unhealthy_pid_before_restart(self) -> None:
+        class FakeProcess:
+            pid = 6262
+
+            def poll(self) -> None:
+                return None
+
+        with (
+            patch(
+                "modules.local_runtime.runtime_status",
+                return_value=(
+                    EXIT_UNHEALTHY,
+                    {"status": "degraded", "pid": 123, "process_running": True},
+                ),
+            ),
+            patch("modules.local_runtime.stop_runtime", return_value=(EXIT_OK, {"status": "stopped"})) as stop,
+            patch("modules.local_runtime._port_available", return_value=(True, None)),
+            patch("modules.local_runtime._wait_for_runtime_health", return_value=True),
+            patch("modules.local_runtime.subprocess.Popen", return_value=FakeProcess()),
+        ):
+            exit_code, payload = recover_runtime(self.paths)
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "running")
+        self.assertTrue(payload["recovered"])
+        stop.assert_called_once()
 
 
 class LocalRuntimeContractTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add `harness start` and `harness recover` so the local runtime can start in the background, clean stale PID files, report port conflicts, and recover unhealthy PID-backed processes
- route the macOS app through the safer lifecycle commands, including Launch at Login startup, Settings controls, and a menu bar Recover Runtime action
- document the v1 daemon model as SMAppService Launch at Login plus app-managed backend supervision, not a LaunchAgent

Closes #326

## Validation
- `swift build`
- `swift run HarnessAppCoreCheck`
- `python3 -m unittest tests.test_local_runtime tests.test_local_setup -v`
- `python3 -m unittest discover -s tests`
- `python3 -m modules.local_runtime --json start --timeout 10`
- `python3 -m modules.local_runtime --json status`
- `python3 -m modules.local_runtime --json recover --timeout 10`
- `python3 -m modules.local_runtime --json stop --timeout 5`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- `./script/build_and_run.sh --verify`

## Preview Note
- Vercel preview failed with no exposed build logs or events; local frontend validation passes and this branch does not change dashboard source.