### PR TITLE
Enforce inert execution handoff previews

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -173,6 +173,8 @@ The first Symphony adapter lives in [`modules/adapters/symphony`](../../modules/
 
 Harness exposes `GET /execution-substrate/handoffs` as a read-only preview of those rendered handoffs. The endpoint renders from the current supervision intent queue, marks `dispatch_enabled=false`, and does not start or contact Symphony. It exists so operators and future runners can inspect the exact payload shape before any live execution transport is enabled.
 
+That preview surface is protected by the execution-substrate contract validator. A valid preview must remain `advisory_only=true`, `dispatch_enabled=false`, `completion_authority=harness_verification`, `mode=render_only`, `runner_completion_is_truth=false`, and `safe_to_execute_live=false`. It must also carry the required runner prohibitions: no marking Harness complete, no treating Linear Done as truth, and no auto-merge without policy. Future live Symphony transport should add a separate execution path rather than weakening this read-only preview contract.
+
 Initial event family:
 
 - `dispatch_requested`

--- a/modules/api.py
+++ b/modules/api.py
@@ -46,6 +46,7 @@ from modules.contracts.execution_substrate import (
     ExecutionSubstrateProvenance,
     execution_substrate_intent_from_dict,
     validate_execution_substrate_event,
+    validate_execution_substrate_handoff_preview,
 )
 from modules.contracts.task_envelope_enforcement import EnforcementAction, EnforcementResult
 from modules.contracts.task_envelope_reconciliation import (
@@ -4609,7 +4610,7 @@ class HarnessApiService:
                 }
             )
 
