### PR TITLE
Document Symphony execution substrate boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ On the inspection side, Harness now also exposes a canonical supervision queue a
 
 On the execution side, Harness now also contains a real Codex Cloud adapter boundary in addition to the stub dispatch path. That adapter projects canonical dispatch input into a Codex Cloud request shape and enforces the repo/bootstrap preflight contract before it will emit a successful advisory completion signal. Live runtime transport is still a separate integration step, but the proof gate is now encoded at the adapter boundary instead of left to convention.
 
+OpenAI's Symphony project gives Harness a clearer lower-level execution-substrate target. Harness should not duplicate a runner whose only job is to poll structured work, create isolated workspaces, launch Codex, and retry stalled attempts. A Symphony-like runner belongs underneath Harness as an advisory scheduler. Harness remains above it as the final verification and trust boundary. The design pivot is documented in [`docs/architecture/symphony-execution-substrate.md`](docs/architecture/symphony-execution-substrate.md).
+
 The same boundary now applies to manual and Linear ingress. Those adapters may submit task intent, coordination metadata, and clarification blockers, but they cannot claim completion, assert acceptance, inject runtime facts, or attach repository execution artifacts such as PRs, commits, branches, or changed-file proofs on initial handoff.
 
 If you are introducing or swapping a desktop agent client such as Hermes, OpenClaw, or a future equivalent, target the canonical `POST /tasks` contract first. The `/ingress/manual`, `/ingress/linear`, and `/ingress/openclaw` routes are translator helpers for those specific payload families, not the universal ingress contract. The source-of-truth ingress shape, prohibited initial-submission fields, and a copyable planning-only example now live in [`docs/api/agent-api-usage.md`](docs/api/agent-api-usage.md) under `Ingress Client Contract`.
@@ -162,6 +164,7 @@ See:
 - [`docs/architecture/local-eval-harness.md`](docs/architecture/local-eval-harness.md)
 - [`docs/architecture/openclaw-executor-adapter.md`](docs/architecture/openclaw-executor-adapter.md)
 - [`docs/architecture/completion-interception-and-artifact-validation-boundary.md`](docs/architecture/completion-interception-and-artifact-validation-boundary.md)
+- [`docs/architecture/symphony-execution-substrate.md`](docs/architecture/symphony-execution-substrate.md)
 
 ## Current Architecture
 

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -16,6 +16,7 @@ Each module below has one owner. Ownership here means responsibility for the mod
 | Work registry sync | Linear integration layer | create and update Linear records, reconcile Harness state with Linear task state, enforce Linear as structured work record and work-coordination surface | decomposition policy, executor runtime control, verification authority |
 | Artifact evidence sync | GitHub integration layer | collect pull request, commit, and review evidence, reconcile artifact state with task state, expose evidence facts to Harness | lifecycle policy, planning decisions |
 | Assignment and routing | Harness core | choose executor type, assign work, reassign stalled tasks, enforce assignment rules | executor implementation details, user-facing clarification |
+| Execution substrate adapter | Executor integration layer | translate Harness dispatch policy into Symphony-like runner requests, ingest runner session events, normalize workspace/session/attempt facts | lifecycle authority, artifact verification, Linear truth, GitHub truth |
 | Execution gateway | Executor integration layer | send tasks to Codex or future workers, collect outputs, normalize execution events | planning, source-of-truth ownership, completion authority |
 | Verification and completion enforcement | Harness core | require artifact-backed completion where applicable, enforce blocked, in-review, failed, and completed semantics, reconcile evidence before terminal state changes | executor implementation details, ingress behavior |
 | Workflow runtime adapter | Workflow substrate layer | persist workflow checkpoints, resume interrupted runs, model orchestration progress through durable state | user-facing ingress, structured work definitions |
@@ -46,6 +47,7 @@ Each module below has one owner. Ownership here means responsibility for the mod
 - Existing tasks must use canonical reevaluation paths for persisted mutation; evaluation surfaces must not smuggle stored lifecycle, assignment, or artifact truth through convenience overlays.
 - Generic reevaluation may attach support artifacts and external facts, and it may reflect fact-only repository artifacts from external sync, but it must not combine repository execution artifacts with executor runtime telemetry for an existing task. New executor-side PR/commit/branch/changed-file proof plus runtime facts belongs to the completion-claim boundary, where Harness can bind it to an execution attempt and enforce execution-contract truth.
 - Executors may report status and outputs, but they do not decide final work state without Harness applying policy and verification rules.
