### PR TITLE
Show execution transport status in dashboard

### DIFF
--- a/components/dashboard/execution-handoff-browser.tsx
+++ b/components/dashboard/execution-handoff-browser.tsx
@@ -12,11 +12,19 @@ import {
 } from "lucide-react";
 import { DashboardHeader } from "@/components/dashboard/header";
 import { Card, CardContent } from "@/components/ui/card";
-import { fetchExecutionSubstrateHandoffs } from "@/lib/harness-api";
-import type { ExecutionSubstrateHandoffPreview } from "@/lib/types";
+import {
+  fetchExecutionSubstrateHandoffs,
+  fetchExecutionSubstrateTransportStatus,
+} from "@/lib/harness-api";
+import type {
+  ExecutionSubstrateHandoffPreview,
+  ExecutionSubstrateTransportStatus,
+} from "@/lib/types";
 
 export function ExecutionHandoffBrowser() {
   const [preview, setPreview] = useState<ExecutionSubstrateHandoffPreview | null>(null);
+  const [transportStatus, setTransportStatus] =
+    useState<ExecutionSubstrateTransportStatus | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -31,13 +39,13 @@ export function ExecutionHandoffBrowser() {
       },
       {
         label: "Dispatch Disabled",
-        value: preview && !preview.dispatch_enabled ? 1 : 0,
+        value: transportStatus && !transportStatus.dispatch_enabled ? 1 : 0,
         icon: Ban,
         tone: "text-warning",
       },
       {
         label: "Harness Authority",
-        value: preview?.completion_authority === "harness_verification" ? 1 : 0,
+        value: transportStatus?.completion_authority === "harness_verification" ? 1 : 0,
         icon: ShieldCheck,
         tone: "text-success",
       },
@@ -48,14 +56,19 @@ export function ExecutionHandoffBrowser() {
         tone: "text-destructive",
       },
     ],
