### PR TITLE
Define Linux portability contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,9 @@ Build a distributable self-contained app bundle and DMG with:
 
 That release path bundles the native app, a frozen `harness` runtime, and prebuilt dashboard assets into `dist/macos-release/Harness.app` and `dist/macos-release/Harness.dmg`. Normal users should not need a repo checkout, Python, Node, `pnpm`, or Docker after install.
 
-See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md), [`docs/architecture/macos-onboarding-assistant.md`](docs/architecture/macos-onboarding-assistant.md), [`docs/architecture/macos-daemon-lifecycle.md`](docs/architecture/macos-daemon-lifecycle.md), [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md), and [`docs/architecture/macos-packaging.md`](docs/architecture/macos-packaging.md).
+Linux shell work remains deferred, but the reusable backend/CLI/dashboard boundaries are now documented in [`docs/architecture/linux-portability-contract.md`](docs/architecture/linux-portability-contract.md).
+
+See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md), [`docs/architecture/macos-onboarding-assistant.md`](docs/architecture/macos-onboarding-assistant.md), [`docs/architecture/macos-daemon-lifecycle.md`](docs/architecture/macos-daemon-lifecycle.md), [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md), [`docs/architecture/macos-packaging.md`](docs/architecture/macos-packaging.md), and [`docs/architecture/linux-portability-contract.md`](docs/architecture/linux-portability-contract.md).
 
 `backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 

--- a/docs/architecture/app-managed-secrets.md
+++ b/docs/architecture/app-managed-secrets.md
@@ -22,6 +22,14 @@ Current secret names:
 
 The `OPENCLAW_REPAIR_BEARER_TOKEN` env name remains the current concrete repair-adapter variable. It is not the product boundary. The stable local-app boundary is the named Harness secret.
 
+Provider selection is platform-aware at the Python boundary:
+
+- `macos-keychain` on Darwin
+- `linux-secret-service` as the deferred Linux provider contract
+- `unsupported-<platform>` on other local-app platforms until a provider exists
+
+Linux Secret Service support is not implemented in this slice. The important part is that the runtime no longer hard-codes the macOS provider name into status or environment surfaces.
+
 ## CLI Contract
 
 The packaged app can call the same command surface that developers can run from a checkout:
@@ -66,3 +74,5 @@ Workflows that need a credential should call `secrets status --require <name>` o
 
 Linux support will use the same Harness secret names and CLI/status contract.
 The provider can later be Secret Service/libsecret or an encrypted local fallback, but it should not change the runtime env mapping or the onboarding contract.
+
+See [linux-portability-contract.md](linux-portability-contract.md).

--- a/docs/architecture/linux-portability-contract.md
+++ b/docs/architecture/linux-portability-contract.md
@@ -1,0 +1,68 @@
+# Linux Portability Contract
+
+`#329` is not a Linux app implementation issue. It is the guardrail issue that keeps the macOS-first work from baking macOS assumptions into Harness core.
+
+Harness is allowed to ship a native macOS shell first. It is not allowed to make the backend, SQLite store, dashboard, or CLI contract depend on Swift, AppKit, Keychain-only semantics, or `.app`-bundle assumptions.
+
+## Platform-Neutral Surfaces
+
+These pieces must remain reusable for a future Linux package:
+
+- Python runtime and backend entrypoints in `modules/local_runtime.py` and `backend.server`
+- SQLite schema, migrations, and store semantics
+- local CLI/process contract exposed as `harness ...`
+- app-managed config model and XDG-compatible data/log paths
+- static dashboard bundle and same-origin API behavior
+- doctor/setup data model and integration semantics
+
+If one of these changes in a macOS feature branch, the change needs to be justified as a portable runtime change, not a shell convenience.
+
+## Replaceable Boundaries
+
+These are allowed to be platform-specific, but only behind explicit boundaries:
+
+| Concern | macOS v1 | Linux later |
+| --- | --- | --- |
+| Secret provider | Keychain / `security` | Secret Service / libsecret, or encrypted local fallback |
+| Auto-start | `SMAppService` Launch at Login | `systemd --user` service or desktop autostart |
+| Notifications | `UserNotifications` | freedesktop notifications |
+| Package format | `.app` + `.dmg` | AppImage, deb, rpm, or tarball |
+| Folder selection | AppKit / Finder picker | XDG portal or toolkit-native picker |
+
+The backend and CLI should consume the same abstract outputs from these boundaries regardless of platform:
+
+- secret names and env mapping
+- runtime lifecycle commands
+- onboarding/setup item status
+- dashboard URL and API base URL
+
+## Current Guardrails
+
+As of the macOS packaging slice:
+
+- the runtime contract is Python, not Swift
+- app-managed paths already support macOS and Linux defaults
+- the bundled dashboard is static and backend-served, not tied to a macOS web runtime
+- contract schema loading works from a repo checkout or bundled runtime
+- secret-provider selection is platform-aware in Python instead of hard-coding `macos-keychain`
+
+That means a future Linux shell can reuse the same backend, SQLite store, dashboard assets, and CLI contract even though the native shell implementation is deferred.
+
+## What Must Not Happen
+
+- Do not move task truth, SQLite writes, or policy enforcement into Swift-only code.
+- Do not make the CLI depend on `.app` bundle layout.
+- Do not rename Harness secret names just because the underlying OS provider changes.
+- Do not make doctor/setup payloads require macOS-only concepts to be considered valid.
+- Do not let packaging scripts become the runtime contract.
+
+## Deferred Linux Decisions
+
+These remain explicitly deferred:
+
+- which Linux package format ships first
+- which desktop toolkit hosts the Linux dashboard window
+- whether the first Linux auto-start path is `systemd --user`, desktop autostart, or both
+- whether the first Linux secret provider is libsecret-only or includes an encrypted local fallback
+
+Those are implementation decisions for a later issue. This contract only locks the boundaries they are allowed to replace.

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -26,7 +26,7 @@ Commands:
 - `harness secrets set <name> --value-stdin`
 - `harness secrets delete <name>`
 
