### PR TITLE
Centralize disabled execution transport policy

### DIFF
--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -175,6 +175,8 @@ Harness exposes `GET /execution-substrate/handoffs` as a read-only preview of th
 
 That preview surface is protected by the execution-substrate contract validator. A valid preview must remain `advisory_only=true`, `dispatch_enabled=false`, `completion_authority=harness_verification`, `mode=render_only`, `runner_completion_is_truth=false`, and `safe_to_execute_live=false`. It must also carry the required runner prohibitions: no marking Harness complete, no treating Linear Done as truth, and no auto-merge without policy. Future live Symphony transport should add a separate execution path rather than weakening this read-only preview contract.
 
+The disabled live-transport posture is also an explicit contract. `modules/contracts/execution_substrate.py` owns the canonical disabled Symphony-compatible policy used by `GET /execution-substrate/transport-status`: `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, `completion_authority=harness_verification`, `runner_completion_is_truth=false`, and `safe_to_execute_live=false`. New live transport work must introduce a separate policy-gated path rather than changing these guardrail fields opportunistically.
+
 Initial event family:
 
 - `dispatch_requested`

--- a/modules/api.py
+++ b/modules/api.py
@@ -44,7 +44,9 @@ from modules.contracts.execution_substrate import (
     ExecutionSubstrateEvent,
     ExecutionSubstrateEventType,
     ExecutionSubstrateProvenance,
+    disabled_execution_substrate_transport_policy,
     execution_substrate_intent_from_dict,
+    validate_disabled_execution_substrate_transport_policy,
     validate_execution_substrate_event,
     validate_execution_substrate_handoff_preview,
 )
@@ -4584,18 +4586,9 @@ class HarnessApiService:
     def get_execution_substrate_transport_status(self) -> tuple[int, dict[str, Any]]:
         """Return the current Symphony-compatible transport posture."""
 
-        return HTTPStatus.OK, {
+        payload = {
             "generated_at": _iso_now(),
-            "substrate_kind": "symphony-compatible",
-            "preferred_runner": "symphony",
-            "transport_status": "disabled",
-            "dispatch_enabled": False,
-            "live_dispatch_enabled": False,
-            "advisory_only": True,
-            "completion_authority": "harness_verification",
-            "runner_completion_is_truth": False,
-            "safe_to_execute_live": False,
-            "events_contract": "execution_substrate_event.v1",
+            **disabled_execution_substrate_transport_policy(),
             "handoff_preview_endpoint": "/execution-substrate/handoffs",
             "intents_endpoint": "/execution-substrate/intents",
             "message": (
@@ -4603,6 +4596,8 @@ class HarnessApiService:
                 "dispatch is disabled until an explicit transport policy is added."
             ),
         }
+        validate_disabled_execution_substrate_transport_policy(payload)
+        return HTTPStatus.OK, payload
 
     def preview_execution_substrate_handoffs(
         self,

--- a/modules/contracts/execution_substrate.py
+++ b/modules/contracts/execution_substrate.py
@@ -64,6 +64,19 @@ _REQUIRED_PROHIBITED_ACTIONS: frozenset[str] = frozenset(
     }
 )
 
+_DISABLED_TRANSPORT_POLICY: dict[str, Any] = {
+    "substrate_kind": "symphony-compatible",
+    "preferred_runner": "symphony",
+    "transport_status": "disabled",
+    "dispatch_enabled": False,
+    "live_dispatch_enabled": False,
+    "advisory_only": True,
+    "completion_authority": "harness_verification",
+    "runner_completion_is_truth": False,
+    "safe_to_execute_live": False,
+    "events_contract": "execution_substrate_event.v1",
+}
+
 
 def _require_non_empty(value: str | None, *, field_name: str) -> None:
     if value is None or not value.strip():
@@ -77,6 +90,23 @@ def _validate_no_lifecycle_authority(payload: dict[str, Any], *, field_name: str
         raise ExecutionSubstrateValidationError(
             f"{field_name} contains prohibited lifecycle authority fields: {names}"
         )
+
+
+def disabled_execution_substrate_transport_policy() -> dict[str, Any]:
+    """Return the canonical inert Symphony-compatible transport policy."""
+
+    return dict(_DISABLED_TRANSPORT_POLICY)
+
+
+def validate_disabled_execution_substrate_transport_policy(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate that a transport posture keeps live execution disabled."""
+
+    for key, expected in _DISABLED_TRANSPORT_POLICY.items():
+        if payload.get(key) != expected:
+            raise ExecutionSubstrateValidationError(
+                f"disabled execution-substrate transport must keep {key}={expected!r}"
+            )
+    return payload
 
 
 @dataclass(frozen=True)
@@ -427,8 +457,10 @@ __all__ = [
     "ExecutionSubstrateProvenance",
     "ExecutionSubstrateValidationError",
     "build_execution_substrate_intent",
+    "disabled_execution_substrate_transport_policy",
     "execution_substrate_intent_from_dict",
     "execution_substrate_intent_to_dict",
+    "validate_disabled_execution_substrate_transport_policy",
     "validate_execution_substrate_artifact_reference",
     "validate_execution_substrate_event",
     "validate_execution_substrate_handoff_preview",

--- a/tests/contracts/test_execution_substrate.py
+++ b/tests/contracts/test_execution_substrate.py
@@ -15,8 +15,10 @@ from modules.contracts.execution_substrate import (
     ExecutionSubstrateProvenance,
     ExecutionSubstrateValidationError,
     build_execution_substrate_intent,
+    disabled_execution_substrate_transport_policy,
     execution_substrate_intent_from_dict,
     execution_substrate_intent_to_dict,
+    validate_disabled_execution_substrate_transport_policy,
     validate_execution_substrate_artifact_reference,
     validate_execution_substrate_event,
     validate_execution_substrate_handoff_preview,
@@ -296,6 +298,29 @@ class ExecutionSubstrateEventTests(unittest.TestCase):
             "safe_to_execute_live=false",
         ):
             validate_execution_substrate_handoff_preview(preview)
+
+    def test_disabled_transport_policy_keeps_live_execution_off(self) -> None:
+        policy = disabled_execution_substrate_transport_policy()
+
+        validated = validate_disabled_execution_substrate_transport_policy(policy)
+
+        self.assertIs(validated, policy)
+        self.assertEqual(policy["transport_status"], "disabled")
+        self.assertFalse(policy["dispatch_enabled"])
+        self.assertFalse(policy["live_dispatch_enabled"])
+        self.assertFalse(policy["runner_completion_is_truth"])
+        self.assertFalse(policy["safe_to_execute_live"])
+        self.assertEqual(policy["completion_authority"], "harness_verification")
+
+    def test_disabled_transport_policy_rejects_enabled_dispatch(self) -> None:
+        policy = disabled_execution_substrate_transport_policy()
+        policy["dispatch_enabled"] = True
+
+        with self.assertRaisesRegex(
+            ExecutionSubstrateValidationError,
+            "dispatch_enabled=False",
+        ):
+            validate_disabled_execution_substrate_transport_policy(policy)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- move the disabled Symphony-compatible transport posture into the execution-substrate contract module
- validate the transport-status API response against that canonical disabled policy
- document the disabled transport posture as an explicit contract and add contract tests for live-dispatch guardrails

## Validation
- python3 -m py_compile modules/contracts/execution_substrate.py modules/api.py
- python3 -m unittest tests.contracts.test_execution_substrate tests.test_api.HarnessHttpApiTests.test_api_exposes_disabled_execution_substrate_transport_status
- python3 -m unittest discover -s tests