### PR TITLE
Expose execution substrate handoff previews

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -171,6 +171,8 @@ Runner-facing intents are also part of the in-code execution-substrate contract.
 
 The first Symphony adapter lives in [`modules/adapters/symphony`](../../modules/adapters/symphony). It only renders a validated intent into an inert Symphony-compatible handoff payload. It does not start Symphony, poll Linear, launch Codex, mutate GitHub, or consume live work. Its purpose is to pin the Harness-to-runner payload shape before adding any daemon transport.
 
+Harness exposes `GET /execution-substrate/handoffs` as a read-only preview of those rendered handoffs. The endpoint renders from the current supervision intent queue, marks `dispatch_enabled=false`, and does not start or contact Symphony. It exists so operators and future runners can inspect the exact payload shape before any live execution transport is enabled.
+
 Initial event family:
 
 - `dispatch_requested`

--- a/modules/api.py
+++ b/modules/api.py
@@ -38,11 +38,13 @@ from modules.contracts.failure_classification import FailureClassification, Fail
 from modules.contracts.task_envelope_lifecycle import ForbiddenTransitionError, apply_task_transition
 from modules.contracts.task_envelope_end_to_end import CanonicalExternalFactBundle
 from modules.contracts.task_envelope_external_facts import ExternalFactValidationError, GitHubArtifactFacts, LinearFacts
+from modules.adapters.symphony import SymphonyExecutionSubstrateAdapter
 from modules.contracts.execution_substrate import (
     ExecutionSubstrateArtifactReference,
     ExecutionSubstrateEvent,
     ExecutionSubstrateEventType,
     ExecutionSubstrateProvenance,
+    execution_substrate_intent_from_dict,
     validate_execution_substrate_event,
 )
 from modules.contracts.task_envelope_enforcement import EnforcementAction, EnforcementResult
@@ -3207,6 +3209,11 @@ def _task_path_components(path: str) -> tuple[str, ...]:
     return tuple(unquote(component) for component in parsed_path.split("/"))
 
 
+def _request_base_url(handler: BaseHTTPRequestHandler) -> str:
+    host = handler.headers.get("Host") or f"{handler.server.server_address[0]}:{handler.server.server_port}"
+    return f"http://{host}"
+
+
 def _serialize_evaluation_record(record: EvaluationRecord) -> dict[str, Any]:
     return _to_jsonable(record)
 
@@ -4575,6 +4582,43 @@ class HarnessApiService:
             "completion_authority": "harness_verification",
         }
 
+    def preview_execution_substrate_handoffs(
+        self,
+        *,
+        harness_base_url: str = "http://127.0.0.1:8765",
+    ) -> tuple[int, dict[str, Any]]:
+        status, intent_payload = self.get_execution_substrate_intents()
+        if status != HTTPStatus.OK:
+            return status, intent_payload
+
+        adapter = SymphonyExecutionSubstrateAdapter(harness_base_url=harness_base_url)
+        handoffs: list[dict[str, Any]] = []
+        for entry in intent_payload["intents"]:
+            intent_payload_entry = entry.get("intent") if isinstance(entry, dict) else None
+            if not isinstance(intent_payload_entry, dict):
+                continue
+            handoffs.append(
+                {
+                    "task_id": str(entry.get("task_id") or ""),
+                    "attention_type": str(entry.get("attention_type") or ""),
+                    "current_status": str(entry.get("current_status") or ""),
+                    "last_activity_at": entry.get("last_activity_at"),
+                    "handoff": adapter.render_handoff(
+                        execution_substrate_intent_from_dict(intent_payload_entry)
+                    ).to_dict(),
+                }
+            )
+
+        return HTTPStatus.OK, {
+            "generated_at": _iso_now(),
+            "handoff_count": len(handoffs),
+            "handoffs": handoffs,
+            "source": "execution_substrate_intents",
+            "advisory_only": True,
+            "dispatch_enabled": False,
+            "completion_authority": "harness_verification",
+        }
+
     def get_evaluation_history(self, task_id: str) -> tuple[int, dict[str, Any]]:
         try:
             self.store.get_task(task_id)
@@ -4651,6 +4695,13 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
 
         if path_components == ("execution-substrate", "intents"):
             status, payload = service.get_execution_substrate_intents()
+            self._write_json(status, payload)
+            return
+
+        if path_components == ("execution-substrate", "handoffs"):
+            status, payload = service.preview_execution_substrate_handoffs(
+                harness_base_url=_request_base_url(self),
+            )
             self._write_json(status, payload)
             return
 

--- a/modules/contracts/execution_substrate.py
+++ b/modules/contracts/execution_substrate.py
@@ -299,6 +299,25 @@ def execution_substrate_intent_to_dict(intent: ExecutionSubstrateIntent) -> dict
     return payload
 
 
