### PR TITLE
Add execution substrate dry-run CLI

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -155,6 +155,15 @@ Harness accepts these events through `POST /tasks/<task_id>/execution-substrate-
 
 The deterministic local dry run lives in [`modules/execution_substrate_dryrun.py`](../../modules/execution_substrate_dryrun.py). It simulates a Symphony-style event stream against a disposable local task and proves that runner handoff remains advisory until Harness verification runs. It also includes an intent-consumer dry run that creates a local retryable task, polls the execution-substrate intent queue, and records advisory runner events without starting Symphony or touching live work.
 
+Run the two local substrate dry runs with:
+
+```bash
+python3 -m modules.execution_substrate_dryrun event-stream
+python3 -m modules.execution_substrate_dryrun intent-consumer
+```
+
+Both commands write a JSON summary to stdout. They use disposable local stores, do not start Symphony, do not read live Linear or GitHub state, and do not authorize task completion. They exist to make the execution-substrate boundary testable before Harness connects a real Symphony runner.
+
 The supervision queue now also exposes `execution_substrate_intent` for attention items that should be continued by a Symphony-compatible runner. This is the replacement for Harness pretending to be the runner in the normal path. A supervisor can submit that intent to Symphony, and Symphony reports back through `POST /tasks/<task_id>/execution-substrate-events`. Harness also exposes `GET /execution-substrate/intents` as a runner-facing filtered projection of those intents. The old direct `/tasks/<task_id>/dispatch` behavior remains only as a compatibility and deterministic-test path.
 
 Initial event family:

--- a/docs/howto/test-and-validate.md
+++ b/docs/howto/test-and-validate.md
@@ -53,6 +53,15 @@ python3 -m modules.reset_dryrun review
 
 The success path should verify a claimed completion. The review path should exhaust the retry path and land in explicit review instead of pretending the task completed.
 
+## Execution Substrate Dry Runs
+
+```bash
+python3 -m modules.execution_substrate_dryrun event-stream
+python3 -m modules.execution_substrate_dryrun intent-consumer
+```
+
+These commands exercise the Symphony-compatible execution substrate boundary locally. They write JSON summaries, use disposable stores, and do not start Symphony or touch live Linear/GitHub work.
+
 ## Local Live Smoke
 
 Only run this when the repo has live `GITHUB_TOKEN` and `LINEAR_API_KEY` access configured:

--- a/modules/execution_substrate_dryrun.py
+++ b/modules/execution_substrate_dryrun.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-import tempfile
+import argparse
+import json
 import os
-from dataclasses import dataclass
+import tempfile
+from dataclasses import asdict, dataclass
 from typing import Any
 
 from modules.api import HarnessApiService
@@ -313,9 +315,58 @@ def run_symphony_intent_consumer_dry_run(
         )
 
 
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run deterministic local Symphony execution-substrate dry runs.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    event_stream = subparsers.add_parser(
+        "event-stream",
+        help="Record a local Symphony-style runner event stream against a disposable task.",
+    )
+    event_stream.add_argument(
+        "--task-id",
+        default="symphony-substrate-dryrun-1",
+        help="Disposable Harness task id to use for the dry run.",
+    )
+
+    intent_consumer = subparsers.add_parser(
+        "intent-consumer",
+        help="Poll local execution-substrate intents and record advisory runner events.",
+    )
+    intent_consumer.add_argument(
+        "--task-id",
+        default="symphony-intent-consumer-dryrun-1",
+        help="Disposable Harness task id to use for the dry run.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "event-stream":
+        result = run_symphony_substrate_dry_run(task_id=args.task_id)
+    elif args.command == "intent-consumer":
+        result = run_symphony_intent_consumer_dry_run(task_id=args.task_id)
+    else:  # pragma: no cover - argparse prevents this branch.
+        parser.error(f"unsupported command: {args.command}")
+
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    return 0
+
+
 __all__ = [
     "ExecutionSubstrateDryRunResult",
     "ExecutionSubstrateIntentDryRunResult",
+    "build_parser",
+    "main",
     "run_symphony_intent_consumer_dry_run",
     "run_symphony_substrate_dry_run",
 ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_execution_substrate_dryrun.py
+++ b/tests/test_execution_substrate_dryrun.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
+import json
 import unittest
 
 from modules.execution_substrate_dryrun import (
+    main,
     run_symphony_intent_consumer_dry_run,
     run_symphony_substrate_dry_run,
 )
@@ -35,6 +39,34 @@ class ExecutionSubstrateDryRunTests(unittest.TestCase):
         self.assertFalse(result.accepted_completion)
         self.assertEqual(result.substrate_event_count, 2)
         self.assertEqual(result.latest_event_type, "runner_session_started")
+
+    def test_event_stream_cli_outputs_json_summary(self) -> None:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = main(["event-stream", "--task-id", "symphony-event-stream-cli-test-1"])
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["task_id"], "symphony-event-stream-cli-test-1")
+        self.assertEqual(payload["event_statuses"], [200, 200, 200, 200, 200])
+        self.assertEqual(payload["final_task_status"], "intake_ready")
+        self.assertFalse(payload["accepted_completion"])
+        self.assertEqual(payload["latest_event_type"], "run_completed_by_executor")
+
+    def test_intent_consumer_cli_outputs_json_summary(self) -> None:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = main(["intent-consumer", "--task-id", "symphony-intent-cli-test-1"])
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["task_id"], "symphony-intent-cli-test-1")
+        self.assertEqual(payload["intent_status"], 200)
+        self.assertEqual(payload["intent_count"], 1)
+        self.assertEqual(payload["consumed_intent_type"], "retry_execution")
+        self.assertEqual(payload["event_statuses"], [200, 200])
+        self.assertEqual(payload["final_task_status"], "blocked")
+        self.assertFalse(payload["accepted_completion"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose the Symphony-compatible substrate dry runs through python3 -m modules.execution_substrate_dryrun
- add JSON CLI coverage for event-stream and intent-consumer dry runs
- document the local-only validation commands and their safety boundary

## Safety
- local disposable stores only
- does not start Symphony
- does not touch live Linear or GitHub work
- executor completion remains advisory, with accepted_completion false

## Validation
- python3 -m unittest tests.test_execution_substrate_dryrun -v
- python3 -m modules.execution_substrate_dryrun event-stream --task-id cli-smoke-event-stream
- python3 -m modules.execution_substrate_dryrun intent-consumer --task-id cli-smoke-intent-consumer
- git diff --check
- python3 -m unittest discover -s tests