### PR TITLE
Package self-contained macOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,15 @@ The native macOS app shell starts under [`apps/macos/HarnessApp`](apps/macos/Har
 ./script/build_and_run.sh
 ```
 
-See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md), [`docs/architecture/macos-onboarding-assistant.md`](docs/architecture/macos-onboarding-assistant.md), [`docs/architecture/macos-daemon-lifecycle.md`](docs/architecture/macos-daemon-lifecycle.md), and [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md).
+Build a distributable self-contained app bundle and DMG with:
+
+```bash
+./script/package_macos_app.sh
+```
+
+That release path bundles the native app, a frozen `harness` runtime, and prebuilt dashboard assets into `dist/macos-release/Harness.app` and `dist/macos-release/Harness.dmg`. Normal users should not need a repo checkout, Python, Node, `pnpm`, or Docker after install.
+
+See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md), [`docs/architecture/macos-onboarding-assistant.md`](docs/architecture/macos-onboarding-assistant.md), [`docs/architecture/macos-daemon-lifecycle.md`](docs/architecture/macos-daemon-lifecycle.md), [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md), and [`docs/architecture/macos-packaging.md`](docs/architecture/macos-packaging.md).
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 

--- a/apps/macos/HarnessApp/README.md
+++ b/apps/macos/HarnessApp/README.md
@@ -22,6 +22,14 @@ The repo-level launch path is:
 ./script/build_and_run.sh --verify
 ```
 
+The distributable packaging path is:
+
+```bash
+./script/package_macos_app.sh
+```
+
+That script stages a self-contained `Harness.app` and `Harness.dmg` under `dist/macos-release/` with a bundled `harness` runtime and prebuilt dashboard assets.
+
 The app reads Harness through the local CLI and HTTP API contract. It must not read SQLite directly.
 
 ## Runtime Lifecycle

--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessBundleResources.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessBundleResources.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+public enum HarnessBundleResources {
+    public static let runtimeExecutableEnvironmentKey = "HARNESS_RUNTIME_EXECUTABLE"
+    public static let dashboardAssetsEnvironmentKey = "HARNESS_DASHBOARD_ASSETS_DIR"
+
+    public static func runtimeExecutableURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:],
+        bundleURL: URL = Bundle.main.bundleURL,
+        resourceURL: URL? = Bundle.main.resourceURL
+    ) -> URL? {
+        if let configured = clean(environment[runtimeExecutableEnvironmentKey]) {
+            let url = URL(fileURLWithPath: configured)
+            return FileManager.default.isExecutableFile(atPath: url.path) ? url : nil
+        }
+        if let configured = clean(infoDictionary["HarnessRuntimeExecutable"] as? String) {
+            let url = resolveBundlePath(configured, bundleURL: bundleURL, resourceURL: resourceURL)
+            return FileManager.default.isExecutableFile(atPath: url.path) ? url : nil
+        }
+        guard let resourceURL else {
+            return nil
+        }
+        let defaultURL = resourceURL
+            .appendingPathComponent("HarnessRuntime", isDirectory: true)
+            .appendingPathComponent("harness", isDirectory: false)
+        return FileManager.default.isExecutableFile(atPath: defaultURL.path) ? defaultURL : nil
+    }
+
+    public static func dashboardAssetsURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:],
+        bundleURL: URL = Bundle.main.bundleURL,
+        resourceURL: URL? = Bundle.main.resourceURL
+    ) -> URL? {
+        if let configured = clean(environment[dashboardAssetsEnvironmentKey]) {
+            let url = URL(fileURLWithPath: configured, isDirectory: true)
+            return FileManager.default.fileExists(atPath: url.appendingPathComponent("index.html").path) ? url : nil
+        }
+        if let configured = clean(infoDictionary["HarnessDashboardAssetsDir"] as? String) {
+            let url = resolveBundlePath(configured, bundleURL: bundleURL, resourceURL: resourceURL)
+            return FileManager.default.fileExists(atPath: url.appendingPathComponent("index.html").path) ? url : nil
+        }
+        guard let resourceURL else {
+            return nil
+        }
+        let defaultURL = resourceURL.appendingPathComponent("Dashboard", isDirectory: true)
+        return FileManager.default.fileExists(atPath: defaultURL.appendingPathComponent("index.html").path)
+            ? defaultURL
+            : nil
+    }
+
+    private static func resolveBundlePath(_ path: String, bundleURL: URL, resourceURL: URL?) -> URL {
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path)
+        }
+        if path.hasPrefix("Contents/") {
+            return bundleURL.appendingPathComponent(path, isDirectory: false)
+        }
+        if let resourceURL {
+            return resourceURL.appendingPathComponent(path, isDirectory: false)
+        }
+        return bundleURL.appendingPathComponent(path, isDirectory: false)
+    }
+
+    private static func clean(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessRuntimeCommand.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessRuntimeCommand.swift
@@ -3,16 +3,25 @@ import Foundation
 public struct HarnessRuntimeCommand: Sendable {
     public let repoRoot: URL
     public let pythonExecutable: String
+    public let runtimeExecutableURL: URL?
     public let environment: [String: String]
 
     public init(
         repoRoot: URL = HarnessRuntimeCommand.defaultRepoRoot(),
         pythonExecutable: String = ProcessInfo.processInfo.environment["HARNESS_PYTHON"] ?? "python3",
+        runtimeExecutableURL: URL? = HarnessBundleResources.runtimeExecutableURL(),
+        bundledDashboardAssetsURL: URL? = HarnessBundleResources.dashboardAssetsURL(),
         environment: [String: String] = [:]
     ) {
         self.repoRoot = repoRoot
         self.pythonExecutable = pythonExecutable
-        self.environment = environment
+        self.runtimeExecutableURL = runtimeExecutableURL
+        var resolvedEnvironment = environment
+        if let bundledDashboardAssetsURL,
+           resolvedEnvironment[HarnessBundleResources.dashboardAssetsEnvironmentKey] == nil {
+            resolvedEnvironment[HarnessBundleResources.dashboardAssetsEnvironmentKey] = bundledDashboardAssetsURL.path
+        }
+        self.environment = resolvedEnvironment
     }
 
     public static func defaultRepoRoot() -> URL {
@@ -41,6 +50,7 @@ public struct HarnessRuntimeCommand: Sendable {
         HarnessRuntimeCommand(
             repoRoot: repoRoot,
             pythonExecutable: pythonExecutable,
+            runtimeExecutableURL: runtimeExecutableURL,
             environment: environment
         )
     }
@@ -109,6 +119,7 @@ public struct HarnessRuntimeCommand: Sendable {
             try runProcess(
                 repoRoot: repoRoot,
                 pythonExecutable: pythonExecutable,
+                runtimeExecutableURL: runtimeExecutableURL,
                 args: ["-m", "modules.local_runtime", "--json"] + args,
                 environment: environment,
                 stdin: stdin,
@@ -173,6 +184,7 @@ public enum HarnessRuntimeCommandError: Error, LocalizedError, Equatable {
 private func runProcess(
     repoRoot: URL,
     pythonExecutable: String,
+    runtimeExecutableURL: URL?,
     args: [String],
     environment: [String: String],
     stdin: String?,
@@ -182,9 +194,15 @@ private func runProcess(
     let stdoutPipe = Pipe()
     let stderrPipe = Pipe()
     let stdinPipe = stdin == nil ? nil : Pipe()
-    process.currentDirectoryURL = repoRoot
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = [pythonExecutable] + args
+    if let runtimeExecutableURL {
+        process.currentDirectoryURL = runtimeExecutableURL.deletingLastPathComponent()
+        process.executableURL = runtimeExecutableURL
+        process.arguments = bundledRuntimeArguments(from: args)
+    } else {
+        process.currentDirectoryURL = repoRoot
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [pythonExecutable] + args
+    }
     process.environment = mergedProcessEnvironment(environment)
     process.standardOutput = stdoutPipe
     process.standardError = stderrPipe
@@ -217,6 +235,10 @@ private func runProcess(
 
 private func mergedProcessEnvironment(_ environment: [String: String]) -> [String: String] {
     ProcessInfo.processInfo.environment.merging(environment) { _, appValue in appValue }
+}
+
+public func bundledRuntimeArguments(from args: [String]) -> [String] {
+    Array(args.dropFirst(2))
 }
 
 private func commandFailureMessage(stdout: String, stderr: String) -> String {

--- a/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
@@ -7,6 +7,9 @@ struct HarnessAppCoreCheck {
         try checksRunningSummaryFromTaskListAndQueue()
         try checksStoppedRuntimeSummary()
         try checksDashboardRoutes()
+        try checksBundleResourceDefaults()
+        try checksBundleResourceOverrides()
+        try checksBundledRuntimeArgumentMapping()
         try checksAttentionNotificationPlannerBuildsActionableEvents()
         try checksAttentionNotificationPlannerDeduplicatesDeliveredEvents()
         try checksAttentionNotificationPlannerBuildsCredentialEvents()
@@ -137,6 +140,108 @@ struct HarnessAppCoreCheck {
             baseURL.dashboardRoute(.reviews).absoluteString == "http://127.0.0.1:8765/dashboard/reviews/",
             "reviews dashboard route"
         )
+    }
+
+    private static func checksBundleResourceDefaults() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let bundleURL = tempRoot.appendingPathComponent("Harness.app", isDirectory: true)
+        let resourceURL = bundleURL.appendingPathComponent("Contents/Resources", isDirectory: true)
+        let runtimeURL = resourceURL.appendingPathComponent("HarnessRuntime/harness", isDirectory: false)
+        let dashboardURL = resourceURL.appendingPathComponent("Dashboard", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: runtimeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dashboardURL, withIntermediateDirectories: true)
+        try "#!/bin/sh\n".write(to: runtimeURL, atomically: true, encoding: .utf8)
+        try Data().write(to: dashboardURL.appendingPathComponent("index.html"))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: runtimeURL.path)
+
+        let runtime = HarnessBundleResources.runtimeExecutableURL(
+            environment: [:],
+            infoDictionary: [:],
+            bundleURL: bundleURL,
+            resourceURL: resourceURL
+        )
+        let dashboard = HarnessBundleResources.dashboardAssetsURL(
+            environment: [:],
+            infoDictionary: [:],
+            bundleURL: bundleURL,
+            resourceURL: resourceURL
+        )
+
+        try require(runtime?.path == runtimeURL.path, "default bundled runtime path")
+        try require(dashboard?.path == dashboardURL.path, "default bundled dashboard path")
+
+        try? FileManager.default.removeItem(at: tempRoot)
+    }
+
+    private static func checksBundleResourceOverrides() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let bundleURL = tempRoot.appendingPathComponent("Harness.app", isDirectory: true)
+        let resourceURL = bundleURL.appendingPathComponent("Contents/Resources", isDirectory: true)
+        let infoRuntimeURL = bundleURL.appendingPathComponent("Contents/Resources/AltRuntime/harness", isDirectory: false)
+        let infoDashboardURL = bundleURL.appendingPathComponent("Contents/Resources/AltDashboard", isDirectory: true)
+        let envRuntimeURL = tempRoot.appendingPathComponent("env-runtime/harness", isDirectory: false)
+        let envDashboardURL = tempRoot.appendingPathComponent("env-dashboard", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: infoRuntimeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: infoDashboardURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: envRuntimeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: envDashboardURL, withIntermediateDirectories: true)
+        try "#!/bin/sh\n".write(to: infoRuntimeURL, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\n".write(to: envRuntimeURL, atomically: true, encoding: .utf8)
+        try Data().write(to: infoDashboardURL.appendingPathComponent("index.html"))
+        try Data().write(to: envDashboardURL.appendingPathComponent("index.html"))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: infoRuntimeURL.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: envRuntimeURL.path)
+
+        let infoDictionary: [String: Any] = [
+            "HarnessRuntimeExecutable": "Contents/Resources/AltRuntime/harness",
+            "HarnessDashboardAssetsDir": "Contents/Resources/AltDashboard"
+        ]
+        let infoRuntime = HarnessBundleResources.runtimeExecutableURL(
+            environment: [:],
+            infoDictionary: infoDictionary,
+            bundleURL: bundleURL,
+            resourceURL: resourceURL
+        )
+        let infoDashboard = HarnessBundleResources.dashboardAssetsURL(
+            environment: [:],
+            infoDictionary: infoDictionary,
+            bundleURL: bundleURL,
+            resourceURL: resourceURL
+        )
+
+        try require(infoRuntime?.path == infoRuntimeURL.path, "info runtime override")
+        try require(infoDashboard?.path == infoDashboardURL.path, "info dashboard override")
+
+        let environment = [
+            HarnessBundleResources.runtimeExecutableEnvironmentKey: envRuntimeURL.path,
+            HarnessBundleResources.dashboardAssetsEnvironmentKey: envDashboardURL.path
+        ]
+        let envRuntime = HarnessBundleResources.runtimeExecutableURL(
+            environment: environment,
+            infoDictionary: infoDictionary,
+            bundleURL: bundleURL,
+            resourceURL: resourceURL
+        )
+        let envDashboard = HarnessBundleResources.dashboardAssetsURL(
+            environment: environment,
+            infoDictionary: infoDictionary,
+            bundleURL: bundleURL,
+            resourceURL: resourceURL
+        )
+
+        try require(envRuntime?.path == envRuntimeURL.path, "environment runtime override")
+        try require(envDashboard?.path == envDashboardURL.path, "environment dashboard override")
+
+        try? FileManager.default.removeItem(at: tempRoot)
+    }
+
+    private static func checksBundledRuntimeArgumentMapping() throws {
+        let bundledArgs = bundledRuntimeArguments(from: ["-m", "modules.local_runtime", "--json", "status"])
+        try require(bundledArgs == ["--json", "status"], "bundled runtime keeps json flag")
     }
 
     private static func checksAttentionNotificationPlannerBuildsActionableEvents() throws {

--- a/docs/architecture/macos-packaging.md
+++ b/docs/architecture/macos-packaging.md
@@ -1,0 +1,112 @@
+# macOS Packaging
+
+Issue #328 is the line between a developer bundle and a distributable local Harness app.
+The goal is not "make Swift build." The goal is "ship a normal macOS app that does not depend on a repo checkout, Python install, Node install, or Docker."
+
+## Package Shape
+
+The packaged bundle should contain:
+
+- the native `HarnessApp` macOS binary
+- a bundled `harness` runtime executable built from `modules/local_runtime.py`
+- all Python runtime dependencies needed by the local runtime contract
+- bundled contract resources such as `schemas/task_envelope.schema.json`
+- prebuilt static dashboard assets
+
+The packaged app must not depend on `HarnessRepoRoot`.
+That key is only for the developer bundle path staged by `script/build_and_run.sh`.
+
+## Runtime Resources
+
+The app bundle resource layout is:
+
+```text
+Harness.app/
+  Contents/
+    MacOS/HarnessApp
+    Resources/
+      HarnessRuntime/
+        harness
+        _internal/...
+      Dashboard/
+        index.html
+        dashboard-manifest.json
+        ...
+```
+
+`HarnessRuntimeCommand` should prefer this bundle-owned runtime executable and bundle-owned dashboard asset directory when they exist.
+Repo-root developer mode remains the fallback.
+
+## Build Flow
+
+The release build entrypoint is:
+
+```bash
+./script/package_macos_app.sh
+```
+
+The script:
+
+1. builds `dist/local-dashboard` with `pnpm build:dashboard:local`
+2. creates a packaging virtualenv
+3. installs `requirements-packaging.txt`
+4. freezes `modules/local_runtime.py` into a bundled `harness` executable with PyInstaller
+5. builds the Swift app in release mode
+6. stages `Harness.app`
+7. signs the bundle ad hoc by default, or with `MACOS_CODESIGN_IDENTITY` when provided
+8. smoke-tests the bundled runtime with `init`, `doctor`, `start`, `status`, and `stop`
+9. creates `dist/macos-release/Harness.dmg`
+
+This is intentionally a build-machine workflow, not an end-user workflow.
+The build machine may need Python, `pnpm`, and Xcode tools.
+The installed app must not.
+
+## Signing And Notarization
+
+For internal validation, ad-hoc signing is acceptable.
+For external distribution, use:
+
+- `MACOS_CODESIGN_IDENTITY` for Developer ID Application signing
+- `MACOS_NOTARY_PROFILE` for `xcrun notarytool` submission
+
+When a notary profile is present, the package script submits the generated DMG, waits for completion, and staples the result.
+
+## Installer Flow
+
+The v1 distribution artifact is a DMG containing `Harness.app`.
+A `.pkg` installer is unnecessary in this slice because Harness does not install a privileged helper, LaunchDaemon, or system-wide service.
+
+Users drag `Harness.app` into Applications and launch it.
+The app then creates its own runtime state under:
+
+- `~/Library/Application Support/Harness/`
+- `~/Library/Logs/Harness/`
+
+## Reset And Uninstall
+
+Removing the app bundle is not the same as removing local state.
+
+To fully remove local Harness state:
+
+1. Quit Harness.
+2. Disable Launch at Login from Settings if it was enabled.
+3. Remove `~/Library/Application Support/Harness/`.
+4. Remove `~/Library/Logs/Harness/`.
+5. Delete Keychain entries stored under `com.knoxanalytics.harness.local-runtime` when a full credential reset is required.
+
+This should be documented in user-facing install docs before external release.
+
+## Validation
+
+At minimum, packaging changes should validate:
+
+```bash
+swift build
+swift run HarnessAppCoreCheck
+python3 -m unittest tests.test_local_runtime tests.test_local_setup -v
+pnpm build
+pnpm build:dashboard:local
+./script/package_macos_app.sh
+```
+
+If signing or notarization wiring changes, also verify the produced app with the relevant macOS distribution tools before claiming external-release readiness.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -276,6 +276,32 @@ http://127.0.0.1:8765/dashboard/
 
 The normal hosted/developer dashboard still uses `pnpm dev` or `pnpm build` and the Next proxy route.
 
+### Build The macOS Release Package
+
+For the self-contained macOS distribution path, build the packaged app instead of the repo-root developer bundle:
+
+```bash
+./script/package_macos_app.sh
+```
+
+That script:
+
+- builds `dist/local-dashboard/`
+- freezes `modules/local_runtime.py` into a bundled `harness` runtime
+- stages `dist/macos-release/Harness.app`
+- signs the bundle ad hoc by default, or with `MACOS_CODESIGN_IDENTITY` when set
+- creates `dist/macos-release/Harness.dmg`
+
+For external distribution, also provide:
+
+```bash
+export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
+export MACOS_NOTARY_PROFILE="harness-notary"
+./script/package_macos_app.sh
+```
+
+See [`docs/architecture/macos-packaging.md`](../architecture/macos-packaging.md) for the packaged bundle layout, uninstall/reset notes, and notarization expectations.
+
 ### One-Command Demo Bootstrap
 
 ```bash

--- a/modules/contracts/schema_loader.py
+++ b/modules/contracts/schema_loader.py
@@ -1,0 +1,43 @@
+"""Helpers for loading contract resources from a repo checkout or frozen bundle."""
+
+from __future__ import annotations
+
+import json
+import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def resolve_contract_resource(
+    relative_path: str | Path,
+    *,
+    search_roots: Iterable[Path] | None = None,
+) -> Path:
+    """Resolve a contract resource from a repo checkout or bundled runtime."""
+
+    candidate_path = Path(relative_path)
+    roots = [Path(root) for root in (search_roots or _default_search_roots())]
+    for root in roots:
+        candidate = root / candidate_path
+        if candidate.exists():
+            return candidate
+    searched = ", ".join(str(root / candidate_path) for root in roots)
+    raise FileNotFoundError(f"Harness contract resource was not found: {searched}")
+
+
+@lru_cache(maxsize=1)
+def load_task_envelope_schema() -> dict[str, Any]:
+    """Load the canonical TaskEnvelope schema once for validation helpers."""
+
+    schema_path = resolve_contract_resource(Path("schemas") / "task_envelope.schema.json")
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+def _default_search_roots() -> list[Path]:
+    roots: list[Path] = []
+    bundled_root = getattr(sys, "_MEIPASS", None)
+    if bundled_root:
+        roots.append(Path(str(bundled_root)))
+    roots.append(Path(__file__).resolve().parents[2])
+    return roots

--- a/modules/contracts/task_envelope_evidence.py
+++ b/modules/contracts/task_envelope_evidence.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator
+from modules.contracts.schema_loader import load_task_envelope_schema
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_SCHEMA_PATH = _REPO_ROOT / "schemas" / "task_envelope.schema.json"
-_ROOT_SCHEMA = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+_ROOT_SCHEMA = load_task_envelope_schema()
 
 
 def _build_defs_validator(def_name: str) -> Draft202012Validator:

--- a/modules/contracts/task_envelope_validation.py
+++ b/modules/contracts/task_envelope_validation.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
+from jsonschema import Draft202012Validator
 from typing import Any
 
-from jsonschema import Draft202012Validator
+from modules.contracts.schema_loader import load_task_envelope_schema
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_SCHEMA_PATH = _REPO_ROOT / "schemas" / "task_envelope.schema.json"
-_SCHEMA = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+_SCHEMA = load_task_envelope_schema()
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 
 

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -53,6 +53,7 @@ ENV_RUNTIME_LOG_PATH = "HARNESS_RUNTIME_LOG_PATH"
 ENV_RUNTIME_HOST = "HARNESS_RUNTIME_HOST"
 ENV_RUNTIME_PORT = "HARNESS_RUNTIME_PORT"
 ENV_RUNTIME_BASE_URL = "HARNESS_RUNTIME_BASE_URL"
+ENV_RUNTIME_EXECUTABLE = "HARNESS_RUNTIME_EXECUTABLE"
 ENV_DASHBOARD_ASSETS_DIR = "HARNESS_DASHBOARD_ASSETS_DIR"
 ENV_SECRET_PROVIDER = "HARNESS_SECRET_PROVIDER"
 ENV_NOTIFICATION_PERMISSION = "HARNESS_NOTIFICATION_PERMISSION"
@@ -382,6 +383,31 @@ def process_is_running(pid: int | None) -> bool:
     return True
 
 
+def runtime_is_frozen() -> bool:
+    return bool(getattr(sys, "frozen", False))
+
+
+def runtime_subprocess_command(
+    paths: RuntimePaths,
+    *,
+    host: str | None = None,
+    port: int | None = None,
+) -> list[str]:
+    runtime_executable = _clean_env_value(ENV_RUNTIME_EXECUTABLE)
+    if runtime_executable:
+        command = [runtime_executable]
+    elif runtime_is_frozen():
+        command = [sys.executable]
+    else:
+        command = [sys.executable, "-m", "modules.local_runtime"]
+    command.extend(["--data-dir", str(paths.data_dir), "--log-dir", str(paths.log_dir), "serve"])
+    if host:
+        command.extend(["--host", host])
+    if port:
+        command.extend(["--port", str(port)])
+    return command
+
+
 def runtime_status(
     config: RuntimeConfig,
     *,
@@ -461,20 +487,7 @@ def start_runtime(
             "paths": _paths_payload(config),
         }
 
-    command = [
-        sys.executable,
-        "-m",
-        "modules.local_runtime",
-        "--data-dir",
-        str(paths.data_dir),
-        "--log-dir",
-        str(paths.log_dir),
-        "serve",
-    ]
-    if host:
-        command.extend(["--host", host])
-    if port:
-        command.extend(["--port", str(port)])
+    command = runtime_subprocess_command(paths, host=host, port=port)
 
     try:
         process = subprocess.Popen(

--- a/requirements-packaging.txt
+++ b/requirements-packaging.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pyinstaller==6.16.0

--- a/script/package_macos_app.sh
+++ b/script/package_macos_app.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="HarnessApp"
+BUNDLE_ID="com.knoxanalytics.harness.local"
+MIN_SYSTEM_VERSION="14.0"
+DEFAULT_VERSION="0.1.0"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_DIR="$ROOT_DIR/apps/macos/HarnessApp"
+BUILD_DIR="$ROOT_DIR/.build/macos-package"
+DIST_DIR="$ROOT_DIR/dist/macos-release"
+APP_BUNDLE="$DIST_DIR/Harness.app"
+APP_CONTENTS="$APP_BUNDLE/Contents"
+APP_MACOS="$APP_CONTENTS/MacOS"
+APP_RESOURCES="$APP_CONTENTS/Resources"
+APP_BINARY="$APP_MACOS/$APP_NAME"
+INFO_PLIST="$APP_CONTENTS/Info.plist"
+RUNTIME_BUILD_DIR="$BUILD_DIR/runtime"
+RUNTIME_DIST_DIR="$RUNTIME_BUILD_DIR/dist"
+RUNTIME_WORK_DIR="$RUNTIME_BUILD_DIR/work"
+RUNTIME_SPEC_DIR="$RUNTIME_BUILD_DIR/spec"
+RUNTIME_STAGING_DIR="$APP_RESOURCES/HarnessRuntime"
+RUNTIME_BINARY="$RUNTIME_STAGING_DIR/harness"
+DASHBOARD_OUTPUT_DIR="$ROOT_DIR/dist/local-dashboard"
+DASHBOARD_STAGING_DIR="$APP_RESOURCES/Dashboard"
+DMG_PATH="$DIST_DIR/Harness.dmg"
+VERIFY_DATA_DIR="$BUILD_DIR/verify-data"
+VERIFY_LOG_DIR="$BUILD_DIR/verify-logs"
+PACKAGING_VENV="$BUILD_DIR/venv"
+
+APP_VERSION="${HARNESS_RELEASE_VERSION:-$DEFAULT_VERSION}"
+BUILD_VERSION="${HARNESS_BUILD_VERSION:-$(git rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)}"
+CODESIGN_IDENTITY="${MACOS_CODESIGN_IDENTITY:-}"
+NOTARY_PROFILE="${MACOS_NOTARY_PROFILE:-}"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required tool: $1" >&2
+    exit 2
+  }
+}
+
+require_tool python3
+require_tool pnpm
+require_tool swift
+require_tool hdiutil
+require_tool codesign
+require_tool xattr
+
+rm -rf "$BUILD_DIR" "$DIST_DIR"
+mkdir -p "$BUILD_DIR" "$DIST_DIR" "$APP_MACOS" "$APP_RESOURCES"
+
+echo "Building packaged dashboard assets..."
+(cd "$ROOT_DIR" && pnpm build:dashboard:local)
+
+echo "Preparing packaging virtualenv..."
+python3 -m venv "$PACKAGING_VENV"
+"$PACKAGING_VENV/bin/python" -m pip install --upgrade pip
+"$PACKAGING_VENV/bin/pip" install -r "$ROOT_DIR/requirements-packaging.txt"
+
+echo "Building bundled Harness runtime..."
+"$PACKAGING_VENV/bin/pyinstaller" \
+  --noconfirm \
+  --clean \
+  --onedir \
+  --name harness \
+  --distpath "$RUNTIME_DIST_DIR" \
+  --workpath "$RUNTIME_WORK_DIR" \
+  --specpath "$RUNTIME_SPEC_DIR" \
+  --add-data "$ROOT_DIR/schemas:schemas" \
+  --hidden-import backend.server \
+  "$ROOT_DIR/modules/local_runtime.py"
+
+if [[ ! -x "$RUNTIME_DIST_DIR/harness/harness" ]]; then
+  echo "bundled Harness runtime was not created" >&2
+  exit 1
+fi
+
+echo "Building macOS app binary..."
+(cd "$APP_DIR" && swift build -c release)
+SWIFT_BIN="$(cd "$APP_DIR" && swift build -c release --show-bin-path)/$APP_NAME"
+if [[ ! -x "$SWIFT_BIN" ]]; then
+  echo "Swift app binary not found at $SWIFT_BIN" >&2
+  exit 1
+fi
+
+echo "Staging app bundle..."
+mkdir -p "$RUNTIME_STAGING_DIR" "$DASHBOARD_STAGING_DIR"
+cp "$SWIFT_BIN" "$APP_BINARY"
+chmod +x "$APP_BINARY"
+cp -R "$RUNTIME_DIST_DIR/harness/." "$RUNTIME_STAGING_DIR/"
+cp -R "$DASHBOARD_OUTPUT_DIR/." "$DASHBOARD_STAGING_DIR/"
+
+cat >"$INFO_PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleIdentifier</key>
+  <string>$BUNDLE_ID</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Harness</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$APP_VERSION</string>
+  <key>CFBundleVersion</key>
+  <string>$BUILD_VERSION</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>$MIN_SYSTEM_VERSION</string>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+  </dict>
+  <key>HarnessRuntimeExecutable</key>
+  <string>Contents/Resources/HarnessRuntime/harness</string>
+  <key>HarnessDashboardAssetsDir</key>
+  <string>Contents/Resources/Dashboard</string>
+</dict>
+</plist>
+PLIST
+
+echo "Signing app bundle..."
+xattr -cr "$APP_BUNDLE"
+if [[ -n "$CODESIGN_IDENTITY" ]]; then
+  codesign --force --deep --options runtime --sign "$CODESIGN_IDENTITY" "$APP_BUNDLE"
+else
+  codesign --force --deep --sign - "$APP_BUNDLE"
+fi
+codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+
+echo "Verifying bundled runtime..."
+mkdir -p "$VERIFY_DATA_DIR" "$VERIFY_LOG_DIR"
+export HARNESS_DASHBOARD_ASSETS_DIR="$DASHBOARD_STAGING_DIR"
+"$RUNTIME_BINARY" --data-dir "$VERIFY_DATA_DIR" --log-dir "$VERIFY_LOG_DIR" --json init >/dev/null
+"$RUNTIME_BINARY" --data-dir "$VERIFY_DATA_DIR" --log-dir "$VERIFY_LOG_DIR" --json doctor >/dev/null
+"$RUNTIME_BINARY" --data-dir "$VERIFY_DATA_DIR" --log-dir "$VERIFY_LOG_DIR" --json start --timeout 10 >/dev/null
+"$RUNTIME_BINARY" --data-dir "$VERIFY_DATA_DIR" --log-dir "$VERIFY_LOG_DIR" --json status >/dev/null
+"$RUNTIME_BINARY" --data-dir "$VERIFY_DATA_DIR" --log-dir "$VERIFY_LOG_DIR" --json stop --timeout 5 >/dev/null
+
+echo "Creating DMG..."
+hdiutil create -volname "Harness" -srcfolder "$APP_BUNDLE" -ov -format UDZO "$DMG_PATH" >/dev/null
+
+if [[ -n "$NOTARY_PROFILE" ]]; then
+  echo "Submitting DMG for notarization..."
+  xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun stapler staple "$APP_BUNDLE"
+  xcrun stapler staple "$DMG_PATH"
+fi
+
+echo "Packaged app: $APP_BUNDLE"
+echo "Packaged disk image: $DMG_PATH"

--- a/tests/contracts/test_schema_loader.py
+++ b/tests/contracts/test_schema_loader.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.contracts.schema_loader import load_task_envelope_schema, resolve_contract_resource
+
+
+class ContractSchemaLoaderTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        load_task_envelope_schema.cache_clear()
+
+    def test_resolve_contract_resource_prefers_bundled_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bundled_root = Path(temp_dir)
+            bundled_schema = bundled_root / "schemas" / "task_envelope.schema.json"
+            bundled_schema.parent.mkdir(parents=True, exist_ok=True)
+            bundled_schema.write_text('{"$schema":"bundle","$defs":{}}', encoding="utf-8")
+
+            with patch("modules.contracts.schema_loader.sys._MEIPASS", str(bundled_root), create=True):
+                resolved = resolve_contract_resource("schemas/task_envelope.schema.json")
+
+        self.assertEqual(resolved, bundled_schema)
+
+    def test_load_task_envelope_schema_reads_from_bundled_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bundled_root = Path(temp_dir)
+            bundled_schema = bundled_root / "schemas" / "task_envelope.schema.json"
+            bundled_schema.parent.mkdir(parents=True, exist_ok=True)
+            bundled_schema.write_text(
+                '{"$schema":"https://example.invalid/schema","$defs":{"artifactRecord":{"type":"object"}}}',
+                encoding="utf-8",
+            )
+
+            load_task_envelope_schema.cache_clear()
+            with patch("modules.contracts.schema_loader.sys._MEIPASS", str(bundled_root), create=True):
+                payload = load_task_envelope_schema()
+
+        self.assertEqual(payload["$schema"], "https://example.invalid/schema")
+        self.assertIn("artifactRecord", payload["$defs"])

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -394,6 +394,32 @@ class LocalRuntimeProcessTests(unittest.TestCase):
         self.assertIn("Recover Runtime", payload["next_action"])
         popen.assert_not_called()
 
+    def test_start_uses_bundled_runtime_executable_when_frozen(self) -> None:
+        class FakeProcess:
+            pid = 4343
+
+            def poll(self) -> None:
+                return None
+
+        with (
+            patch("modules.local_runtime.fetch_runtime_health", return_value=(None, None, "not running")),
+            patch("modules.local_runtime._port_available", return_value=(True, None)),
+            patch("modules.local_runtime._wait_for_runtime_health", return_value=True),
+            patch("modules.local_runtime.runtime_is_frozen", return_value=True),
+            patch("modules.local_runtime.sys.executable", "/Applications/Harness.app/Contents/Resources/HarnessRuntime/harness"),
+            patch("modules.local_runtime.subprocess.Popen", return_value=FakeProcess()) as popen,
+        ):
+            exit_code, payload = start_runtime(self.paths)
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(payload["status"], "running")
+        self.assertEqual(
+            popen.call_args.args[0][0],
+            "/Applications/Harness.app/Contents/Resources/HarnessRuntime/harness",
+        )
+        self.assertNotIn("-m", popen.call_args.args[0])
+        self.assertIn("serve", popen.call_args.args[0])
+
     def test_recover_stops_unhealthy_pid_before_restart(self) -> None:
         class FakeProcess:
             pid = 6262


### PR DESCRIPTION
Closes #328

## Summary
- package a self-contained macOS `Harness.app` and `Harness.dmg` with a bundled frozen `harness` runtime and packaged dashboard assets
- teach the macOS app shell and Python contract validators to resolve bundled runtime, dashboard, and schema resources without a repo checkout
- document the release packaging, install, signing, notarization, and local development flows for the packaged app path

## Validation
- `python3 -m unittest discover -s tests`
- `python3 -m unittest tests.contracts.test_schema_loader -v`
- `swift run HarnessAppCoreCheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:dashboard:local`
- `bash script/package_macos_app.sh`
- `bash script/build_and_run.sh --verify`
- `git diff --check`