### PR TITLE
Add execution substrate event contract

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -147,6 +147,8 @@ GitHub stores artifact facts. It does not decide Harness lifecycle state.
 
 The runner integration should emit advisory events into Harness. These events should be append-only and attempt-scoped.
 
+The first in-code contract lives in [`modules/contracts/execution_substrate.py`](../../modules/contracts/execution_substrate.py). It intentionally models runner events as advisory input, not as lifecycle authority.
+
 Initial event family:
 
 - `dispatch_requested`

--- a/modules/contracts/__init__.py
+++ b/modules/contracts/__init__.py
@@ -47,6 +47,16 @@ from .execution_advisory import (
     validate_execution_event,
     validate_execution_provenance,
 )
+from .execution_substrate import (
+    ExecutionSubstrateArtifactReference,
+    ExecutionSubstrateEvent,
+    ExecutionSubstrateEventType,
+    ExecutionSubstrateProvenance,
+    ExecutionSubstrateValidationError,
+    validate_execution_substrate_artifact_reference,
+    validate_execution_substrate_event,
+    validate_execution_substrate_provenance,
+)
 from .task_envelope_enforcement import (
     EnforcementAction,
     EnforcementInput,
@@ -131,6 +141,11 @@ __all__ = [
     "ExecutionEvent",
     "ExecutionEventType",
     "ExecutionProvenance",
+    "ExecutionSubstrateArtifactReference",
+    "ExecutionSubstrateEvent",
+    "ExecutionSubstrateEventType",
+    "ExecutionSubstrateProvenance",
+    "ExecutionSubstrateValidationError",
     "ExternalFactValidationError",
     "ForbiddenTransitionError",
     "GitHubArtifactFacts",
@@ -186,6 +201,9 @@ __all__ = [
     "validate_artifact_reference",
     "validate_execution_event",
     "validate_execution_provenance",
+    "validate_execution_substrate_artifact_reference",
+    "validate_execution_substrate_event",
+    "validate_execution_substrate_provenance",
     "validate_branch_fact",
     "validate_changed_files_summary",
     "validate_commit_fact",

--- a/modules/contracts/execution_substrate.py
+++ b/modules/contracts/execution_substrate.py
@@ -1,0 +1,188 @@
+"""Canonical execution-substrate event models.
+
+These models describe events from a Symphony-like runner. They are distinct
+from executor events because the runner owns workspace/session orchestration,
+not task completion truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class ExecutionSubstrateValidationError(ValueError):
+    """Raised when execution-substrate events are malformed."""
+
+
+class ExecutionSubstrateEventType(StrEnum):
+    """Canonical event family emitted by Symphony-like runner substrates."""
+
+    DISPATCH_REQUESTED = "dispatch_requested"
+    DISPATCH_STARTED = "dispatch_started"
+    WORKSPACE_PREPARED = "workspace_prepared"
+    RUNNER_SESSION_STARTED = "runner_session_started"
+    RUN_HEARTBEAT = "run_heartbeat"
+    PROGRESS_REPORTED = "progress_reported"
+    ARTIFACT_REPORTED = "artifact_reported"
+    HANDOFF_REPORTED = "handoff_reported"
+    RUN_STALLED = "run_stalled"
+    RUN_TIMED_OUT = "run_timed_out"
+    RUN_FAILED = "run_failed"
+    RETRY_SCHEDULED = "retry_scheduled"
+    RETRY_STARTED = "retry_started"
+    RUN_CANCELLED = "run_cancelled"
+    RUN_COMPLETED_BY_EXECUTOR = "run_completed_by_executor"
+
+
+_PROHIBITED_LIFECYCLE_KEYS: frozenset[str] = frozenset(
+    {
+        "accepted_completion",
+        "authorized_transition",
+        "canonical_status",
+        "completion_authorized",
+        "harness_status",
+        "lifecycle_status",
+        "target_status",
+        "verified_complete",
+    }
+)
+
+
+def _require_non_empty(value: str | None, *, field_name: str) -> None:
+    if value is None or not value.strip():
+        raise ExecutionSubstrateValidationError(f"{field_name} is required")
+
+
+def _validate_no_lifecycle_authority(payload: dict[str, Any], *, field_name: str) -> None:
+    forbidden = sorted(set(payload).intersection(_PROHIBITED_LIFECYCLE_KEYS))
+    if forbidden:
+        names = ", ".join(forbidden)
+        raise ExecutionSubstrateValidationError(
+            f"{field_name} contains prohibited lifecycle authority fields: {names}"
+        )
+
+
+@dataclass(frozen=True)
+class ExecutionSubstrateProvenance:
+    """Source attribution for a runner event."""
+
+    source_system: str
+    source_type: str
+    source_id: str
+    captured_by: str | None = None
+
+
+@dataclass(frozen=True)
+class ExecutionSubstrateArtifactReference:
+    """Artifact reference reported by a runner before Harness verification."""
+
+    artifact_type: str
+    reported_by: str
+    reported_at: str
+    source_attempt_id: str
+    verification_status: str = "unverified"
+    repository: str | None = None
+    branch: str | None = None
+    commit_sha: str | None = None
+    pr_url: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecutionSubstrateEvent:
+    """Append-only advisory event from a Symphony-like runner."""
+
+    event_id: str
+    task_id: str
+    attempt_id: str
+    runner_kind: str
+    runner_session_id: str
+    executor_kind: str
+    workspace_id: str
+    event_type: ExecutionSubstrateEventType
+    occurred_at: str
+    provenance: ExecutionSubstrateProvenance
+    payload: dict[str, Any] = field(default_factory=dict)
+    artifact_references: tuple[ExecutionSubstrateArtifactReference, ...] = ()
+
+
+def validate_execution_substrate_provenance(
+    provenance: ExecutionSubstrateProvenance,
+) -> ExecutionSubstrateProvenance:
+    """Validate runner event provenance."""
+
+    _require_non_empty(provenance.source_system, field_name="provenance.source_system")
+    _require_non_empty(provenance.source_type, field_name="provenance.source_type")
+    _require_non_empty(provenance.source_id, field_name="provenance.source_id")
+    return provenance
+
+
+def validate_execution_substrate_artifact_reference(
+    artifact_reference: ExecutionSubstrateArtifactReference,
+) -> ExecutionSubstrateArtifactReference:
+    """Validate an unverified runner-reported artifact reference."""
+
+    _require_non_empty(artifact_reference.artifact_type, field_name="artifact_reference.artifact_type")
+    _require_non_empty(artifact_reference.reported_by, field_name="artifact_reference.reported_by")
+    _require_non_empty(artifact_reference.reported_at, field_name="artifact_reference.reported_at")
+    _require_non_empty(
+        artifact_reference.source_attempt_id,
+        field_name="artifact_reference.source_attempt_id",
+    )
+    _require_non_empty(
+        artifact_reference.verification_status,
+        field_name="artifact_reference.verification_status",
+    )
+    if artifact_reference.verification_status == "verified":
+        raise ExecutionSubstrateValidationError(
+            "runner-reported artifacts must not start with verification_status=verified"
+        )
+    if not any(
+        (
+            artifact_reference.repository,
+            artifact_reference.branch,
+            artifact_reference.commit_sha,
+            artifact_reference.pr_url,
+        )
+    ):
+        raise ExecutionSubstrateValidationError(
+            "artifact_reference must include at least one locator: repository, branch, commit_sha, or pr_url"
+        )
+    _validate_no_lifecycle_authority(
+        artifact_reference.metadata,
+        field_name="artifact_reference.metadata",
+    )
+    return artifact_reference
+
+
+def validate_execution_substrate_event(event: ExecutionSubstrateEvent) -> ExecutionSubstrateEvent:
+    """Validate a Symphony-like runner event as advisory-only execution input."""
+
+    _require_non_empty(event.event_id, field_name="event.event_id")
+    _require_non_empty(event.task_id, field_name="event.task_id")
+    _require_non_empty(event.attempt_id, field_name="event.attempt_id")
+    _require_non_empty(event.runner_kind, field_name="event.runner_kind")
+    _require_non_empty(event.runner_session_id, field_name="event.runner_session_id")
+    _require_non_empty(event.executor_kind, field_name="event.executor_kind")
+    _require_non_empty(event.workspace_id, field_name="event.workspace_id")
+    _require_non_empty(event.occurred_at, field_name="event.occurred_at")
+    validate_execution_substrate_provenance(event.provenance)
+    _validate_no_lifecycle_authority(event.payload, field_name="event.payload")
+
+    for artifact_reference in event.artifact_references:
+        validate_execution_substrate_artifact_reference(artifact_reference)
+    return event
+
+
+__all__ = [
+    "ExecutionSubstrateArtifactReference",
+    "ExecutionSubstrateEvent",
+    "ExecutionSubstrateEventType",
+    "ExecutionSubstrateProvenance",
+    "ExecutionSubstrateValidationError",
+    "validate_execution_substrate_artifact_reference",
+    "validate_execution_substrate_event",
+    "validate_execution_substrate_provenance",
+]

--- a/tests/contracts/test_execution_substrate.py
+++ b/tests/contracts/test_execution_substrate.py
@@ -1,0 +1,115 @@
+"""Tests for Symphony-compatible execution-substrate events."""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+
+from modules.contracts.execution_substrate import (
+    ExecutionSubstrateArtifactReference,
+    ExecutionSubstrateEvent,
+    ExecutionSubstrateEventType,
+    ExecutionSubstrateProvenance,
+    ExecutionSubstrateValidationError,
+    validate_execution_substrate_artifact_reference,
+    validate_execution_substrate_event,
+)
+
+
+class ExecutionSubstrateEventTests(unittest.TestCase):
+    def _provenance(self) -> ExecutionSubstrateProvenance:
+        return ExecutionSubstrateProvenance(
+            source_system="symphony",
+            source_type="runner_event",
+            source_id="runner-session-1:event-1",
+            captured_by="execution_substrate_adapter",
+        )
+
+    def _event(self, event_type: ExecutionSubstrateEventType) -> ExecutionSubstrateEvent:
+        return ExecutionSubstrateEvent(
+            event_id="event-1",
+            task_id="task-1",
+            attempt_id="attempt-1",
+            runner_kind="symphony",
+            runner_session_id="runner-session-1",
+            executor_kind="codex_app_server",
+            workspace_id="workspace/task-1",
+            event_type=event_type,
+            occurred_at="2026-04-27T20:00:00Z",
+            provenance=self._provenance(),
+        )
+
+    def test_validate_event_accepts_runner_handoff(self) -> None:
+        event = self._event(ExecutionSubstrateEventType.HANDOFF_REPORTED)
+
+        validated = validate_execution_substrate_event(event)
+
+        self.assertEqual(validated.event_type, ExecutionSubstrateEventType.HANDOFF_REPORTED)
+        self.assertEqual(validated.runner_kind, "symphony")
+
+    def test_executor_completed_event_remains_advisory_only(self) -> None:
+        event = replace(
+            self._event(ExecutionSubstrateEventType.RUN_COMPLETED_BY_EXECUTOR),
+            payload={
+                "reported_complete": True,
+                "handoff_state": "human_review",
+                "summary": "Executor reports the work is ready for Harness verification.",
+            },
+        )
+
+        validated = validate_execution_substrate_event(event)
+
+        self.assertTrue(validated.payload["reported_complete"])
+        self.assertNotIn("target_status", validated.payload)
+        self.assertNotIn("verified_complete", validated.payload)
+
+    def test_event_rejects_lifecycle_authority_payload(self) -> None:
+        event = replace(
+            self._event(ExecutionSubstrateEventType.RUN_COMPLETED_BY_EXECUTOR),
+            payload={
+                "reported_complete": True,
+                "target_status": "completed",
+            },
+        )
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "prohibited lifecycle authority",
+        ):
+            validate_execution_substrate_event(event)
+
+    def test_runner_reported_artifacts_start_unverified(self) -> None:
+        artifact = ExecutionSubstrateArtifactReference(
+            artifact_type="pull_request",
+            repository="sfayka/Harness",
+            branch="codex/task-1",
+            pr_url="https://github.com/sfayka/Harness/pull/1",
+            reported_by="symphony",
+            reported_at="2026-04-27T20:00:00Z",
+            source_attempt_id="attempt-1",
+        )
+
+        validated = validate_execution_substrate_artifact_reference(artifact)
+
+        self.assertEqual(validated.verification_status, "unverified")
+
+    def test_runner_reported_artifact_cannot_self_verify(self) -> None:
+        artifact = ExecutionSubstrateArtifactReference(
+            artifact_type="pull_request",
+            repository="sfayka/Harness",
+            pr_url="https://github.com/sfayka/Harness/pull/1",
+            reported_by="symphony",
+            reported_at="2026-04-27T20:00:00Z",
+            source_attempt_id="attempt-1",
+            verification_status="verified",
+        )
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "must not start with verification_status=verified",
+        ):
+            validate_execution_substrate_artifact_reference(artifact)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Symphony-compatible execution substrate event contract
- model runner provenance, workspace/session/attempt context, and runner-reported artifact references
- enforce that runner events and artifacts are advisory only and cannot self-authorize lifecycle transitions or verified completion
- export the new contract through modules.contracts and link it from the Symphony architecture doc

## Validation
- python3 -m unittest tests.contracts.test_execution_substrate tests.contracts.test_execution_advisory -v
- python3 -m unittest discover -s tests
- git diff --check

## Notes
- no Symphony runtime installed or executed
- no Linear or GitHub work mutations from a runner
- runner-reported artifacts start unverified until Harness performs trusted readback