-The CLI supports `--json` for app-shell consumption. JSON output is the contract the macOS menu-bar app should use.
+The CLI supports `--json` for app-shell consumption. JSON output is the contract the macOS menu-bar app should use, and it is also the portability boundary a future Linux shell must reuse.
 
 ## App-Managed Paths
 
@@ -100,6 +100,8 @@ python3 -m modules.local_runtime --json secrets delete github_token
 Secret status output is redacted. It reports configured, missing, unavailable, and error states without returning token values.
 Existing environment variables win over Keychain values so native developer `.env.local` workflows still work.
 
+Provider selection is platform-aware. Darwin uses `macos-keychain`; Linux is reserved for the `linux-secret-service` boundary even though the Linux provider is still deferred.
+
 See [app-managed-secrets.md](app-managed-secrets.md).
 
 ## Guided Setup
@@ -158,7 +160,7 @@ The backend exposes two app-shell-safe probes:
 
 - `GET /health`: canonical backend and storage health.
 - `GET /runtime/status`: local app runtime status envelope that includes mode, API base URL,
-  store backend, schema readiness, and app-managed paths.
+  store backend, secret provider, schema readiness, and app-managed paths.
 
 `harness status --json` calls the local health endpoint and returns:
 
@@ -236,3 +238,5 @@ The local API binds to loopback by default. Network exposure is out of scope for
 ```text
 http://127.0.0.1:<runtime-port>/dashboard
 ```
+
+See [linux-portability-contract.md](linux-portability-contract.md) for the platform-neutral versus shell-specific boundaries.

--- a/docs/architecture/macos-packaging.md
+++ b/docs/architecture/macos-packaging.md
@@ -3,6 +3,8 @@
 Issue #328 is the line between a developer bundle and a distributable local Harness app.
 The goal is not "make Swift build." The goal is "ship a normal macOS app that does not depend on a repo checkout, Python install, Node install, or Docker."
 
