### PR TITLE
Emit Symphony supervision intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,8 @@ python3 -m unittest discover -s tests
 Run the controlled autonomous dry run that exercises:
 
 - canonical task creation through `POST /evaluate`
-- OpenClaw-style retry supervision through `GET /supervision/queue` and redispatch
+- supervision through `GET /supervision/queue`, which now produces Symphony-compatible execution-substrate intents by default
+- legacy direct redispatch only because this controlled compatibility dry run explicitly enables it
 - Codex Cloud adapter proof validation
 - post-dispatch GitHub-backed sync through `POST /sync/github` that closes the missing changed-file evidence gap
 

--- a/docs/architecture/guided-integration-setup.md
+++ b/docs/architecture/guided-integration-setup.md
@@ -32,7 +32,7 @@ Default onboarding only requires the local Harness runtime:
 - SQLite schema readiness
 - accessible selected workspace folders, if any were selected
 
-Missing GitHub, Linear, and ingress/executor setup appears as incomplete optional work.
+Missing GitHub, Linear, execution-substrate, and legacy ingress/executor setup appears as incomplete optional work.
 Those integrations become blockers only when the user selects a workflow that needs them.
 
 Warnings for API stopped, dashboard assets, notifications, or Launch at Login are actionable, but they do not block runtime-only onboarding.
@@ -52,7 +52,7 @@ Current workflow gates:
 
 - `github-proof` requires GitHub artifact verification.
 - `linear-sync` requires Linear coordination.
-- `repair-dispatch` requires an ingress/executor bridge.
+- `repair-dispatch` requires the execution substrate.
 
 Multiple `--workflow` flags can be passed when the app needs to validate a combined workflow.
 
@@ -110,9 +110,10 @@ printf '%s' "$TOKEN" | python3 -m modules.local_runtime --json secrets set githu
 printf '%s' "$TOKEN" | python3 -m modules.local_runtime --json secrets set linear_api_key --value-stdin
 ```
 
-The ingress/executor item must stay client-neutral in UI copy.
-It should describe the connection as a desktop-agent bridge for OpenClaw, Hermes, Codex, or a future equivalent.
-The current doctor still recognizes OpenClaw-shaped adapter variables because that is the existing bridge wiring, not the Harness product boundary.
+The execution-substrate item should name Symphony as the preferred runner without giving it completion authority.
+The legacy ingress/executor item must stay client-neutral in UI copy.
+It should describe the connection as a compatibility desktop-agent bridge for OpenClaw, Hermes, Codex, or a future equivalent.
+The current doctor still recognizes OpenClaw-shaped adapter variables because that is existing bridge wiring, not the Harness product boundary.
 
 ## Validation Source
 
@@ -124,6 +125,7 @@ Current mapping:
 - Local runtime: `app_data_dir`, `log_dir`, `config`, `sqlite`, `api_health`, `dashboard`, `notification_permission`, `launch_at_login`, `workspace_folders`
 - GitHub: `github_connection`
 - Linear: `linear_connection`
-- Ingress/executor: `ingress_executor`
+- Execution substrate: `execution_substrate`
+- Legacy ingress/executor: `ingress_executor`
 
 This keeps the app, CLI, and docs aligned around one diagnostic source.

--- a/docs/architecture/setup-doctor.md
+++ b/docs/architecture/setup-doctor.md
@@ -60,7 +60,8 @@ The current doctor covers:
 - `dashboard`: packaged dashboard asset availability and dashboard HTTP route reachability when the API is running.
 - `github_connection`: GitHub credential setup state.
 - `linear_connection`: Linear credential setup state.
-- `ingress_executor`: desktop-agent bridge setup state for the current OpenClaw-shaped adapter wiring, without making OpenClaw the product boundary.
+- `execution_substrate`: Symphony-compatible execution-substrate availability.
+- `ingress_executor`: legacy desktop-agent bridge setup state for the current OpenClaw-shaped adapter wiring, without making OpenClaw the product boundary.
 - `notification_permission`: notification permission state reported by the app shell.
 - `launch_at_login`: launch-at-login state reported by the app shell.
 - `workspace_folders`: configured local workspace folder availability.
@@ -74,7 +75,14 @@ Until the Swift app owns these directly, the CLI reads these environment variabl
 - `HARNESS_LAUNCH_AT_LOGIN`: `enabled` or `disabled`.
 - `HARNESS_WORKSPACE_FOLDERS`: `os.pathsep`-separated folder paths selected by the user.
 
-Current desktop-agent bridge checks read the existing adapter variables:
+Execution-substrate checks read:
+
+- `HARNESS_SYMPHONY_BIN`
+- `SYMPHONY_BIN`
+- `symphony` on `PATH`
+- the Knox Analytics `Infrastructure/symphony/elixir/bin/symphony` convention
+
+Current legacy desktop-agent bridge checks read the existing adapter variables:
 
 - `OPENCLAW_CONFIG_PATH`
 - `OPENCLAW_STATE_DIR`
@@ -82,7 +90,7 @@ Current desktop-agent bridge checks read the existing adapter variables:
 - `OPENCLAW_BASE_URL`
 
 Those names are adapter wiring, not the product boundary.
-The UI should describe the setup item as a desktop-agent bridge for OpenClaw, Hermes, Codex, or a future equivalent.
+The UI should describe the execution-substrate setup item as a Symphony-compatible runner and the ingress/executor setup item as a legacy compatibility bridge.
 
 ## Safety Rules
 
@@ -95,7 +103,7 @@ The UI should describe the setup item as a desktop-agent bridge for OpenClaw, He
 ## Guided Setup Mapping
 
 `harness setup status --json` consumes this doctor payload.
-It keeps default onboarding limited to the local runtime and marks GitHub, Linear, and ingress/executor setup as optional until a selected workflow requires them.
+It keeps default onboarding limited to the local runtime and marks GitHub, Linear, execution-substrate, and legacy ingress/executor setup as optional until a selected workflow requires them.
 
 Use workflow gates when needed:
 

--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -155,6 +155,8 @@ Harness accepts these events through `POST /tasks/<task_id>/execution-substrate-
 
 The deterministic local dry run lives in [`modules/execution_substrate_dryrun.py`](../../modules/execution_substrate_dryrun.py). It simulates a Symphony-style event stream against a disposable local task and proves that runner handoff remains advisory until Harness verification runs.
 