+def execution_substrate_intent_from_dict(payload: dict[str, Any]) -> ExecutionSubstrateIntent:
+    """Deserialize and validate an execution-substrate intent payload."""
+
+    intent = ExecutionSubstrateIntent(
+        intent_type=ExecutionSubstrateIntentType(str(payload["intent_type"])),
+        substrate_kind=str(payload["substrate_kind"]),
+        task_id=str(payload["task_id"]),
+        source=str(payload["source"]),
+        reason=str(payload["reason"]),
+        suggested_action=str(payload["suggested_action"]),
+        events_endpoint=str(payload["events_endpoint"]),
+        advisory_only=bool(payload["advisory_only"]),
+        completion_authority=str(payload["completion_authority"]),
+        prohibited_actions=tuple(str(action) for action in payload["prohibited_actions"]),
+        metadata=dict(payload["metadata"]) if isinstance(payload.get("metadata"), dict) else {},
+    )
+    return validate_execution_substrate_intent(intent)
+
+
 __all__ = [
     "ExecutionSubstrateArtifactReference",
     "ExecutionSubstrateEvent",
@@ -308,6 +327,7 @@ __all__ = [
     "ExecutionSubstrateProvenance",
     "ExecutionSubstrateValidationError",
     "build_execution_substrate_intent",
+    "execution_substrate_intent_from_dict",
     "execution_substrate_intent_to_dict",
     "validate_execution_substrate_artifact_reference",
     "validate_execution_substrate_event",

--- a/modules/execution_substrate_dryrun.py
+++ b/modules/execution_substrate_dryrun.py
@@ -12,8 +12,7 @@ from typing import Any
 from modules.adapters.symphony import SymphonyExecutionSubstrateAdapter
 from modules.api import HarnessApiService
 from modules.contracts.execution_substrate import (
-    ExecutionSubstrateIntent,
-    ExecutionSubstrateIntentType,
+    execution_substrate_intent_from_dict,
 )
 from modules.demo_cases import build_demo_request
 from modules.intake.task_envelope import create_task_envelope
@@ -242,26 +241,6 @@ def _with_env_var(name: str, value: str):
     return _EnvGuard()
 
 
-def _intent_from_payload(intent_payload: dict[str, Any]) -> ExecutionSubstrateIntent:
-    return ExecutionSubstrateIntent(
-        intent_type=ExecutionSubstrateIntentType(str(intent_payload["intent_type"])),
-        substrate_kind=str(intent_payload["substrate_kind"]),
-        task_id=str(intent_payload["task_id"]),
-        source=str(intent_payload["source"]),
-        reason=str(intent_payload["reason"]),
-        suggested_action=str(intent_payload["suggested_action"]),
-        events_endpoint=str(intent_payload["events_endpoint"]),
-        advisory_only=bool(intent_payload["advisory_only"]),
-        completion_authority=str(intent_payload["completion_authority"]),
-        prohibited_actions=tuple(str(action) for action in intent_payload["prohibited_actions"]),
-        metadata=(
-            dict(intent_payload["metadata"])
-            if isinstance(intent_payload.get("metadata"), dict)
-            else {}
-        ),
-    )
-
-
 def _create_retryable_task_and_poll_intent(
     *,
     service: HarnessApiService,
@@ -386,7 +365,7 @@ def run_symphony_handoff_dry_run(
         intent_entry = intent_payload["intents"][0]
         handoff = SymphonyExecutionSubstrateAdapter(
             harness_base_url=harness_base_url,
-        ).render_handoff(_intent_from_payload(intent_entry["intent"]))
+        ).render_handoff(execution_substrate_intent_from_dict(intent_entry["intent"]))
         handoff_payload = handoff.to_dict()
         return ExecutionSubstrateHandoffDryRunResult(
             task_id=task_id,

--- a/tests/contracts/test_execution_substrate.py
+++ b/tests/contracts/test_execution_substrate.py
@@ -14,6 +14,7 @@ from modules.contracts.execution_substrate import (
     ExecutionSubstrateProvenance,
     ExecutionSubstrateValidationError,
     build_execution_substrate_intent,
+    execution_substrate_intent_from_dict,
     execution_substrate_intent_to_dict,
     validate_execution_substrate_artifact_reference,
     validate_execution_substrate_event,
@@ -136,6 +137,11 @@ class ExecutionSubstrateEventTests(unittest.TestCase):
         self.assertIn("mark_harness_complete", payload["prohibited_actions"])
         self.assertIn("move_linear_to_done_as_truth", payload["prohibited_actions"])
         self.assertIn("auto_merge_without_policy", payload["prohibited_actions"])
+
+        round_tripped = execution_substrate_intent_from_dict(payload)
+        self.assertEqual(round_tripped.intent_type, intent.intent_type)
+        self.assertEqual(round_tripped.task_id, intent.task_id)
+        self.assertEqual(round_tripped.completion_authority, "harness_verification")
 
     def test_builds_stale_task_intent_as_investigation_request(self) -> None:
         intent = build_execution_substrate_intent(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5465,6 +5465,39 @@ class HarnessApiServiceTests(unittest.TestCase):
         self.assertEqual(intent_entry["intent"]["intent_type"], "retry_execution")
         self.assertEqual(intent_entry["intent"]["completion_authority"], "harness_verification")
 
+    def test_service_previews_execution_substrate_handoffs_without_dispatch(self) -> None:
+        payload = _request_payload("blocked_insufficient_evidence")
+        payload["request"]["runtime_facts"] = {
+            "executor_reported_failure": True,
+            "attempt_count": 1,
+            "latest_attempt_outcome": "failed",
+        }
+
+        with patch.dict(os.environ, {"HARNESS_CLASSIFIED_RETRY_BUDGET": "2"}):
+            status, response = self.service.evaluate(payload)
+        preview_status, preview_payload = self.service.preview_execution_substrate_handoffs(
+            harness_base_url="http://harness.test",
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(preview_status, 200)
+        self.assertEqual(preview_payload["handoff_count"], 1)
+        self.assertFalse(preview_payload["dispatch_enabled"])
+        self.assertEqual(preview_payload["completion_authority"], "harness_verification")
+        handoff_entry = preview_payload["handoffs"][0]
+        self.assertEqual(handoff_entry["task_id"], response["task_envelope"]["id"])
+        self.assertEqual(handoff_entry["attention_type"], "retryable_failure")
+        handoff = handoff_entry["handoff"]
+        self.assertEqual(handoff["mode"], "render_only")
+        self.assertEqual(handoff["intent"]["intent_type"], "retry_execution")
+        self.assertEqual(handoff["harness_boundary"]["completion_authority"], "harness_verification")
+        self.assertFalse(handoff["harness_boundary"]["runner_completion_is_truth"])
+        self.assertFalse(handoff["metadata"]["safe_to_execute_live"])
+        self.assertEqual(
+            handoff["callback"]["events_url"],
+            f"http://harness.test/tasks/{response['task_envelope']['id']}/execution-substrate-events",
+        )
+
 
 class HarnessHttpApiTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -6652,6 +6685,32 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(intent_entry["task_id"], create_payload["task_envelope"]["id"])
         self.assertEqual(intent_entry["attention_type"], "retryable_failure")
         self.assertEqual(intent_entry["intent"]["intent_type"], "retry_execution")
+
+    def test_api_exposes_execution_substrate_handoff_preview_endpoint(self) -> None:
+        payload = _request_payload("blocked_insufficient_evidence")
+        payload["request"]["runtime_facts"] = {
+            "executor_reported_failure": True,
+            "attempt_count": 1,
+            "latest_attempt_outcome": "failed",
+        }
+        create_status, create_payload = self._post_json("/evaluate", payload)
+
+        status, preview_payload = self._get_json("/execution-substrate/handoffs")
+
+        self.assertEqual(create_status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(preview_payload["handoff_count"], 1)
+        self.assertFalse(preview_payload["dispatch_enabled"])
+        handoff_entry = preview_payload["handoffs"][0]
+        self.assertEqual(handoff_entry["task_id"], create_payload["task_envelope"]["id"])
+        handoff = handoff_entry["handoff"]
+        self.assertEqual(handoff["mode"], "render_only")
+        self.assertEqual(handoff["intent"]["completion_authority"], "harness_verification")
+        self.assertFalse(handoff["metadata"]["safe_to_execute_live"])
+        self.assertIn(
+            f"/tasks/{create_payload['task_envelope']['id']}/execution-substrate-events",
+            handoff["callback"]["events_url"],
+        )
 
     def test_api_openclaw_ingress_rejects_invalid_payload_without_persisting_state(self) -> None:
         payload = _openclaw_ingress_payload(task_id="task-openclaw-invalid-1")


### PR DESCRIPTION
## Summary
- add read-only execution substrate handoff previews at GET /execution-substrate/handoffs
- render previews from the existing supervision intent queue through the Symphony render-only adapter
- add canonical execution-substrate intent deserialization and reuse it in the handoff dry run

## Safety
- preview only; dispatch_enabled=false
- does not start or contact Symphony
- does not mutate Linear or GitHub
- preserves completion_authority=harness_verification
- rendered handoffs remain render_only and safe_to_execute_live=false

## Validation
- python3 -m unittest tests.contracts.test_execution_substrate tests.adapters.test_symphony_execution_substrate_adapter -v
- python3 -m unittest tests.test_api.HarnessApiServiceTests.test_service_exposes_execution_substrate_intents_from_supervision_queue tests.test_api.HarnessApiServiceTests.test_service_previews_execution_substrate_handoffs_without_dispatch -v
- python3 -m unittest tests.test_api.HarnessHttpApiTests.test_api_exposes_execution_substrate_intents_endpoint tests.test_api.HarnessHttpApiTests.test_api_exposes_execution_substrate_handoff_preview_endpoint -v
- python3 -m unittest tests.test_execution_substrate_dryrun -v
- git diff --check
- python3 -m unittest discover -s tests