### PR TITLE
Verify reader-facing release commands

### DIFF
--- a/docs/architecture/macos-packaging.md
+++ b/docs/architecture/macos-packaging.md
@@ -63,6 +63,9 @@ This is intentionally a build-machine workflow, not an end-user workflow.
 The build machine may need Python, `pnpm`, and Xcode tools.
 The installed app must not.
 
+Before signing, the package script strips signing-forbidden extended attributes such as `com.apple.FinderInfo` and `com.apple.ResourceFork` from the staged app bundle.
+That matters because copied dashboard/runtime artifacts can inherit macOS metadata that makes `codesign` reject the bundle.
+
 The packaging smoke test uses `HARNESS_PACKAGE_VERIFY_PORT`, defaulting to `18765`, so it can run while a developer's normal local Harness app already owns `127.0.0.1:8765`.
 
 ## Signing And Notarization

--- a/docs/howto/test-and-validate.md
+++ b/docs/howto/test-and-validate.md
@@ -21,6 +21,8 @@ python3 -m unittest discover -s tests
 From a checkout:
 
 ```bash
+pnpm build:dashboard:local
+export HARNESS_DASHBOARD_ASSETS_DIR="$PWD/dist/local-dashboard"
 python3 -m modules.local_runtime --json init
 python3 -m modules.local_runtime --json start
 python3 -m modules.local_runtime --json status
@@ -28,6 +30,8 @@ python3 -m modules.local_runtime --json doctor
 python3 -m modules.local_runtime --json recover
 python3 -m modules.local_runtime --json stop
 ```
+
+The dashboard asset export matters for checkout validation. Without it, the runtime can still be healthy, but `doctor` will warn that the embedded dashboard cannot render packaged UI assets.
 
 A packaged build should expose the same contract as `harness ...`.
 

--- a/docs/release/documentation-readiness-checklist.md
+++ b/docs/release/documentation-readiness-checklist.md
@@ -22,4 +22,4 @@ Use this checklist before calling Harness local-app documentation release-ready.
 - [x] Run the gated live reset smoke with real GitHub and Linear dry-run targets. See [live-reset-smoke-2026-04-23.md](live-reset-smoke-2026-04-23.md).
 - [ ] Verify a Developer ID signed and notarized DMG, not only the ad-hoc internal package.
   Current local blocker: `security find-identity -v -p codesigning` reports `0 valid identities found`, so this machine cannot produce a Developer ID signed DMG yet. See [macos-notarization-readiness-2026-04-24.md](macos-notarization-readiness-2026-04-24.md).
-- [ ] Re-run every reader-facing command after the final app UI and installer flow land.
+- [x] Re-run every reader-facing command after the final app UI and installer flow land. See [reader-command-verification-2026-04-27.md](reader-command-verification-2026-04-27.md).

--- a/docs/release/reader-command-verification-2026-04-27.md
+++ b/docs/release/reader-command-verification-2026-04-27.md
@@ -1,0 +1,149 @@
+# Reader-Facing Command Verification
+
+Date: 2026-04-27
+
+## Purpose
+
+Re-run the commands shown in the reader-facing Harness docs after the macOS first-run UI, packaged dashboard, and installer flow landed.
+
+The live reset smoke command is not rerun in this pass because it creates real GitHub and Linear dry-run artifacts. That gate is tracked separately in `live-reset-smoke-2026-04-23.md`.
+
+## Environment Notes
+
+Some commands had to run outside the Codex sandbox because they bind loopback ports or because Turbopack starts worker processes that the sandbox blocks.
+
+Swift and package builds used the installed macOS 15 SDK:
+
+```bash
+SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
+CLANG_MODULE_CACHE_PATH=/tmp/harness-clang-module-cache
+```
+
+Reason: this host's selected CommandLineTools macOS 26 SDK is mismatched with the selected Swift compiler. That is a host toolchain issue, not a Harness runtime issue.
+
+The worktree still contains unrelated untracked duplicate `* 2` files. For Swift/package validation, the duplicate Swift source was temporarily moved out and restored so SwiftPM saw the tracked source set.
+
+## Passed Commands
+
+Backend and reset validation:
+
+```bash
+python3 -m unittest tests.test_fastapi_backend tests.test_reset_dryrun tests.test_autonomous_dryrun tests.test_unattended_dryruns -v
+python3 -m unittest discover -s tests
+python3 -m modules.reset_dryrun success
+python3 -m modules.reset_dryrun review
+```
+
+Results:
+
+- fast backend/reset/autonomous/unattended suite: `25` tests passed
+- full backend suite: `842` tests passed, `17` skipped
+- reset success: final verdict `verified_done`
+- reset review: final verdict `needs_review`
+
+Frontend validation:
+
+```bash
+pnpm lint
+pnpm build
+pnpm build:dashboard:local
+```
+
+Results:
+
+- lint passed
+- Next.js production build passed
+- local dashboard static asset build passed and wrote `dist/local-dashboard`
+
+Local runtime lifecycle, using isolated temp data/log paths and a non-default port:
+
+```bash
+export HARNESS_APP_DATA_DIR=/tmp/harness-reader-runtime-assets.9JIWFV/data
+export HARNESS_APP_LOG_DIR=/tmp/harness-reader-runtime-assets.9JIWFV/logs
+export HARNESS_DASHBOARD_ASSETS_DIR="$PWD/dist/local-dashboard"
+python3 -m modules.local_runtime --json init --port 18771
+python3 -m modules.local_runtime --json start --port 18771
+python3 -m modules.local_runtime --json status
+python3 -m modules.local_runtime --json doctor
+python3 -m modules.local_runtime --json recover
+python3 -m modules.local_runtime --json stop
+```
+
+Results:
+
+- runtime initialized local SQLite state
+- runtime started and reported `status: running`
+- health reported `status: ok`
+- doctor reported `fail: 0`
+- dashboard check passed when `HARNESS_DASHBOARD_ASSETS_DIR` pointed at `dist/local-dashboard`
+- recover restarted the runtime cleanly
+- stop shut the runtime down
+
+Health endpoint:
+
+```bash
+python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
+curl -sS http://127.0.0.1:8000/health
+```
+
+Result:
+
+```json
+{"status":"ok","store_backend":"sqlite","database_configured":true,"database_host":null,"database_schema_ready":true}
+```
+
+macOS package command:
+
+```bash
+HARNESS_PACKAGE_VERIFY_PORT=18773 ./script/package_macos_app.sh
+```
+
+Result:
+
+- built packaged dashboard assets
+- froze the bundled `harness` runtime
+- built the Swift app in release mode
+- staged `dist/macos-release/Harness.app`
+- ad-hoc signed and verified the app bundle
+- smoke-tested the bundled runtime
+- created `dist/macos-release/Harness.dmg`
+
+The first package attempt exposed a real packaging bug: `codesign` rejected the staged app because `com.apple.FinderInfo` was attached to `Harness.app`. The package script now strips signing-forbidden extended attributes before signing.
+
+## Guardrail Commands
+
+Official-release strict mode still fails correctly on this machine because no Developer ID Application identity is installed:
+
+```bash
+HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
+```
+
+Result:
+
+```text
+HARNESS_REQUIRE_NOTARIZATION=1 requires MACOS_CODESIGN_IDENTITY.
+```
+
+With a fake identity:
+
+```bash
+MACOS_CODESIGN_IDENTITY='Developer ID Application: Example' \
+MACOS_NOTARY_PROFILE=harness-notary \
+HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
+```
+
+Result:
+
+```text
+codesign identity not found in the active keychain: Developer ID Application: Example
+```
+
+## Remaining Blocker
+
+Reader-facing commands are current and verified, except for the separately gated live smoke that creates external artifacts. The only release-blocking item left is external macOS distribution proof: install a real Developer ID Application certificate, configure the notarytool profile, then run:
+
+```bash
+export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
+export MACOS_NOTARY_PROFILE="harness-notary"
+HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
+```

