### PR TITLE
Add Symphony intent handoff adapter

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -168,6 +168,8 @@ The supervision queue now also exposes `execution_substrate_intent` for attentio
 
 Runner-facing intents are also part of the in-code execution-substrate contract. Supervision builds them through `build_execution_substrate_intent` rather than hand-writing arbitrary queue payloads. A valid intent must remain advisory, must preserve `completion_authority=harness_verification`, and must explicitly prohibit marking Harness complete, moving Linear to Done as truth, or auto-merging without policy. This gives a Symphony adapter a stable handoff shape while keeping Harness above the runner as the verification boundary.
 
+The first Symphony adapter lives in [`modules/adapters/symphony`](../../modules/adapters/symphony). It only renders a validated intent into an inert Symphony-compatible handoff payload. It does not start Symphony, poll Linear, launch Codex, mutate GitHub, or consume live work. Its purpose is to pin the Harness-to-runner payload shape before adding any daemon transport.
+
 Initial event family:
 
 - `dispatch_requested`

--- a/modules/adapters/symphony/README.md
+++ b/modules/adapters/symphony/README.md
@@ -1,0 +1,19 @@
+# Symphony Execution Substrate Adapter
+
+This adapter renders Harness execution-substrate intents into a Symphony-compatible handoff payload.
+
+Current scope:
+
+- accept only validated `ExecutionSubstrateIntent` objects
+- preserve `completion_authority=harness_verification`
+- include the Harness callback endpoint for runner events
+- carry explicit runner prohibitions for completion, Linear Done state, and auto-merge
+- produce an inert `render_only` payload for local tests and future transport wiring
+
+Non-goals:
+
+- starting Symphony
+- polling Linear
+- launching Codex
+- mutating GitHub
+- accepting runner completion as Harness completion truth

--- a/modules/adapters/symphony/__init__.py
+++ b/modules/adapters/symphony/__init__.py
@@ -1,0 +1,11 @@
+"""Symphony-compatible execution substrate adapter."""
+
+from modules.adapters.symphony.execution_substrate_adapter import (
+    SymphonyExecutionSubstrateAdapter,
+    SymphonyHandoffPayload,
+)
+
+__all__ = [
+    "SymphonyExecutionSubstrateAdapter",
+    "SymphonyHandoffPayload",
+]

