### PR TITLE
Expose execution transport policy in setup status

### DIFF
--- a/docs/architecture/guided-integration-setup.md
+++ b/docs/architecture/guided-integration-setup.md
@@ -72,6 +72,7 @@ Each item reports:
 - `next_action`
 - `setup_actions`
 - `validation`
+- `execution_transport` for the `execution_substrate` item only
 
 Item status values:
 
@@ -111,6 +112,7 @@ printf '%s' "$TOKEN" | python3 -m modules.local_runtime --json secrets set linea
 ```
 
 The execution-substrate item should name Symphony as the preferred runner without giving it completion authority.
+It also exposes a normalized `execution_transport` object with `preferred_runner`, `mode`, `live_dispatch_enabled`, `completion_authority`, and `runner_completion_is_truth`. `live_dispatch_enabled` must remain `false` until Harness has an explicit live Symphony transport policy.
 The legacy ingress/executor item must stay client-neutral in UI copy.
 It should describe the connection as a compatibility desktop-agent bridge for OpenClaw, Hermes, Codex, or a future equivalent.
 The current doctor still recognizes OpenClaw-shaped adapter variables because that is existing bridge wiring, not the Harness product boundary.

--- a/modules/local_setup.py
+++ b/modules/local_setup.py
@@ -370,7 +370,7 @@ def _build_setup_item(
         missing_completion_checks=missing_completion_checks,
     )
     blocks_onboarding = required and status != "complete"
-    return {
+    item = {
         "id": definition.id,
         "title": definition.title,
         "category": definition.category,
@@ -391,6 +391,25 @@ def _build_setup_item(
             "checks": [_summarize_check(check) for check in relevant_checks],
             "missing_check_codes": missing_completion_checks,
         },
+    }
+    if definition.id == "execution_substrate":
+        item["execution_transport"] = _execution_transport_policy(relevant_checks)
+    return item
+
+
+def _execution_transport_policy(checks: list[dict[str, Any]]) -> dict[str, Any]:
+    details: dict[str, Any] = {}
+    for check in checks:
+        raw_details = check.get("details")
+        if isinstance(raw_details, dict):
+            details.update(raw_details)
+
+    return {
+        "preferred_runner": str(details.get("preferred_runner") or "symphony"),
+        "mode": str(details.get("mode") or "unknown"),
+        "live_dispatch_enabled": bool(details.get("live_dispatch_enabled")),
+        "completion_authority": str(details.get("completion_authority") or "harness_verification"),
+        "runner_completion_is_truth": bool(details.get("runner_completion_is_truth")),
     }
 
 

--- a/tests/test_local_setup.py
+++ b/tests/test_local_setup.py
@@ -58,13 +58,22 @@ def healthy_runtime_doctor_payload(
 
 
 def check(code: str, status: str, *, next_action: str = "No action needed.") -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "code": code,
         "status": status,
         "message": f"{code} is {status}.",
         "impact": f"{code} impact.",
         "next_action": next_action,
     }
+    if code == "execution_substrate":
+        payload["details"] = {
+            "preferred_runner": "symphony",
+            "mode": "installed" if status == "pass" else "unconfigured",
+            "live_dispatch_enabled": False,
+            "completion_authority": "harness_verification",
+            "runner_completion_is_truth": False,
+        }
+    return payload
 
 
 class GuidedSetupStatusTests(unittest.TestCase):
@@ -129,6 +138,14 @@ class GuidedSetupStatusTests(unittest.TestCase):
         self.assertTrue(substrate["required"])
         self.assertFalse(items["ingress_executor"]["required"])
         self.assertIn("Symphony", substrate["compatible_clients"])
+        self.assertEqual(substrate["execution_transport"]["preferred_runner"], "symphony")
+        self.assertEqual(substrate["execution_transport"]["mode"], "unconfigured")
+        self.assertFalse(substrate["execution_transport"]["live_dispatch_enabled"])
+        self.assertEqual(
+            substrate["execution_transport"]["completion_authority"],
+            "harness_verification",
+        )
+        self.assertFalse(substrate["execution_transport"]["runner_completion_is_truth"])
         self.assertIn("verification", " ".join(substrate["notes"]))
 
     def test_configured_symphony_substrate_completes_repair_dispatch_setup(self) -> None:
@@ -142,6 +159,8 @@ class GuidedSetupStatusTests(unittest.TestCase):
         self.assertEqual(payload["required_blockers"], [])
         self.assertEqual(items["execution_substrate"]["status"], "complete")
         self.assertTrue(items["execution_substrate"]["required"])
+        self.assertEqual(items["execution_substrate"]["execution_transport"]["mode"], "installed")
+        self.assertFalse(items["execution_substrate"]["execution_transport"]["live_dispatch_enabled"])
 
     def test_configured_broken_runtime_blocks_onboarding(self) -> None:
         payload = healthy_runtime_doctor_payload()


### PR DESCRIPTION
## Summary
- add a normalized execution_transport block to the guided setup execution-substrate item
- surface preferred runner, installed/unconfigured mode, live dispatch disabled, Harness completion authority, and runner completion distrust
- document the setup contract so the app does not have to parse nested doctor details

## Validation
- git diff --check
- python3 -m unittest tests.test_local_setup
- python3 -m unittest discover -s tests (874 tests, 17 skipped)