--- a/script/package_macos_app.sh
+++ b/script/package_macos_app.sh
@@ -79,6 +79,23 @@ validate_distribution_prerequisites() {
   fi
 }
 
+strip_forbidden_bundle_xattrs() {
+  xattr -cr "$APP_BUNDLE"
+  find "$APP_BUNDLE" -exec xattr -d com.apple.FinderInfo {} \; 2>/dev/null || true
+  find "$APP_BUNDLE" -exec xattr -d com.apple.ResourceFork {} \; 2>/dev/null || true
+  find "$APP_BUNDLE" -exec xattr -d 'com.apple.fileprovider.fpfs#P' {} \; 2>/dev/null || true
+}
+
+assert_no_forbidden_bundle_xattrs() {
+  local forbidden
+  forbidden="$(find "$APP_BUNDLE" -print0 | xargs -0 xattr 2>/dev/null | grep -E 'com\\.apple\\.(FinderInfo|ResourceFork)' || true)"
+  if [[ -n "$forbidden" ]]; then
+    echo "app bundle contains signing-forbidden extended attributes:" >&2
+    echo "$forbidden" >&2
+    exit 2
+  fi
+}
+
 require_tool python3
 require_tool pnpm
 require_tool swift
@@ -173,7 +190,8 @@ cat >"$INFO_PLIST" <<PLIST
 PLIST
 
 echo "Signing app bundle..."
-xattr -cr "$APP_BUNDLE"
+strip_forbidden_bundle_xattrs
+assert_no_forbidden_bundle_xattrs
 if [[ -n "$CODESIGN_IDENTITY" ]]; then
   codesign --force --deep --options runtime --sign "$CODESIGN_IDENTITY" "$APP_BUNDLE"
 else


### PR DESCRIPTION
## Summary
- add release proof for reader-facing command verification after the macOS app/docs work landed
- update the validation guide so checkout runtime doctor uses built dashboard assets
- harden macOS packaging by stripping signing-forbidden xattrs before codesign
- mark the reader-command release checklist item complete while keeping Developer ID notarization blocked

## Validation
- python3 -m unittest tests.test_fastapi_backend tests.test_reset_dryrun tests.test_autonomous_dryrun tests.test_unattended_dryruns -v
- python3 -m unittest discover -s tests
- python3 -m modules.reset_dryrun success
- python3 -m modules.reset_dryrun review
- pnpm lint
- pnpm build
- pnpm build:dashboard:local
- isolated local_runtime init/start/status/doctor/recover/stop with HARNESS_DASHBOARD_ASSETS_DIR
- temporary uvicorn + curl -sS http://127.0.0.1:8000/health
- HARNESS_PACKAGE_VERIFY_PORT=18773 ./script/package_macos_app.sh
- HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh fails fast without Developer ID identity
- bash -n script/package_macos_app.sh
- git diff --check

## Notes
- Live reset smoke was not rerun in this pass because it creates real GitHub/Linear artifacts and already has separate release proof.
- The host still lacks Developer ID signing identity: security find-identity -v -p codesigning returns 0 valid identities.
- Existing untracked duplicate " 2" files remain untouched and unstaged.