+- Symphony-like runners may schedule isolated executor attempts, report handoffs, and retry within explicit budgets, but they do not decide final work state.
 
 ## Required Contracts
 
@@ -89,6 +91,26 @@ Required fields should eventually include:
 - timestamp
 - payload
 
+### Execution Substrate Event Contract
+
+Message from a Symphony-like runner back to Harness.
+
+Required fields should eventually include:
+
+- event identifier
+- task identifier
+- attempt identifier
+- runner kind
+- runner session identifier
+- executor kind
+- workspace identifier
+- event type
+- timestamp
+- payload
+- provenance
+
+Execution substrate events are advisory. They can trigger reevaluation, retry handling, or artifact synchronization, but they cannot authorize canonical completion.
+
 ### Verification Contract
 
 Evidence required before Harness accepts a task as complete.
@@ -109,3 +131,4 @@ Required fields should eventually include:
 - treating workflow checkpoint state as the product-facing source of truth
 - storing business workflow policy inside a vendor-specific orchestration graph
 - trusting executor completion claims without evidence or system-of-record reconciliation
+- treating a Symphony-like runner as Harness lifecycle truth

--- a/docs/architecture/runtime-execution-contract.md
+++ b/docs/architecture/runtime-execution-contract.md
@@ -8,6 +8,8 @@ Harness is a reliability/control-plane system. The runtime coordinates execution
 
 The runtime is not the planner, not the dispatcher, and not the verifier.
 
+A Symphony-like runner is one possible runtime or execution-substrate implementation. It may poll eligible work, create isolated workspaces, launch Codex sessions, detect stalls, and report handoffs. It still emits advisory execution facts only. Harness remains responsible for verification, reconciliation, manual review, and lifecycle acceptance.
+
 ## Runtime Role
 
 The runtime is responsible for coordinating task execution once a task has been assigned to a worker.
@@ -468,6 +470,8 @@ Retry policy is not invented by the runtime.
 
 The runtime applies the policy given by Harness core or higher-level orchestration rules.
 
+When the runtime is backed by a Symphony-like daemon, retry state must still obey Harness budgets. A daemon loop may keep work moving only while a task, project, repository, and executor all remain within explicit retry, wall-clock, idle-time, and spend limits. Budget exhaustion must stop automatic continuation rather than letting the runner relaunch work forever.
+
 ## Budget Governance
 
 The runtime may observe budget consumption, but it does not invent budget policy.
@@ -592,3 +596,4 @@ The goal is that a reviewer can answer:
 - [Trace Continuity Model](trace-continuity.md)
 - [Execution Budget Model](execution-budget-model.md)
 - [Artifact And Completion Evidence](artifact-and-completion-evidence.md)
+- [Symphony Execution Substrate](symphony-execution-substrate.md)

