### PR TITLE
Show execution transport status in task details

### DIFF
--- a/components/dashboard/task-detail-panel.tsx
+++ b/components/dashboard/task-detail-panel.tsx
@@ -13,6 +13,8 @@ import {
   Link2,
   Maximize2,
   Minimize2,
+  Power,
+  ShieldCheck,
 } from "lucide-react";
 import { TaskTimeline } from "./task-timeline";
 import { EvidencePanel } from "./evidence-panel";
@@ -33,6 +35,16 @@ export function TaskDetailPanel({
   isExpanded = false,
   onToggleExpand,
 }: TaskDetailPanelProps) {
+  const executionSummary = task.execution_summary ?? {
+    attempt_count: 0,
+    latest_status: null,
+    latest_dispatch_origin: null,
+    latest_execution_transport_status: null,
+    latest_live_dispatch_enabled: null,
+    latest_completion_authority: null,
+    latest_runner_completion_is_truth: null,
+  };
+
   return (
     <div className="flex flex-col h-full bg-card border-l border-border">
       {/* Header */}
@@ -232,6 +244,57 @@ export function TaskDetailPanel({
                 </CardContent>
               </Card>
             )}
+
+            {/* Execution Transport */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle>Execution Transport</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+                  <div>
+                    <dt className="text-xs text-muted-foreground">Transport</dt>
+                    <dd className="mt-0.5 font-medium">
+                      {executionSummary.latest_execution_transport_status || (
+                        <span className="text-muted-foreground">none</span>
+                      )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-muted-foreground">Live Dispatch</dt>
+                    <dd className="mt-0.5 flex items-center gap-1">
+                      <Power className="h-3 w-3 text-muted-foreground" />
+                      <span>
+                        {executionSummary.latest_live_dispatch_enabled === null
+                          ? "none"
+                          : executionSummary.latest_live_dispatch_enabled
+                            ? "enabled"
+                            : "disabled"}
+                      </span>
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-muted-foreground">Authority</dt>
+                    <dd className="mt-0.5 flex items-center gap-1">
+                      <ShieldCheck className="h-3 w-3 text-muted-foreground" />
+                      <span className="font-mono text-xs">
+                        {executionSummary.latest_completion_authority || "none"}
+                      </span>
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-muted-foreground">Runner Truth</dt>
+                    <dd className="mt-0.5">
+                      {executionSummary.latest_runner_completion_is_truth === null
+                        ? "none"
+                        : executionSummary.latest_runner_completion_is_truth
+                          ? "trusted"
+                          : "not trusted"}
+                    </dd>
+                  </div>
+                </dl>
+              </CardContent>
+            </Card>
 
             {/* Timeline - moves to left column in expanded mode */}
             {isExpanded && <TaskTimeline events={task.timeline} />}

--- a/lib/harness-api.ts
+++ b/lib/harness-api.ts
@@ -197,6 +197,10 @@ function mapTask(readModel: Record<string, unknown>, timelineOverride?: Timeline
     readModel.review_summary && typeof readModel.review_summary === "object"
       ? (readModel.review_summary as Record<string, unknown>)
       : {};
+  const executionSummary =
+    readModel.execution_summary && typeof readModel.execution_summary === "object"
+      ? (readModel.execution_summary as Record<string, unknown>)
+      : {};
   const evaluationSummary =
     readModel.evaluation_summary && typeof readModel.evaluation_summary === "object"
       ? (readModel.evaluation_summary as Record<string, unknown>)
@@ -359,6 +363,25 @@ function mapTask(readModel: Record<string, unknown>, timelineOverride?: Timeline
       decisions: Array.isArray(reviewSummary.decisions)
         ? reviewSummary.decisions.map((decision) => mapReviewDecision(decision as Record<string, unknown>)).filter(Boolean) as ReviewDecision[]
         : [],
+    },
+    execution_summary: {
+      attempt_count: Number(executionSummary.attempt_count ?? 0),
+      latest_status:
+        (executionSummary.latest_status as string | null | undefined) ?? null,
+      latest_dispatch_origin:
+        (executionSummary.latest_dispatch_origin as string | null | undefined) ?? null,
+      latest_execution_transport_status:
+        (executionSummary.latest_execution_transport_status as string | null | undefined) ?? null,
+      latest_live_dispatch_enabled:
+        typeof executionSummary.latest_live_dispatch_enabled === "boolean"
+          ? executionSummary.latest_live_dispatch_enabled
+          : null,
+      latest_completion_authority:
+        (executionSummary.latest_completion_authority as string | null | undefined) ?? null,
+      latest_runner_completion_is_truth:
+        typeof executionSummary.latest_runner_completion_is_truth === "boolean"
+          ? executionSummary.latest_runner_completion_is_truth
+          : null,
     },
     evaluation_summary: {
       count: Number(evaluationSummary.count ?? 0),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -134,6 +134,16 @@ export interface ReviewSummary {
   decisions: ReviewDecision[];
 }
 
+export interface ExecutionSummary {
+  attempt_count: number;
+  latest_status: string | null;
+  latest_dispatch_origin: string | null;
+  latest_execution_transport_status: string | null;
+  latest_live_dispatch_enabled: boolean | null;
+  latest_completion_authority: string | null;
+  latest_runner_completion_is_truth: boolean | null;
+}
+
 export interface TimelineEvent {
   event_id: string;
   event_type:
@@ -171,6 +181,7 @@ export interface Task {
   verification_summary: VerificationSummary | null;
   reconciliation_summary: ReconciliationSummary | null;
   review_summary: ReviewSummary;
+  execution_summary?: ExecutionSummary;
   evaluation_summary: {
     count: number;
     latest_action: string | null;

--- a/tests/frontend/task-execution-summary.test.ts
+++ b/tests/frontend/task-execution-summary.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fetchTaskDetail } from "../../lib/harness-api";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("maps read-model execution transport summary fields", async () => {
+  const responses = new Map<string, unknown>([
+    [
+      "/api/harness/tasks/task-1/read-model",
+      {
+        task: {
+          task_id: "task-1",
+          title: "Execution transport projection",
+          description: "Verify latest transport status maps into the dashboard model.",
+          current_status: "blocked",
+          objective_summary: null,
+          origin: {
+            source_system: "harness",
+            source_type: "test",
+            source_id: "task-1",
+          },
+          relationships: {},
+          evidence_summary: {},
+          review_summary: {},
+          evaluation_summary: {},
+          timestamps: {
+            created_at: "2026-04-30T19:00:00Z",
+            updated_at: "2026-04-30T19:01:00Z",
+            completed_at: null,
+          },
+          execution_summary: {
+            attempt_count: 1,
+            latest_status: "blocked",
+            latest_dispatch_origin: "automatic",
+            latest_execution_transport_status: "disabled",
+            latest_live_dispatch_enabled: false,
+            latest_completion_authority: "harness_verification",
+            latest_runner_completion_is_truth: false,
+          },
+        },
+      },
+    ],
+    ["/api/harness/tasks/task-1/timeline", { timeline: [] }],
+  ]);
+
+  globalThis.fetch = async (url) => {
+    const payload = responses.get(String(url));
+    assert.notEqual(payload, undefined, `unexpected URL ${url}`);
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const task = await fetchTaskDetail("task-1");
+
+  assert.equal(task.execution_summary?.attempt_count, 1);
+  assert.equal(task.execution_summary?.latest_status, "blocked");
+  assert.equal(task.execution_summary?.latest_dispatch_origin, "automatic");
+  assert.equal(task.execution_summary?.latest_execution_transport_status, "disabled");
+  assert.equal(task.execution_summary?.latest_live_dispatch_enabled, false);
+  assert.equal(task.execution_summary?.latest_completion_authority, "harness_verification");
+  assert.equal(task.execution_summary?.latest_runner_completion_is_truth, false);
+});


### PR DESCRIPTION
## Summary
- map read-model execution_summary transport fields into the dashboard Task model
- show a compact Execution Transport card in task details
- add frontend coverage for the read-model execution transport mapping

## Validation
- git diff --check
- pnpm test:frontend (rerun with sandbox permission after tsx IPC EPERM)
- pnpm lint
- pnpm build
- Browser check: /tasks against disposable Harness API showed the seeded task list with no application console errors; current MCP browser tools support navigation but not clicking the task row, so the detail card is covered by the frontend mapping test and production build