### PR TITLE
Add execution handoff dashboard view

### DIFF
--- a/app/execution/page.tsx
+++ b/app/execution/page.tsx
@@ -1,0 +1,5 @@
+import { ExecutionHandoffBrowser } from "@/components/dashboard/execution-handoff-browser";
+
+export default function ExecutionPage() {
+  return <ExecutionHandoffBrowser />;
+}

--- a/components/dashboard/execution-handoff-browser.tsx
+++ b/components/dashboard/execution-handoff-browser.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  Power,
+  RefreshCw,
+  Route,
+  ShieldCheck,
+} from "lucide-react";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { Card, CardContent } from "@/components/ui/card";
+import { fetchExecutionSubstrateHandoffs } from "@/lib/harness-api";
+import type { ExecutionSubstrateHandoffPreview } from "@/lib/types";
+
+export function ExecutionHandoffBrowser() {
+  const [preview, setPreview] = useState<ExecutionSubstrateHandoffPreview | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const handoffs = useMemo(() => preview?.handoffs ?? [], [preview]);
+  const safetyStats = useMemo(
+    () => [
+      {
+        label: "Rendered Handoffs",
+        value: handoffs.length,
+        icon: Route,
+        tone: "text-info",
+      },
+      {
+        label: "Dispatch Disabled",
+        value: preview && !preview.dispatch_enabled ? 1 : 0,
+        icon: Ban,
+        tone: "text-warning",
+      },
+      {
+        label: "Harness Authority",
+        value: preview?.completion_authority === "harness_verification" ? 1 : 0,
+        icon: ShieldCheck,
+        tone: "text-success",
+      },
+      {
+        label: "Live-Safe Payloads",
+        value: handoffs.filter((entry) => entry.handoff.metadata.safe_to_execute_live).length,
+        icon: Power,
+        tone: "text-destructive",
+      },
+    ],
+    [handoffs, preview],
+  );
+
+  async function loadPreview() {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      setPreview(await fetchExecutionSubstrateHandoffs());
+    } catch (error) {
+      setLoadError(
+        error instanceof Error
+          ? error.message
+          : "Execution substrate handoffs could not be loaded.",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadPreview();
+  }, []);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <DashboardHeader />
+
+      <main className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-7xl space-y-6 p-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <Route className="h-5 w-5 text-info" />
+                <h1 className="text-2xl font-semibold text-foreground">
+                  Execution
+                </h1>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Read-only preview of Symphony-compatible handoff payloads from the Harness supervision queue.
+              </p>
+            </div>
+            <button
+              onClick={() => void loadPreview()}
+              disabled={isLoading}
+              className="flex h-9 items-center gap-2 rounded-md border border-border bg-card px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
+              <span>{isLoading ? "Refreshing" : "Refresh"}</span>
+            </button>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+            {safetyStats.map((stat) => (
+              <Card key={stat.label}>
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-xs text-muted-foreground">{stat.label}</p>
+                      <p className="mt-1 text-2xl font-semibold">{stat.value}</p>
+                    </div>
+                    <div
+                      className={`flex h-10 w-10 items-center justify-center rounded-md bg-muted ${stat.tone}`}
+                    >
+                      <stat.icon className="h-5 w-5" />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {loadError ? (
+            <Card className="border-destructive/40">
+              <CardContent className="p-6">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-foreground">
+                      Execution handoffs could not be loaded
+                    </p>
+                    <p className="text-sm text-muted-foreground">{loadError}</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ) : isLoading ? (
+            <div className="rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
+              Loading execution handoffs from Harness...
+            </div>
+          ) : handoffs.length === 0 ? (
+            <Card>
+              <CardContent className="p-8">
+                <p className="text-sm font-medium text-foreground">
+                  No execution handoffs returned
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Harness did not return any runner-facing handoff previews from the current supervision queue.
+                </p>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {handoffs.map((entry) => (
+                <Card key={`${entry.task_id}:${entry.handoff.intent.intent_type}`}>
+                  <CardContent className="space-y-4 p-5">
+                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="font-mono text-sm font-semibold text-foreground">
+                            {entry.task_id}
+                          </p>
+                          <span className="rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+                            {entry.attention_type}
+                          </span>
+                          <span className="rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+                            {entry.current_status}
+                          </span>
+                        </div>
+                        <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                          {entry.handoff.intent.reason}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2 rounded-md border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+                        <CheckCircle2 className="h-4 w-4 text-success" />
+                        {entry.handoff.mode}
+                      </div>
+                    </div>
+
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <PreviewField
+                        label="Intent"
+                        value={entry.handoff.intent.intent_type}
+                      />
+                      <PreviewField
+                        label="Authority"
+                        value={entry.handoff.harness_boundary.completion_authority}
+                      />
+                      <PreviewField
+                        label="Callback"
+                        value={entry.handoff.callback.events_endpoint}
+                      />
+                    </div>
+
+                    <div className="rounded-md border border-border bg-muted/50 p-3">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Runner Prohibitions
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {entry.handoff.runner_policy.prohibited_actions.map((action) => (
+                          <span
+                            key={action}
+                            className="rounded-md bg-background px-2 py-1 text-xs text-muted-foreground"
+                          >
+                            {action}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function PreviewField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-md border border-border bg-muted/50 p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 truncate font-mono text-sm text-foreground" title={value}>
+        {value || "none"}
+      </p>
+    </div>
+  );
+}

--- a/components/dashboard/header.tsx
+++ b/components/dashboard/header.tsx
@@ -11,6 +11,7 @@ export function DashboardHeader() {
     { href: "/verification", label: "Verification" },
     { href: "/reconciliation", label: "Reconciliation" },
     { href: "/reviews", label: "Reviews" },
+    { href: "/execution", label: "Execution" },
   ];
 
   return (

--- a/lib/harness-api.ts
+++ b/lib/harness-api.ts
@@ -2,6 +2,7 @@ import type {
   ReconciliationStatus,
   ReviewDecision,
   ReviewRequest,
+  ExecutionSubstrateHandoffPreview,
   Task,
   TimelineEvent,
   VerificationStatus,
@@ -433,4 +434,96 @@ export async function fetchTaskDetail(taskId: string): Promise<Task> {
     ? timelinePayload.timeline.map((event) => mapTimelineEvent(event))
     : [];
   return mapTask(taskPayload.task, timeline);
+}
+
+function mapStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(String) : [];
+}
+
+function mapExecutionSubstrateHandoff(entry: Record<string, unknown>) {
+  const handoff =
+    entry.handoff && typeof entry.handoff === "object"
+      ? (entry.handoff as Record<string, unknown>)
+      : {};
+  const intent =
+    handoff.intent && typeof handoff.intent === "object"
+      ? (handoff.intent as Record<string, unknown>)
+      : {};
+  const harnessBoundary =
+    handoff.harness_boundary && typeof handoff.harness_boundary === "object"
+      ? (handoff.harness_boundary as Record<string, unknown>)
+      : {};
+  const runnerPolicy =
+    handoff.runner_policy && typeof handoff.runner_policy === "object"
+      ? (handoff.runner_policy as Record<string, unknown>)
+      : {};
+  const callback =
+    handoff.callback && typeof handoff.callback === "object"
+      ? (handoff.callback as Record<string, unknown>)
+      : {};
+  const metadata =
+    handoff.metadata && typeof handoff.metadata === "object"
+      ? (handoff.metadata as Record<string, unknown>)
+      : {};
+
+  return {
+    task_id: String(entry.task_id ?? ""),
+    attention_type: String(entry.attention_type ?? ""),
+    current_status: String(entry.current_status ?? ""),
+    last_activity_at: (entry.last_activity_at as string | null | undefined) ?? null,
+    handoff: {
+      adapter: String(handoff.adapter ?? ""),
+      mode: String(handoff.mode ?? ""),
+      intent: {
+        intent_type: String(intent.intent_type ?? ""),
+        substrate_kind: String(intent.substrate_kind ?? ""),
+        task_id: String(intent.task_id ?? ""),
+        source: String(intent.source ?? ""),
+        reason: String(intent.reason ?? ""),
+        suggested_action: String(intent.suggested_action ?? ""),
+        advisory_only: Boolean(intent.advisory_only),
+        events_endpoint: String(intent.events_endpoint ?? ""),
+        completion_authority: String(intent.completion_authority ?? ""),
+        prohibited_actions: mapStringArray(intent.prohibited_actions),
+      },
+      harness_boundary: {
+        completion_authority: String(harnessBoundary.completion_authority ?? ""),
+        advisory_only: Boolean(harnessBoundary.advisory_only),
+        runner_completion_is_truth: Boolean(harnessBoundary.runner_completion_is_truth),
+        artifact_verification_required: Boolean(harnessBoundary.artifact_verification_required),
+      },
+      runner_policy: {
+        substrate_kind: String(runnerPolicy.substrate_kind ?? ""),
+        allowed_intent_type: String(runnerPolicy.allowed_intent_type ?? ""),
+        prohibited_actions: mapStringArray(runnerPolicy.prohibited_actions),
+      },
+      callback: {
+        events_endpoint: String(callback.events_endpoint ?? ""),
+        events_url: String(callback.events_url ?? ""),
+        event_contract: String(callback.event_contract ?? ""),
+      },
+      metadata: {
+        task_id: String(metadata.task_id ?? ""),
+        source: String(metadata.source ?? ""),
+        safe_to_execute_live: Boolean(metadata.safe_to_execute_live),
+      },
+    },
+  };
+}
+
+export async function fetchExecutionSubstrateHandoffs(): Promise<ExecutionSubstrateHandoffPreview> {
+  const payload = (await fetchJson("/execution-substrate/handoffs")) as Record<string, unknown>;
+  const handoffs = Array.isArray(payload.handoffs)
+    ? payload.handoffs.map((entry) => mapExecutionSubstrateHandoff(entry as Record<string, unknown>))
+    : [];
+
+  return {
+    generated_at: String(payload.generated_at ?? ""),
+    handoff_count: Number(payload.handoff_count ?? handoffs.length),
+    handoffs,
+    source: String(payload.source ?? ""),
+    advisory_only: Boolean(payload.advisory_only),
+    dispatch_enabled: Boolean(payload.dispatch_enabled),
+    completion_authority: String(payload.completion_authority ?? ""),
+  };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -185,3 +185,57 @@ export interface Task {
   timeline: TimelineEvent[];
   priority: Priority;
 }
+
+export interface ExecutionSubstrateHandoff {
+  task_id: string;
+  attention_type: string;
+  current_status: string;
+  last_activity_at: string | null;
+  handoff: {
+    adapter: string;
+    mode: string;
+    intent: {
+      intent_type: string;
+      substrate_kind: string;
+      task_id: string;
+      source: string;
+      reason: string;
+      suggested_action: string;
+      advisory_only: boolean;
+      events_endpoint: string;
+      completion_authority: string;
+      prohibited_actions: string[];
+    };
+    harness_boundary: {
+      completion_authority: string;
+      advisory_only: boolean;
+      runner_completion_is_truth: boolean;
+      artifact_verification_required: boolean;
+    };
+    runner_policy: {
+      substrate_kind: string;
+      allowed_intent_type: string;
+      prohibited_actions: string[];
+    };
+    callback: {
+      events_endpoint: string;
+      events_url: string;
+      event_contract: string;
+    };
+    metadata: {
+      task_id: string;
+      source: string;
+      safe_to_execute_live: boolean;
+    };
+  };
+}
+
+export interface ExecutionSubstrateHandoffPreview {
+  generated_at: string;
+  handoff_count: number;
+  handoffs: ExecutionSubstrateHandoff[];
+  source: string;
+  advisory_only: boolean;
+  dispatch_enabled: boolean;
+  completion_authority: string;
+}

--- a/tests/frontend/execution-substrate-handoffs.test.ts
+++ b/tests/frontend/execution-substrate-handoffs.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fetchExecutionSubstrateHandoffs } from "../../lib/harness-api";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("maps execution substrate handoff previews from Harness", async () => {
+  globalThis.fetch = async (url) => {
+    assert.equal(url, "/api/harness/execution-substrate/handoffs");
+    return new Response(
+      JSON.stringify({
+        generated_at: "2026-04-30T15:00:00Z",
+        handoff_count: 1,
+        source: "execution_substrate_intents",
+        advisory_only: true,
+        dispatch_enabled: false,
+        completion_authority: "harness_verification",
+        handoffs: [
+          {
+            task_id: "task-1",
+            attention_type: "retryable_failure",
+            current_status: "blocked",
+            last_activity_at: null,
+            handoff: {
+              adapter: "symphony-execution-substrate",
+              mode: "render_only",
+              intent: {
+                intent_type: "retry_execution",
+                substrate_kind: "symphony-compatible",
+                task_id: "task-1",
+                source: "harness_supervision_queue",
+                reason: "Task is retryable.",
+                suggested_action: "retry_or_redispatch",
+                advisory_only: true,
+                events_endpoint: "/tasks/task-1/execution-substrate-events",
+                completion_authority: "harness_verification",
+                prohibited_actions: ["mark_harness_complete"],
+              },
+              harness_boundary: {
+                completion_authority: "harness_verification",
+                advisory_only: true,
+                runner_completion_is_truth: false,
+                artifact_verification_required: true,
+              },
+              runner_policy: {
+                substrate_kind: "symphony-compatible",
+                allowed_intent_type: "retry_execution",
+                prohibited_actions: ["mark_harness_complete"],
+              },
+              callback: {
+                events_endpoint: "/tasks/task-1/execution-substrate-events",
+                events_url: "http://harness.test/tasks/task-1/execution-substrate-events",
+                event_contract: "execution_substrate_event.v1",
+              },
+              metadata: {
+                task_id: "task-1",
+                source: "harness_supervision_queue",
+                safe_to_execute_live: false,
+              },
+            },
+          },
+        ],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+
+  const preview = await fetchExecutionSubstrateHandoffs();
+
+  assert.equal(preview.handoff_count, 1);
+  assert.equal(preview.dispatch_enabled, false);
+  assert.equal(preview.completion_authority, "harness_verification");
+  assert.equal(preview.handoffs[0].handoff.mode, "render_only");
+  assert.equal(preview.handoffs[0].handoff.metadata.safe_to_execute_live, false);
+  assert.equal(
+    preview.handoffs[0].handoff.callback.events_endpoint,
+    "/tasks/task-1/execution-substrate-events",
+  );
+});


### PR DESCRIPTION
## Summary
- add a read-only Execution dashboard page for Symphony-compatible handoff previews
- map GET /execution-substrate/handoffs through the dashboard API client
- add header navigation and frontend coverage for the handoff preview mapper

## Safety
- UI is read-only
- no dispatch controls are added
- rendered payloads continue to show render_only, dispatch disabled, Harness verification authority, and safe_to_execute_live=false
- no Symphony process is started or contacted

## Validation
- pnpm test:frontend
- pnpm lint
- pnpm build
- python3 -m unittest tests.test_api.HarnessApiServiceTests.test_service_previews_execution_substrate_handoffs_without_dispatch tests.test_api.HarnessHttpApiTests.test_api_exposes_execution_substrate_handoff_preview_endpoint -v
- git diff --check
- local route smoke: pnpm exec next dev --turbopack -p 3107, then curl -I http://localhost:3107/execution -> HTTP 200