--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -1,0 +1,482 @@
+# Symphony Execution Substrate
+
+## Purpose
+
+Define how Harness should respond to OpenAI's Symphony project without weakening Harness's source-of-truth boundary.
+
+Symphony validates the need for a daemonized execution substrate that keeps Codex working on structured tasks. It does not replace Harness. Harness remains the control plane, verification layer, and lifecycle authority. A Symphony-like service may run work, retry work, preserve per-issue workspaces, and report execution facts. It must not decide whether work is complete.
+
+References:
+
+- [OpenAI Symphony repository](https://github.com/openai/symphony)
+- [Symphony service specification](https://github.com/openai/symphony/blob/main/SPEC.md)
+- [Symphony Elixir reference implementation](https://github.com/openai/symphony/blob/main/elixir/README.md)
+- [OpenAI Symphony announcement](https://openai.com/index/open-source-codex-orchestration-symphony/)
+- [OpenAI Harness engineering post](https://openai.com/index/harness-engineering/)
+
+## Decision
+
+Harness should wrap a Symphony-like runner as an execution substrate.
+
+Harness should not build a duplicate low-level daemon whose only purpose is to poll Linear, create workspaces, launch Codex, and keep attempts moving. Symphony's public spec is now the right shape for that lower layer.
+
+Harness should also not collapse into Symphony. Symphony is a runner and tracker reader. Harness is the source of verified lifecycle truth.
+
+The intended stack is:
+
+```text
+Ambiguous product or software idea
+        |
+Clarification and PRD/spec generation
+        |
+Harness planning and decomposition
+        |
+Linear project, issue, and dependency graph
+        |
+Harness dispatch policy and execution budgets
+        |
+Symphony-like execution substrate
+        |
+Codex / Codex Cloud / future workers
+        |
+GitHub commits, pull requests, CI, reviews, artifacts
+        |
+Harness verification, reconciliation, manual review, completion authority
+```
+
+This preserves the current source-of-truth model:
+
+- Linear is the source of truth for intended and structured work.
+- GitHub is the source of truth for executed code artifacts.
+- Executors are replaceable workers.
+- A Symphony-like runner is an execution scheduler.
+- Harness is the source of truth for verified lifecycle state.
+
+## What Symphony Validates
+
+Symphony validates the parts of the Harness thesis that were most likely to become operational bottlenecks:
+
+- Work should be represented in a structured work surface before agents execute it.
+- Long-running agent execution should be daemonized instead of driven by manual terminal supervision.
+- Each unit of work should get an isolated workspace.
+- Execution policy should be repo-owned and versioned, similar to `WORKFLOW.md`.
+- Multiple agent runs require bounded concurrency, retry state, and operator-visible runtime status.
+- Execution summaries are not enough; systems need artifacts, logs, and handoff states.
+
+The important strategic implication is that Harness should spend less effort on bespoke executor scheduling and more effort on the things Symphony intentionally does not own: clarification, decomposition, verification, reconciliation, lifecycle policy, manual review, and project-level completion.
+
+## What Harness Should Borrow
+
+Harness should adopt these Symphony concepts either directly or through compatible abstractions:
+
+- Repo-owned execution workflow contract, initially `WORKFLOW.md` or a Harness-specific profile that can generate one.
+- Per-issue or per-task deterministic workspace roots.
+- Bounded concurrency by repository, project, executor class, and risk level.
+- Poll/reconcile loop for eligible Linear issues.
+- Stop active runs when Linear state, dependency state, or Harness policy makes the issue ineligible.
+- Retry queue with attempt count, retry reason, due time, and exponential backoff.
+- Stall and timeout detection based on heartbeats and progress facts.
+- Runtime snapshot with running sessions, retrying sessions, rate-limit state, token usage, and seconds running.
+- App Server style integration for Codex where available, instead of terminal scraping.
+- Dynamic tool exposure for privileged integrations so worker sessions do not receive raw broad-scope tokens.
+- Workflow prompt construction that receives issue context, attempt context, and prior handoff context.
+
+These are execution-substrate concerns. They should feed Harness with advisory events and artifact references, not canonical lifecycle decisions.
+
+## What Harness Must Not Copy
+
+Harness must not copy the parts of a high-trust Symphony deployment that assume the runner and agents can mutate truth safely.
+
+Do not copy:
+
+- Agent-authored Linear state as completion truth.
+- Agent-authored acceptance criteria changes after PRD/spec approval without Harness or human review.
+- Automatic move to `Done` as a runner success state.
+- Auto-merge as a default behavior.
+- Unbounded retry loops.
+- In-memory runner state as durable Harness truth.
+- Broad raw Linear or GitHub mutation tools inside worker sessions without Harness-owned audit and policy boundaries.
+- Runner success summaries as completion evidence.
+- Silent recovery from external mismatches.
+
+The safe rule is simple: the runner may reach a handoff state; Harness decides whether the handoff is acceptable.
+
+## Boundary Model
+
+### Symphony-Like Runner Owns
+
+- Polling for eligible work when delegated by Harness policy.
+- Creating or reusing isolated workspaces.
+- Launching Codex or another selected executor.
+- Passing workflow prompts and attempt context.
+- Observing heartbeats, stalls, timeouts, and worker exits.
+- Scheduling execution-level retries within Harness-provided budgets.
+- Emitting normalized execution events and artifact references.
+- Cleaning up or preserving workspaces according to configured policy.
+
+### Harness Owns
+
+- Clarification interviews and missing-information handling.
+- PRD or PRD-like spec approval state.
+- Decomposition into epics, issues, dependencies, checkpoints, and validation tasks.
+- Dispatch policy and execution budgets.
+- Canonical `TaskEnvelope` meaning.
+- Lifecycle transitions.
+- Verification policy.
+- GitHub artifact readback and validation.
+- Linear reconciliation.
+- Sticky manual review gates.
+- Project-level completion rollups.
+- Operator-facing truth.
+
+### Linear Owns
+
+- Visible work coordination.
+- Projects, issues, dependencies, labels, assignees, priorities, and workflow status.
+- Human and agent collaboration around intended work.
+
+Linear does not decide whether artifact-backed completion should be trusted.
+
+### GitHub Owns
+
+- Branches, commits, pull requests, changed files, CI status, reviews, and merge state.
+
+GitHub stores artifact facts. It does not decide Harness lifecycle state.
+
+## Runner Event Contract
+
+The runner integration should emit advisory events into Harness. These events should be append-only and attempt-scoped.
+
+Initial event family:
+
+- `dispatch_requested`
+- `dispatch_started`
+- `workspace_prepared`
+- `runner_session_started`
+- `run_heartbeat`
+- `progress_reported`
+- `artifact_reported`
+- `handoff_reported`
+- `run_stalled`
+- `run_timed_out`
+- `run_failed`
+- `retry_scheduled`
+- `retry_started`
+- `run_cancelled`
+- `run_completed_by_executor`
+
+These names are intentionally execution-facing. None of them mean Harness has accepted completion.
+
+Required event fields:
+
+- `event_id`
+- `task_id`
+- `attempt_id`
+- `runner_kind`
+- `runner_session_id`
+- `executor_kind`
+- `workspace_id`
+- `timestamp`
+- `event_type`
+- `payload`
+- `provenance`
+
+Required artifact reference fields when the runner reports artifacts:
+
+- `artifact_type`
+- `repository`
+- `branch`
+- `commit_sha`
+- `pr_url`
+- `source_attempt_id`
+- `reported_by`
+- `reported_at`
+- `verification_status`
+
+Runner-reported artifact references start as unverified unless they come from a separate trusted sync path, such as Harness-controlled GitHub API readback.
+
+## TaskEnvelope Impact
+
+Harness should add a canonical execution-substrate surface to `TaskEnvelope`, or formalize the same shape under existing observability fields before schema expansion.
+
+Proposed `execution` section:
+
+```json
+{
+  "execution": {
+    "substrate": {
+      "kind": "symphony",
+      "implementation": "symphony-compatible",
+      "version": null
+    },
+    "dispatch_policy_id": "policy.default.code-change",
+    "workspace_id": "repo/KNO-123",
+    "runner_session_id": "session_...",
+    "current_attempt_id": "attempt_...",
+    "attempt_count": 1,
+    "handoff_state": "human_review",
+    "runner_claims": [],
+    "budgets": {
+      "max_attempts": 3,
+      "max_wall_clock_seconds": 7200,
+      "max_idle_seconds": 900,
+      "max_token_budget": null
+    }
+  }
+}
+```
+
+Rules:
+
+- `execution` stores dispatch and runtime facts, not completion truth.
+- `runner_claims` are advisory and must not authorize lifecycle transitions.
+- Attempt history should remain append-only, either inside execution records or linked audit records.
+- `assigned_executor` remains the current active assignment, not an execution ledger.
+- GitHub artifact truth still belongs under canonical artifact/evidence surfaces after validation.
+
+Do not add this schema field casually before Phase 1 proves the minimum data needed. The first implementation may project these fields into `observability.execution_metadata` while the docs settle.
+
+## Linear Integration Impact
+
+Harness should treat Symphony's Linear usage as scheduling input, not lifecycle authority.
+
+Recommended Linear model:
+
+- Harness-created or Harness-approved issues are executable.
+- Agent-created follow-up issues enter `proposed` or `needs_triage` until accepted.
+- Runner may move issues to a handoff state such as `Human Review`.
+- Runner may add PR links and progress comments.
+- Runner may not mark work as Harness-verified complete.
+- Runner may not rewrite accepted acceptance criteria without review.
+- Harness writes back verification status separately, either as labels, comments, custom fields, or a dedicated status convention.
+
+Linear dependencies should gate runner dispatch. A runner should not start a dependent issue simply because it appears active if Harness or Linear blockers are unresolved.
+
+## Retry Model Impact
+
+Harness should split retry causes instead of treating all continuation as the same loop.
+
+Retry classes:
+
+- `runner_retry`: process crash, transient transport failure, stalled Codex session, timeout.
+- `repair_retry`: missing PR, missing commit, stale branch readback, CI status unavailable.
+- `spec_retry`: unclear task, missing acceptance criteria, contradictory scope.
+- `verification_retry`: GitHub, Linear, CI, or review facts unavailable.
+- `policy_retry`: allowed redispatch after manual review or Harness recovery.
+
+Each class needs separate budgets:
+
+- max attempts
+- max wall-clock duration
+- max idle duration
+- max token or spend budget when available
+- max artifact churn
+- escalation target after exhaustion
+
+Budget exhaustion must stop automatic continuation. It may move the task to `blocked`, `failed`, or `in_review` depending on class and evidence. It must not silently keep the daemon alive.
+
+## Dashboard Impact
+
+The dashboard should expose execution state without blurring it into verification state.
+
+Add an execution-substrate section or view that shows:
+
+- active runner sessions
+- retry queue
+- stalled sessions
+- attempt counts
+- workspace identifiers
+- runner handoff state
+- current Linear state
+- reported artifacts
+- GitHub verification state
+- Harness lifecycle state
+- blocking mismatch reasons
+- budget consumption
+
+The UI copy and read-model contract should preserve this distinction:
+
+- `Executor says done` means advisory handoff.
+- `Artifacts verified` means GitHub/CI/review facts satisfy the relevant evidence contract.
+- `Harness complete` means lifecycle acceptance passed verification and reconciliation.
+
+No dashboard surface should display a runner handoff as final project completion.
+
+## Verification Model Impact
+
+Runner handoff should trigger reevaluation. It should not complete work.
+
+For code-bearing work, Harness must independently fetch and validate:
+
+- repository
+- branch
+- commit SHA
+- pull request URL
+- pull request head SHA
+- changed files
+- CI checks
+- review state
+- merge state
+- required evidence policy
+
+Completion can be accepted only when:
+
+- acceptance criteria are satisfied or explicitly waived through review
+- required artifacts are present and coherent
+- required checks pass
+- manual review gates are resolved
+- Linear state and Harness state do not have a blocking mismatch
+- dependency and project rollup gates are satisfied
+
+Project-level `done` is stricter than task-level completion. A project may report done only when all required child tasks, validation tasks, dependencies, and review gates are complete.
+
+## Safety Rules
+
+These rules apply before any live Symphony-style runner is enabled against real work.
+
+1. No live work execution in Phase 0.
+2. No automatic merge in Phase 1 or Phase 2.
+3. No agent-written Linear completion truth.
+4. No unbounded retries.
+5. No runner state as Harness canonical state.
+6. No broad raw mutation tokens inside worker sessions unless mediated, scoped, and audited.
+7. No silent mock or fallback data in dashboard execution state.
+8. No acceptance criteria rewrites after approval without explicit review.
+9. No worker-created issues entering the executable DAG without Harness or human acceptance.
+10. No executor summary accepted without independent artifact verification.
+
+## Phase 0: Documentation And Design Only
+
+Goal: align architecture before implementation.
+
+Allowed work:
+
+- Add this document.
+- Cross-link existing architecture docs.
+- Define the runner event contract.
+- Define TaskEnvelope impact as a proposal.
+- Define no-live-work safety constraints.
+- Identify duplicated scheduler/runner code for later removal or wrapping.
+
+Not allowed:
+
+- Installing Symphony.
+- Running Symphony against live work.
+- Creating Linear issues.
+- Creating GitHub PRs from a runner.
+- Adding auto-merge.
+- Giving worker sessions broad Linear or GitHub mutation authority.
+
+Exit criteria:
+
+- The architecture boundary is documented.
+- The next disposable-repo trial is specified.
+- Future implementation agents can tell which code belongs in Harness and which belongs in the runner layer.
+
+## Phase 1: Local Dry Run / Disposable Repo Trial
+
+Goal: prove the runner/Harness boundary without operational risk.
+
+Scope:
+
+- Use a disposable repository.
+- Use fake Linear data or a non-production test project.
+- Run a Symphony-like loop locally or simulate its event stream.
+- Capture runner events into Harness as advisory execution facts.
+- Exercise workspace creation, session start, heartbeat, handoff, stall, timeout, and retry events.
+- Verify that Harness refuses to convert runner success into completion without GitHub artifact readback.
+
+Required proof:
+
+- A runner handoff triggers Harness reevaluation.
+- Missing artifacts block completion.
+- Valid GitHub readback can satisfy evidence policy.
+- Retry budget exhaustion stops automatic continuation.
+- Dashboard separates execution status from verification status.
+
+Still not allowed:
+
+- Live production work.
+- Auto-merge.
+- Agent-authored completion truth.
+
+## Phase 2: Limited Linear/GitHub Integration
+
+Goal: connect the execution substrate to real systems with tight limits.
+
+Scope:
+
+- One selected repository.
+- One selected Linear project or label.
+- Harness-approved executable issues only.
+- Runner may move issues to a handoff state, not `Done`.
+- Runner may attach PR links and progress comments.
+- Harness independently reads GitHub artifacts.
+- Harness writes verified status back to Linear.
+- Manual approval required before merge.
+
+Required controls:
+
+- Per-task attempt budget.
+- Per-project concurrency cap.
+- Kill switch for the runner.
+- Pause switch for project and issue.
+- Read-only dashboard visibility.
+- Audit log for every external mutation.
+
+Exit criteria:
+
+- Real Linear issue can be executed into a PR handoff.
+- Harness blocks completion when proof is missing or contradictory.
+- Harness accepts completion only after evidence and reconciliation pass.
+- No runner path can mark Harness task `completed` directly.
+
+## Phase 3: Productionized Harness Execution Substrate
+
+Goal: make Symphony-like execution a replaceable substrate under Harness.
+
+Scope:
+
+- Hardened runner adapter.
+- Persisted dispatch, attempt, retry, and event state in Harness.
+- Project-level DAG orchestration from approved specs into Linear.
+- Repair dispatch when verification fails.
+- Operator controls for pause, resume, cancel, redispatch, and quarantine.
+- Policy profiles for low-risk, normal, and high-risk work.
+
+Possible future auto-merge:
+
+Auto-merge should remain off by default. It may become a policy-gated capability only for explicitly low-risk work after Harness proves:
+
+- required CI checks pass
+- review requirements pass or are waived by policy
+- PR branch and commit match the current execution attempt
+- no blocking Linear/GitHub/Harness mismatch exists
+- rollback or repair path is defined
+- audit trail records the reason merge was allowed
+
+## Duplicative Harness Areas To Revisit
+
+After Phase 0 is merged, review these areas for code that should wrap a Symphony-like substrate instead of duplicating one:
+
+- low-level execution loop mechanics
+- executor retry scheduling
+- workspace lifecycle assumptions
+- Codex-specific dispatch glue
+- stale supervision loops that only keep workers busy
+- dashboard runtime status that lacks runner/session semantics
+
+Do not remove verification, reconciliation, completion-claim interception, manual review, TaskEnvelope validation, or GitHub artifact validation. Those are Harness core.
+
+## Recommended Next Implementation PR
+
+After this design PR merges, the next PR should be a dry-run runner-event ingestion slice:
+
+- Add a small `ExecutionSubstrateEvent` contract.
+- Add tests proving runner completion events are advisory only.
+- Add a local fixture that simulates Symphony events for one disposable task.
+- Project those events into the existing read-model without changing lifecycle truth.
+- Do not run Symphony against live work.
+- Do not mutate Linear or GitHub.
+
+That PR moves Harness toward a Symphony-compatible architecture without creating operational risk.

--- a/docs/architecture/system-context.md
+++ b/docs/architecture/system-context.md
@@ -13,12 +13,14 @@ Harness sits underneath the user-facing and agent-facing work surface as the sys
 - Harness is the control plane and reliability layer beneath that work surface.
 - GitHub is the source of truth for code artifacts such as pull requests and commits.
 - Executors such as Codex are workers.
+- A Symphony-like execution substrate may schedule isolated executor runs, but it is not completion truth.
 - The workflow substrate provides persistence, resumability, and coordination state for Harness itself.
 
 Stated another way:
 
 - Linear is the source of truth for intended work.
 - GitHub is the source of truth for executed artifacts.
+- Symphony-like runners are execution schedulers.
 - Harness is the source of truth for verified state and lifecycle correctness.
 
 ## Context Diagram
@@ -33,6 +35,8 @@ flowchart LR
     L --> H["Harness\nControl plane and reliability layer"]
     H --> G["GitHub\nArtifact evidence source of truth"]
     H --> S["Workflow substrate\nPersistence and resumability"]
+    H --> R["Execution substrate\nSymphony-like runner"]
+    R --> E
     H --> E["Executors\nCodex and future workers"]
     E --> H
     H --> L
@@ -79,6 +83,15 @@ flowchart LR
 - stores execution checkpoints and internal coordination state
 - does not replace Linear as the source of truth for work items
 
+### Execution Substrate
+
+- polls or receives eligible work under Harness policy
+- creates isolated workspaces for attempts
+- launches Codex or future executor sessions
+- tracks runner sessions, stalls, retries, and handoffs
+- emits advisory execution events and artifact references
+- does not verify completion or own lifecycle state
+
 ### Executors
 
 - perform assigned work
@@ -93,6 +106,7 @@ flowchart LR
 - Linear owns work coordination and structured work records, not completion enforcement semantics.
 - GitHub owns artifact evidence records, not lifecycle policy.
 - Executors do not own planning, routing, or lifecycle policy.
+- A Symphony-like execution substrate does not own completion truth.
 - The workflow substrate owns resumability, not product-level work semantics.
 - completion is not accepted as true unless Harness can reconcile it with artifacts and system-of-record state
 
@@ -101,5 +115,12 @@ flowchart LR
 - ingress, control-plane enforcement, systems of record, and execution remain separable
 - Linear-facing coordination can evolve without changing Harness verification and enforcement logic
 - executor implementations can change without changing Harness core planning logic
+- runner implementations can change if they emit the same advisory execution-substrate events
 - workflow technology can change if Harness state transitions are modeled explicitly
 - model-native reasoning improvements do not displace Harness as long as correctness, evidence, and auditability remain Harness-owned concerns
+
+## Related Documents
+
+- [symphony-execution-substrate.md](symphony-execution-substrate.md)
+- [runtime-execution-contract.md](runtime-execution-contract.md)
+- [verification-and-completion-enforcement.md](verification-and-completion-enforcement.md)

--- a/docs/architecture/task-envelope.md
+++ b/docs/architecture/task-envelope.md
@@ -440,6 +440,10 @@ Runtime observations:
 - `observability.retries`
 - `observability.execution_metadata`
 
+A future schema revision may promote Symphony-compatible runner data into a dedicated `execution` object. Until that field is proven by a dry-run implementation, runner session identifiers, workspace identifiers, attempt counters, handoff state, and execution-substrate correlation IDs should remain neutral runtime observations under `observability.execution_metadata` or linked attempt records.
+
+Runner data must not be stored in artifact evidence fields until Harness has independently validated the referenced artifacts. A runner-reported PR URL or commit SHA is an advisory artifact reference; GitHub readback and verification decide whether it becomes trusted completion evidence.
+
 This distinction matters because Linear and Harness business logic should reason over business state, while substrates and executors contribute runtime observations.
 
 ## Module Expectations
@@ -480,3 +484,8 @@ This distinction matters because Linear and Harness business logic should reason
 ## Schema Reference
 
 The machine-readable schema lives in [task_envelope.schema.json](../../schemas/task_envelope.schema.json).
+
+Related architecture:
+
+- [symphony-execution-substrate.md](symphony-execution-substrate.md)
+- [runtime-execution-contract.md](runtime-execution-contract.md)


### PR DESCRIPTION
## Summary
- add a Symphony execution-substrate architecture doc
- define the Harness/Symphony/Linear/GitHub truth boundary
- document runner events, TaskEnvelope impact, retry/dashboard/verification implications, safety rules, and phased rollout
- cross-link the new boundary from README and existing architecture docs

## Validation
- git diff --check
- verified local architecture links referenced by the new docs exist

## Notes
- design/docs only
- does not install or run Symphony
- does not create Linear issues or mutate GitHub work artifacts