+The supervision queue now also exposes `execution_substrate_intent` for attention items that should be continued by a Symphony-compatible runner. This is the replacement for Harness pretending to be the runner in the normal path. A supervisor can submit that intent to Symphony, and Symphony reports back through `POST /tasks/<task_id>/execution-substrate-events`. The old direct `/tasks/<task_id>/dispatch` behavior remains only as a compatibility and deterministic-test path.
+
 Initial event family:
 
 - `dispatch_requested`

--- a/modules/autonomous_dryrun.py
+++ b/modules/autonomous_dryrun.py
@@ -329,7 +329,11 @@ def run_retryable_codex_supervision_dry_run(
             initial_queue_entry = _find_queue_entry(initial_queue_payload, task_id=task_id)
 
             supervisor = OpenClawHarnessSupervisor(base_url)
-            cycle = supervisor.run_cycle(allow_redispatch=True, executor="codex")
+            cycle = supervisor.run_cycle(
+                allow_redispatch=True,
+                allow_legacy_direct_dispatch=True,
+                executor="codex",
+            )
 
             post_dispatch_task_status, post_dispatch_task_payload = _request_json(base_url, "GET", f"/tasks/{task_id}")
             if post_dispatch_task_status >= 400:
@@ -432,7 +436,11 @@ def run_stale_codex_supervision_dry_run(
             initial_queue_entry = _find_queue_entry(initial_queue_payload, task_id=task_id)
 
             supervisor = OpenClawHarnessSupervisor(base_url)
-            cycle = supervisor.run_cycle(allow_redispatch=True, executor="codex")
+            cycle = supervisor.run_cycle(
+                allow_redispatch=True,
+                allow_legacy_direct_dispatch=True,
+                executor="codex",
+            )
 
             task_status, task_payload = _request_json(base_url, "GET", f"/tasks/{task_id}")
             final_queue_status, final_queue_payload = _request_json(base_url, "GET", "/supervision/queue")

--- a/modules/connectors/openclaw_supervisor.py
+++ b/modules/connectors/openclaw_supervisor.py
@@ -27,6 +27,8 @@ class OpenClawSupervisionDecision:
     timeline_event_count: int
     can_autonomously_dispatch: bool
     proposed_dispatch_payload: dict[str, Any] | None
+    can_request_execution_substrate: bool
+    proposed_execution_substrate_intent: dict[str, Any] | None
     can_autonomously_sync: bool
     proposed_sync_payload: dict[str, Any] | None
     read_model: dict[str, Any]
@@ -211,6 +213,13 @@ class OpenClawHarnessSupervisor:
                 if can_dispatch
                 else None
             ),
+            can_request_execution_substrate=can_dispatch
+            and isinstance(entry.get("execution_substrate_intent"), dict),
+            proposed_execution_substrate_intent=(
+                dict(entry["execution_substrate_intent"])
+                if can_dispatch and isinstance(entry.get("execution_substrate_intent"), dict)
+                else None
+            ),
             can_autonomously_sync=can_sync,
             proposed_sync_payload=sync_payload,
             read_model=read_model_payload,
@@ -235,6 +244,7 @@ class OpenClawHarnessSupervisor:
         allow_redispatch: bool = False,
         allow_sync: bool = False,
         executor: str = "codex",
+        allow_legacy_direct_dispatch: bool = False,
     ) -> OpenClawSupervisionCycleResult:
         queue_status, queue_payload = self.client.get_supervision_queue()
         if queue_status >= 400:
