### PR TITLE
Add macOS attention notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ See:
 - App-managed secret storage is implemented in [`modules/local_secrets.py`](modules/local_secrets.py) and documented in [`docs/architecture/app-managed-secrets.md`](docs/architecture/app-managed-secrets.md).
 - Local dashboard packaging is documented in [`docs/architecture/local-dashboard-packaging.md`](docs/architecture/local-dashboard-packaging.md).
 - Setup doctor output is documented in [`docs/architecture/setup-doctor.md`](docs/architecture/setup-doctor.md).
+- The macOS menu-bar app can request optional notifications and delivers attention alerts from canonical Harness queue/setup surfaces; delivery is reversible from Settings and never reads SQLite directly.
 
 ## Hosted Deployment Target
 

--- a/apps/macos/HarnessApp/README.md
+++ b/apps/macos/HarnessApp/README.md
@@ -51,6 +51,22 @@ It reports app-owned facts back to the CLI with:
 GitHub, Linear, and repair callback tokens entered in the assistant are saved through the app-managed secret boundary with stdin.
 They are not persisted in Swift preferences.
 
+## Notifications
+
+Notifications are optional and reversible from Settings.
+The app asks for macOS notification permission during onboarding, but denial does not block setup, runtime startup, or dashboard use.
+
+When notifications are enabled and authorized, the app schedules local alerts from canonical Harness attention/setup surfaces:
+
+- manual review required
+- repair dispatch failed when the API surfaces that attention type
+- stale executor / active task with no recent canonical activity
+- budget threshold crossed when the API surfaces that attention type
+- integration credential attention from guided setup status
+
+Notification clicks reopen the relevant surface: review and task attention opens the dashboard route, and integration credential attention opens the setup assistant.
+The Swift app does not read SQLite to find notification events.
+
 ## Dashboard
 
 The dashboard opens inside the app from the menu bar.

--- a/apps/macos/HarnessApp/Sources/HarnessApp/AppPreferenceKeys.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/AppPreferenceKeys.swift
@@ -3,4 +3,6 @@ import Foundation
 enum AppPreferenceKeys {
     static let onboardingCompleted = "com.knoxanalytics.harness.onboarding.completed"
     static let workspaceFolders = "com.knoxanalytics.harness.workspaceFolders"
+    static let attentionNotificationsEnabled = "com.knoxanalytics.harness.notifications.attention.enabled"
+    static let deliveredNotificationIDs = "com.knoxanalytics.harness.notifications.delivered.ids"
 }

