### PR TITLE
Add macOS notarization release guardrail

### DIFF
--- a/docs/architecture/macos-packaging.md
+++ b/docs/architecture/macos-packaging.md
@@ -72,8 +72,10 @@ For external distribution, use:
 
 - `MACOS_CODESIGN_IDENTITY` for Developer ID Application signing
 - `MACOS_NOTARY_PROFILE` for `xcrun notarytool` submission
+- `HARNESS_REQUIRE_NOTARIZATION=1` to fail fast when either release prerequisite is missing
 
 When a notary profile is present, the package script submits the generated DMG, waits for completion, and staples the result.
+When `HARNESS_REQUIRE_NOTARIZATION=1` is set, the script refuses to continue without both a configured Developer ID Application identity and a notary profile.
 
 ## Installer Flow
 

--- a/docs/howto/local-quickstart.md
+++ b/docs/howto/local-quickstart.md
@@ -25,8 +25,10 @@ The internal validation package is ad-hoc signed unless `MACOS_CODESIGN_IDENTITY
 ```bash
 export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
 export MACOS_NOTARY_PROFILE="harness-notary"
-./script/package_macos_app.sh
+HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
 ```
+
+`HARNESS_REQUIRE_NOTARIZATION=1` is the release guardrail. It fails before build work starts if the Developer ID identity or notary profile is missing, so an official release cannot accidentally ship from an ad-hoc internal package.
 
 After installing the app, first run should guide the user through:
 

--- a/docs/howto/troubleshoot.md
+++ b/docs/howto/troubleshoot.md
@@ -76,7 +76,15 @@ Internal validation packages may be ad-hoc signed. External distribution require
 ```bash
 export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
 export MACOS_NOTARY_PROFILE="harness-notary"
-./script/package_macos_app.sh
+HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
 ```
 
 Then verify signing and notarization before publishing the DMG.
+
+If the command fails before building with `codesign identity not found`, inspect the available identities:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+Official distribution needs a valid `Developer ID Application` certificate installed in the active keychain. An ad-hoc package is acceptable for internal validation, but it is not an official release artifact.

--- a/docs/release/documentation-readiness-checklist.md
+++ b/docs/release/documentation-readiness-checklist.md
@@ -21,4 +21,5 @@ Use this checklist before calling Harness local-app documentation release-ready.
 
 - [x] Run the gated live reset smoke with real GitHub and Linear dry-run targets. See [live-reset-smoke-2026-04-23.md](live-reset-smoke-2026-04-23.md).
 - [ ] Verify a Developer ID signed and notarized DMG, not only the ad-hoc internal package.
+  Current local blocker: `security find-identity -v -p codesigning` reports `0 valid identities found`, so this machine cannot produce a Developer ID signed DMG yet. See [macos-notarization-readiness-2026-04-24.md](macos-notarization-readiness-2026-04-24.md).
 - [ ] Re-run every reader-facing command after the final app UI and installer flow land.

--- a/docs/release/macos-notarization-readiness-2026-04-24.md
+++ b/docs/release/macos-notarization-readiness-2026-04-24.md
@@ -1,0 +1,51 @@
+# macOS Notarization Readiness
+
+Date: 2026-04-24
+
+## Purpose
+
+Check whether this machine can complete the remaining official-release gate: a Developer ID signed and notarized `Harness.dmg`.
+
+## Current Result
+
+This machine is not ready to produce the official distribution artifact.
+
+```bash
+security find-identity -v -p codesigning
+```
+
+Result:
+
+```text
+0 valid identities found
+```
+
+Without a valid `Developer ID Application` identity in the active keychain, `codesign` cannot produce the signature Apple expects for notarization.
+
+## Release Guardrail Added
+
+The packaging script now supports strict official-release mode:
+
+```bash
+export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
+export MACOS_NOTARY_PROFILE="harness-notary"
+HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
+```
+
+With `HARNESS_REQUIRE_NOTARIZATION=1`, the script fails before build work starts if either release prerequisite is missing:
+
+- `MACOS_CODESIGN_IDENTITY`
+- `MACOS_NOTARY_PROFILE`
+
+If `MACOS_CODESIGN_IDENTITY` is set but not visible in `security find-identity -v -p codesigning`, the script fails with an operator-readable message.
+
+## Needed To Complete The Gate
+
+1. Install the Apple Developer ID Application certificate into the active keychain.
+2. Configure a notarytool keychain profile, for example `harness-notary`.
+3. Run the strict package command above.
+4. Confirm the script submits the DMG, waits for notarization, staples the app and DMG, and leaves `dist/macos-release/Harness.dmg` ready for external distribution.
+
+## Boundary
+
+The existing ad-hoc package remains valid for internal validation. It is not an official release artifact and must not be treated as equivalent to a Developer ID signed and notarized DMG.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -299,7 +299,7 @@ For external distribution, also provide:
 ```bash
 export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
 export MACOS_NOTARY_PROFILE="harness-notary"