-    [handoffs, preview],
+    [handoffs, transportStatus],
   );
 
   async function loadPreview() {
     setIsLoading(true);
     setLoadError(null);
     try {
-      setPreview(await fetchExecutionSubstrateHandoffs());
+      const [nextTransportStatus, nextPreview] = await Promise.all([
+        fetchExecutionSubstrateTransportStatus(),
+        fetchExecutionSubstrateHandoffs(),
+      ]);
+      setTransportStatus(nextTransportStatus);
+      setPreview(nextPreview);
     } catch (error) {
       setLoadError(
         error instanceof Error
@@ -118,6 +131,46 @@ export function ExecutionHandoffBrowser() {
               </Card>
             ))}
           </div>
+
+          <Card>
+            <CardContent className="p-5">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Power className="h-4 w-4 text-warning" />
+                    <p className="text-sm font-medium text-foreground">
+                      Transport Status
+                    </p>
+                    <span className="rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+                      {transportStatus?.transport_status || "unknown"}
+                    </span>
+                  </div>
+                  <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                    {transportStatus?.message ||
+                      "Harness has not returned execution transport posture yet."}
+                  </p>
+                </div>
+                <div className="grid min-w-0 gap-3 sm:grid-cols-2 lg:min-w-[28rem]">
+                  <PreviewField
+                    label="Runner"
+                    value={transportStatus?.preferred_runner || "unknown"}
+                  />
+                  <PreviewField
+                    label="Live Dispatch"
+                    value={transportStatus?.live_dispatch_enabled ? "enabled" : "disabled"}
+                  />
+                  <PreviewField
+                    label="Authority"
+                    value={transportStatus?.completion_authority || "unknown"}
+                  />
+                  <PreviewField
+                    label="Event Contract"
+                    value={transportStatus?.events_contract || "unknown"}
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
 
           {loadError ? (
             <Card className="border-destructive/40">

--- a/lib/harness-api.ts
+++ b/lib/harness-api.ts
@@ -3,6 +3,7 @@ import type {
   ReviewDecision,
   ReviewRequest,
   ExecutionSubstrateHandoffPreview,
+  ExecutionSubstrateTransportStatus,
   Task,
   TimelineEvent,
   VerificationStatus,
@@ -525,5 +526,26 @@ export async function fetchExecutionSubstrateHandoffs(): Promise<ExecutionSubstr
     advisory_only: Boolean(payload.advisory_only),
     dispatch_enabled: Boolean(payload.dispatch_enabled),
     completion_authority: String(payload.completion_authority ?? ""),
+  };
+}
+
+export async function fetchExecutionSubstrateTransportStatus(): Promise<ExecutionSubstrateTransportStatus> {
+  const payload = (await fetchJson("/execution-substrate/transport-status")) as Record<string, unknown>;
+
+  return {
+    generated_at: String(payload.generated_at ?? ""),
+    substrate_kind: String(payload.substrate_kind ?? ""),
+    preferred_runner: String(payload.preferred_runner ?? ""),
+    transport_status: String(payload.transport_status ?? ""),
+    dispatch_enabled: Boolean(payload.dispatch_enabled),
+    live_dispatch_enabled: Boolean(payload.live_dispatch_enabled),
+    advisory_only: Boolean(payload.advisory_only),
+    completion_authority: String(payload.completion_authority ?? ""),
+    runner_completion_is_truth: Boolean(payload.runner_completion_is_truth),
+    safe_to_execute_live: Boolean(payload.safe_to_execute_live),
+    events_contract: String(payload.events_contract ?? ""),
+    handoff_preview_endpoint: String(payload.handoff_preview_endpoint ?? ""),
+    intents_endpoint: String(payload.intents_endpoint ?? ""),
+    message: String(payload.message ?? ""),
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -239,3 +239,20 @@ export interface ExecutionSubstrateHandoffPreview {
   dispatch_enabled: boolean;
   completion_authority: string;
 }
+
+export interface ExecutionSubstrateTransportStatus {
+  generated_at: string;
+  substrate_kind: string;
+  preferred_runner: string;
+  transport_status: string;
+  dispatch_enabled: boolean;
+  live_dispatch_enabled: boolean;
+  advisory_only: boolean;
+  completion_authority: string;
+  runner_completion_is_truth: boolean;
+  safe_to_execute_live: boolean;
+  events_contract: string;
+  handoff_preview_endpoint: string;
+  intents_endpoint: string;
+  message: string;
+}

--- a/tests/frontend/execution-substrate-handoffs.test.ts
+++ b/tests/frontend/execution-substrate-handoffs.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { fetchExecutionSubstrateHandoffs } from "../../lib/harness-api";
+import {
+  fetchExecutionSubstrateHandoffs,
+  fetchExecutionSubstrateTransportStatus,
+} from "../../lib/harness-api";
 
 const originalFetch = globalThis.fetch;
 
@@ -81,4 +84,39 @@ test("maps execution substrate handoff previews from Harness", async () => {
     preview.handoffs[0].handoff.callback.events_endpoint,
     "/tasks/task-1/execution-substrate-events",
   );
+});
+
+test("maps execution substrate transport status from Harness", async () => {
+  globalThis.fetch = async (url) => {
+    assert.equal(url, "/api/harness/execution-substrate/transport-status");
+    return new Response(
+      JSON.stringify({
+        generated_at: "2026-04-30T16:50:00Z",
+        substrate_kind: "symphony-compatible",
+        preferred_runner: "symphony",
+        transport_status: "disabled",
+        dispatch_enabled: false,
+        live_dispatch_enabled: false,
+        advisory_only: true,
+        completion_authority: "harness_verification",
+        runner_completion_is_truth: false,
+        safe_to_execute_live: false,
+        events_contract: "execution_substrate_event.v1",
+        handoff_preview_endpoint: "/execution-substrate/handoffs",
+        intents_endpoint: "/execution-substrate/intents",
+        message: "Symphony live dispatch is disabled.",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+
+  const status = await fetchExecutionSubstrateTransportStatus();
+
+  assert.equal(status.transport_status, "disabled");
+  assert.equal(status.preferred_runner, "symphony");
+  assert.equal(status.dispatch_enabled, false);
+  assert.equal(status.live_dispatch_enabled, false);
+  assert.equal(status.completion_authority, "harness_verification");
+  assert.equal(status.runner_completion_is_truth, false);
+  assert.equal(status.safe_to_execute_live, false);
 });


### PR DESCRIPTION
## Summary
- fetch GET /execution-substrate/transport-status from the dashboard client
- show the disabled Symphony transport posture on the Execution dashboard
- add frontend type mapping and tests for the transport status payload

## Validation
- git diff --check
- pnpm test:frontend (rerun with sandbox permission after tsx IPC EPERM)
- pnpm lint
- pnpm build
- Browser check: http://127.0.0.1:3112/execution against disposable Harness API on port 8000; page showed Transport Status disabled, Live Dispatch disabled, Authority harness_verification, with no console errors beyond normal dev tooling logs