### PR TITLE
Add macOS release prerequisite preflight

### DIFF
--- a/docs/architecture/macos-packaging.md
+++ b/docs/architecture/macos-packaging.md
@@ -80,6 +80,16 @@ For external distribution, use:
 When a notary profile is present, the package script submits the generated DMG, waits for completion, and staples the result.
 When `HARNESS_REQUIRE_NOTARIZATION=1` is set, the script refuses to continue without both a configured Developer ID Application identity and a notary profile.
 
+Use this preflight before starting the full build:
+
+```bash
+export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
+export MACOS_NOTARY_PROFILE="harness-notary"
+./script/package_macos_app.sh --check-release-prereqs
+```
+
+The preflight checks local inputs only. It does not build the app, create a DMG, submit to Apple, or prove that the notary profile can authenticate with Apple's service.
+
 ## Installer Flow
 
 The v1 distribution artifact is a DMG containing `Harness.app`.

--- a/docs/howto/local-quickstart.md
+++ b/docs/howto/local-quickstart.md
@@ -30,6 +30,12 @@ HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
 
 `HARNESS_REQUIRE_NOTARIZATION=1` is the release guardrail. It fails before build work starts if the Developer ID identity or notary profile is missing, so an official release cannot accidentally ship from an ad-hoc internal package.
 
+Check the local release prerequisites before the full build:
+
+```bash
+./script/package_macos_app.sh --check-release-prereqs
+```
+
 After installing the app, first run should guide the user through:
 
 - local runtime initialization

--- a/docs/howto/troubleshoot.md
+++ b/docs/howto/troubleshoot.md
@@ -88,3 +88,9 @@ security find-identity -v -p codesigning
 ```
 
 Official distribution needs a valid `Developer ID Application` certificate installed in the active keychain. An ad-hoc package is acceptable for internal validation, but it is not an official release artifact.
+
+After installing the certificate and configuring the notary profile, run the local preflight before starting a full package build:
+
+```bash
+./script/package_macos_app.sh --check-release-prereqs
+```

--- a/docs/release/macos-notarization-readiness-2026-04-24.md
+++ b/docs/release/macos-notarization-readiness-2026-04-24.md
@@ -32,6 +32,14 @@ export MACOS_NOTARY_PROFILE="harness-notary"
 HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
 ```
 
+Before running the full package build, verify the local release prerequisites without building or uploading anything:
+
+```bash
+export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
+export MACOS_NOTARY_PROFILE="harness-notary"
+./script/package_macos_app.sh --check-release-prereqs
+```
+
 With `HARNESS_REQUIRE_NOTARIZATION=1`, the script fails before build work starts if either release prerequisite is missing:
 
 - `MACOS_CODESIGN_IDENTITY`
@@ -43,8 +51,9 @@ If `MACOS_CODESIGN_IDENTITY` is set but not visible in `security find-identity -
 
 1. Install the Apple Developer ID Application certificate into the active keychain.
 2. Configure a notarytool keychain profile, for example `harness-notary`.
-3. Run the strict package command above.
-4. Confirm the script submits the DMG, waits for notarization, staples the app and DMG, and leaves `dist/macos-release/Harness.dmg` ready for external distribution.
+3. Run `./script/package_macos_app.sh --check-release-prereqs`.
+4. Run the strict package command above.
+5. Confirm the script submits the DMG, waits for notarization, staples the app and DMG, and leaves `dist/macos-release/Harness.dmg` ready for external distribution.
 
 ## Boundary
 

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -299,6 +299,7 @@ For external distribution, also provide:
 ```bash
 export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
 export MACOS_NOTARY_PROFILE="harness-notary"
+./script/package_macos_app.sh --check-release-prereqs
 HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
 ```
 

--- a/script/package_macos_app.sh
+++ b/script/package_macos_app.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+MODE="${1:-package}"
 APP_NAME="HarnessApp"
 BUNDLE_ID="com.knoxanalytics.harness.local"
 MIN_SYSTEM_VERSION="14.0"
@@ -79,6 +80,15 @@ validate_distribution_prerequisites() {
   fi
 }
 
+check_release_prerequisites() {
+  REQUIRE_NOTARIZATION=1
+  validate_distribution_prerequisites
+  echo "macOS release prerequisites are configured."
+  echo "codesign identity: $CODESIGN_IDENTITY"
+  echo "notary profile: $NOTARY_PROFILE"
+  echo "Next: HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh"
+}
+
 strip_forbidden_bundle_xattrs() {
   xattr -cr "$APP_BUNDLE"
   find "$APP_BUNDLE" -exec xattr -d com.apple.FinderInfo {} \; 2>/dev/null || true
@@ -104,6 +114,19 @@ require_tool codesign
 require_tool xattr
 require_tool security
 require_tool xcrun
+
+case "$MODE" in
+  package)
+    ;;
+  --check-release-prereqs|check-release-prereqs)
+    check_release_prerequisites
+    exit 0
+    ;;
+  *)
+    echo "usage: $0 [package|--check-release-prereqs]" >&2
+    exit 2
+    ;;
+esac
 
 validate_distribution_prerequisites
 


### PR DESCRIPTION
## Summary
- add ./script/package_macos_app.sh --check-release-prereqs for local Developer ID/notary prerequisite checks
- document the preflight in packaging, setup, quickstart, troubleshooting, and notarization readiness docs
- keep the preflight local-only: it does not build, create a DMG, upload to Apple, or prove online notary authentication

## Validation
- bash -n script/package_macos_app.sh
- ./script/package_macos_app.sh --check-release-prereqs fails fast without MACOS_CODESIGN_IDENTITY
- MACOS_CODESIGN_IDENTITY='Developer ID Application: Example' MACOS_NOTARY_PROFILE=harness-notary ./script/package_macos_app.sh --check-release-prereqs fails fast with identity-not-found
- git diff --check

## Notes
- Dummy github_token cleanup was attempted and the normal app-managed provider reports github_token missing.
- Existing untracked duplicate " 2" files remain untouched and unstaged.