### PR TITLE
Clarify Symphony setup is not live dispatch

### DIFF
--- a/docs/architecture/setup-doctor.md
+++ b/docs/architecture/setup-doctor.md
@@ -82,6 +82,8 @@ Execution-substrate checks read:
 - `symphony` on `PATH`
 - the Knox Analytics `Infrastructure/symphony/elixir/bin/symphony` convention
 
+When the execution substrate is found, the check reports `status=pass` and `details.mode=installed`. When it is not found, the check reports `status=warn` and `details.mode=unconfigured`. Both states must keep `details.live_dispatch_enabled=false`, `details.completion_authority=harness_verification`, and `details.runner_completion_is_truth=false`. The doctor confirms installation posture only; it does not authorize Harness to dispatch live Symphony work or trust runner completion.
+
 Current legacy desktop-agent bridge checks read the existing adapter variables:
 
 - `OPENCLAW_CONFIG_PATH`

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -862,6 +862,9 @@ def _check_execution_substrate() -> RuntimeCheck:
                     "binary": str(candidate),
                     "checked_candidates": [str(path) for path in candidates],
                     "mode": "installed",
+                    "live_dispatch_enabled": False,
+                    "completion_authority": "harness_verification",
+                    "runner_completion_is_truth": False,
                 },
             )
 
@@ -880,6 +883,9 @@ def _check_execution_substrate() -> RuntimeCheck:
             "preferred_runner": "symphony",
             "checked_candidates": [str(path) for path in candidates],
             "mode": "unconfigured",
+            "live_dispatch_enabled": False,
+            "completion_authority": "harness_verification",
+            "runner_completion_is_truth": False,
         },
     )
 

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -25,6 +25,7 @@ from modules.local_runtime import (
     serve_runtime,
     start_runtime,
     stop_runtime,
+    _check_execution_substrate,
 )
 
 
@@ -155,6 +156,12 @@ class LocalRuntimeCliTests(unittest.TestCase):
         self.assertEqual(checks["github_connection"]["status"], "pass")
         self.assertEqual(checks["linear_connection"]["status"], "pass")
         self.assertEqual(checks["execution_substrate"]["status"], "pass")
+        self.assertFalse(checks["execution_substrate"]["details"]["live_dispatch_enabled"])
+        self.assertEqual(
+            checks["execution_substrate"]["details"]["completion_authority"],
+            "harness_verification",
+        )
+        self.assertFalse(checks["execution_substrate"]["details"]["runner_completion_is_truth"])
         self.assertEqual(checks["ingress_executor"]["status"], "pass")
         self.assertEqual(checks["notification_permission"]["status"], "pass")
         self.assertEqual(checks["launch_at_login"]["status"], "pass")
@@ -162,6 +169,18 @@ class LocalRuntimeCliTests(unittest.TestCase):
         self.assertIn("harness serve", checks["api_health"]["next_action"])
         self.assertTrue(all(check.get("impact") for check in payload["checks"]))
         self.assertTrue(all(check.get("next_action") for check in payload["checks"]))
+
+    def test_execution_substrate_warning_still_preserves_harness_authority(self) -> None:
+        missing_binary = self.data_path / "missing-symphony"
+
+        with patch("modules.local_runtime._symphony_binary_candidates", return_value=[missing_binary]):
+            check = _check_execution_substrate()
+
+        self.assertEqual(check.status, "warn")
+        self.assertEqual(check.details["mode"], "unconfigured")
+        self.assertFalse(check.details["live_dispatch_enabled"])
+        self.assertEqual(check.details["completion_authority"], "harness_verification")
+        self.assertFalse(check.details["runner_completion_is_truth"])
 
     def test_doctor_fails_when_configured_workspace_folder_is_missing(self) -> None:
         self._run_cli("init")


### PR DESCRIPTION
## Summary
- add explicit execution-substrate doctor details showing live dispatch remains disabled even when Symphony is installed
- keep Harness completion authority and runner-completion distrust visible in both installed and unconfigured setup states
- document the setup-doctor distinction between substrate installation posture and live execution authorization

## Validation
- git diff --check
- python3 -m unittest tests.test_local_runtime tests.test_local_setup
- python3 -m unittest discover -s tests (873 tests, 17 skipped)