### PR TITLE
Label direct dispatch as legacy compatibility

### DIFF
--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -34,14 +34,15 @@ Queue entries are derived from canonical read-model and timeline truth and curre
 - `retryable_failure`
 - `stale_active_task`
 
-OpenClaw, Hermes, or another supervisor may use those entries to decide what to inspect next, but the actual task mutation still has to go back through canonical submission, dispatch, completion-claim, or reevaluation paths.
+OpenClaw, Hermes, Symphony, or another supervisor may use those entries to decide what to inspect next, but the actual task mutation still has to go back through canonical submission, execution-substrate event ingestion, GitHub sync, completion-claim, or reevaluation paths.
 
 The repository now includes a thin example supervisor loop in [`modules/connectors/openclaw_supervisor.py`](../../modules/connectors/openclaw_supervisor.py). That file is the current concrete OpenClaw-shaped example, not an architectural requirement. It does not mutate review, clarification, or proof decisions on its own. It only:
 
 - polls `GET /supervision/queue`
 - enriches queue entries with canonical inspection surfaces
 - may trigger `POST /sync/github` when the queue shows `github_sync_required` and the latest persisted execution attempt already carries enough repository proof to construct a bounded sync payload
-- optionally triggers `POST /tasks/<task_id>/dispatch` for bounded redispatch when the queue recommends `retry_or_redispatch` and the current canonical task state remains dispatchable
+- emits a Symphony-compatible `execution_substrate_intent` for retryable or stale execution work by default
+- may still trigger `POST /tasks/<task_id>/dispatch` only when explicitly running the legacy direct-dispatch compatibility path
 
 `POST /tasks` is an intake/planning creation path, not a completion-reporting path. A brand-new task may include objective, planning, support artifacts, coordination metadata, and clarification blockers, but it must not arrive with claimed completion, acceptance assertions, runtime facts, validated completion evidence, execution attempts, advisory completion claims, reconciliation history, or runtime/terminal lifecycle state already attached.
 
@@ -237,17 +238,19 @@ If that task is accepted, the ingress client should treat these as the canonical
 
 ### Manual Dispatch Bridge
 
-- `POST /tasks/<task_id>/dispatch` manually dispatches an existing canonical task to an executor adapter.
+- `POST /tasks/<task_id>/dispatch` is the legacy direct-dispatch bridge for manually dispatching an existing canonical task to an executor adapter.
+- New runner integrations should prefer the supervision queue's `execution_substrate_intent` plus `POST /tasks/<task_id>/execution-substrate-events`.
 - The request supports:
   - `request.executor` (optional: `codex`, `openclaw`, or `stub-executor`; default `codex`)
   - `request.execution_parameters` (optional object for advisory execution metadata)
   - `request.artifact_references` (optional list of advisory artifact references such as PR URL, commit SHA, and branch metadata)
+- Successful responses include `dispatch.compatibility_mode=true`, `dispatch.dispatch_surface=legacy_direct_dispatch`, and `dispatch.preferred_execution_surface=execution_substrate`.
 - Dispatch:
   - records a new execution attempt under `observability.execution_metadata.execution_attempts`
   - records advisory completion claim metadata
   - automatically triggers canonical reevaluation through the existing completion-claim path
 - Dispatch remains advisory-only and must not bypass verification, reconciliation, lifecycle enforcement, or review gates.
-- The repository now includes a Codex Cloud adapter boundary that can be injected into dispatch for `request.executor="codex"`. That adapter requires repo/bootstrap preflight proof before it will emit a successful advisory completion path.
+- The repository still includes a Codex Cloud adapter boundary that can be injected into this compatibility bridge for `request.executor="codex"`. That adapter requires repo/bootstrap preflight proof before it will emit a successful advisory completion path.
 
 - Existing-task reevaluation uses the stored task snapshot as the source of truth.
 - `POST /evaluate` may still be used as an evaluation surface for an existing task id, but it no longer accepts submission-style mutation overlays for that stored task.

--- a/docs/integration/openclaw-harness-spike.md
+++ b/docs/integration/openclaw-harness-spike.md
@@ -108,15 +108,16 @@ The loop remains intentionally narrow:
 
 It currently performs bounded autonomous follow-ups only when the canonical task state is still dispatchable:
 
