### PR TITLE
Add execution substrate intent contract

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -166,6 +166,8 @@ Both commands write a JSON summary to stdout. They use disposable local stores, 
 
 The supervision queue now also exposes `execution_substrate_intent` for attention items that should be continued by a Symphony-compatible runner. This is the replacement for Harness pretending to be the runner in the normal path. A supervisor can submit that intent to Symphony, and Symphony reports back through `POST /tasks/<task_id>/execution-substrate-events`. Harness also exposes `GET /execution-substrate/intents` as a runner-facing filtered projection of those intents. The old direct `/tasks/<task_id>/dispatch` behavior remains only as a compatibility and deterministic-test path.
 
+Runner-facing intents are also part of the in-code execution-substrate contract. Supervision builds them through `build_execution_substrate_intent` rather than hand-writing arbitrary queue payloads. A valid intent must remain advisory, must preserve `completion_authority=harness_verification`, and must explicitly prohibit marking Harness complete, moving Linear to Done as truth, or auto-merging without policy. This gives a Symphony adapter a stable handoff shape while keeping Harness above the runner as the verification boundary.
+
 Initial event family:
 
 - `dispatch_requested`

--- a/modules/contracts/execution_substrate.py
+++ b/modules/contracts/execution_substrate.py
@@ -36,6 +36,13 @@ class ExecutionSubstrateEventType(StrEnum):
     RUN_COMPLETED_BY_EXECUTOR = "run_completed_by_executor"
 
 
