### PR TITLE
Ingest execution substrate events

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -149,6 +149,8 @@ The runner integration should emit advisory events into Harness. These events sh
 
 The first in-code contract lives in [`modules/contracts/execution_substrate.py`](../../modules/contracts/execution_substrate.py). It intentionally models runner events as advisory input, not as lifecycle authority.
 
+Harness accepts these events through `POST /tasks/<task_id>/execution-substrate-events`. That endpoint appends validated runner events to `observability.execution_metadata.execution_substrate_events` and projects them into the read-model and timeline. It does not run verification, mutate Linear or GitHub, or authorize a lifecycle transition.
+
 Initial event family:
 
 - `dispatch_requested`

--- a/modules/api.py
+++ b/modules/api.py
@@ -38,6 +38,13 @@ from modules.contracts.failure_classification import FailureClassification, Fail
 from modules.contracts.task_envelope_lifecycle import ForbiddenTransitionError, apply_task_transition
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
 from modules.contracts.task_envelope_external_facts import ExternalFactValidationError, GitHubArtifactFacts, LinearFacts
+from modules.contracts.execution_substrate import (
+    ExecutionSubstrateArtifactReference,
+    ExecutionSubstrateEvent,
+    ExecutionSubstrateEventType,
+    ExecutionSubstrateProvenance,
+    validate_execution_substrate_event,
+)
 from modules.contracts.task_envelope_enforcement import EnforcementAction, EnforcementResult
 from modules.contracts.task_envelope_reconciliation import (
     ExpectedCodeContext,
@@ -1342,6 +1349,121 @@ def _with_execution_attempt_record(task_envelope: dict[str, Any], *, attempt: di
 
     execution_attempts.append(deepcopy(attempt))
     execution_metadata["execution_attempts"] = execution_attempts
+    merged_task["observability"]["execution_metadata"] = execution_metadata
+    merged_task["timestamps"]["updated_at"] = _iso_now()
+    return merged_task
+
+
+def _parse_execution_substrate_artifact_reference(
+    payload: dict[str, Any],
+    *,
+    field_name: str,
+) -> ExecutionSubstrateArtifactReference:
+    return ExecutionSubstrateArtifactReference(
+        artifact_type=_require_non_empty_string(payload.get("artifact_type"), field_name=f"{field_name}.artifact_type"),
+        reported_by=_require_non_empty_string(payload.get("reported_by"), field_name=f"{field_name}.reported_by"),
+        reported_at=_require_non_empty_string(payload.get("reported_at"), field_name=f"{field_name}.reported_at"),
+        source_attempt_id=_require_non_empty_string(
+            payload.get("source_attempt_id"),
+            field_name=f"{field_name}.source_attempt_id",
+        ),
+        verification_status=_optional_non_empty_string(
+            payload.get("verification_status"),
+            field_name=f"{field_name}.verification_status",
+        )
+        or "unverified",
+        repository=_optional_non_empty_string(payload.get("repository"), field_name=f"{field_name}.repository"),
+        branch=_optional_non_empty_string(payload.get("branch"), field_name=f"{field_name}.branch"),
+        commit_sha=_optional_non_empty_string(payload.get("commit_sha"), field_name=f"{field_name}.commit_sha"),
+        pr_url=_optional_non_empty_string(payload.get("pr_url"), field_name=f"{field_name}.pr_url"),
+        metadata=_optional_mapping(payload.get("metadata"), field_name=f"{field_name}.metadata") or {},
+    )
+
+
+def _parse_execution_substrate_event(payload: dict[str, Any], *, task_id: str) -> ExecutionSubstrateEvent:
+    event_payload = _require_mapping(payload.get("event"), field_name="event")
+    provenance_payload = _require_mapping(event_payload.get("provenance"), field_name="event.provenance")
+    artifact_references = tuple(
+        _parse_execution_substrate_artifact_reference(
+            artifact_reference,
+            field_name=f"event.artifact_references[{index}]",
+        )
+        for index, artifact_reference in enumerate(
+            _optional_object_list(
+                event_payload.get("artifact_references"),
+                field_name="event.artifact_references",
+            )
+        )
+    )
+    event_task_id = _require_non_empty_string(event_payload.get("task_id"), field_name="event.task_id")
+    if event_task_id != task_id:
+        raise ApiRequestError("event.task_id must match the URL task id")
+    event_type = _require_non_empty_string(event_payload.get("event_type"), field_name="event.event_type")
+    try:
+        parsed_event_type = ExecutionSubstrateEventType(event_type)
+    except ValueError as error:
+        raise ApiRequestError(f"Unsupported execution substrate event_type: {event_type}") from error
+
+    return validate_execution_substrate_event(
+        ExecutionSubstrateEvent(
+            event_id=_require_non_empty_string(event_payload.get("event_id"), field_name="event.event_id"),
+            task_id=event_task_id,
+            attempt_id=_require_non_empty_string(event_payload.get("attempt_id"), field_name="event.attempt_id"),
+            runner_kind=_require_non_empty_string(
+                event_payload.get("runner_kind"),
+                field_name="event.runner_kind",
+            ),
+            runner_session_id=_require_non_empty_string(
+                event_payload.get("runner_session_id"),
+                field_name="event.runner_session_id",
+            ),
+            executor_kind=_require_non_empty_string(
+                event_payload.get("executor_kind"),
+                field_name="event.executor_kind",
+            ),
+            workspace_id=_require_non_empty_string(event_payload.get("workspace_id"), field_name="event.workspace_id"),
+            event_type=parsed_event_type,
+            occurred_at=_require_non_empty_string(event_payload.get("occurred_at"), field_name="event.occurred_at"),
+            provenance=ExecutionSubstrateProvenance(
+                source_system=_require_non_empty_string(
+                    provenance_payload.get("source_system"),
+                    field_name="event.provenance.source_system",
+                ),
+                source_type=_require_non_empty_string(
+                    provenance_payload.get("source_type"),
+                    field_name="event.provenance.source_type",
+                ),
+                source_id=_require_non_empty_string(
+                    provenance_payload.get("source_id"),
+                    field_name="event.provenance.source_id",
+                ),
+                captured_by=_optional_non_empty_string(
+                    provenance_payload.get("captured_by"),
+                    field_name="event.provenance.captured_by",
+                ),
+            ),
+            payload=_optional_mapping(event_payload.get("payload"), field_name="event.payload") or {},
+            artifact_references=artifact_references,
+        )
+    )
+
+
+def _with_execution_substrate_event(task_envelope: dict[str, Any], *, event: ExecutionSubstrateEvent) -> dict[str, Any]:
+    merged_task = deepcopy(task_envelope)
+    execution_metadata = dict(merged_task["observability"]["execution_metadata"] or {})
+    existing_events = execution_metadata.get("execution_substrate_events")
+    if existing_events is None:
+        events: list[dict[str, Any]] = []
+    elif isinstance(existing_events, list):
+        events = [deepcopy(item) for item in existing_events]
+    else:
+        raise ApiRequestError("observability.execution_metadata.execution_substrate_events must be an array")
+
+    event_payload = _to_jsonable(event)
+    if any(isinstance(existing, dict) and existing.get("event_id") == event.event_id for existing in events):
+        raise ApiRequestError(f"execution substrate event {event.event_id!r} already exists for this task")
+    events.append(event_payload)
+    execution_metadata["execution_substrate_events"] = events
     merged_task["observability"]["execution_metadata"] = execution_metadata
     merged_task["timestamps"]["updated_at"] = _iso_now()
     return merged_task
@@ -4181,6 +4303,35 @@ class HarnessApiService:
         response_payload["requires_review"] = _review_gate_is_active(stored_task, updated_records)
         return status, response_payload
 
+    def submit_execution_substrate_event(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        try:
+            stored_task = self.store.get_task(task_id)
+        except TaskEnvelopeNotFoundError:
+            return HTTPStatus.NOT_FOUND, {"error": f"Task {task_id!r} was not found"}
+
+        try:
+            event = _parse_execution_substrate_event(payload, task_id=task_id)
+            updated_task = _with_execution_substrate_event(stored_task, event=event)
+        except Exception as error:
+            return HTTPStatus.BAD_REQUEST, {
+                "error": str(error),
+                "invalid_input": True,
+            }
+
+        stored_task = self.store.update_task(updated_task)
+        read_model = self.read_model_service.build_task_read_model(task_id)
+        return HTTPStatus.OK, {
+            "task_envelope": _to_jsonable(stored_task),
+            "execution_substrate_event": _to_jsonable(event),
+            "execution_summary": read_model.execution_summary,
+            "accepted_completion": stored_task.get("status") == "completed",
+            "requires_review": _review_gate_is_active(
+                stored_task,
+                self.store.list_evaluation_records(task_id),
+            ),
+            "action": "execution_substrate_event_recorded",
+        }
+
     def dispatch_task(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         try:
             stored_task = self.store.get_task(task_id)
@@ -4453,7 +4604,7 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
         } and not (
             len(path_components) == 3
             and path_components[0] == "tasks"
-            and path_components[2] in {"reevaluate", "completion-claims", "dispatch"}
+            and path_components[2] in {"reevaluate", "completion-claims", "dispatch", "execution-substrate-events"}
         ):
             self._write_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
             return
@@ -4481,6 +4632,12 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
             status, response_payload = service.evaluate(payload)
         elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "completion-claims":
             status, response_payload = service.submit_completion_claim(path_components[1], payload)
+        elif (
+            len(path_components) == 3
+            and path_components[0] == "tasks"
+            and path_components[2] == "execution-substrate-events"
+        ):
+            status, response_payload = service.submit_execution_substrate_event(path_components[1], payload)
         elif len(path_components) == 3 and path_components[0] == "tasks" and path_components[2] == "dispatch":
             status, response_payload = service.dispatch_task(path_components[1], payload)
         else:

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -509,8 +509,28 @@ def _latest_execution_attempt(execution_attempts: list[dict[str, Any]]) -> dict[
     )
 
 
+def _latest_execution_substrate_event(substrate_events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    valid_events = [event for event in substrate_events if isinstance(event, dict)]
+    if not valid_events:
+        return None
+    return max(
+        valid_events,
+        key=lambda event: (
+            _parse_iso_timestamp(str(event.get("occurred_at") or "")),
+            str(event.get("event_id") or ""),
+        ),
+    )
+
+
 def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord, ...]) -> dict[str, Any]:
-    execution_attempts = ((task_envelope.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []
+    execution_metadata = (task_envelope.get("observability") or {}).get("execution_metadata") or {}
+    execution_attempts = execution_metadata.get("execution_attempts") or []
+    substrate_events = execution_metadata.get("execution_substrate_events") or []
+    latest_substrate_event = (
+        _latest_execution_substrate_event(substrate_events)
+        if isinstance(substrate_events, list)
+        else None
+    )
     review_summary = _build_review_summary(records)
     latest_failure_summary = _latest_failure_summary(
         records,
@@ -534,6 +554,8 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
         return {
             "attempt_count": 0,
             "latest_attempt": None,
+            "substrate_event_count": len(substrate_events) if isinstance(substrate_events, list) else 0,
+            "latest_substrate_event": dict(latest_substrate_event) if latest_substrate_event is not None else None,
             "latest_artifact_references": [],
             "total_attempts": len(records),
             "retry_count": retry_count,
@@ -563,6 +585,18 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
     return {
         "attempt_count": attempt_count,
         "latest_attempt": dict(latest_attempt) if latest_attempt is not None else None,
+        "substrate_event_count": len(substrate_events) if isinstance(substrate_events, list) else 0,
+        "latest_substrate_event": dict(latest_substrate_event) if latest_substrate_event is not None else None,
+        "latest_runner_session_id": (
+            latest_substrate_event.get("runner_session_id")
+            if isinstance(latest_substrate_event, dict)
+            else None
+        ),
+        "latest_workspace_id": (
+            latest_substrate_event.get("workspace_id")
+            if isinstance(latest_substrate_event, dict)
+            else None
+        ),
         "latest_status": latest_attempt.get("status") if isinstance(latest_attempt, dict) else None,
         "latest_dispatch_origin": (
             ((latest_attempt.get("metadata") or {}).get("dispatch_mode"))
@@ -685,7 +719,28 @@ def _build_timeline(task_envelope: TaskEnvelope, records: tuple[EvaluationRecord
             }
         )
 
-    execution_attempts = ((task_envelope.get("observability") or {}).get("execution_metadata") or {}).get("execution_attempts") or []
+    execution_metadata = (task_envelope.get("observability") or {}).get("execution_metadata") or {}
+    substrate_events = execution_metadata.get("execution_substrate_events") or []
+    if isinstance(substrate_events, list):
+        for index, substrate_event in enumerate(substrate_events):
+            if not isinstance(substrate_event, dict):
+                continue
+            events.append(
+                {
+                    "event_id": f"{task_envelope['id']}:execution_substrate:{substrate_event.get('event_id') or index}",
+                    "event_type": "execution_substrate_event_recorded",
+                    "occurred_at": substrate_event.get("occurred_at") or timestamps.get("updated_at"),
+                    "summary": f"Execution substrate event: {substrate_event.get('event_type')}",
+                    "source": (
+                        ((substrate_event.get("provenance") or {}).get("source_system"))
+                        or substrate_event.get("runner_kind")
+                        or "execution_substrate"
+                    ),
+                    "details": dict(substrate_event),
+                }
+            )
+
+    execution_attempts = execution_metadata.get("execution_attempts") or []
     for index, attempt in enumerate(execution_attempts):
         if not isinstance(attempt, dict):
             continue

--- a/tests/test_execution_substrate_ingestion.py
+++ b/tests/test_execution_substrate_ingestion.py
@@ -1,0 +1,163 @@
+"""Tests for advisory execution-substrate event ingestion."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from modules.api import HarnessApiService
+from modules.intake.task_envelope import create_task_envelope
+from modules.store import FileBackedHarnessStore
+
+
+def _task(task_id: str = "task-substrate-ingest-1") -> dict:
+    return create_task_envelope(
+        {
+            "id": task_id,
+            "title": "Record Symphony runner event",
+            "description": "Persist a runner event without trusting it as completion.",
+            "origin": {
+                "source_system": "linear",
+                "source_type": "synchronization",
+                "source_id": "KNO-999",
+            },
+            "acceptance_criteria": [
+                {
+                    "id": "ac-1",
+                    "description": "Harness records runner status as advisory runtime context.",
+                    "required": True,
+                }
+            ],
+        },
+        now="2026-04-27T20:00:00Z",
+    )
+
+
+def _runner_event_payload(task_id: str = "task-substrate-ingest-1") -> dict:
+    return {
+        "event": {
+            "event_id": "runner-event-1",
+            "task_id": task_id,
+            "attempt_id": "attempt-1",
+            "runner_kind": "symphony",
+            "runner_session_id": "runner-session-1",
+            "executor_kind": "codex_app_server",
+            "workspace_id": "workspace/task-substrate-ingest-1",
+            "event_type": "run_completed_by_executor",
+            "occurred_at": "2026-04-27T20:05:00Z",
+            "provenance": {
+                "source_system": "symphony",
+                "source_type": "runner_event",
+                "source_id": "runner-session-1:runner-event-1",
+                "captured_by": "execution_substrate_adapter",
+            },
+            "payload": {
+                "reported_complete": True,
+                "handoff_state": "human_review",
+                "summary": "Codex reports the work is ready for Harness verification.",
+            },
+            "artifact_references": [
+                {
+                    "artifact_type": "pull_request",
+                    "repository": "sfayka/Harness",
+                    "branch": "codex/task-substrate-ingest-1",
+                    "pr_url": "https://github.com/sfayka/Harness/pull/999",
+                    "reported_by": "symphony",
+                    "reported_at": "2026-04-27T20:05:00Z",
+                    "source_attempt_id": "attempt-1",
+                }
+            ],
+        }
+    }
+
+
+class ExecutionSubstrateIngestionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = FileBackedHarnessStore(self.temp_dir.name)
+        self.service = HarnessApiService(store=self.store)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_runner_completion_event_is_stored_as_advisory_runtime_fact(self) -> None:
+        task = self.store.create_task(_task())
+
+        status, payload = self.service.submit_execution_substrate_event(
+            str(task["id"]),
+            _runner_event_payload(),
+        )
+
+        stored_task = self.store.get_task(str(task["id"]))
+        execution_metadata = stored_task["observability"]["execution_metadata"]
+        substrate_events = execution_metadata["execution_substrate_events"]
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["action"], "execution_substrate_event_recorded")
+        self.assertFalse(payload["accepted_completion"])
+        self.assertEqual(stored_task["status"], "intake_ready")
+        self.assertEqual(len(substrate_events), 1)
+        self.assertEqual(substrate_events[0]["event_type"], "run_completed_by_executor")
+        self.assertEqual(substrate_events[0]["artifact_references"][0]["verification_status"], "unverified")
+        self.assertEqual(payload["execution_summary"]["substrate_event_count"], 1)
+        self.assertEqual(payload["execution_summary"]["latest_runner_session_id"], "runner-session-1")
+
+    def test_runner_event_rejects_lifecycle_authority(self) -> None:
+        task = self.store.create_task(_task("task-substrate-ingest-2"))
+        payload = _runner_event_payload("task-substrate-ingest-2")
+        payload["event"]["payload"]["target_status"] = "completed"
+
+        status, response = self.service.submit_execution_substrate_event(str(task["id"]), payload)
+
+        stored_task = self.store.get_task(str(task["id"]))
+        execution_metadata = stored_task["observability"]["execution_metadata"]
+
+        self.assertEqual(status, 400)
+        self.assertTrue(response["invalid_input"])
+        self.assertIn("prohibited lifecycle authority", response["error"])
+        self.assertNotIn("execution_substrate_events", execution_metadata)
+        self.assertEqual(stored_task["status"], "intake_ready")
+
+    def test_read_model_and_timeline_expose_substrate_events(self) -> None:
+        task = self.store.create_task(_task("task-substrate-ingest-3"))
+        payload = _runner_event_payload("task-substrate-ingest-3")
+
+        status, _ = self.service.submit_execution_substrate_event(str(task["id"]), payload)
+        read_model_status, read_model_payload = self.service.get_task_read_model(str(task["id"]))
+        timeline_status, timeline_payload = self.service.get_task_timeline(str(task["id"]))
+
+        timeline_events = [
+            event
+            for event in timeline_payload["timeline"]
+            if event["event_type"] == "execution_substrate_event_recorded"
+        ]
+
+        self.assertEqual(status, 200)
+        self.assertEqual(read_model_status, 200)
+        self.assertEqual(timeline_status, 200)
+        self.assertEqual(read_model_payload["task"]["execution_summary"]["substrate_event_count"], 1)
+        self.assertEqual(
+            read_model_payload["task"]["execution_summary"]["latest_substrate_event"]["event_type"],
+            "run_completed_by_executor",
+        )
+        self.assertEqual(len(timeline_events), 1)
+        self.assertEqual(timeline_events[0]["details"]["runner_kind"], "symphony")
+
+    def test_duplicate_runner_event_id_is_rejected(self) -> None:
+        task = self.store.create_task(_task("task-substrate-ingest-4"))
+        payload = _runner_event_payload("task-substrate-ingest-4")
+
+        first_status, _ = self.service.submit_execution_substrate_event(str(task["id"]), payload)
+        second_status, second_payload = self.service.submit_execution_substrate_event(str(task["id"]), payload)
+
+        stored_task = self.store.get_task(str(task["id"]))
+        substrate_events = stored_task["observability"]["execution_metadata"]["execution_substrate_events"]
+
+        self.assertEqual(first_status, 200)
+        self.assertEqual(second_status, 400)
+        self.assertIn("already exists", second_payload["error"])
+        self.assertEqual(len(substrate_events), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add POST /tasks/<task_id>/execution-substrate-events for validated Symphony-like runner events
- append substrate events under observability.execution_metadata.execution_substrate_events without running verification or changing lifecycle state
- project latest runner session/workspace and event count into the read model
- add execution-substrate timeline events for operator inspection
- document the endpoint in the Symphony execution-substrate architecture note

## Validation
- python3 -m unittest tests.test_execution_substrate_ingestion tests.contracts.test_execution_substrate -v
- python3 -m unittest discover -s tests
- git diff --check

## Notes
- runner completion remains advisory only
- runner-reported artifacts remain unverified
- no Linear/GitHub mutations and no Symphony runtime execution