### PR TITLE
Project execution transport status in read model

### DIFF
--- a/docs/api/agent-api-usage.md
+++ b/docs/api/agent-api-usage.md
@@ -368,7 +368,9 @@ On `GET /tasks` and `GET /tasks/<task_id>/read-model`, `execution_summary.attemp
 
 `execution_summary.total_attempts` is broader: it can include retry/evaluation-chain activity even when no new execution-attempt record exists. It must never be lower than `attempt_count`, because inspection surfaces cannot truthfully report fewer total attempts than the canonical execution-attempt history already attached to the task.
 
-`execution_summary.latest_attempt`, `latest_status`, `latest_dispatch_origin`, and `latest_attempt_validation` must follow the newest recorded execution attempt by `recorded_at`. Clients must not treat storage append order as authoritative when execution-attempt arrays are out of sequence.
+`execution_summary.latest_attempt`, `latest_status`, `latest_dispatch_origin`, `latest_attempt_validation`, and latest execution-transport fields must follow the newest recorded execution attempt by `recorded_at`. Clients must not treat storage append order as authoritative when execution-attempt arrays are out of sequence.
+
+When present, `execution_summary.latest_execution_transport_status`, `latest_live_dispatch_enabled`, `latest_completion_authority`, and `latest_runner_completion_is_truth` are projections from the latest recorded execution attempt metadata. They let clients see that a legacy attempt is still compatibility-mode dispatch with Harness completion authority without parsing raw attempt metadata.
 
 ## Linear Facts Workflow Rule
 

--- a/modules/read_model.py
+++ b/modules/read_model.py
@@ -554,6 +554,10 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
         return {
             "attempt_count": 0,
             "latest_attempt": None,
+            "latest_execution_transport_status": None,
+            "latest_live_dispatch_enabled": None,
+            "latest_completion_authority": None,
+            "latest_runner_completion_is_truth": None,
             "substrate_event_count": len(substrate_events) if isinstance(substrate_events, list) else 0,
             "latest_substrate_event": dict(latest_substrate_event) if latest_substrate_event is not None else None,
             "latest_artifact_references": [],
@@ -573,6 +577,11 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
         if validation.get("failure_type") == "invalid_execution_attempt":
             invalid_attempt_count += 1
     retry_eligible = bool((latest_failure_summary or {}).get("recoverable"))
+    latest_attempt_metadata = (
+        latest_attempt.get("metadata")
+        if isinstance(latest_attempt, dict) and isinstance(latest_attempt.get("metadata"), dict)
+        else {}
+    )
     failure_state = _failure_state(
         failure_type=(
             str(latest_failure_summary.get("failure_type"))
@@ -585,6 +594,10 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
     return {
         "attempt_count": attempt_count,
         "latest_attempt": dict(latest_attempt) if latest_attempt is not None else None,
+        "latest_execution_transport_status": latest_attempt_metadata.get("execution_transport_status"),
+        "latest_live_dispatch_enabled": latest_attempt_metadata.get("live_dispatch_enabled"),
+        "latest_completion_authority": latest_attempt_metadata.get("completion_authority"),
+        "latest_runner_completion_is_truth": latest_attempt_metadata.get("runner_completion_is_truth"),
         "substrate_event_count": len(substrate_events) if isinstance(substrate_events, list) else 0,
         "latest_substrate_event": dict(latest_substrate_event) if latest_substrate_event is not None else None,
         "latest_runner_session_id": (
@@ -599,12 +612,12 @@ def _build_execution_summary(task_envelope: TaskEnvelope, records: tuple[Evaluat
         ),
         "latest_status": latest_attempt.get("status") if isinstance(latest_attempt, dict) else None,
         "latest_dispatch_origin": (
-            ((latest_attempt.get("metadata") or {}).get("dispatch_mode"))
+            latest_attempt_metadata.get("dispatch_mode")
             if isinstance(latest_attempt, dict)
             else None
         ),
         "latest_attempt_validation": (
-            dict((((latest_attempt.get("metadata") or {}).get("attempt_validation")) or {}))
+            dict((latest_attempt_metadata.get("attempt_validation") or {}))
             if isinstance(latest_attempt, dict)
             else None
         ),

--- a/tests/test_read_model.py
+++ b/tests/test_read_model.py
@@ -1347,6 +1347,16 @@ class HarnessReadModelServiceTests(unittest.TestCase):
         self.assertEqual(read_status, 200)
         self.assertEqual(read_payload["task"]["execution_summary"]["attempt_count"], 1)
         self.assertIsNotNone(read_payload["task"]["execution_summary"]["latest_attempt"])
+        self.assertEqual(
+            read_payload["task"]["execution_summary"]["latest_execution_transport_status"],
+            "disabled",
+        )
+        self.assertFalse(read_payload["task"]["execution_summary"]["latest_live_dispatch_enabled"])
+        self.assertEqual(
+            read_payload["task"]["execution_summary"]["latest_completion_authority"],
+            "harness_verification",
+        )
+        self.assertFalse(read_payload["task"]["execution_summary"]["latest_runner_completion_is_truth"])
 
     def test_read_model_total_attempts_does_not_undercount_recorded_execution_attempts(self) -> None:
         submit_status, submit_payload = self.service.submit(


### PR DESCRIPTION
## Summary
- project latest execution transport status from attempt metadata into execution_summary
- expose latest live-dispatch, completion-authority, and runner-completion-truth fields without requiring clients to parse raw attempt metadata
- document latest transport fields in the agent API guide

## Validation
- git diff --check
- python3 -m unittest tests.test_read_model.HarnessReadModelServiceTests.test_read_model_includes_execution_summary_after_dispatch
- python3 -m unittest discover -s tests (874 tests, 17 skipped)