### PR TITLE
Route Symphony handoff dry run through disabled transport

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -163,7 +163,7 @@ python3 -m modules.execution_substrate_dryrun intent-consumer
 python3 -m modules.execution_substrate_dryrun handoff
 ```
 
-These commands write a JSON summary to stdout. They use disposable local stores, do not start Symphony, do not read live Linear or GitHub state, and do not authorize task completion. The `handoff` command renders the Symphony-compatible adapter payload and marks it `safe_to_execute_live=false`. They exist to make the execution-substrate boundary testable before Harness connects a real Symphony runner.
+These commands write a JSON summary to stdout. They use disposable local stores, do not start Symphony, do not read live Linear or GitHub state, and do not authorize task completion. The `handoff` command renders the Symphony-compatible payload through the disabled transport boundary and marks `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, and `safe_to_execute_live=false`. They exist to make the execution-substrate boundary testable before Harness connects a real Symphony runner.
 
 The supervision queue now also exposes `execution_substrate_intent` for attention items that should be continued by a Symphony-compatible runner. This is the replacement for Harness pretending to be the runner in the normal path. A supervisor can submit that intent to Symphony, and Symphony reports back through `POST /tasks/<task_id>/execution-substrate-events`. Harness also exposes `GET /execution-substrate/intents` as a runner-facing filtered projection of those intents. The old direct `/tasks/<task_id>/dispatch` behavior remains only as a compatibility and deterministic-test path.
 

--- a/docs/howto/test-and-validate.md
+++ b/docs/howto/test-and-validate.md
@@ -61,7 +61,7 @@ python3 -m modules.execution_substrate_dryrun intent-consumer
 python3 -m modules.execution_substrate_dryrun handoff
 ```
 
-These commands exercise the Symphony-compatible execution substrate boundary locally. They write JSON summaries, use disposable stores, and do not start Symphony or touch live Linear/GitHub work. The `handoff` command renders the payload Harness would hand to a Symphony-compatible runner while keeping `safe_to_execute_live=false`.
+These commands exercise the Symphony-compatible execution substrate boundary locally. They write JSON summaries, use disposable stores, and do not start Symphony or touch live Linear/GitHub work. The `handoff` command renders the payload Harness would hand to a Symphony-compatible runner through the disabled transport boundary while keeping `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, and `safe_to_execute_live=false`.
 
 ## Local Live Smoke
 

--- a/modules/execution_substrate_dryrun.py
+++ b/modules/execution_substrate_dryrun.py
@@ -9,7 +9,7 @@ import tempfile
 from dataclasses import asdict, dataclass
 from typing import Any
 
-from modules.adapters.symphony import SymphonyExecutionSubstrateAdapter
+from modules.adapters.symphony import DisabledSymphonyExecutionTransport
 from modules.api import HarnessApiService
 from modules.contracts.execution_substrate import (
     execution_substrate_intent_from_dict,
@@ -60,8 +60,11 @@ class ExecutionSubstrateHandoffDryRunResult:
     intent_status: int
     intent_count: int
     rendered_intent_type: str | None
+    transport_status: str
     handoff_mode: str
     events_url: str
+    dispatch_enabled: bool
+    live_dispatch_enabled: bool
     completion_authority: str
     runner_completion_is_truth: bool
     safe_to_execute_live: bool
@@ -363,10 +366,10 @@ def run_symphony_handoff_dry_run(
         )
 
         intent_entry = intent_payload["intents"][0]
-        handoff = SymphonyExecutionSubstrateAdapter(
+        transport_result = DisabledSymphonyExecutionTransport(
             harness_base_url=harness_base_url,
-        ).render_handoff(execution_substrate_intent_from_dict(intent_entry["intent"]))
-        handoff_payload = handoff.to_dict()
+        ).preview(execution_substrate_intent_from_dict(intent_entry["intent"]))
+        handoff_payload = transport_result.handoff
         return ExecutionSubstrateHandoffDryRunResult(
             task_id=task_id,
             initial_task_status=(
@@ -377,12 +380,13 @@ def run_symphony_handoff_dry_run(
             intent_status=intent_status,
             intent_count=int(intent_payload["intent_count"]),
             rendered_intent_type=handoff_payload["intent"].get("intent_type"),
+            transport_status=transport_result.status,
             handoff_mode=str(handoff_payload["mode"]),
             events_url=str(handoff_payload["callback"]["events_url"]),
-            completion_authority=str(handoff_payload["harness_boundary"]["completion_authority"]),
-            runner_completion_is_truth=bool(
-                handoff_payload["harness_boundary"]["runner_completion_is_truth"]
-            ),
+            dispatch_enabled=transport_result.dispatch_enabled,
+            live_dispatch_enabled=transport_result.live_dispatch_enabled,
+            completion_authority=transport_result.completion_authority,
+            runner_completion_is_truth=transport_result.runner_completion_is_truth,
             safe_to_execute_live=bool(handoff_payload["metadata"]["safe_to_execute_live"]),
         )
 

--- a/tests/test_execution_substrate_dryrun.py
+++ b/tests/test_execution_substrate_dryrun.py
@@ -51,11 +51,14 @@ class ExecutionSubstrateDryRunTests(unittest.TestCase):
         self.assertEqual(result.intent_status, 200)
         self.assertEqual(result.intent_count, 1)
         self.assertEqual(result.rendered_intent_type, "retry_execution")
+        self.assertEqual(result.transport_status, "disabled")
         self.assertEqual(result.handoff_mode, "render_only")
         self.assertEqual(
             result.events_url,
             "http://harness.test/tasks/symphony-handoff-test-1/execution-substrate-events",
         )
+        self.assertFalse(result.dispatch_enabled)
+        self.assertFalse(result.live_dispatch_enabled)
         self.assertEqual(result.completion_authority, "harness_verification")
         self.assertFalse(result.runner_completion_is_truth)
         self.assertFalse(result.safe_to_execute_live)
@@ -105,7 +108,10 @@ class ExecutionSubstrateDryRunTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(payload["task_id"], "symphony-handoff-cli-test-1")
         self.assertEqual(payload["rendered_intent_type"], "retry_execution")
+        self.assertEqual(payload["transport_status"], "disabled")
         self.assertEqual(payload["handoff_mode"], "render_only")
+        self.assertFalse(payload["dispatch_enabled"])
+        self.assertFalse(payload["live_dispatch_enabled"])
         self.assertEqual(payload["completion_authority"], "harness_verification")
         self.assertFalse(payload["runner_completion_is_truth"])
         self.assertFalse(payload["safe_to_execute_live"])


### PR DESCRIPTION
## Summary
- route the execution-substrate handoff dry run through DisabledSymphonyExecutionTransport.preview()
- include transport_status, dispatch_enabled, and live_dispatch_enabled in the dry-run JSON summary
- update validation docs to make the disabled transport state explicit

## Validation
- git diff --check
- python3 -m unittest tests.test_execution_substrate_dryrun
- python3 -m modules.execution_substrate_dryrun handoff --task-id symphony-disabled-transport-check --harness-base-url http://harness.test
- python3 -m unittest discover -s tests (873 tests, 17 skipped)