### PR TITLE
Add execution dashboard macOS route

### DIFF
--- a/apps/macos/HarnessApp/Sources/HarnessAppCore/DashboardRoute.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCore/DashboardRoute.swift
@@ -5,6 +5,7 @@ public enum DashboardRoute: String, CaseIterable, Identifiable, Sendable {
     case verification
     case reconciliation
     case reviews
+    case execution
 
     public var id: String { rawValue }
 
@@ -18,6 +19,8 @@ public enum DashboardRoute: String, CaseIterable, Identifiable, Sendable {
             return "Reconciliation"
         case .reviews:
             return "Reviews"
+        case .execution:
+            return "Execution"
         }
     }
 
@@ -31,6 +34,8 @@ public enum DashboardRoute: String, CaseIterable, Identifiable, Sendable {
             return "/dashboard/reconciliation/"
         case .reviews:
             return "/dashboard/reviews/"
+        case .execution:
+            return "/dashboard/execution/"
         }
     }
 }

--- a/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
+++ b/apps/macos/HarnessApp/Sources/HarnessAppCoreCheck/main.swift
@@ -141,6 +141,10 @@ struct HarnessAppCoreCheck {
             baseURL.dashboardRoute(.reviews).absoluteString == "http://127.0.0.1:8765/dashboard/reviews/",
             "reviews dashboard route"
         )
+        try require(
+            baseURL.dashboardRoute(.execution).absoluteString == "http://127.0.0.1:8765/dashboard/execution/",
+            "execution dashboard route"
+        )
     }
 
     private static func checksBundleResourceDefaults() throws {

--- a/docs/architecture/macos-dashboard-window.md
+++ b/docs/architecture/macos-dashboard-window.md
@@ -26,6 +26,7 @@ The window exposes the current dashboard routes as first-class toolbar choices:
 - `Verification`: `/dashboard/verification/`
 - `Reconciliation`: `/dashboard/reconciliation/`
 - `Reviews`: `/dashboard/reviews/`
+- `Execution`: `/dashboard/execution/`
 
 These are the same routes used by the packaged local dashboard.
 The app must not introduce a separate route model that contradicts the dashboard.

--- a/docs/architecture/macos-menu-bar-controller.md
+++ b/docs/architecture/macos-menu-bar-controller.md
@@ -78,6 +78,7 @@ The window preserves the canonical local dashboard routes:
 - `/dashboard/verification/`
 - `/dashboard/reconciliation/`
 - `/dashboard/reviews/`
+- `/dashboard/execution/`
 
 Closing the dashboard window does not stop the runtime.
 The menu bar remains useful without the dashboard window open.

--- a/scripts/build-local-dashboard.mjs
+++ b/scripts/build-local-dashboard.mjs
@@ -75,6 +75,7 @@ async function writeManifest() {
       "/dashboard/verification/",
       "/dashboard/reconciliation/",
       "/dashboard/reviews/",
+      "/dashboard/execution/",
     ],
   };
   await writeFile(


### PR DESCRIPTION
## Summary
- add the Execution dashboard route to the macOS DashboardRoute enum
- include /dashboard/execution/ in the local dashboard manifest
- update macOS dashboard/menu-bar route docs and CoreCheck route assertions

## Safety
- route parity only
- no dashboard mutations or dispatch controls
- no Symphony execution path is enabled

## Validation
- git diff --check
- pnpm build:dashboard:local
- verified dist/local-dashboard/dashboard-manifest.json includes /dashboard/execution/

## Validation note
- swift run HarnessAppCoreCheck was attempted with SwiftPM/cache permissions, but it is currently blocked by the unrelated untracked file apps/macos/HarnessApp/Sources/HarnessAppCore/HarnessBundleResources 2.swift, which redeclares HarnessBundleResources. I left that untracked file untouched.