### PR TITLE
Expose execution substrate transport status

### DIFF
--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -23,10 +23,16 @@ For existing tasks, treat `POST /tasks/<task_id>/reevaluate` as the authoritativ
 - `GET /tasks/<task_id>/timeline`: canonical ordered audit timeline for one task
 - `GET /supervision/queue`: canonical attention queue for autonomous supervisors such as OpenClaw, Hermes, or a future desktop agent client
 - `GET /execution-substrate/intents`: runner-facing projection of Symphony-compatible execution continuation intents
+- `GET /execution-substrate/transport-status`: read-only transport posture for the Symphony-compatible execution substrate
+- `GET /execution-substrate/handoffs`: read-only preview of rendered Symphony-compatible handoff payloads
 
 `GET /supervision/queue` is projection-only. It does not create work, mutate task state, or authorize follow-up actions. It exists so an ingress-side supervisor can poll Harness for the tasks that currently need intervention without rebuilding policy client-side from raw task payloads.
 
 `GET /execution-substrate/intents` is also projection-only. It filters the supervision queue down to entries that carry `execution_substrate_intent`, so a Symphony-compatible runner can poll only the work that belongs to the execution substrate. The response is advisory and still points completion authority back to Harness verification.
+
+`GET /execution-substrate/transport-status` is the operator-readable transport guardrail. It currently reports `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, `completion_authority=harness_verification`, `runner_completion_is_truth=false`, and `safe_to_execute_live=false`. That endpoint is posture, not permission. A live Symphony transport must add a separate policy-gated execution path instead of changing this status silently.
+
+`GET /execution-substrate/handoffs` renders the handoff payloads for current execution-substrate intents without starting Symphony, mutating GitHub, updating Linear, or trusting runner completion. It exists for inspection and future adapter development.
 
 Queue entries are derived from canonical read-model and timeline truth and currently classify:
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -4583,6 +4583,29 @@ class HarnessApiService:
             "completion_authority": "harness_verification",
         }
 
+    def get_execution_substrate_transport_status(self) -> tuple[int, dict[str, Any]]:
+        """Return the current Symphony-compatible transport posture."""
+
+        return HTTPStatus.OK, {
+            "generated_at": _iso_now(),
+            "substrate_kind": "symphony-compatible",
+            "preferred_runner": "symphony",
+            "transport_status": "disabled",
+            "dispatch_enabled": False,
+            "live_dispatch_enabled": False,
+            "advisory_only": True,
+            "completion_authority": "harness_verification",
+            "runner_completion_is_truth": False,
+            "safe_to_execute_live": False,
+            "events_contract": "execution_substrate_event.v1",
+            "handoff_preview_endpoint": "/execution-substrate/handoffs",
+            "intents_endpoint": "/execution-substrate/intents",
+            "message": (
+                "Harness can render Symphony-compatible handoffs, but live Symphony "
+                "dispatch is disabled until an explicit transport policy is added."
+            ),
+        }
+
     def preview_execution_substrate_handoffs(
         self,
         *,
@@ -4698,6 +4721,11 @@ class HarnessApiHandler(BaseHTTPRequestHandler):
 
         if path_components == ("execution-substrate", "intents"):
             status, payload = service.get_execution_substrate_intents()
+            self._write_json(status, payload)
+            return
+
+        if path_components == ("execution-substrate", "transport-status"):
+            status, payload = service.get_execution_substrate_transport_status()
             self._write_json(status, payload)
             return
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6686,6 +6686,22 @@ class HarnessHttpApiTests(unittest.TestCase):
         self.assertEqual(intent_entry["attention_type"], "retryable_failure")
         self.assertEqual(intent_entry["intent"]["intent_type"], "retry_execution")
 
+    def test_api_exposes_disabled_execution_substrate_transport_status(self) -> None:
+        status, payload = self._get_json("/execution-substrate/transport-status")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["substrate_kind"], "symphony-compatible")
+        self.assertEqual(payload["preferred_runner"], "symphony")
+        self.assertEqual(payload["transport_status"], "disabled")
+        self.assertFalse(payload["dispatch_enabled"])
+        self.assertFalse(payload["live_dispatch_enabled"])
+        self.assertTrue(payload["advisory_only"])
+        self.assertEqual(payload["completion_authority"], "harness_verification")
+        self.assertFalse(payload["runner_completion_is_truth"])
+        self.assertFalse(payload["safe_to_execute_live"])
+        self.assertEqual(payload["handoff_preview_endpoint"], "/execution-substrate/handoffs")
+        self.assertEqual(payload["intents_endpoint"], "/execution-substrate/intents")
+
     def test_api_exposes_execution_substrate_handoff_preview_endpoint(self) -> None:
         payload = _request_payload("blocked_insufficient_evidence")
         payload["request"]["runtime_facts"] = {


### PR DESCRIPTION
## Summary
- add GET /execution-substrate/transport-status as a read-only Symphony transport posture endpoint
- report disabled live transport, Harness completion authority, advisory-only semantics, and preview/intents endpoints
- document the endpoint in the agent API usage guide

## Validation
- git diff --check
- python3 -m unittest tests.test_api.HarnessHttpApiTests.test_api_exposes_disabled_execution_substrate_transport_status
- python3 -m unittest discover -s tests (874 tests, 17 skipped)