+class ExecutionSubstrateIntentType(StrEnum):
+    """Runner-facing execution intents Harness may hand to a substrate."""
+
+    RETRY_EXECUTION = "retry_execution"
+    INVESTIGATE_OR_RESTART_EXECUTION = "investigate_or_restart_execution"
+
+
 _PROHIBITED_LIFECYCLE_KEYS: frozenset[str] = frozenset(
     {
         "accepted_completion",
@@ -46,6 +53,14 @@ _PROHIBITED_LIFECYCLE_KEYS: frozenset[str] = frozenset(
         "lifecycle_status",
         "target_status",
         "verified_complete",
+    }
+)
+
+_REQUIRED_PROHIBITED_ACTIONS: frozenset[str] = frozenset(
+    {
+        "mark_harness_complete",
+        "move_linear_to_done_as_truth",
+        "auto_merge_without_policy",
     }
 )
 
@@ -106,6 +121,35 @@ class ExecutionSubstrateEvent:
     provenance: ExecutionSubstrateProvenance
     payload: dict[str, Any] = field(default_factory=dict)
     artifact_references: tuple[ExecutionSubstrateArtifactReference, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExecutionSubstrateIntent:
+    """Validated advisory request for a runner substrate to continue work."""
+
+    intent_type: ExecutionSubstrateIntentType
+    substrate_kind: str
+    task_id: str
+    source: str
+    reason: str
+    suggested_action: str
+    events_endpoint: str
+    advisory_only: bool = True
+    completion_authority: str = "harness_verification"
+    prohibited_actions: tuple[str, ...] = tuple(sorted(_REQUIRED_PROHIBITED_ACTIONS))
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _intent_type_for_attention(
+    *,
+    attention_type: str,
+    suggested_action: str,
+) -> ExecutionSubstrateIntentType | None:
+    if attention_type == "retryable_failure" and suggested_action == "retry_or_redispatch":
+        return ExecutionSubstrateIntentType.RETRY_EXECUTION
+    if attention_type == "stale_active_task" and suggested_action == "investigate_staleness":
+        return ExecutionSubstrateIntentType.INVESTIGATE_OR_RESTART_EXECUTION
+    return None
 
 
 def validate_execution_substrate_provenance(
@@ -176,13 +220,97 @@ def validate_execution_substrate_event(event: ExecutionSubstrateEvent) -> Execut
     return event
 
 
+def validate_execution_substrate_intent(intent: ExecutionSubstrateIntent) -> ExecutionSubstrateIntent:
+    """Validate a Harness-to-runner execution intent as advisory only."""
+
+    _require_non_empty(intent.intent_type.value, field_name="intent.intent_type")
+    _require_non_empty(intent.substrate_kind, field_name="intent.substrate_kind")
+    _require_non_empty(intent.task_id, field_name="intent.task_id")
+    _require_non_empty(intent.source, field_name="intent.source")
+    _require_non_empty(intent.reason, field_name="intent.reason")
+    _require_non_empty(intent.suggested_action, field_name="intent.suggested_action")
+    _require_non_empty(intent.events_endpoint, field_name="intent.events_endpoint")
+    _require_non_empty(intent.completion_authority, field_name="intent.completion_authority")
+    if intent.advisory_only is not True:
+        raise ExecutionSubstrateValidationError("execution-substrate intents must be advisory_only=true")
+    if intent.completion_authority != "harness_verification":
+        raise ExecutionSubstrateValidationError(
+            "execution-substrate intents must keep completion_authority=harness_verification"
+        )
+    missing_actions = sorted(_REQUIRED_PROHIBITED_ACTIONS.difference(intent.prohibited_actions))
+    if missing_actions:
+        names = ", ".join(missing_actions)
+        raise ExecutionSubstrateValidationError(
+            f"execution-substrate intent is missing required prohibited actions: {names}"
+        )
+    _validate_no_lifecycle_authority(intent.metadata, field_name="intent.metadata")
+    return intent
+
+
+def build_execution_substrate_intent(
+    *,
+    task_id: str,
+    attention_type: str,
+    suggested_action: str,
+    reason: str,
+    source: str = "harness_supervision_queue",
+    substrate_kind: str = "symphony-compatible",
+    metadata: dict[str, Any] | None = None,
+) -> ExecutionSubstrateIntent | None:
+    """Build a validated runner-facing intent for an eligible supervision entry."""
+
+    intent_type = _intent_type_for_attention(
+        attention_type=attention_type,
+        suggested_action=suggested_action,
+    )
+    if intent_type is None:
+        return None
+    intent = ExecutionSubstrateIntent(
+        intent_type=intent_type,
+        substrate_kind=substrate_kind,
+        task_id=task_id,
+        source=source,
+        reason=reason,
+        suggested_action=suggested_action,
+        events_endpoint=f"/tasks/{task_id}/execution-substrate-events",
+        metadata=metadata or {},
+    )
+    return validate_execution_substrate_intent(intent)
+
+
+def execution_substrate_intent_to_dict(intent: ExecutionSubstrateIntent) -> dict[str, Any]:
+    """Serialize an execution-substrate intent for API and adapter payloads."""
+
+    validate_execution_substrate_intent(intent)
+    payload = {
+        "intent_type": intent.intent_type.value,
+        "substrate_kind": intent.substrate_kind,
+        "task_id": intent.task_id,
+        "source": intent.source,
+        "reason": intent.reason,
+        "suggested_action": intent.suggested_action,
+        "advisory_only": intent.advisory_only,
+        "events_endpoint": intent.events_endpoint,
+        "completion_authority": intent.completion_authority,
+        "prohibited_actions": list(intent.prohibited_actions),
+    }
+    if intent.metadata:
+        payload["metadata"] = dict(intent.metadata)
+    return payload
+
+
 __all__ = [
     "ExecutionSubstrateArtifactReference",
     "ExecutionSubstrateEvent",
     "ExecutionSubstrateEventType",
+    "ExecutionSubstrateIntent",
+    "ExecutionSubstrateIntentType",
     "ExecutionSubstrateProvenance",
     "ExecutionSubstrateValidationError",
+    "build_execution_substrate_intent",
+    "execution_substrate_intent_to_dict",
     "validate_execution_substrate_artifact_reference",
     "validate_execution_substrate_event",
+    "validate_execution_substrate_intent",
     "validate_execution_substrate_provenance",
 ]

--- a/modules/supervision.py
+++ b/modules/supervision.py
@@ -7,6 +7,10 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from modules.read_model import HarnessReadModelService
+from modules.contracts.execution_substrate import (
+    build_execution_substrate_intent,
+    execution_substrate_intent_to_dict,
+)
 from modules.store import HarnessStore, build_harness_store
 
 _CODE_EXECUTION_ARTIFACT_TYPES = frozenset({"branch", "commit", "pull_request", "changed_file"})
@@ -211,32 +215,18 @@ class HarnessSupervisionService:
         suggested_action: str,
         reason: str,
     ) -> dict[str, Any] | None:
-        if attention_type == "retryable_failure" and suggested_action == "retry_or_redispatch":
-            intent_type = "retry_execution"
-        elif attention_type == "stale_active_task" and suggested_action == "investigate_staleness":
-            intent_type = "investigate_or_restart_execution"
-        else:
-            return None
-
         task_id = str(task.get("task_id") or "")
         if not task_id:
             return None
-        return {
-            "intent_type": intent_type,
-            "substrate_kind": "symphony-compatible",
-            "task_id": task_id,
-            "source": "harness_supervision_queue",
-            "reason": reason,
-            "suggested_action": suggested_action,
-            "advisory_only": True,
-            "events_endpoint": f"/tasks/{task_id}/execution-substrate-events",
-            "completion_authority": "harness_verification",
-            "prohibited_actions": [
-                "mark_harness_complete",
-                "move_linear_to_done_as_truth",
-                "auto_merge_without_policy",
-            ],
-        }
+        intent = build_execution_substrate_intent(
+            task_id=task_id,
+            attention_type=attention_type,
+            suggested_action=suggested_action,
+            reason=reason,
+        )
+        if intent is None:
+            return None
+        return execution_substrate_intent_to_dict(intent)
 
     def list_attention_queue(self) -> list[dict[str, Any]]:
         priority = {

--- a/tests/contracts/test_execution_substrate.py
+++ b/tests/contracts/test_execution_substrate.py
@@ -9,10 +9,15 @@ from modules.contracts.execution_substrate import (
     ExecutionSubstrateArtifactReference,
     ExecutionSubstrateEvent,
     ExecutionSubstrateEventType,
+    ExecutionSubstrateIntent,
+    ExecutionSubstrateIntentType,
     ExecutionSubstrateProvenance,
     ExecutionSubstrateValidationError,
+    build_execution_substrate_intent,
+    execution_substrate_intent_to_dict,
     validate_execution_substrate_artifact_reference,
     validate_execution_substrate_event,
+    validate_execution_substrate_intent,
 )
 
 
@@ -109,6 +114,89 @@ class ExecutionSubstrateEventTests(unittest.TestCase):
             "must not start with verification_status=verified",
         ):
             validate_execution_substrate_artifact_reference(artifact)
+
+    def test_builds_retry_intent_as_advisory_harness_handoff(self) -> None:
+        intent = build_execution_substrate_intent(
+            task_id="task-1",
+            attention_type="retryable_failure",
+            suggested_action="retry_or_redispatch",
+            reason="Task is retryable.",
+        )
+
+        self.assertIsNotNone(intent)
+        assert intent is not None
+        payload = execution_substrate_intent_to_dict(intent)
+
+        self.assertEqual(payload["intent_type"], "retry_execution")
+        self.assertEqual(payload["substrate_kind"], "symphony-compatible")
+        self.assertEqual(payload["task_id"], "task-1")
+        self.assertTrue(payload["advisory_only"])
+        self.assertEqual(payload["events_endpoint"], "/tasks/task-1/execution-substrate-events")
+        self.assertEqual(payload["completion_authority"], "harness_verification")
+        self.assertIn("mark_harness_complete", payload["prohibited_actions"])
+        self.assertIn("move_linear_to_done_as_truth", payload["prohibited_actions"])
+        self.assertIn("auto_merge_without_policy", payload["prohibited_actions"])
+
+    def test_builds_stale_task_intent_as_investigation_request(self) -> None:
+        intent = build_execution_substrate_intent(
+            task_id="task-1",
+            attention_type="stale_active_task",
+            suggested_action="investigate_staleness",
+            reason="Task is stale.",
+        )
+
+        self.assertIsNotNone(intent)
+        assert intent is not None
+        self.assertEqual(
+            intent.intent_type,
+            ExecutionSubstrateIntentType.INVESTIGATE_OR_RESTART_EXECUTION,
+        )
+
+    def test_intent_builder_ignores_non_runner_attention_items(self) -> None:
+        intent = build_execution_substrate_intent(
+            task_id="task-1",
+            attention_type="review_required",
+            suggested_action="manual_review",
+            reason="Review is required.",
+        )
+
+        self.assertIsNone(intent)
+
+    def test_intent_rejects_completion_authority_transfer(self) -> None:
+        intent = ExecutionSubstrateIntent(
+            intent_type=ExecutionSubstrateIntentType.RETRY_EXECUTION,
+            substrate_kind="symphony-compatible",
+            task_id="task-1",
+            source="harness_supervision_queue",
+            reason="Task is retryable.",
+            suggested_action="retry_or_redispatch",
+            events_endpoint="/tasks/task-1/execution-substrate-events",
+            completion_authority="symphony",
+        )
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "completion_authority=harness_verification",
+        ):
+            validate_execution_substrate_intent(intent)
+
+    def test_intent_rejects_missing_prohibited_actions(self) -> None:
+        intent = ExecutionSubstrateIntent(
+            intent_type=ExecutionSubstrateIntentType.RETRY_EXECUTION,
+            substrate_kind="symphony-compatible",
+            task_id="task-1",
+            source="harness_supervision_queue",
+            reason="Task is retryable.",
+            suggested_action="retry_or_redispatch",
+            events_endpoint="/tasks/task-1/execution-substrate-events",
+            prohibited_actions=("mark_harness_complete",),
+        )
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "missing required prohibited actions",
+        ):
+            validate_execution_substrate_intent(intent)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a canonical ExecutionSubstrateIntent contract for Harness-to-runner handoff
- route supervision execution_substrate_intent payloads through the validated contract builder
- document that runner-facing intents are advisory and preserve Harness verification authority

## Safety
- no Symphony process is started
- no Linear or GitHub mutation is introduced
- intents require advisory_only true
- intents require completion_authority=harness_verification
- intents must prohibit marking Harness complete, moving Linear to Done as truth, and auto-merge without policy

## Validation
- python3 -m unittest tests.contracts.test_execution_substrate tests.test_supervision -v
- python3 -m unittest tests.test_api.HarnessApiServiceTests.test_service_exposes_execution_substrate_intents_from_supervision_queue -v
- python3 -m unittest tests.test_execution_substrate_dryrun -v
- python3 -m modules.execution_substrate_dryrun intent-consumer --task-id contract-intent-cli-smoke
- git diff --check
- python3 -m unittest discover -s tests