@@ -269,7 +279,30 @@ class OpenClawHarnessSupervisor:
                     )
                 )
                 continue
-            if allow_redispatch and decision.can_autonomously_dispatch and decision.proposed_dispatch_payload is not None:
+            if (
+                allow_redispatch
+                and decision.can_request_execution_substrate
+                and decision.proposed_execution_substrate_intent is not None
+                and not allow_legacy_direct_dispatch
+            ):
+                action_results.append(
+                    OpenClawSupervisionActionResult(
+                        task_id=decision.task_id,
+                        attention_type=decision.attention_type,
+                        action_status="execution_substrate_dispatch_intent",
+                        http_status=None,
+                        action="submit_to_execution_substrate",
+                        resulting_task_status=decision.current_status,
+                    )
+                )
+                continue
+
+            if (
+                allow_redispatch
+                and allow_legacy_direct_dispatch
+                and decision.can_autonomously_dispatch
+                and decision.proposed_dispatch_payload is not None
+            ):
                 dispatch_status, dispatch_payload = self.client.dispatch_task(
                     decision.task_id,
                     payload=decision.proposed_dispatch_payload,

--- a/modules/supervision.py
+++ b/modules/supervision.py
@@ -32,6 +32,7 @@ class SupervisionQueueEntry:
     clarification_status: str
     failure_state: str
     retry_eligible: bool
+    execution_substrate_intent: dict[str, Any] | None
 
 
 class HarnessSupervisionService:
@@ -202,6 +203,41 @@ class HarnessSupervisionService:
             )
         return None
 