--- a/apps/macos/HarnessApp/Sources/HarnessApp/DashboardWindowView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/DashboardWindowView.swift
@@ -3,12 +3,10 @@ import SwiftUI
 
 struct DashboardWindowView: View {
     @ObservedObject var model: HarnessMenuBarModel
-    @State private var selectedRoute: DashboardRoute = .tasks
 
     var body: some View {
         VStack(spacing: 0) {
             DashboardToolbar(
-                selectedRoute: $selectedRoute,
                 routeURL: routeURL,
                 model: model
             )
@@ -42,18 +40,20 @@ struct DashboardWindowView: View {
     }
 
     private var routeURL: URL? {
-        model.dashboardURL?.dashboardRoute(selectedRoute)
+        model.dashboardURL?.dashboardRoute(model.selectedDashboardRoute)
     }
 }
 
 private struct DashboardToolbar: View {
-    @Binding var selectedRoute: DashboardRoute
     let routeURL: URL?
     @ObservedObject var model: HarnessMenuBarModel
 
     var body: some View {
         HStack(spacing: 12) {
-            Picker("Dashboard Route", selection: $selectedRoute) {
+            Picker("Dashboard Route", selection: Binding(
+                get: { model.selectedDashboardRoute },
+                set: { model.selectDashboardRoute($0) }
+            )) {
                 ForEach(DashboardRoute.allCases) { route in
                     Text(route.title).tag(route)
                 }

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessApp.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessApp.swift
@@ -1,9 +1,29 @@
 import AppKit
 import SwiftUI
+import UserNotifications
 
-final class HarnessAppDelegate: NSObject, NSApplicationDelegate {
+final class HarnessAppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.banner, .sound]
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        await MainActor.run {
+            HarnessNotificationDestinationBroker.shared.request(
+                userInfo: response.notification.request.content.userInfo
+            )
+        }
     }
 }
 

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarLabel.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarLabel.swift
@@ -1,4 +1,5 @@
 import AppKit
+import HarnessAppCore
 import SwiftUI
 
 struct HarnessMenuBarLabel: View {
@@ -6,6 +7,7 @@ struct HarnessMenuBarLabel: View {
     @ObservedObject var model: HarnessMenuBarModel
     @AppStorage(AppPreferenceKeys.onboardingCompleted) private var onboardingCompleted = false
     @AppStorage(AppPreferenceKeys.workspaceFolders) private var storedWorkspaceFolders = ""
+    @AppStorage(AppPreferenceKeys.attentionNotificationsEnabled) private var attentionNotificationsEnabled = true
     @State private var didRunLaunchTask = false
 
     var body: some View {
@@ -15,6 +17,7 @@ struct HarnessMenuBarLabel: View {
                     return
                 }
                 didRunLaunchTask = true
+                model.setAttentionNotificationsEnabled(attentionNotificationsEnabled)
                 model.startPolling()
                 let launchState = MacOSSetupState.launchAtLoginState()
                 let notificationState = await MacOSSetupState.notificationPermissionState()
@@ -38,6 +41,33 @@ struct HarnessMenuBarLabel: View {
                     openWindow(id: "onboarding")
                     NSApp.activate(ignoringOtherApps: true)
                 }
+                if let pendingUserInfo = HarnessNotificationDestinationBroker.shared.takePendingUserInfo() {
+                    openNotificationDestination(userInfo: pendingUserInfo)
+                }
             }
+            .onChange(of: attentionNotificationsEnabled) { _, enabled in
+                model.setAttentionNotificationsEnabled(enabled)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .harnessNotificationDestinationRequested)) { notification in
+                HarnessNotificationDestinationBroker.shared.clearPendingUserInfo()
+                openNotificationDestination(userInfo: notification.userInfo ?? [:])
+            }
+    }
+
+    private func openNotificationDestination(userInfo: [AnyHashable: Any]) {
+        let destinationKind = userInfo[HarnessNotificationUserInfoKey.destinationKind] as? String
+        if destinationKind == HarnessNotificationDestinationKind.setupAssistant.rawValue {
+            openWindow(id: "onboarding")
+            NSApp.activate(ignoringOtherApps: true)
+            Task { await model.refreshSetupStatus() }
+            return
+        }
+
+        let routeValue = userInfo[HarnessNotificationUserInfoKey.dashboardRoute] as? String
+        let route = routeValue.flatMap(DashboardRoute.init(rawValue:)) ?? .tasks
+        model.selectDashboardRoute(route)
+        openWindow(id: "dashboard")
+        NSApp.activate(ignoringOtherApps: true)
+        Task { await model.prepareDashboard() }
     }
 }

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarModel.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessMenuBarModel.swift
@@ -10,20 +10,27 @@ final class HarnessMenuBarModel: ObservableObject {
     @Published private(set) var dashboardURL: URL?
     @Published private(set) var dashboardMessage = "Open the dashboard to inspect full Harness progress."
     @Published private(set) var isPreparingDashboard = false
+    @Published private(set) var selectedDashboardRoute: DashboardRoute = .tasks
     @Published private(set) var setupStatus: GuidedSetupStatusPayload?
     @Published private(set) var setupMessage = "Setup has not been checked yet."
     @Published private(set) var isCheckingSetup = false
 
     private var runtime: HarnessRuntimeCommand
     private let apiClient: HarnessAPIClient
+    private let notificationScheduler: HarnessNotificationScheduler
     private var pollingTask: Task<Void, Never>?
+    private var attentionNotificationsEnabled: Bool
 
     init(
         runtime: HarnessRuntimeCommand = HarnessRuntimeCommand(),
-        apiClient: HarnessAPIClient = HarnessAPIClient()
+        apiClient: HarnessAPIClient = HarnessAPIClient(),
+        notificationScheduler: HarnessNotificationScheduler? = nil,
+        attentionNotificationsEnabled: Bool = UserDefaults.standard.object(forKey: AppPreferenceKeys.attentionNotificationsEnabled) as? Bool ?? true
     ) {
         self.runtime = runtime
         self.apiClient = apiClient
+        self.notificationScheduler = notificationScheduler ?? HarnessNotificationScheduler()
+        self.attentionNotificationsEnabled = attentionNotificationsEnabled
     }
 
     deinit {
@@ -58,6 +65,7 @@ final class HarnessMenuBarModel: ObservableObject {
                 tasks: tasks,
                 queue: queue
             )
+            await publishAttentionNotifications(tasks: tasks, queue: queue, setupStatus: setupStatus)
         } catch {
             snapshot = HarnessMenuSummaryBuilder.errorSnapshot(error.localizedDescription)
         }
@@ -65,6 +73,14 @@ final class HarnessMenuBarModel: ObservableObject {
 
     func updateAppEnvironment(_ environment: [String: String]) {
         runtime = runtime.withEnvironment(environment)
+    }
+
+    func setAttentionNotificationsEnabled(_ enabled: Bool) {
+        attentionNotificationsEnabled = enabled
+    }
+
+    func selectDashboardRoute(_ route: DashboardRoute) {
+        selectedDashboardRoute = route
     }
 
     func refreshSetupStatus(workflows: [String] = []) async {
@@ -83,6 +99,7 @@ final class HarnessMenuBarModel: ObservableObject {
             setupStatus = nil
             setupMessage = "Setup could not be checked: \(error.localizedDescription)"
         }
+        await publishAttentionNotifications(tasks: nil, queue: nil, setupStatus: setupStatus)
         isCheckingSetup = false
     }
 
@@ -235,5 +252,22 @@ final class HarnessMenuBarModel: ObservableObject {
             .appendingPathComponent("Logs")
             .appendingPathComponent("Harness")
             .path
+    }
+
+    private func publishAttentionNotifications(
+        tasks: TaskListPayload?,
+        queue: SupervisionQueuePayload?,
+        setupStatus: GuidedSetupStatusPayload?
+    ) async {
+        let candidates = HarnessAttentionNotificationPlanner.plan(
+            tasks: tasks,
+            queue: queue,
+            setupStatus: setupStatus,
+            deliveredNotificationIDs: notificationScheduler.deliveredNotificationIDs()
+        )
+        await notificationScheduler.deliver(
+            candidates,
+            notificationsEnabled: attentionNotificationsEnabled
+        )
     }
 }

--- a/apps/macos/HarnessApp/Sources/HarnessApp/HarnessNotificationScheduler.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/HarnessNotificationScheduler.swift
@@ -1,0 +1,131 @@
+import Foundation
+import HarnessAppCore
+import UserNotifications
+
+enum HarnessNotificationUserInfoKey {
+    static let destinationKind = "destination_kind"
+    static let dashboardRoute = "dashboard_route"
+    static let notificationID = "notification_id"
+}
+
+enum HarnessNotificationDestinationKind: String {
+    case dashboard
+    case setupAssistant = "setup_assistant"
+}
+
+extension Notification.Name {
+    static let harnessNotificationDestinationRequested = Notification.Name(
+        "com.knoxanalytics.harness.notification.destinationRequested"
+    )
+}
+
+@MainActor
+final class HarnessNotificationDestinationBroker {
+    static let shared = HarnessNotificationDestinationBroker()
+
+    private var pendingUserInfo: [AnyHashable: Any]?
+
+    private init() {}
+
+    func request(userInfo: [AnyHashable: Any]) {
+        pendingUserInfo = userInfo
+        NotificationCenter.default.post(
+            name: .harnessNotificationDestinationRequested,
+            object: nil,
+            userInfo: userInfo
+        )
+    }
+
+    func takePendingUserInfo() -> [AnyHashable: Any]? {
+        let userInfo = pendingUserInfo
+        pendingUserInfo = nil
+        return userInfo
+    }
+
+    func clearPendingUserInfo() {
+        pendingUserInfo = nil
+    }
+}
+
+@MainActor
+final class HarnessNotificationScheduler {
+    private let center: UNUserNotificationCenter
+    private let defaults: UserDefaults
+
+    init(
+        center: UNUserNotificationCenter = .current(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.center = center
+        self.defaults = defaults
+    }
+
+    func deliveredNotificationIDs() -> Set<String> {
+        Set(defaults.stringArray(forKey: AppPreferenceKeys.deliveredNotificationIDs) ?? [])
+    }
+
+    func deliver(
+        _ candidates: [HarnessAttentionNotification],
+        notificationsEnabled: Bool
+    ) async {
+        guard notificationsEnabled, !candidates.isEmpty else {
+            return
+        }
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus.allowsHarnessDelivery else {
+            return
+        }
+
+        var deliveredIDs = deliveredNotificationIDs()
+        for candidate in candidates where !deliveredIDs.contains(candidate.id) {
+            do {
+                try await center.add(request(for: candidate))
+                deliveredIDs.insert(candidate.id)
+            } catch {
+                continue
+            }
+        }
+        storeDeliveredNotificationIDs(deliveredIDs)
+    }
+
+    private func request(for candidate: HarnessAttentionNotification) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        content.title = candidate.title
+        content.body = candidate.body
+        content.sound = .default
+        content.userInfo = userInfo(for: candidate)
+        return UNNotificationRequest(identifier: candidate.id, content: content, trigger: nil)
+    }
+
+    private func userInfo(for candidate: HarnessAttentionNotification) -> [String: String] {
+        var userInfo = [
+            HarnessNotificationUserInfoKey.notificationID: candidate.id
+        ]
+        switch candidate.destination {
+        case .dashboard(let route):
+            userInfo[HarnessNotificationUserInfoKey.destinationKind] = HarnessNotificationDestinationKind.dashboard.rawValue
+            userInfo[HarnessNotificationUserInfoKey.dashboardRoute] = route.rawValue
+        case .setupAssistant:
+            userInfo[HarnessNotificationUserInfoKey.destinationKind] = HarnessNotificationDestinationKind.setupAssistant.rawValue
+        }
+        return userInfo
+    }
+
+    private func storeDeliveredNotificationIDs(_ ids: Set<String>) {
+        let capped = Array(ids.sorted().suffix(500))
+        defaults.set(capped, forKey: AppPreferenceKeys.deliveredNotificationIDs)
+    }
+}
+
+private extension UNAuthorizationStatus {
+    var allowsHarnessDelivery: Bool {
+        switch self {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined, .denied:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessApp/SettingsView.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessApp/SettingsView.swift
@@ -1,13 +1,16 @@
 import HarnessAppCore
 import SwiftUI
+import UserNotifications
 
 struct SettingsView: View {
     @ObservedObject var model: HarnessMenuBarModel
     @AppStorage(AppPreferenceKeys.workspaceFolders) private var storedWorkspaceFolders = ""
+    @AppStorage(AppPreferenceKeys.attentionNotificationsEnabled) private var attentionNotificationsEnabled = true
     @State private var launchAtLogin: LaunchAtLoginState = .unknown
     @State private var notificationPermission: NotificationPermissionState = .unknown
     @State private var platformMessage: String?
     @State private var isUpdatingLaunchAtLogin = false
+    @State private var isUpdatingNotifications = false
 
     var body: some View {
         Form {
@@ -54,8 +57,25 @@ struct SettingsView: View {
                 }
             }
 
+            Section("Notifications") {
+                Toggle("Attention Notifications", isOn: $attentionNotificationsEnabled)
+                LabeledContent("macOS Permission", value: notificationPermission.displayName)
+                Text("When enabled and authorized by macOS, Harness sends local notifications for manual review, stalled executor, repair-dispatch, budget, and integration credential attention events.")
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Button("Request Permission") {
+                        Task { await requestNotifications() }
+                    }
+                    Button("Refresh") {
+                        Task { await refreshPlatformState() }
+                    }
+                }
+                .disabled(isUpdatingNotifications)
+            }
+
             Section("Operation") {
-                Text("The menu bar reads local runtime status and task counts through the Harness CLI and HTTP API. It does not read SQLite directly. Launch at Login starts the app; the app supervises the backend as an app-managed child process.")
+                Text("The menu bar reads local runtime status and task counts through the Harness CLI and HTTP API. It does not read SQLite directly. Launch at Login starts the app; the app supervises the backend as an app-managed child process. Notifications are derived from canonical Harness attention/setup surfaces, not direct database polling.")
                     .foregroundStyle(.secondary)
             }
         }
@@ -64,6 +84,9 @@ struct SettingsView: View {
         .frame(width: 620)
         .task {
             await refreshPlatformState()
+        }
+        .onChange(of: attentionNotificationsEnabled) { _, enabled in
+            model.setAttentionNotificationsEnabled(enabled)
         }
     }
 
@@ -97,6 +120,20 @@ struct SettingsView: View {
         launchAtLogin = MacOSSetupState.launchAtLoginState()
         notificationPermission = await MacOSSetupState.notificationPermissionState()
         await applySetupEnvironment()
+    }
+
+    @MainActor
+    private func requestNotifications() async {
+        isUpdatingNotifications = true
+        notificationPermission = await MacOSSetupState.requestNotificationPermission()
+        attentionNotificationsEnabled = notificationPermission == .authorized
+        model.setAttentionNotificationsEnabled(attentionNotificationsEnabled)
+        platformMessage = notificationPermission == .authorized
+            ? "Notifications are authorized."
+            : "Notifications are optional. Harness can run without them."
+        await applySetupEnvironment()
+        await model.refreshSetupStatus()
+        isUpdatingNotifications = false
     }
 
     @MainActor

--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessAttentionNotification.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessAttentionNotification.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+public enum HarnessAttentionNotificationKind: String, Equatable, Sendable {
+    case manualReviewRequired
+    case repairDispatchFailed
+    case executorStalled
+    case budgetThresholdCrossed
+    case credentialDisconnected
+}
+
+public enum HarnessAttentionNotificationDestination: Equatable, Sendable {
+    case dashboard(DashboardRoute)
+    case setupAssistant
+}
+
+public struct HarnessAttentionNotification: Equatable, Identifiable, Sendable {
+    public let id: String
+    public let kind: HarnessAttentionNotificationKind
+    public let title: String
+    public let body: String
+    public let destination: HarnessAttentionNotificationDestination
+}
+
+public enum HarnessAttentionNotificationPlanner {
+    public static func plan(
+        tasks: TaskListPayload?,
+        queue: SupervisionQueuePayload?,
+        setupStatus: GuidedSetupStatusPayload?,
+        deliveredNotificationIDs: Set<String>
+    ) -> [HarnessAttentionNotification] {
+        var candidates: [HarnessAttentionNotification] = []
+        let taskTitles = Dictionary(
+            uniqueKeysWithValues: (tasks?.tasks ?? []).map { item in
+                (item.taskID, clean(item.title) ?? item.taskID)
+            }
+        )
+
+        for entry in queue?.queue ?? [] {
+            guard let candidate = notificationCandidate(for: entry, taskTitles: taskTitles) else {
+                continue
+            }
+            candidates.append(candidate)
+        }
+
+        candidates.append(contentsOf: credentialCandidates(from: setupStatus))
+
+        return candidates.filter { !deliveredNotificationIDs.contains($0.id) }
+    }
+
+    private static func notificationCandidate(
+        for entry: SupervisionQueueEntry,
+        taskTitles: [String: String]
+    ) -> HarnessAttentionNotification? {
+        let taskID = entry.taskID
+        let attentionType = entry.attentionType
+        let displayTitle = clean(entry.title) ?? taskTitles[taskID] ?? taskID
+        let id = "task:\(taskID):\(attentionType)"
+
+        switch attentionType {
+        case "review_required":
+            if describesRepairDispatchFailure(entry) {
+                return HarnessAttentionNotification(
+                    id: id,
+                    kind: .repairDispatchFailed,
+                    title: "Harness repair dispatch failed",
+                    body: "\(displayTitle) needs repair bridge attention.",
+                    destination: .dashboard(.tasks)
+                )
+            }
+            return HarnessAttentionNotification(
+                id: id,
+                kind: .manualReviewRequired,
+                title: "Harness needs review",
+                body: "\(displayTitle) is waiting for an explicit review decision.",
+                destination: .dashboard(.reviews)
+            )
+        case "repair_dispatch_failed":
+            return HarnessAttentionNotification(
+                id: id,
+                kind: .repairDispatchFailed,
+                title: "Harness repair dispatch failed",
+                body: "\(displayTitle) needs repair bridge attention.",
+                destination: .dashboard(.tasks)
+            )
+        case "stale_active_task":
+            return HarnessAttentionNotification(
+                id: id,
+                kind: .executorStalled,
+                title: "Harness executor appears stalled",
+                body: "\(displayTitle) has no recent canonical activity.",
+                destination: .dashboard(.tasks)
+            )
+        case "budget_threshold_crossed":
+            return HarnessAttentionNotification(
+                id: id,
+                kind: .budgetThresholdCrossed,
+                title: "Harness budget threshold crossed",
+                body: "\(displayTitle) crossed a configured execution budget threshold.",
+                destination: .dashboard(.reviews)
+            )
+        case "credential_expired", "credential_disconnected", "integration_credential_disconnected":
+            return HarnessAttentionNotification(
+                id: id,
+                kind: .credentialDisconnected,
+                title: "Harness integration needs attention",
+                body: "\(displayTitle) needs to be reconnected before dependent workflows can run.",
+                destination: .setupAssistant
+            )
+        default:
+            return nil
+        }
+    }
+
+    private static func credentialCandidates(
+        from setupStatus: GuidedSetupStatusPayload?
+    ) -> [HarnessAttentionNotification] {
+        guard let setupStatus, setupStatus.runtimeReady else {
+            return []
+        }
+        let attentionItemIDs = Set(setupStatus.optionalAttention + setupStatus.requiredBlockers)
+        return setupStatus.items.compactMap { item -> HarnessAttentionNotification? in
+            guard attentionItemIDs.contains(item.id), item.category == "integration", !item.secretNames.isEmpty else {
+                return nil
+            }
+            return HarnessAttentionNotification(
+                id: "setup:\(item.id):credential_attention",
+                kind: .credentialDisconnected,
+                title: "Harness integration needs attention",
+                body: "\(item.title) needs to be reconnected before dependent workflows can run.",
+                destination: .setupAssistant
+            )
+        }
+    }
+
+    private static func clean(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func describesRepairDispatchFailure(_ entry: SupervisionQueueEntry) -> Bool {
+        let text = [entry.title, entry.reason, entry.suggestedAction]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+        return text.contains("repair dispatch")
+            || text.contains("dispatch repair")
+            || text.contains("repair bridge")
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/MenuBarSummary.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/MenuBarSummary.swift
@@ -126,12 +126,18 @@ public struct SupervisionQueuePayload: Decodable, Equatable, Sendable {
 
 public struct SupervisionQueueEntry: Decodable, Equatable, Sendable {
     public let taskID: String
+    public let title: String?
     public let attentionType: String
+    public let suggestedAction: String?
+    public let reason: String?
     public let stale: Bool?
 
     enum CodingKeys: String, CodingKey {
         case taskID = "task_id"
+        case title
         case attentionType = "attention_type"
+        case suggestedAction = "suggested_action"
+        case reason
         case stale
     }
 }

--- a/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
@@ -7,6 +7,9 @@ struct HarnessAppCoreCheck {
         try checksRunningSummaryFromTaskListAndQueue()
         try checksStoppedRuntimeSummary()
         try checksDashboardRoutes()
+        try checksAttentionNotificationPlannerBuildsActionableEvents()
+        try checksAttentionNotificationPlannerDeduplicatesDeliveredEvents()
+        try checksAttentionNotificationPlannerBuildsCredentialEvents()
         try checksGuidedSetupPayloadDecoding()
         try checksRuntimeControlPayloadDecoding()
         print("HarnessAppCoreCheck passed")
@@ -134,6 +137,196 @@ struct HarnessAppCoreCheck {
             baseURL.dashboardRoute(.reviews).absoluteString == "http://127.0.0.1:8765/dashboard/reviews/",
             "reviews dashboard route"
         )
+    }
+
+    private static func checksAttentionNotificationPlannerBuildsActionableEvents() throws {
+        let tasks = try decode(
+            TaskListPayload.self,
+            """
+            {
+              "tasks": [
+                {
+                  "task_id": "review-1",
+                  "title": "Review Required",
+                  "current_status": "in_review",
+                  "review_summary": {"status": "requested"},
+                  "verification_summary": {"requires_review": true},
+                  "failure_summary": {"state": "review_required"},
+                  "execution_summary": {"failure_state": "review_required", "retry_eligible": false}
+                },
+                {
+                  "task_id": "stale-1",
+                  "title": "Stale Executor",
+                  "current_status": "assigned",
+                  "review_summary": {"status": "none"},
+                  "verification_summary": {"requires_review": false},
+                  "failure_summary": {"state": "clear"},
+                  "execution_summary": {"failure_state": "clear", "retry_eligible": false}
+                }
+              ]
+            }
+            """
+        )
+        let queue = try decode(
+            SupervisionQueuePayload.self,
+            """
+            {
+              "queue": [
+                {
+                  "task_id": "review-1",
+                  "title": "Review Required",
+                  "attention_type": "review_required",
+                  "suggested_action": "resolve_review_gate",
+                  "reason": "Task has an active manual review gate.",
+                  "stale": false
+                },
+                {
+                  "task_id": "repair-1",
+                  "title": "Repair Failed",
+                  "attention_type": "repair_dispatch_failed",
+                  "suggested_action": "inspect_repair_bridge",
+                  "reason": "Harness could not dispatch repair work.",
+                  "stale": false
+                },
+                {
+                  "task_id": "stale-1",
+                  "title": "Stale Executor",
+                  "attention_type": "stale_active_task",
+                  "suggested_action": "investigate_staleness",
+                  "reason": "Task is active without recent canonical activity.",
+                  "stale": true
+                },
+                {
+                  "task_id": "budget-1",
+                  "title": "Budget Warning",
+                  "attention_type": "budget_threshold_crossed",
+                  "suggested_action": "review_budget",
+                  "reason": "Execution budget threshold was crossed.",
+                  "stale": false
+                }
+              ]
+            }
+            """
+        )
+
+        let candidates = HarnessAttentionNotificationPlanner.plan(
+            tasks: tasks,
+            queue: queue,
+            setupStatus: nil,
+            deliveredNotificationIDs: []
+        )
+
+        try require(candidates.map(\.kind) == [
+            .manualReviewRequired,
+            .repairDispatchFailed,
+            .executorStalled,
+            .budgetThresholdCrossed,
+        ], "attention notification kinds")
+        try require(candidates[0].id == "task:review-1:review_required", "review notification id")
+        try require(candidates[0].destination == .dashboard(.reviews), "review destination")
+        try require(candidates[1].destination == .dashboard(.tasks), "repair destination")
+        try require(candidates[2].body.contains("Stale Executor"), "stale notification body")
+        try require(candidates[3].title == "Harness budget threshold crossed", "budget notification title")
+    }
+
+    private static func checksAttentionNotificationPlannerDeduplicatesDeliveredEvents() throws {
+        let queue = try decode(
+            SupervisionQueuePayload.self,
+            """
+            {
+              "queue": [
+                {
+                  "task_id": "review-1",
+                  "title": "Review Required",
+                  "attention_type": "review_required",
+                  "suggested_action": "resolve_review_gate",
+                  "reason": "Task has an active manual review gate.",
+                  "stale": false
+                },
+                {
+                  "task_id": "stale-1",
+                  "title": "Stale Executor",
+                  "attention_type": "stale_active_task",
+                  "suggested_action": "investigate_staleness",
+                  "reason": "Task is active without recent canonical activity.",
+                  "stale": true
+                }
+              ]
+            }
+            """
+        )
+
+        let candidates = HarnessAttentionNotificationPlanner.plan(
+            tasks: nil,
+            queue: queue,
+            setupStatus: nil,
+            deliveredNotificationIDs: ["task:review-1:review_required"]
+        )
+
+        try require(candidates.map(\.id) == ["task:stale-1:stale_active_task"], "deduplicated notifications")
+    }
+
+    private static func checksAttentionNotificationPlannerBuildsCredentialEvents() throws {
+        let setupStatus = try decode(
+            GuidedSetupStatusPayload.self,
+            """
+            {
+              "status": "ready",
+              "onboarding_complete": true,
+              "runtime_ready": true,
+              "selected_workflows": [],
+              "available_workflows": [],
+              "required_blockers": [],
+              "optional_incomplete": ["github"],
+              "optional_attention": ["github"],
+              "doctor_summary": {"pass": 4, "warn": 1, "fail": 0},
+              "items": [
+                {
+                  "id": "github",
+                  "title": "GitHub",
+                  "category": "integration",
+                  "required": false,
+                  "status": "blocked",
+                  "blocks_onboarding": false,
+                  "purpose": "Verify GitHub artifacts.",
+                  "what_user_needs": ["A GitHub token."],
+                  "how_harness_validates": "Harness checks credential status.",
+                  "next_action": "Reconnect GitHub in Harness setup.",
+                  "doctor_check_codes": ["github_connection"],
+                  "secret_names": ["github_token"],
+                  "compatible_clients": [],
+                  "setup_actions": [],
+                  "notes": [],
+                  "validation": {
+                    "status": "warn",
+                    "checks": [
+                      {
+                        "code": "github_connection",
+                        "status": "warn",
+                        "message": "GitHub credential is disconnected.",
+                        "impact": "GitHub verification is unavailable.",
+                        "next_action": "Reconnect GitHub in Harness setup."
+                      }
+                    ],
+                    "missing_check_codes": []
+                  }
+                }
+              ]
+            }
+            """
+        )
+
+        let candidates = HarnessAttentionNotificationPlanner.plan(
+            tasks: nil,
+            queue: nil,
+            setupStatus: setupStatus,
+            deliveredNotificationIDs: []
+        )
+
+        try require(candidates.count == 1, "credential notification count")
+        try require(candidates[0].id == "setup:github:credential_attention", "credential notification id")
+        try require(candidates[0].kind == .credentialDisconnected, "credential notification kind")
+        try require(candidates[0].destination == .setupAssistant, "credential destination")
     }
 
     private static func checksGuidedSetupPayloadDecoding() throws {

--- a/docs/architecture/macos-menu-bar-controller.md
+++ b/docs/architecture/macos-menu-bar-controller.md
@@ -101,4 +101,22 @@ The assistant reports app-owned facts to the setup doctor through environment ov
 It does not change Harness task truth, read SQLite, or bypass canonical API/read-model/timeline surfaces.
 
 Launch at Login and crash/stale-process recovery are implemented through the app-managed lifecycle contract.
-Issue #327 still owns actionable notification delivery.
+
+## Notifications
+
+The menu-bar app delivers optional local notifications when macOS permission and the app-level Settings toggle both allow delivery.
+Notification denial is treated as a user preference, not a setup failure.
+
+Notification candidates come from Harness surfaces the app already reads:
+
+- `GET /supervision/queue` for task attention such as `review_required`, `repair_dispatch_failed`, `stale_active_task`, and `budget_threshold_crossed`
+- guided setup status for integration credential attention after the local runtime is ready
+
+The app stores delivered notification IDs in user defaults to avoid resending the same task/setup attention event on every poll.
+It does not use SQLite, filesystem scans, or private backend internals to discover notification events.
+
+Clicking a notification posts an in-app destination request:
+
+- review and budget attention opens the dashboard review route
+- repair and stale executor attention opens the dashboard task route
+- integration credential attention opens the setup assistant

--- a/docs/architecture/macos-onboarding-assistant.md
+++ b/docs/architecture/macos-onboarding-assistant.md
@@ -71,10 +71,16 @@ If onboarding has been completed, the app then starts the local runtime through 
 The backend remains an app-managed child process, not a separate LaunchAgent.
 
 Notifications are requested through the native notification authorization prompt.
-Issue #327 still owns attention-event delivery: manual-review alerts, repair-dispatch failures, stalled executors, budget thresholds, and credential-expiry notifications.
+Notification event delivery is permission-aware and can be disabled later from Settings without affecting core app usage.
 
 The assistant records and validates permission state.
-Notification event delivery remains separate from permission capture.
+The menu-bar app then delivers attention notifications from canonical Harness queue/setup surfaces when delivery is enabled:
+
+- manual-review alerts
+- repair-dispatch failures when surfaced by the API
+- stalled executor alerts
+- budget threshold alerts when surfaced by the API
+- integration credential attention
 
 ## Integrations
 


### PR DESCRIPTION
## Summary
- add a tested notification planner for canonical Harness attention/setup events
- schedule permission-aware local macOS notifications with delivered-event dedupe
- route notification clicks to the dashboard review/tasks surfaces or setup assistant
- add a reversible Settings toggle and update macOS app docs

Closes #327

## Validation
- `swift build`
- `swift run HarnessAppCoreCheck`
- `python3 -m unittest tests.test_local_runtime tests.test_local_setup -v`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- `./script/build_and_run.sh --verify`

## Preview Note
- Vercel preview failed with no exposed build logs or events; local frontend validation passes and this branch only changes macOS app/docs/test code.