### PR TITLE
Add Symphony handoff dry run

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -160,9 +160,10 @@ Run the two local substrate dry runs with:
 ```bash
 python3 -m modules.execution_substrate_dryrun event-stream
 python3 -m modules.execution_substrate_dryrun intent-consumer
+python3 -m modules.execution_substrate_dryrun handoff
 ```
 
-Both commands write a JSON summary to stdout. They use disposable local stores, do not start Symphony, do not read live Linear or GitHub state, and do not authorize task completion. They exist to make the execution-substrate boundary testable before Harness connects a real Symphony runner.
+These commands write a JSON summary to stdout. They use disposable local stores, do not start Symphony, do not read live Linear or GitHub state, and do not authorize task completion. The `handoff` command renders the Symphony-compatible adapter payload and marks it `safe_to_execute_live=false`. They exist to make the execution-substrate boundary testable before Harness connects a real Symphony runner.
 
 The supervision queue now also exposes `execution_substrate_intent` for attention items that should be continued by a Symphony-compatible runner. This is the replacement for Harness pretending to be the runner in the normal path. A supervisor can submit that intent to Symphony, and Symphony reports back through `POST /tasks/<task_id>/execution-substrate-events`. Harness also exposes `GET /execution-substrate/intents` as a runner-facing filtered projection of those intents. The old direct `/tasks/<task_id>/dispatch` behavior remains only as a compatibility and deterministic-test path.
 

--- a/docs/howto/test-and-validate.md
+++ b/docs/howto/test-and-validate.md
@@ -58,9 +58,10 @@ The success path should verify a claimed completion. The review path should exha
 ```bash
 python3 -m modules.execution_substrate_dryrun event-stream
 python3 -m modules.execution_substrate_dryrun intent-consumer
+python3 -m modules.execution_substrate_dryrun handoff
 ```
 
-These commands exercise the Symphony-compatible execution substrate boundary locally. They write JSON summaries, use disposable stores, and do not start Symphony or touch live Linear/GitHub work.
+These commands exercise the Symphony-compatible execution substrate boundary locally. They write JSON summaries, use disposable stores, and do not start Symphony or touch live Linear/GitHub work. The `handoff` command renders the payload Harness would hand to a Symphony-compatible runner while keeping `safe_to_execute_live=false`.
 
 ## Local Live Smoke
 

--- a/modules/execution_substrate_dryrun.py
+++ b/modules/execution_substrate_dryrun.py
@@ -9,7 +9,12 @@ import tempfile
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from modules.adapters.symphony import SymphonyExecutionSubstrateAdapter
 from modules.api import HarnessApiService
+from modules.contracts.execution_substrate import (
+    ExecutionSubstrateIntent,
+    ExecutionSubstrateIntentType,
+)
 from modules.demo_cases import build_demo_request
 from modules.intake.task_envelope import create_task_envelope
 from modules.runtime_scenario_builders import to_jsonable
@@ -45,6 +50,22 @@ class ExecutionSubstrateIntentDryRunResult:
     accepted_completion: bool
     substrate_event_count: int
     latest_event_type: str | None
+
+
+@dataclass(frozen=True)
+class ExecutionSubstrateHandoffDryRunResult:
+    """Structured result from rendering a Symphony-compatible handoff payload."""
+
+    task_id: str
+    initial_task_status: str | None
+    intent_status: int
+    intent_count: int
+    rendered_intent_type: str | None
+    handoff_mode: str
+    events_url: str
+    completion_authority: str
+    runner_completion_is_truth: bool
+    safe_to_execute_live: bool
 
 
 def _disposable_task(task_id: str) -> dict[str, Any]:
@@ -221,6 +242,45 @@ def _with_env_var(name: str, value: str):
     return _EnvGuard()
 
 