+This document is macOS-specific on purpose. The cross-platform guardrails that keep this package work from polluting Harness core live in [linux-portability-contract.md](linux-portability-contract.md).
+
 ## Package Shape
 
 The packaged bundle should contain:

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -20,8 +20,8 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from modules.local_secrets import (
+    create_secret_store,
     LocalSecretError,
-    MacOSKeychainSecretStore,
     SecretStatus,
     collect_secret_statuses,
     load_app_managed_secrets_into_environment,
@@ -306,6 +306,7 @@ def init_runtime(
 def apply_runtime_environment(config: RuntimeConfig, *, config_path: Path) -> None:
     """Apply app-managed runtime environment for backend startup."""
 
+    secret_store = create_secret_store()
     os.environ["HARNESS_STORE_BACKEND"] = "sqlite"
     os.environ["HARNESS_SQLITE_PATH"] = str(config.database_path)
     os.environ[ENV_RUNTIME_MODE] = "local-app"
@@ -316,8 +317,11 @@ def apply_runtime_environment(config: RuntimeConfig, *, config_path: Path) -> No
     os.environ[ENV_RUNTIME_PORT] = str(config.port)
     os.environ[ENV_RUNTIME_BASE_URL] = config.base_url
     os.environ.setdefault(ENV_DASHBOARD_ASSETS_DIR, str(config.dashboard_assets_dir))
-    load_app_managed_secrets_into_environment(store=create_secret_store())
-    os.environ.setdefault(ENV_SECRET_PROVIDER, "macos-keychain")
+    load_app_managed_secrets_into_environment(store=secret_store)
+    os.environ.setdefault(
+        ENV_SECRET_PROVIDER,
+        str(getattr(secret_store, "provider_name", "app-managed-secret-store")),
+    )
 
 
 def fetch_runtime_health(
@@ -1231,11 +1235,6 @@ def build_parser() -> argparse.ArgumentParser:
     secrets_delete_parser.add_argument("name", help="Secret name")
 
     return parser
-
-
-def create_secret_store() -> MacOSKeychainSecretStore:
-    return MacOSKeychainSecretStore()
-
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()

--- a/modules/local_secrets.py
+++ b/modules/local_secrets.py
@@ -196,6 +196,65 @@ class MacOSKeychainSecretStore:
         return resolved
 
 
+class LinuxSecretServiceSecretStore:
+    """Linux secret-store contract placeholder for future Secret Service support."""
+
+    provider_name = "linux-secret-service"
+
+    def __init__(self, *, platform_name: str | None = None) -> None:
+        self._platform_name = platform_name or platform.system()
+
+    def get_secret(self, name: str) -> str:
+        definition = get_secret_definition(name)
+        raise SecretProviderUnavailableError(
+            f"{definition.label} is unavailable because the Linux Secret Service provider is not implemented yet. "
+            "Use developer env-file mode until the Linux local-app secret provider ships."
+        )
+
+    def set_secret(self, name: str, value: str) -> None:
+        definition = get_secret_definition(name)
+        raise SecretProviderUnavailableError(
+            f"{definition.label} cannot be stored because the Linux Secret Service provider is not implemented yet."
+        )
+
+    def delete_secret(self, name: str) -> bool:
+        get_secret_definition(name)
+        raise SecretProviderUnavailableError(
+            "Linux Secret Service deletion is unavailable until the Linux local-app secret provider is implemented."
+        )
+
+
+class UnsupportedPlatformSecretStore:
+    """Fallback contract placeholder for unsupported local-app secret providers."""
+
+    def __init__(self, *, platform_name: str | None = None) -> None:
+        self._platform_name = platform_name or platform.system()
+
+    @property
+    def provider_name(self) -> str:
+        return f"unsupported-{self._platform_name.lower()}"
+
+    def get_secret(self, name: str) -> str:
+        definition = get_secret_definition(name)
+        raise SecretProviderUnavailableError(
+            f"{definition.label} is unavailable because Harness does not have an app-managed secret provider "
+            f"for {self._platform_name}."
+        )
+
+    def set_secret(self, name: str, value: str) -> None:
+        definition = get_secret_definition(name)
+        raise SecretProviderUnavailableError(
+            f"{definition.label} cannot be stored because Harness does not have an app-managed secret provider "
+            f"for {self._platform_name}."
+        )
+
+    def delete_secret(self, name: str) -> bool:
+        get_secret_definition(name)
+        raise SecretProviderUnavailableError(
+            f"Harness does not have an app-managed secret provider for {self._platform_name}."
+        )
+
+
 class InMemorySecretStore:
     """Small test and fixture secret store. Not used for persisted app secrets."""
 
@@ -222,6 +281,15 @@ class InMemorySecretStore:
         return self.values.pop(name, None) is not None
 
 
+def create_secret_store(*, platform_name: str | None = None) -> SecretStore:
+    resolved_platform = platform_name or platform.system()
+    if resolved_platform == "Darwin":
+        return MacOSKeychainSecretStore(platform_name=resolved_platform)
+    if resolved_platform == "Linux":
+        return LinuxSecretServiceSecretStore(platform_name=resolved_platform)
+    return UnsupportedPlatformSecretStore(platform_name=resolved_platform)
+
+
 def load_app_managed_secrets_into_environment(
     *,
     store: SecretStore | None = None,
@@ -233,7 +301,7 @@ def load_app_managed_secrets_into_environment(
     explicitly exported variables keep working.
     """
 
-    secret_store = store or MacOSKeychainSecretStore()
+    secret_store = store or create_secret_store()
     statuses: list[SecretStatus] = []
     for definition in SECRET_DEFINITIONS:
         current_value = os.environ.get(definition.env_var)
@@ -259,7 +327,7 @@ def collect_secret_statuses(
     store: SecretStore | None = None,
     required_names: Iterable[str] = (),
 ) -> list[SecretStatus]:
-    secret_store = store or MacOSKeychainSecretStore()
+    secret_store = store or create_secret_store()
     required = set(required_names)
     for name in required:
         get_secret_definition(name)

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -9,7 +9,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from modules.local_secrets import InMemorySecretStore
+from modules.local_secrets import InMemorySecretStore, LinuxSecretServiceSecretStore
 from modules.local_runtime import (
     DEFAULT_API_PORT,
     EXIT_OK,
@@ -87,7 +87,8 @@ class LocalRuntimeCliTests(unittest.TestCase):
     def test_status_reports_stopped_when_health_is_unreachable(self) -> None:
         self._run_cli("init")
 
-        exit_code, payload = self._run_cli("status", "--timeout", "0.01")
+        with patch("modules.local_runtime.fetch_runtime_health", return_value=(None, None, "not running")):
+            exit_code, payload = self._run_cli("status", "--timeout", "0.01")
 
         self.assertEqual(exit_code, EXIT_UNHEALTHY)
         self.assertEqual(payload["status"], "stopped")
@@ -126,6 +127,7 @@ class LocalRuntimeCliTests(unittest.TestCase):
                 },
                 clear=True,
             ),
+            patch("modules.local_runtime.fetch_runtime_health", return_value=(None, None, "not running")),
             patch(
                 "modules.local_runtime.create_secret_store",
                 return_value=InMemorySecretStore(
@@ -293,6 +295,7 @@ class LocalRuntimeProcessTests(unittest.TestCase):
             observed["sqlite_path"] = os.environ.get("HARNESS_SQLITE_PATH")
             observed["runtime_mode"] = os.environ.get("HARNESS_RUNTIME_MODE")
             observed["dashboard_assets_dir"] = os.environ.get("HARNESS_DASHBOARD_ASSETS_DIR")
+            observed["secret_provider"] = os.environ.get("HARNESS_SECRET_PROVIDER")
             observed["github_token"] = os.environ.get("GITHUB_TOKEN")
             print("server-started")
 
@@ -316,11 +319,32 @@ class LocalRuntimeProcessTests(unittest.TestCase):
         self.assertEqual(observed["sqlite_path"], str(self.paths.database_path))
         self.assertEqual(observed["runtime_mode"], "local-app")
         self.assertEqual(observed["dashboard_assets_dir"], str(self.paths.dashboard_assets_dir))
+        self.assertEqual(observed["secret_provider"], "memory")
         self.assertEqual(observed["github_token"], "ghp_secret")
         self.assertFalse(self.paths.pid_path.exists())
         log_text = self.paths.log_path.read_text(encoding="utf-8")
         self.assertIn("server-started", log_text)
         self.assertNotIn("ghp_secret", log_text)
+
+    def test_serve_uses_platform_secret_provider_without_macos_assumption(self) -> None:
+        observed: dict[str, object] = {}
+
+        def fake_run_uvicorn(config) -> None:  # noqa: ANN001
+            observed["secret_provider"] = os.environ.get("HARNESS_SECRET_PROVIDER")
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("modules.local_runtime._assert_port_available"),
+            patch(
+                "modules.local_runtime.create_secret_store",
+                return_value=LinuxSecretServiceSecretStore(platform_name="Linux"),
+            ),
+            patch("modules.local_runtime._run_uvicorn", side_effect=fake_run_uvicorn),
+        ):
+            exit_code = serve_runtime(self.paths)
+
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(observed["secret_provider"], "linux-secret-service")
 
     def test_stop_treats_missing_or_stale_process_as_stopped(self) -> None:
         config, _ = init_runtime(self.paths)
@@ -476,6 +500,7 @@ class LocalRuntimeContractTests(unittest.TestCase):
             os.environ,
             {
                 "HARNESS_RUNTIME_MODE": "local-app",
+                "HARNESS_SECRET_PROVIDER": "linux-secret-service",
                 "HARNESS_RUNTIME_BASE_URL": "http://127.0.0.1:8765",
                 "HARNESS_RUNTIME_CONFIG_PATH": "/tmp/harness/config.json",
                 "HARNESS_RUNTIME_DATA_DIR": "/tmp/harness",
@@ -494,6 +519,7 @@ class LocalRuntimeContractTests(unittest.TestCase):
 
         self.assertEqual(payload["status"], "running")
         self.assertEqual(payload["mode"], "local-app")
+        self.assertEqual(payload["secret_provider"], "linux-secret-service")
         self.assertEqual(payload["api_base_url"], "http://127.0.0.1:8765")
         self.assertEqual(payload["store_backend"], "sqlite")
         self.assertEqual(payload["paths"]["database_path"], "/tmp/harness/harness.db")

--- a/tests/test_local_secrets.py
+++ b/tests/test_local_secrets.py
@@ -6,10 +6,13 @@ import unittest
 from unittest.mock import patch
 
 from modules.local_secrets import (
+    create_secret_store,
     InMemorySecretStore,
+    LinuxSecretServiceSecretStore,
     MacOSKeychainSecretStore,
     SecretNotFoundError,
     SecretProviderUnavailableError,
+    UnsupportedPlatformSecretStore,
     collect_secret_statuses,
     load_app_managed_secrets_into_environment,
     secret_status_payload,
@@ -83,6 +86,30 @@ class MacOSKeychainSecretStoreTests(unittest.TestCase):
 
 
 class LocalSecretStatusTests(unittest.TestCase):
+    def test_create_secret_store_selects_macos_keychain_on_darwin(self) -> None:
+        store = create_secret_store(platform_name="Darwin")
+
+        self.assertIsInstance(store, MacOSKeychainSecretStore)
+        self.assertEqual(store.provider_name, "macos-keychain")
+
+    def test_create_secret_store_selects_linux_placeholder_on_linux(self) -> None:
+        store = create_secret_store(platform_name="Linux")
+
+        self.assertIsInstance(store, LinuxSecretServiceSecretStore)
+        self.assertEqual(store.provider_name, "linux-secret-service")
+
+    def test_create_secret_store_falls_back_on_unsupported_platform(self) -> None:
+        store = create_secret_store(platform_name="FreeBSD")
+
+        self.assertIsInstance(store, UnsupportedPlatformSecretStore)
+        self.assertEqual(store.provider_name, "unsupported-freebsd")
+
+    def test_linux_secret_store_reports_unavailable_until_implemented(self) -> None:
+        store = LinuxSecretServiceSecretStore(platform_name="Linux")
+
+        with self.assertRaises(SecretProviderUnavailableError):
+            store.get_secret("github_token")
+
     def test_loads_app_managed_secrets_into_missing_environment_vars(self) -> None:
         store = InMemorySecretStore(
             {


### PR DESCRIPTION
Closes #329

## Summary
- add an explicit Linux portability architecture contract so the macOS-first local app work keeps backend, CLI, SQLite, dashboard, and doctor/setup boundaries reusable
- make Python secret-provider selection platform-aware instead of hard-coding `macos-keychain` into runtime status and environment surfaces
- add tests that lock the provider boundary and keep local-runtime behavior deterministic even when a real local runtime is already running

## Validation
- `python3 -m unittest tests.test_local_secrets tests.test_local_runtime -v`
- `python3 -m unittest discover -s tests`
- `git diff --check`