-- if the queue surfaces `retryable_failure`, the loop may call `POST /tasks/<task_id>/dispatch` with an explicit `dispatch_trigger=openclaw_supervision_loop`
-- if the queue surfaces `stale_active_task` for an `assigned` or `dispatch_ready` task, the loop may call the same canonical dispatch endpoint to kick stalled work back into motion
+- if the queue surfaces `retryable_failure`, the loop now emits an `execution_substrate_intent` by default so a Symphony-compatible runner can continue the work
+- if the queue surfaces `stale_active_task` for an `assigned` or `dispatch_ready` task, the loop now emits an `execution_substrate_intent` by default so a Symphony-compatible runner can investigate or restart the work
+- the old `POST /tasks/<task_id>/dispatch` follow-up remains available only when explicitly running the legacy direct-dispatch compatibility path with `dispatch_trigger=openclaw_supervision_loop`
 - if the queue surfaces `github_sync_required`, the loop may call `POST /sync/github` using repository and branch facts already recorded in the canonical execution summary
 
 That keeps OpenClaw thin while proving the next autonomy step:
 
 - OpenClaw can observe what needs attention
 - OpenClaw can inspect the canonical evidence behind that attention
-- OpenClaw can trigger a governed redispatch or GitHub sync without bypassing Harness lifecycle enforcement
+- OpenClaw can hand execution continuation to a runner substrate or trigger GitHub sync without bypassing Harness lifecycle enforcement
 
 Since the spike was written, Harness added a dedicated OpenClaw ingress adapter endpoint (`POST /ingress/openclaw`) that still delegates into canonical submission semantics (`POST /tasks`) rather than introducing a separate control-plane contract.
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -4442,6 +4442,10 @@ class HarnessApiService:
                 "dispatch_trigger": dispatch_trigger,
                 "dispatch_mode": dispatch_mode,
                 "dispatch_reason": dispatch_reason,
+                "dispatch_surface": "legacy_direct_dispatch",
+                "compatibility_mode": True,
+                "preferred_execution_surface": "execution_substrate",
+                "execution_substrate_events_endpoint": f"/tasks/{task_id}/execution-substrate-events",
                 "executor": executor,
                 "execution_parameters": dict(execution_parameters),
                 "dispatch_at": dispatch_recorded_at,
@@ -4474,6 +4478,10 @@ class HarnessApiService:
                 "attempt_id": attempt_id,
                 "executor": executor,
                 "attempt_status": attempt_status,
+                "dispatch_surface": "legacy_direct_dispatch",
+                "compatibility_mode": True,
+                "preferred_execution_surface": "execution_substrate",
+                "execution_substrate_events_endpoint": f"/tasks/{task_id}/execution-substrate-events",
             }
         return status, response_payload
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4304,10 +4304,20 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(dispatch_status, 200)
         self.assertEqual(dispatch_response["dispatch"]["attempt_id"], "attempt-1")
         self.assertEqual(dispatch_response["dispatch"]["executor"], "codex")
+        self.assertEqual(dispatch_response["dispatch"]["dispatch_surface"], "legacy_direct_dispatch")
+        self.assertTrue(dispatch_response["dispatch"]["compatibility_mode"])
+        self.assertEqual(dispatch_response["dispatch"]["preferred_execution_surface"], "execution_substrate")
+        self.assertEqual(
+            dispatch_response["dispatch"]["execution_substrate_events_endpoint"],
+            f"/tasks/{task_id}/execution-substrate-events",
+        )
         self.assertIn(
             dispatch_response["dispatch"]["attempt_status"],
             {"started", "in_progress", "completed", "failed", "blocked"},
         )
+        latest_attempt = dispatch_response["task_envelope"]["observability"]["execution_metadata"]["execution_attempts"][-1]
+        self.assertEqual(latest_attempt["metadata"]["dispatch_surface"], "legacy_direct_dispatch")
+        self.assertTrue(latest_attempt["metadata"]["compatibility_mode"])
         self.assertEqual(timeline_status, 200)
         self.assertTrue(any(event["event_type"] == "task_dispatched" for event in timeline_payload["timeline"]))
         self.assertTrue(any(event["event_type"] == "execution_event_recorded" for event in timeline_payload["timeline"]))
@@ -7166,6 +7176,8 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(submit_response["task_envelope"]["status"], "dispatch_ready")
         self.assertEqual(dispatch_status, 200)
         self.assertEqual(dispatch_response["dispatch"]["task_id"], task_id)
+        self.assertEqual(dispatch_response["dispatch"]["dispatch_surface"], "legacy_direct_dispatch")
+        self.assertTrue(dispatch_response["dispatch"]["compatibility_mode"])
 
     def test_api_can_reevaluate_completed_task_back_to_blocked_for_contradictory_facts(self) -> None:
         initial_payload = _request_payload("accepted_completion")


### PR DESCRIPTION
## Summary
- label successful /tasks/<task_id>/dispatch responses as legacy direct-dispatch compatibility
- persist the same compatibility metadata on execution attempt records
- update agent API and OpenClaw spike docs to point new runner integrations toward supervision intents plus execution-substrate events

## Validation
- python3 -m unittest tests.test_api tests.e2e.test_control_plane_dispatch_audit_flows -v
- python3 -m unittest discover -s tests
- git diff --check

No live Symphony runs, Linear mutations, or production GitHub artifact mutations were performed.