+def _intent_from_payload(intent_payload: dict[str, Any]) -> ExecutionSubstrateIntent:
+    return ExecutionSubstrateIntent(
+        intent_type=ExecutionSubstrateIntentType(str(intent_payload["intent_type"])),
+        substrate_kind=str(intent_payload["substrate_kind"]),
+        task_id=str(intent_payload["task_id"]),
+        source=str(intent_payload["source"]),
+        reason=str(intent_payload["reason"]),
+        suggested_action=str(intent_payload["suggested_action"]),
+        events_endpoint=str(intent_payload["events_endpoint"]),
+        advisory_only=bool(intent_payload["advisory_only"]),
+        completion_authority=str(intent_payload["completion_authority"]),
+        prohibited_actions=tuple(str(action) for action in intent_payload["prohibited_actions"]),
+        metadata=(
+            dict(intent_payload["metadata"])
+            if isinstance(intent_payload.get("metadata"), dict)
+            else {}
+        ),
+    )
+
+
+def _create_retryable_task_and_poll_intent(
+    *,
+    service: HarnessApiService,
+    task_id: str,
+) -> tuple[dict[str, Any], int, dict[str, Any]]:
+    with _with_env_var("HARNESS_CLASSIFIED_RETRY_BUDGET", "2"):
+        create_status, create_payload = service.evaluate(_intent_creation_payload(task_id))
+    if create_status != 200:
+        raise RuntimeError(f"intent dry run create failed with HTTP {create_status}")
+
+    intent_status, intent_payload = service.get_execution_substrate_intents()
+    if intent_status != 200:
+        raise RuntimeError(f"intent dry run poll failed with HTTP {intent_status}")
+    intents = intent_payload.get("intents") if isinstance(intent_payload.get("intents"), list) else []
+    if not intents:
+        raise RuntimeError("intent dry run did not produce an execution-substrate intent")
+    return create_payload, int(intent_status), intent_payload
+
+
 def run_symphony_substrate_dry_run(
     *,
     task_id: str = "symphony-substrate-dryrun-1",
@@ -273,19 +333,12 @@ def run_symphony_intent_consumer_dry_run(
     with tempfile.TemporaryDirectory() as temp_dir:
         store = FileBackedHarnessStore(temp_dir)
         service = HarnessApiService(store=store)
-        with _with_env_var("HARNESS_CLASSIFIED_RETRY_BUDGET", "2"):
-            create_status, create_payload = service.evaluate(_intent_creation_payload(task_id))
-        if create_status != 200:
-            raise RuntimeError(f"intent dry run create failed with HTTP {create_status}")
+        create_payload, intent_status, intent_payload = _create_retryable_task_and_poll_intent(
+            service=service,
+            task_id=task_id,
+        )
 
-        intent_status, intent_payload = service.get_execution_substrate_intents()
-        if intent_status != 200:
-            raise RuntimeError(f"intent dry run poll failed with HTTP {intent_status}")
-        intents = intent_payload.get("intents") if isinstance(intent_payload.get("intents"), list) else []
-        if not intents:
-            raise RuntimeError("intent dry run did not produce an execution-substrate intent")
-
-        intent_entry = intents[0]
+        intent_entry = intent_payload["intents"][0]
         event_statuses = tuple(
             service.submit_execution_substrate_event(task_id, event_payload)[0]
             for event_payload in _intent_consumer_events(intent_entry)
@@ -315,6 +368,46 @@ def run_symphony_intent_consumer_dry_run(
         )
 
 
+def run_symphony_handoff_dry_run(
+    *,
+    task_id: str = "symphony-handoff-dryrun-1",
+    harness_base_url: str = "http://127.0.0.1:8765",
+) -> ExecutionSubstrateHandoffDryRunResult:
+    """Render a Symphony-compatible handoff payload from a local Harness intent."""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = FileBackedHarnessStore(temp_dir)
+        service = HarnessApiService(store=store)
+        create_payload, intent_status, intent_payload = _create_retryable_task_and_poll_intent(
+            service=service,
+            task_id=task_id,
+        )
+
+        intent_entry = intent_payload["intents"][0]
+        handoff = SymphonyExecutionSubstrateAdapter(
+            harness_base_url=harness_base_url,
+        ).render_handoff(_intent_from_payload(intent_entry["intent"]))
+        handoff_payload = handoff.to_dict()
+        return ExecutionSubstrateHandoffDryRunResult(
+            task_id=task_id,
+            initial_task_status=(
+                str((create_payload.get("task_envelope") or {}).get("status"))
+                if isinstance(create_payload.get("task_envelope"), dict)
+                else None
+            ),
+            intent_status=intent_status,
+            intent_count=int(intent_payload["intent_count"]),
+            rendered_intent_type=handoff_payload["intent"].get("intent_type"),
+            handoff_mode=str(handoff_payload["mode"]),
+            events_url=str(handoff_payload["callback"]["events_url"]),
+            completion_authority=str(handoff_payload["harness_boundary"]["completion_authority"]),
+            runner_completion_is_truth=bool(
+                handoff_payload["harness_boundary"]["runner_completion_is_truth"]
+            ),
+            safe_to_execute_live=bool(handoff_payload["metadata"]["safe_to_execute_live"]),
+        )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run deterministic local Symphony execution-substrate dry runs.",
@@ -340,6 +433,21 @@ def build_parser() -> argparse.ArgumentParser:
         default="symphony-intent-consumer-dryrun-1",
         help="Disposable Harness task id to use for the dry run.",
     )
+
+    handoff = subparsers.add_parser(
+        "handoff",
+        help="Render a local Symphony-compatible handoff payload without starting Symphony.",
+    )
+    handoff.add_argument(
+        "--task-id",
+        default="symphony-handoff-dryrun-1",
+        help="Disposable Harness task id to use for the dry run.",
+    )
+    handoff.add_argument(
+        "--harness-base-url",
+        default="http://127.0.0.1:8765",
+        help="Base Harness URL to use when rendering callback URLs.",
+    )
     return parser
 
 
@@ -351,6 +459,11 @@ def main(argv: list[str] | None = None) -> int:
         result = run_symphony_substrate_dry_run(task_id=args.task_id)
     elif args.command == "intent-consumer":
         result = run_symphony_intent_consumer_dry_run(task_id=args.task_id)
+    elif args.command == "handoff":
+        result = run_symphony_handoff_dry_run(
+            task_id=args.task_id,
+            harness_base_url=args.harness_base_url,
+        )
     else:  # pragma: no cover - argparse prevents this branch.
         parser.error(f"unsupported command: {args.command}")
 
@@ -360,9 +473,11 @@ def main(argv: list[str] | None = None) -> int:
 
 __all__ = [
     "ExecutionSubstrateDryRunResult",
+    "ExecutionSubstrateHandoffDryRunResult",
     "ExecutionSubstrateIntentDryRunResult",
     "build_parser",
     "main",
+    "run_symphony_handoff_dry_run",
     "run_symphony_intent_consumer_dry_run",
     "run_symphony_substrate_dry_run",
 ]

--- a/tests/test_execution_substrate_dryrun.py
+++ b/tests/test_execution_substrate_dryrun.py
@@ -9,6 +9,7 @@ import unittest
 
 from modules.execution_substrate_dryrun import (
     main,
+    run_symphony_handoff_dry_run,
     run_symphony_intent_consumer_dry_run,
     run_symphony_substrate_dry_run,
 )
@@ -40,6 +41,25 @@ class ExecutionSubstrateDryRunTests(unittest.TestCase):
         self.assertEqual(result.substrate_event_count, 2)
         self.assertEqual(result.latest_event_type, "runner_session_started")
 
+    def test_symphony_handoff_dry_run_renders_adapter_payload_without_execution(self) -> None:
+        result = run_symphony_handoff_dry_run(
+            task_id="symphony-handoff-test-1",
+            harness_base_url="http://harness.test",
+        )
+
+        self.assertEqual(result.initial_task_status, "blocked")
+        self.assertEqual(result.intent_status, 200)
+        self.assertEqual(result.intent_count, 1)
+        self.assertEqual(result.rendered_intent_type, "retry_execution")
+        self.assertEqual(result.handoff_mode, "render_only")
+        self.assertEqual(
+            result.events_url,
+            "http://harness.test/tasks/symphony-handoff-test-1/execution-substrate-events",
+        )
+        self.assertEqual(result.completion_authority, "harness_verification")
+        self.assertFalse(result.runner_completion_is_truth)
+        self.assertFalse(result.safe_to_execute_live)
+
     def test_event_stream_cli_outputs_json_summary(self) -> None:
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
@@ -67,6 +87,28 @@ class ExecutionSubstrateDryRunTests(unittest.TestCase):
         self.assertEqual(payload["event_statuses"], [200, 200])
         self.assertEqual(payload["final_task_status"], "blocked")
         self.assertFalse(payload["accepted_completion"])
+
+    def test_handoff_cli_outputs_json_summary(self) -> None:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = main(
+                [
+                    "handoff",
+                    "--task-id",
+                    "symphony-handoff-cli-test-1",
+                    "--harness-base-url",
+                    "http://harness.test",
+                ]
+            )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["task_id"], "symphony-handoff-cli-test-1")
+        self.assertEqual(payload["rendered_intent_type"], "retry_execution")
+        self.assertEqual(payload["handoff_mode"], "render_only")
+        self.assertEqual(payload["completion_authority"], "harness_verification")
+        self.assertFalse(payload["runner_completion_is_truth"])
+        self.assertFalse(payload["safe_to_execute_live"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a local handoff dry-run path to modules.execution_substrate_dryrun
- exercise Harness supervision intent -> validated intent contract -> Symphony render-only adapter
- document the handoff dry-run command alongside the existing substrate dry runs

## Safety
- does not start Symphony
- does not touch live Linear or GitHub work
- uses disposable local stores
- rendered handoff remains render_only
- completion_authority remains harness_verification
- safe_to_execute_live remains false

## Validation
- python3 -m unittest tests.test_execution_substrate_dryrun tests.adapters.test_symphony_execution_substrate_adapter -v
- python3 -m modules.execution_substrate_dryrun handoff --task-id handoff-cli-smoke --harness-base-url http://harness.test
- python3 -m unittest tests.test_execution_substrate_dryrun -v
- python3 -m modules.execution_substrate_dryrun handoff --task-id handoff-cli-smoke-2 --harness-base-url http://harness.test
- git diff --check
- python3 -m unittest discover -s tests