-./script/package_macos_app.sh
+HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
 ```
 
 See [`docs/architecture/macos-packaging.md`](../architecture/macos-packaging.md) for the packaged bundle layout, uninstall/reset notes, and notarization expectations.

--- a/script/package_macos_app.sh
+++ b/script/package_macos_app.sh
@@ -34,6 +34,7 @@ APP_VERSION="${HARNESS_RELEASE_VERSION:-$DEFAULT_VERSION}"
 BUILD_VERSION="${HARNESS_BUILD_VERSION:-$(git rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)}"
 CODESIGN_IDENTITY="${MACOS_CODESIGN_IDENTITY:-}"
 NOTARY_PROFILE="${MACOS_NOTARY_PROFILE:-}"
+REQUIRE_NOTARIZATION="${HARNESS_REQUIRE_NOTARIZATION:-0}"
 
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -42,12 +43,52 @@ require_tool() {
   }
 }
 
+truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+codesign_identity_available() {
+  local identity="$1"
+  security find-identity -v -p codesigning | grep -F "$identity" >/dev/null 2>&1
+}
+
+validate_distribution_prerequisites() {
+  if [[ -n "$NOTARY_PROFILE" && -z "$CODESIGN_IDENTITY" ]]; then
+    echo "MACOS_NOTARY_PROFILE requires MACOS_CODESIGN_IDENTITY; notarization must use a Developer ID signed app." >&2
+    exit 2
+  fi
+
+  if truthy "$REQUIRE_NOTARIZATION"; then
+    if [[ -z "$CODESIGN_IDENTITY" ]]; then
+      echo "HARNESS_REQUIRE_NOTARIZATION=1 requires MACOS_CODESIGN_IDENTITY." >&2
+      exit 2
+    fi
+    if [[ -z "$NOTARY_PROFILE" ]]; then
+      echo "HARNESS_REQUIRE_NOTARIZATION=1 requires MACOS_NOTARY_PROFILE." >&2
+      exit 2
+    fi
+  fi
+
+  if [[ -n "$CODESIGN_IDENTITY" ]] && ! codesign_identity_available "$CODESIGN_IDENTITY"; then
+    echo "codesign identity not found in the active keychain: $CODESIGN_IDENTITY" >&2
+    echo "Install the Developer ID Application certificate or choose an identity from: security find-identity -v -p codesigning" >&2
+    exit 2
+  fi
+}
+
 require_tool python3
 require_tool pnpm
 require_tool swift
 require_tool hdiutil
 require_tool codesign
 require_tool xattr
+require_tool security
+require_tool xcrun
+
+validate_distribution_prerequisites
 
 rm -rf "$BUILD_DIR" "$DIST_DIR"
 mkdir -p "$BUILD_DIR" "$DIST_DIR" "$APP_MACOS" "$APP_RESOURCES"


### PR DESCRIPTION
## Summary
- add strict official-release mode to the macOS packaging script via HARNESS_REQUIRE_NOTARIZATION=1
- fail early when Developer ID signing identity or notary profile inputs are missing
- document the current local blocker: this machine has 0 valid codesigning identities
- update release/how-to/setup docs to use the strict command for external distribution

## Validation
- bash -n script/package_macos_app.sh
- HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh fails before build work with missing identity
- MACOS_CODESIGN_IDENTITY='Developer ID Application: Example' MACOS_NOTARY_PROFILE=harness-notary HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh fails before build work with identity-not-found message
- git diff --check

## Notes
- I did not submit anything to Apple. Notarization upload still needs a real Developer ID Application certificate and configured notarytool keychain profile.
- Existing untracked duplicate " 2" files remain untouched and unstaged.