--- a/modules/adapters/symphony/execution_substrate_adapter.py
+++ b/modules/adapters/symphony/execution_substrate_adapter.py
@@ -1,0 +1,81 @@
+"""Symphony-compatible execution substrate handoff adapter.
+
+This module deliberately renders a handoff payload only. It does not start
+Symphony, poll Linear, mutate GitHub, or claim Harness lifecycle completion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from modules.contracts.execution_substrate import (
+    ExecutionSubstrateIntent,
+    execution_substrate_intent_to_dict,
+    validate_execution_substrate_intent,
+)
+
+
+@dataclass(frozen=True)
+class SymphonyHandoffPayload:
+    """Local representation of the payload Harness can hand to Symphony."""
+
+    adapter: str
+    mode: str
+    intent: dict[str, Any]
+    harness_boundary: dict[str, Any]
+    runner_policy: dict[str, Any]
+    callback: dict[str, Any]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the handoff payload for tests, logs, and future transports."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SymphonyExecutionSubstrateAdapter:
+    """Render validated Harness intents into Symphony-compatible handoff payloads."""
+
+    harness_base_url: str
+    adapter_name: str = "symphony-execution-substrate"
+
+    def render_handoff(self, intent: ExecutionSubstrateIntent) -> SymphonyHandoffPayload:
+        """Render an inert runner handoff for a validated execution-substrate intent."""
+
+        validated = validate_execution_substrate_intent(intent)
+        intent_payload = execution_substrate_intent_to_dict(validated)
+        events_endpoint = intent_payload["events_endpoint"]
+        return SymphonyHandoffPayload(
+            adapter=self.adapter_name,
+            mode="render_only",
+            intent=intent_payload,
+            harness_boundary={
+                "completion_authority": "harness_verification",
+                "advisory_only": True,
+                "runner_completion_is_truth": False,
+                "artifact_verification_required": True,
+            },
+            runner_policy={
+                "substrate_kind": intent_payload["substrate_kind"],
+                "allowed_intent_type": intent_payload["intent_type"],
+                "prohibited_actions": list(intent_payload["prohibited_actions"]),
+            },
+            callback={
+                "events_endpoint": events_endpoint,
+                "events_url": f"{self.harness_base_url.rstrip('/')}{events_endpoint}",
+                "event_contract": "execution_substrate_event.v1",
+            },
+            metadata={
+                "task_id": intent_payload["task_id"],
+                "source": intent_payload["source"],
+                "safe_to_execute_live": False,
+            },
+        )
+
+
+__all__ = [
+    "SymphonyExecutionSubstrateAdapter",
+    "SymphonyHandoffPayload",
+]

--- a/tests/adapters/test_symphony_execution_substrate_adapter.py
+++ b/tests/adapters/test_symphony_execution_substrate_adapter.py
@@ -1,0 +1,86 @@
+"""Tests for the Symphony-compatible execution substrate handoff adapter."""
+
+from __future__ import annotations
+
+import unittest
+
+from modules.adapters.symphony import SymphonyExecutionSubstrateAdapter
+from modules.contracts.execution_substrate import (
+    ExecutionSubstrateIntent,
+    ExecutionSubstrateIntentType,
+    ExecutionSubstrateValidationError,
+    build_execution_substrate_intent,
+)
+
+
+class SymphonyExecutionSubstrateAdapterTests(unittest.TestCase):
+    def test_render_handoff_preserves_harness_completion_authority(self) -> None:
+        intent = build_execution_substrate_intent(
+            task_id="task-symphony-1",
+            attention_type="retryable_failure",
+            suggested_action="retry_or_redispatch",
+            reason="Task is retryable.",
+        )
+        assert intent is not None
+        adapter = SymphonyExecutionSubstrateAdapter(harness_base_url="http://127.0.0.1:8765")
+
+        payload = adapter.render_handoff(intent).to_dict()
+
+        self.assertEqual(payload["mode"], "render_only")
+        self.assertEqual(payload["intent"]["intent_type"], "retry_execution")
+        self.assertTrue(payload["intent"]["advisory_only"])
+        self.assertEqual(payload["intent"]["completion_authority"], "harness_verification")
+        self.assertEqual(payload["harness_boundary"]["completion_authority"], "harness_verification")
+        self.assertFalse(payload["harness_boundary"]["runner_completion_is_truth"])
+        self.assertTrue(payload["harness_boundary"]["artifact_verification_required"])
+        self.assertEqual(
+            payload["callback"]["events_url"],
+            "http://127.0.0.1:8765/tasks/task-symphony-1/execution-substrate-events",
+        )
+        self.assertFalse(payload["metadata"]["safe_to_execute_live"])
+
+    def test_render_handoff_carries_runner_prohibitions(self) -> None:
+        intent = build_execution_substrate_intent(
+            task_id="task-symphony-2",
+            attention_type="stale_active_task",
+            suggested_action="investigate_staleness",
+            reason="Task is stale.",
+        )
+        assert intent is not None
+        payload = SymphonyExecutionSubstrateAdapter(
+            harness_base_url="http://harness.test/",
+        ).render_handoff(intent).to_dict()
+
+        self.assertEqual(payload["intent"]["intent_type"], "investigate_or_restart_execution")
+        self.assertEqual(payload["runner_policy"]["substrate_kind"], "symphony-compatible")
+        self.assertIn("mark_harness_complete", payload["runner_policy"]["prohibited_actions"])
+        self.assertIn("move_linear_to_done_as_truth", payload["runner_policy"]["prohibited_actions"])
+        self.assertIn("auto_merge_without_policy", payload["runner_policy"]["prohibited_actions"])
+        self.assertEqual(
+            payload["callback"]["events_url"],
+            "http://harness.test/tasks/task-symphony-2/execution-substrate-events",
+        )
+
+    def test_render_handoff_rejects_intent_that_transfers_completion_authority(self) -> None:
+        intent = ExecutionSubstrateIntent(
+            intent_type=ExecutionSubstrateIntentType.RETRY_EXECUTION,
+            substrate_kind="symphony-compatible",
+            task_id="task-symphony-3",
+            source="harness_supervision_queue",
+            reason="Task is retryable.",
+            suggested_action="retry_or_redispatch",
+            events_endpoint="/tasks/task-symphony-3/execution-substrate-events",
+            completion_authority="symphony",
+        )
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "completion_authority=harness_verification",
+        ):
+            SymphonyExecutionSubstrateAdapter(
+                harness_base_url="http://127.0.0.1:8765",
+            ).render_handoff(intent)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a render-only Symphony execution substrate adapter
- convert validated ExecutionSubstrateIntent objects into inert Symphony-compatible handoff payloads
- document the adapter scope and non-goals

## Safety
- does not start Symphony
- does not poll Linear
- does not launch Codex
- does not mutate GitHub
- preserves completion_authority=harness_verification
- marks handoff payloads as safe_to_execute_live false

## Validation
- python3 -m unittest tests.adapters.test_symphony_execution_substrate_adapter tests.contracts.test_execution_substrate -v
- git diff --check
- python3 -m unittest discover -s tests