+    @staticmethod
+    def _execution_substrate_intent(
+        task: dict[str, Any],
+        *,
+        attention_type: str,
+        suggested_action: str,
+        reason: str,
+    ) -> dict[str, Any] | None:
+        if attention_type == "retryable_failure" and suggested_action == "retry_or_redispatch":
+            intent_type = "retry_execution"
+        elif attention_type == "stale_active_task" and suggested_action == "investigate_staleness":
+            intent_type = "investigate_or_restart_execution"
+        else:
+            return None
+
+        task_id = str(task.get("task_id") or "")
+        if not task_id:
+            return None
+        return {
+            "intent_type": intent_type,
+            "substrate_kind": "symphony-compatible",
+            "task_id": task_id,
+            "source": "harness_supervision_queue",
+            "reason": reason,
+            "suggested_action": suggested_action,
+            "advisory_only": True,
+            "events_endpoint": f"/tasks/{task_id}/execution-substrate-events",
+            "completion_authority": "harness_verification",
+            "prohibited_actions": [
+                "mark_harness_complete",
+                "move_linear_to_done_as_truth",
+                "auto_merge_without_policy",
+            ],
+        }
+
     def list_attention_queue(self) -> list[dict[str, Any]]:
         priority = {
             "review_required": 0,
@@ -219,6 +255,12 @@ class HarnessSupervisionService:
             if attention is None:
                 continue
             attention_type, suggested_action, reason, stale = attention
+            execution_substrate_intent = self._execution_substrate_intent(
+                task,
+                attention_type=attention_type,
+                suggested_action=suggested_action,
+                reason=reason,
+            )
             queue.append(
                 asdict(
                     SupervisionQueueEntry(
@@ -234,6 +276,7 @@ class HarnessSupervisionService:
                         clarification_status=str(((task.get("clarification_summary") or {}).get("status")) or "none"),
                         failure_state=str(((task.get("failure_summary") or {}).get("state")) or "clear"),
                         retry_eligible=bool(((task.get("execution_summary") or {}).get("retry_eligible"))),
+                        execution_substrate_intent=execution_substrate_intent,
                     )
                 )
             )

--- a/tests/connectors/test_openclaw_supervisor.py
+++ b/tests/connectors/test_openclaw_supervisor.py
@@ -125,6 +125,8 @@ class OpenClawHarnessSupervisorTests(unittest.TestCase):
         self.assertGreaterEqual(review_decision.evaluation_history_count, 2)
         self.assertFalse(review_decision.can_autonomously_dispatch)
         self.assertIsNone(review_decision.proposed_dispatch_payload)
+        self.assertFalse(review_decision.can_request_execution_substrate)
+        self.assertIsNone(review_decision.proposed_execution_substrate_intent)
         self.assertEqual(actions[review_decision.task_id].action_status, "manual_review_required")
 
         clarification_decision = decisions["task-openclaw-supervisor-clarification-1"]
@@ -135,9 +137,11 @@ class OpenClawHarnessSupervisorTests(unittest.TestCase):
         self.assertGreaterEqual(clarification_decision.evaluation_history_count, 1)
         self.assertFalse(clarification_decision.can_autonomously_dispatch)
         self.assertIsNone(clarification_decision.proposed_dispatch_payload)
+        self.assertFalse(clarification_decision.can_request_execution_substrate)
+        self.assertIsNone(clarification_decision.proposed_execution_substrate_intent)
         self.assertEqual(actions[clarification_decision.task_id].action_status, "clarification_required")
 
-    def test_cycle_can_trigger_bounded_redispatch_for_retryable_failure(self) -> None:
+    def test_cycle_emits_substrate_intent_for_retryable_failure_by_default(self) -> None:
         retry_payload = {"request": to_jsonable(build_demo_request("blocked_insufficient_evidence"))}
         retry_payload["request"]["runtime_facts"] = {
             "executor_reported_failure": True,
@@ -162,14 +166,27 @@ class OpenClawHarnessSupervisorTests(unittest.TestCase):
             retry_decision.proposed_dispatch_payload["request"]["dispatch_trigger"],
             "openclaw_supervision_loop",
         )
+        self.assertTrue(retry_decision.can_request_execution_substrate)
+        self.assertEqual(
+            retry_decision.proposed_execution_substrate_intent["intent_type"],
+            "retry_execution",
+        )
+        self.assertEqual(
+            retry_decision.proposed_execution_substrate_intent["events_endpoint"],
+            f"/tasks/{task_id}/execution-substrate-events",
+        )
+        self.assertEqual(
+            retry_decision.proposed_execution_substrate_intent["completion_authority"],
+            "harness_verification",
+        )
 
         retry_action = actions[task_id]
-        self.assertEqual(retry_action.action_status, "redispatch_triggered")
-        self.assertEqual(retry_action.http_status, 200)
-        self.assertIsNotNone(retry_action.action)
-        self.assertIn(retry_action.resulting_task_status, {"blocked", "completed", "failed", "in_review"})
+        self.assertEqual(retry_action.action_status, "execution_substrate_dispatch_intent")
+        self.assertIsNone(retry_action.http_status)
+        self.assertEqual(retry_action.action, "submit_to_execution_substrate")
+        self.assertEqual(retry_action.resulting_task_status, "blocked")
 
-    def test_cycle_can_trigger_bounded_redispatch_for_stale_active_task(self) -> None:
+    def test_cycle_emits_substrate_intent_for_stale_active_task_by_default(self) -> None:
         self.service.supervision_service = HarnessSupervisionService(
             store=self.service.store,
             now_provider=lambda: "2026-04-16T12:00:00Z",
@@ -217,12 +234,46 @@ class OpenClawHarnessSupervisorTests(unittest.TestCase):
             stale_decision.proposed_dispatch_payload["request"]["dispatch_trigger"],
             "openclaw_supervision_loop",
         )
+        self.assertTrue(stale_decision.can_request_execution_substrate)
+        self.assertEqual(
+            stale_decision.proposed_execution_substrate_intent["intent_type"],
+            "investigate_or_restart_execution",
+        )
+        self.assertEqual(
+            stale_decision.proposed_execution_substrate_intent["completion_authority"],
+            "harness_verification",
+        )
 
         stale_action = actions[task_id]
-        self.assertEqual(stale_action.action_status, "redispatch_triggered")
-        self.assertEqual(stale_action.http_status, 200)
-        self.assertIsNotNone(stale_action.action)
-        self.assertIn(stale_action.resulting_task_status, {"blocked", "completed", "failed", "in_review"})
+        self.assertEqual(stale_action.action_status, "execution_substrate_dispatch_intent")
+        self.assertIsNone(stale_action.http_status)
+        self.assertEqual(stale_action.action, "submit_to_execution_substrate")
+        self.assertEqual(stale_action.resulting_task_status, "assigned")
+
+    def test_cycle_can_still_use_legacy_direct_dispatch_when_explicitly_enabled(self) -> None:
+        retry_payload = {"request": to_jsonable(build_demo_request("blocked_insufficient_evidence"))}
+        retry_payload["request"]["runtime_facts"] = {
+            "executor_reported_failure": True,
+            "attempt_count": 1,
+            "latest_attempt_outcome": "failed",
+        }
+        create_status, create_payload = self._request_json("POST", "/evaluate", retry_payload)
+        self.assertEqual(create_status, 200)
+        task_id = create_payload["task_envelope"]["id"]
+
+        supervisor = OpenClawHarnessSupervisor(self.base_url)
+        cycle = supervisor.run_cycle(
+            allow_redispatch=True,
+            allow_legacy_direct_dispatch=True,
+            executor="codex",
+        )
+        actions = {result.task_id: result for result in cycle.action_results}
+
+        retry_action = actions[task_id]
+        self.assertEqual(retry_action.action_status, "redispatch_triggered")
+        self.assertEqual(retry_action.http_status, 200)
+        self.assertIsNotNone(retry_action.action)
+        self.assertIn(retry_action.resulting_task_status, {"blocked", "completed", "failed", "in_review"})
 
     def test_cycle_can_trigger_github_sync_for_sync_required_attention(self) -> None:
         submit_status, submit_payload = self.client.submit_task(

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -121,10 +121,16 @@ class HarnessSupervisionServiceTests(unittest.TestCase):
         retry_item = queue[retry_response["task_envelope"]["id"]]
         self.assertEqual(retry_item["attention_type"], "retryable_failure")
         self.assertEqual(retry_item["suggested_action"], "retry_or_redispatch")
+        self.assertEqual(retry_item["execution_substrate_intent"]["intent_type"], "retry_execution")
+        self.assertEqual(
+            retry_item["execution_substrate_intent"]["completion_authority"],
+            "harness_verification",
+        )
 
         invalid_item = queue[invalid_response["task_envelope"]["id"]]
         self.assertEqual(invalid_item["attention_type"], "invalid_execution_attempt")
         self.assertEqual(invalid_item["suggested_action"], "request_fresh_proof_or_rework")
+        self.assertIsNone(invalid_item["execution_substrate_intent"])
 
     def test_queue_surfaces_stale_active_tasks(self) -> None:
         stale_payload = _manual_happy_path_overlay_payload()
@@ -162,6 +168,10 @@ class HarnessSupervisionServiceTests(unittest.TestCase):
         self.assertEqual(stale_item["attention_type"], "stale_active_task")
         self.assertEqual(stale_item["suggested_action"], "investigate_staleness")
         self.assertTrue(stale_item["stale"])
+        self.assertEqual(
+            stale_item["execution_substrate_intent"]["intent_type"],
+            "investigate_or_restart_execution",
+        )
 
     def test_queue_surfaces_github_sync_required_when_valid_execution_proof_exists_without_synced_artifacts(self) -> None:
         payload = _manual_happy_path_overlay_payload()


### PR DESCRIPTION
## Summary
- add Symphony-compatible execution substrate intents to supervision queue entries for retryable and stale execution work
- make the OpenClaw supervisor emit substrate dispatch intents by default instead of calling Harness direct dispatch
- keep legacy direct dispatch available only when explicitly enabled for deterministic compatibility dry runs
- update setup and Symphony docs to reflect execution substrate as the primary dispatch continuation path

## Validation
- python3 -m unittest tests.test_supervision tests.test_local_setup tests.test_local_runtime tests.test_execution_substrate_ingestion tests.test_execution_substrate_dryrun -v
- python3 -m unittest tests.test_autonomous_dryrun tests.connectors.test_openclaw_supervisor -v
- python3 -m unittest discover -s tests
- git diff --check

No live Symphony runs, Linear issue mutations, or production GitHub artifact mutations were performed.