-        return HTTPStatus.OK, {
+        preview_payload = {
             "generated_at": _iso_now(),
             "handoff_count": len(handoffs),
             "handoffs": handoffs,
@@ -4618,6 +4619,8 @@ class HarnessApiService:
             "dispatch_enabled": False,
             "completion_authority": "harness_verification",
         }
+        validate_execution_substrate_handoff_preview(preview_payload)
+        return HTTPStatus.OK, preview_payload
 
     def get_evaluation_history(self, task_id: str) -> tuple[int, dict[str, Any]]:
         try:

--- a/modules/contracts/execution_substrate.py
+++ b/modules/contracts/execution_substrate.py
@@ -318,6 +318,106 @@ def execution_substrate_intent_from_dict(payload: dict[str, Any]) -> ExecutionSu
     return validate_execution_substrate_intent(intent)
 
 
+def validate_execution_substrate_handoff_preview(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate that a rendered handoff preview is inert and Harness-authoritative.
+
+    This is intentionally stricter than runner event validation. The preview
+    endpoint is an operator/adapter inspection surface, not a live transport.
+    """
+
+    if payload.get("advisory_only") is not True:
+        raise ExecutionSubstrateValidationError(
+            "execution-substrate handoff previews must be advisory_only=true"
+        )
+    if payload.get("dispatch_enabled") is not False:
+        raise ExecutionSubstrateValidationError(
+            "execution-substrate handoff previews must keep dispatch_enabled=false"
+        )
+    if payload.get("completion_authority") != "harness_verification":
+        raise ExecutionSubstrateValidationError(
+            "execution-substrate handoff previews must keep completion_authority=harness_verification"
+        )
+
+    handoffs = payload.get("handoffs")
+    if not isinstance(handoffs, list):
+        raise ExecutionSubstrateValidationError(
+            "execution-substrate handoff previews must include a handoffs list"
+        )
+
+    for index, entry in enumerate(handoffs):
+        if not isinstance(entry, dict):
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must be an object"
+            )
+        handoff = entry.get("handoff")
+        if not isinstance(handoff, dict):
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must include a handoff object"
+            )
+        if handoff.get("mode") != "render_only":
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must keep mode=render_only"
+            )
+
+        intent_payload = handoff.get("intent")
+        if not isinstance(intent_payload, dict):
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must include an intent object"
+            )
+        validate_execution_substrate_intent(execution_substrate_intent_from_dict(intent_payload))
+
+        harness_boundary = handoff.get("harness_boundary")
+        if not isinstance(harness_boundary, dict):
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must include harness_boundary"
+            )
+        if harness_boundary.get("completion_authority") != "harness_verification":
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must keep Harness completion authority"
+            )
+        if harness_boundary.get("advisory_only") is not True:
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must keep harness_boundary.advisory_only=true"
+            )
+        if harness_boundary.get("runner_completion_is_truth") is not False:
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must keep runner_completion_is_truth=false"
+            )
+        if harness_boundary.get("artifact_verification_required") is not True:
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must require artifact verification"
+            )
+
+        runner_policy = handoff.get("runner_policy")
+        if not isinstance(runner_policy, dict):
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must include runner_policy"
+            )
+        prohibited_actions = runner_policy.get("prohibited_actions")
+        if not isinstance(prohibited_actions, list):
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must include runner_policy.prohibited_actions"
+            )
+        missing_actions = sorted(_REQUIRED_PROHIBITED_ACTIONS.difference(prohibited_actions))
+        if missing_actions:
+            names = ", ".join(missing_actions)
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} is missing prohibited actions: {names}"
+            )
+
+        metadata = handoff.get("metadata")
+        if not isinstance(metadata, dict):
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must include metadata"
+            )
+        if metadata.get("safe_to_execute_live") is not False:
+            raise ExecutionSubstrateValidationError(
+                f"execution-substrate handoff preview entry {index} must keep safe_to_execute_live=false"
+            )
+
+    return payload
+
+
 __all__ = [
     "ExecutionSubstrateArtifactReference",
     "ExecutionSubstrateEvent",
@@ -331,6 +431,7 @@ __all__ = [
     "execution_substrate_intent_to_dict",
     "validate_execution_substrate_artifact_reference",
     "validate_execution_substrate_event",
+    "validate_execution_substrate_handoff_preview",
     "validate_execution_substrate_intent",
     "validate_execution_substrate_provenance",
 ]

--- a/tests/contracts/test_execution_substrate.py
+++ b/tests/contracts/test_execution_substrate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import unittest
 from dataclasses import replace
+from typing import Any
 
 from modules.contracts.execution_substrate import (
     ExecutionSubstrateArtifactReference,
@@ -18,6 +19,7 @@ from modules.contracts.execution_substrate import (
     execution_substrate_intent_to_dict,
     validate_execution_substrate_artifact_reference,
     validate_execution_substrate_event,
+    validate_execution_substrate_handoff_preview,
     validate_execution_substrate_intent,
 )
 
@@ -44,6 +46,58 @@ class ExecutionSubstrateEventTests(unittest.TestCase):
             occurred_at="2026-04-27T20:00:00Z",
             provenance=self._provenance(),
         )
+
+    def _handoff_preview(self) -> dict[str, Any]:
+        intent = build_execution_substrate_intent(
+            task_id="task-1",
+            attention_type="retryable_failure",
+            suggested_action="retry_or_redispatch",
+            reason="Task is retryable.",
+        )
+        assert intent is not None
+        intent_payload = execution_substrate_intent_to_dict(intent)
+        return {
+            "generated_at": "2026-04-30T15:00:00Z",
+            "handoff_count": 1,
+            "source": "execution_substrate_intents",
+            "advisory_only": True,
+            "dispatch_enabled": False,
+            "completion_authority": "harness_verification",
+            "handoffs": [
+                {
+                    "task_id": "task-1",
+                    "attention_type": "retryable_failure",
+                    "current_status": "blocked",
+                    "last_activity_at": None,
+                    "handoff": {
+                        "adapter": "symphony-execution-substrate",
+                        "mode": "render_only",
+                        "intent": intent_payload,
+                        "harness_boundary": {
+                            "completion_authority": "harness_verification",
+                            "advisory_only": True,
+                            "runner_completion_is_truth": False,
+                            "artifact_verification_required": True,
+                        },
+                        "runner_policy": {
+                            "substrate_kind": "symphony-compatible",
+                            "allowed_intent_type": "retry_execution",
+                            "prohibited_actions": intent_payload["prohibited_actions"],
+                        },
+                        "callback": {
+                            "events_endpoint": "/tasks/task-1/execution-substrate-events",
+                            "events_url": "http://harness.test/tasks/task-1/execution-substrate-events",
+                            "event_contract": "execution_substrate_event.v1",
+                        },
+                        "metadata": {
+                            "task_id": "task-1",
+                            "source": "harness_supervision_queue",
+                            "safe_to_execute_live": False,
+                        },
+                    },
+                },
+            ],
+        }
 
     def test_validate_event_accepts_runner_handoff(self) -> None:
         event = self._event(ExecutionSubstrateEventType.HANDOFF_REPORTED)
@@ -203,6 +257,45 @@ class ExecutionSubstrateEventTests(unittest.TestCase):
             "missing required prohibited actions",
         ):
             validate_execution_substrate_intent(intent)
+
+    def test_handoff_preview_guardrail_accepts_inert_preview(self) -> None:
+        preview = self._handoff_preview()
+
+        validated = validate_execution_substrate_handoff_preview(preview)
+
+        self.assertIs(validated, preview)
+
+    def test_handoff_preview_guardrail_rejects_live_dispatch(self) -> None:
+        preview = self._handoff_preview()
+        preview["dispatch_enabled"] = True
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "dispatch_enabled=false",
+        ):
+            validate_execution_substrate_handoff_preview(preview)
+
+    def test_handoff_preview_guardrail_rejects_runner_completion_truth(self) -> None:
+        preview = self._handoff_preview()
+        handoff = preview["handoffs"][0]["handoff"]
+        handoff["harness_boundary"]["runner_completion_is_truth"] = True
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "runner_completion_is_truth=false",
+        ):
+            validate_execution_substrate_handoff_preview(preview)
+
+    def test_handoff_preview_guardrail_rejects_live_safe_flag(self) -> None:
+        preview = self._handoff_preview()
+        handoff = preview["handoffs"][0]["handoff"]
+        handoff["metadata"]["safe_to_execute_live"] = True
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "safe_to_execute_live=false",
+        ):
+            validate_execution_substrate_handoff_preview(preview)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an execution-substrate preview validator that rejects live dispatch, runner completion authority, and live-safe handoff flags
- call the validator before returning GET /execution-substrate/handoffs
- document that live Symphony transport must use a separate path instead of weakening the read-only preview contract

## Validation
- git diff --check
- python3 -m unittest tests.contracts.test_execution_substrate tests.test_api.HarnessApiServiceTests.test_service_previews_execution_substrate_handoffs_without_dispatch tests.test_api.HarnessHttpApiTests.test_api_exposes_execution_substrate_handoff_preview_endpoint
- python3 -m unittest discover -s tests (872 tests, 17 skipped)