### PR TITLE
Pivot supported surfaces to CLI and web

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Do not collapse these roles:
 - Harness normalizes and evaluates
 - GitHub and Linear provide external facts
 - dashboard reads canonical inspection APIs
+- CLI and web dashboard are the supported operator surfaces
 
 Harness is not:
 
@@ -32,6 +33,7 @@ Harness is not:
 - an agent runtime
 - a chatbot UI
 - a replacement for Linear coordination
+- a native desktop-app product
 - a place where worker claims are accepted without policy enforcement
 
 ## Non-Goals
@@ -42,7 +44,23 @@ Do not casually turn this repo into:
 - a generic project-management surface
 - a mutation-heavy dashboard app
 - a tightly coupled OpenClaw runtime extension
+- a native macOS app distribution project
 - a fake demo system that hides whether data is live or sample
+
+## Operator Surface Direction
+
+Harness is now CLI + API + web dashboard first.
+
+The native macOS app under `apps/macos/HarnessApp` is legacy/experimental code. Do not add new native macOS features, packaging work, notarization work, menu-bar behavior, notification behavior, or onboarding behavior unless a task explicitly reopens that product decision.
+
+Keep reusable runtime pieces in portable Python/TypeScript surfaces:
+
+- `python3 -m modules.local_runtime ...`
+- hosted/local backend APIs
+- the Next.js dashboard
+- static local dashboard assets served by the Python backend
+
+If existing macOS code needs to remain buildable while it is still in the tree, keep fixes minimal and compatibility-focused. Do not make Harness core depend on Swift, AppKit, `.app` bundle layout, Keychain-only semantics, Launch at Login, or macOS notification APIs.
 
 ## Invariants That Must Not Be Broken
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In hosted Vercel runtimes, the reset slice is not allowed to take the whole back
 - An operational reconciliation path that can enter `reconciling`, repair missing PR artifacts, and then delegate back into canonical reevaluation.
 
 Harness is not a PM tool, an agent runtime, or a chatbot UI.
+Harness is also no longer pursuing a native macOS app as a supported product surface. The supported operator surfaces are the CLI/runtime contract, the backend API, and the web dashboard. The Swift app under `apps/macos/HarnessApp` remains legacy/experimental code while the reusable local runtime and dashboard packaging pieces are preserved. See [`docs/adrs/0005-cli-web-operator-surface.md`](docs/adrs/0005-cli-web-operator-surface.md).
 Client-specific ingress adapters are also intentionally narrow. The repo currently includes an OpenClaw-shaped ingress translator, but the same restriction applies to Hermes or any future desktop agent client: it can submit task intent, provenance, and planning-ready work into Harness, but it cannot declare `executing` or `completed`, inject executor runtime telemetry, or claim completion on initial handoff. If a client wants to hand work off as `planned`, it must provide explicit planning-grade objective fields plus a concrete `plan_summary`, and it cannot declare unresolved conditions at the same time. If it also supplies parent/dependency/capability structure, that structure must be canonical and non-self-referential before Harness will persist it. If unresolved ambiguity still exists, Harness now converts that upstream signal into canonical clarification and blocks the task instead of letting vague work look ready. Execution and completion truth must still come back through executor/reporting paths that Harness can verify.
 
 On the inspection side, Harness now also exposes a canonical supervision queue at `GET /supervision/queue`. That queue is a read-only attention projection for external supervisors and Symphony-compatible runner adapters. It surfaces tasks that currently need attention because they are in review, blocked on clarification, retryable, carrying invalid execution proof, waiting on canonical GitHub sync, or stale. `GET /execution-substrate/intents` provides the runner-facing filtered view of only the Symphony-compatible continuation intents. Neither endpoint authorizes actions on its own, and neither replaces canonical reevaluation, execution-substrate event ingestion, completion-claim, or GitHub sync paths.
@@ -172,14 +173,14 @@ See:
 ### Frontend
 
 - Next.js 16 app in [`app/`](app) with shared dashboard components in [`components/`](components).
-- Root route redirects to `/tasks` in normal Next mode. The static local-app export renders the tasks view at `/dashboard/` so the packaged dashboard has a working entrypoint.
+- Root route redirects to `/tasks` in normal Next mode. The static local dashboard export renders the tasks view at `/dashboard/` so a Python-served local dashboard has a working entrypoint.
 - Main working views:
   - `/tasks`
   - `/verification`
   - `/reconciliation`
   - `/reviews`
 - Frontend reads backend data through the Next proxy route at [`app/api/harness/[...path]/route.ts`](app/api/harness/[...path]/route.ts).
-- Local app builds can also export the dashboard as static assets under `/dashboard` with [`scripts/build-local-dashboard.mjs`](scripts/build-local-dashboard.mjs). That packageable path serves the dashboard from the Python backend and calls the same-origin Harness API directly, so normal users do not need Node or `pnpm`.
+- Local CLI/web builds can also export the dashboard as static assets under `/dashboard` with [`scripts/build-local-dashboard.mjs`](scripts/build-local-dashboard.mjs). That packageable path serves the dashboard from the Python backend and calls the same-origin Harness API directly, so operators do not need Node or `pnpm`.
 - The frontend requires a reachable backend, either through the hosted Next proxy or the local same-origin API. If the backend is missing or unreachable, the UI shows an error; it does not silently switch to fake live data.
 
 ### Backend
@@ -213,16 +214,16 @@ See:
 - Store selection is controlled by `HARNESS_STORE_BACKEND`.
 - Supported backends:
   - `file` for local JSON-backed development.
-  - `sqlite` for durable local app state without Docker or hosted services.
+  - `sqlite` for durable local CLI/web state without Docker or hosted services.
   - `postgres` for durable hosted state.
 - Postgres storage is implemented in [`modules/store.py`](modules/store.py) and bootstrapped with [`sql/postgres/001_harness_store.sql`](sql/postgres/001_harness_store.sql).
 - SQLite storage is implemented in [`modules/store.py`](modules/store.py) and [`modules/reset/store.py`](modules/reset/store.py). Harness creates the local database and schema automatically.
 - The default hosted deployment target is Neon-backed Postgres attached through Vercel. Harness stores canonical task and evaluation payloads as JSONB in `tasks` and `evaluation_records`.
-- The local app runtime contract is implemented in [`modules/local_runtime.py`](modules/local_runtime.py) and documented in [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md).
+- The local runtime contract is implemented in [`modules/local_runtime.py`](modules/local_runtime.py) and documented in [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md).
 - App-managed secret storage is implemented in [`modules/local_secrets.py`](modules/local_secrets.py) and documented in [`docs/architecture/app-managed-secrets.md`](docs/architecture/app-managed-secrets.md).
 - Local dashboard packaging is documented in [`docs/architecture/local-dashboard-packaging.md`](docs/architecture/local-dashboard-packaging.md).
 - Setup doctor output is documented in [`docs/architecture/setup-doctor.md`](docs/architecture/setup-doctor.md).
-- The macOS menu-bar app can request optional notifications and delivers attention alerts from canonical Harness queue/setup surfaces; delivery is reversible from Settings and never reads SQLite directly.
+- The deprecated macOS menu-bar app remains legacy code only; supported local operation should use the CLI/runtime contract and web dashboard.
 
 ## Hosted Deployment Target
 
@@ -256,7 +257,7 @@ Backend inspection routes:
 - `GET /tasks/<task_id>/read-model`: canonical detail surface for current task truth.
 - `GET /tasks/<task_id>/timeline`: canonical audit timeline.
 - `GET /supervision/queue`: canonical autonomous-supervision triage surface.
-- `GET /runtime/status`: local app runtime status envelope for menu-bar polling.
+- `GET /runtime/status`: local runtime status envelope for CLI/web packaging and automation.
 
 For triage surfaces, `review_required` stays distinct from terminal failure. If a task is in `in_review`, the projected `failure_summary.state` and `execution_summary.failure_state` remain `review_required` rather than collapsing into `failed`.
 
@@ -279,11 +280,11 @@ Backend storage environment variables:
 - `HARNESS_STORE_BACKEND`
   - Supported values: `file`, `sqlite`, `postgres`
   - Default in [`.env.example`](.env.example): `file`
-  - Self-contained local app mode should use `sqlite`
+  - Self-contained local CLI/web mode should use `sqlite`
   - Hosted Vercel deployments auto-select `postgres` when managed Postgres connection variables are present
 - `HARNESS_SQLITE_PATH`
   - Optional explicit SQLite database file path when `HARNESS_STORE_BACKEND=sqlite`
-  - macOS local app default: `~/Library/Application Support/Harness/harness.db`
+  - macOS local default: `~/Library/Application Support/Harness/harness.db`
   - Linux default: `$XDG_DATA_HOME/harness/harness.db`, or `~/.local/share/harness/harness.db` when `XDG_DATA_HOME` is unset
   - If `HARNESS_STORE_ROOT` is set and `HARNESS_SQLITE_PATH` is not, Harness uses `<HARNESS_STORE_ROOT>/harness.db`
 - Postgres connection string
@@ -313,7 +314,7 @@ If the reset verifier rejects a claim and the repair callback itself cannot be d
 
 The `OPENCLAW_*` variable names remain because the current repo-owned repair receiver adapter is OpenClaw-specific today. They should be treated as implementation details, not as the architectural boundary.
 
-For native local development, `backend.server` now auto-loads both repo-root `.env.local` and `config/openclaw/.env.local`. When the current repo-owned OpenClaw local config exports `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, Harness prefers a local `openclaw agent --local` repair dispatch over the HTTP callback path.
+For local development, `backend.server` now auto-loads both repo-root `.env.local` and `config/openclaw/.env.local`. When the current repo-owned OpenClaw local config exports `OPENCLAW_CONFIG_PATH` or `OPENCLAW_STATE_DIR`, Harness prefers a local `openclaw agent --local` repair dispatch over the HTTP callback path.
 
 Relevant supporting files:
 
@@ -348,9 +349,9 @@ export HARNESS_SQLITE_PATH="$HOME/Library/Application Support/Harness/harness.db
 python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
 
-SQLite mode creates the database and schema automatically, enables WAL mode and foreign keys, and stores canonical tasks, evaluation records, and reset verifier contracts in the local database. This is the intended persistence base for the self-contained local app.
+SQLite mode creates the database and schema automatically, enables WAL mode and foreign keys, and stores canonical tasks, evaluation records, and reset verifier contracts in the local database. This is the intended persistence base for self-contained local CLI/web usage.
 
-Run the local app runtime contract from a repo checkout:
+Run the local runtime contract from a repo checkout:
 
 ```bash
 python3 -m modules.local_runtime --json init
@@ -364,9 +365,9 @@ python3 -m modules.local_runtime --json recover
 python3 -m modules.local_runtime --json stop
 ```
 
-Packaged builds should expose the same contract as `harness init`, `harness start`, `harness serve`, `harness status`, `harness doctor`, `harness setup status`, `harness open`, `harness recover`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so normal users do not need Docker, Node, `pnpm`, or repo-local shell exports.
+Future packaged CLI builds should expose the same contract as `harness init`, `harness start`, `harness serve`, `harness status`, `harness doctor`, `harness setup status`, `harness open`, `harness recover`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so operators do not need Docker, Node, `pnpm`, or repo-local shell exports.
 
-Build the packageable dashboard assets for the local app path:
+Build the packageable dashboard assets for the local CLI/web path:
 
 ```bash
 pnpm build:dashboard:local
@@ -374,7 +375,7 @@ pnpm build:dashboard:local
 
 The output lives in `dist/local-dashboard/`. When `HARNESS_DASHBOARD_ASSETS_DIR` points at that directory, the Python backend serves the dashboard at `/dashboard` from the same process that serves the local API.
 
-Store app-managed secrets for packaged local app usage:
+Store app-managed secrets for local CLI/web usage:
 
 ```bash
 printf '%s' "$GITHUB_TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin
@@ -382,9 +383,9 @@ printf '%s' "$LINEAR_API_KEY" | python3 -m modules.local_runtime --json secrets 
 python3 -m modules.local_runtime --json secrets status --require github_token
 ```
 
-The secrets command reports setup state without printing token values. Developer `.env.local` mode remains supported for native local development, but packaged app onboarding should use the secret store instead of asking users to edit env files.
+The secrets command reports setup state without printing token values. Developer `.env.local` mode remains supported for local development, but normal local CLI/web usage should prefer the secret store instead of asking operators to edit env files.
 
-Use guided setup status for the onboarding flow:
+Use guided setup status for CLI/web setup:
 
 ```bash
 python3 -m modules.local_runtime --json setup status
@@ -393,27 +394,22 @@ python3 -m modules.local_runtime --json setup status --workflow linear-sync
 python3 -m modules.local_runtime --json setup status --workflow repair-dispatch
 ```
 
-Default onboarding only requires a healthy local Harness runtime. GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the user selects a workflow that requires it. See [`docs/architecture/guided-integration-setup.md`](docs/architecture/guided-integration-setup.md).
+Default setup only requires a healthy local Harness runtime. GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the user selects a workflow that requires it. See [`docs/architecture/guided-integration-setup.md`](docs/architecture/guided-integration-setup.md).
 
-The native macOS app shell starts under [`apps/macos/HarnessApp`](apps/macos/HarnessApp). It is a SwiftPM menu-bar app that reads runtime/task state through the local CLI and API contracts, not through direct SQLite access. It opens first-run onboarding automatically, exposes setup again from the menu bar, controls Launch at Login through `SMAppService`, supervises the backend through app-managed `start`/`stop`/`recover` commands, and opens the full local dashboard inside an app window while keeping browser/copy-URL fallbacks for debugging. Build and launch development builds with:
+The native macOS app shell under [`apps/macos/HarnessApp`](apps/macos/HarnessApp) is deprecated as a supported product surface. Do not treat the Swift menu-bar app, Launch at Login, notifications, first-run windows, signing, or notarization as the normal Harness path. The reusable pieces that still matter are the portable CLI/runtime contract, SQLite local persistence, secret storage boundary, and static dashboard assets served by the Python backend.
+
+The legacy development commands still exist for compatibility, but they are not part of the recommended operator path:
 
 ```bash
 ./script/build_and_run.sh
-```
-
-Build a distributable self-contained app bundle and DMG with:
-
-```bash
 ./script/package_macos_app.sh
 ```
 
-That release path bundles the native app, a frozen `harness` runtime, and prebuilt dashboard assets into `dist/macos-release/Harness.app` and `dist/macos-release/Harness.dmg`. Normal users should not need a repo checkout, Python, Node, `pnpm`, or Docker after install.
+No new product work should depend on those commands. Normal Harness operation should be CLI + API + web dashboard.
 
-Linux shell work remains deferred, but the reusable backend/CLI/dashboard boundaries are now documented in [`docs/architecture/linux-portability-contract.md`](docs/architecture/linux-portability-contract.md).
+See [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md), [`docs/architecture/local-dashboard-packaging.md`](docs/architecture/local-dashboard-packaging.md), and [`docs/architecture/setup-doctor.md`](docs/architecture/setup-doctor.md). The older macOS architecture notes remain for historical context only.
 
-See [`docs/architecture/macos-menu-bar-controller.md`](docs/architecture/macos-menu-bar-controller.md), [`docs/architecture/macos-onboarding-assistant.md`](docs/architecture/macos-onboarding-assistant.md), [`docs/architecture/macos-daemon-lifecycle.md`](docs/architecture/macos-daemon-lifecycle.md), [`docs/architecture/macos-dashboard-window.md`](docs/architecture/macos-dashboard-window.md), [`docs/architecture/macos-packaging.md`](docs/architecture/macos-packaging.md), and [`docs/architecture/linux-portability-contract.md`](docs/architecture/linux-portability-contract.md).
-
-`backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for native local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
+`backend.server` now auto-loads repo-root `.env.local` and `config/openclaw/.env.local` for local development. That means the backend can pick up `GITHUB_TOKEN`, `LINEAR_API_KEY`, and the repo-owned current-client config/state paths without manual shell export steps.
 
 Run the backend with Postgres:
 

--- a/apps/macos/HarnessApp/README.md
+++ b/apps/macos/HarnessApp/README.md
@@ -1,7 +1,10 @@
 # Harness macOS App
 
-This is the native macOS shell for local Harness operation.
-The first slices are a menu-bar controller with runtime controls and summary counts, a first-run setup assistant, and an embedded dashboard window for full inspection.
+Status: deprecated.
+
+This native macOS shell is no longer a supported Harness product surface. Keep it as legacy/experimental code while the repo pivots to CLI + API + web dashboard operation.
+
+Do not add new menu-bar, first-run onboarding, notification, Launch at Login, signing, notarization, or distribution features unless the native app decision is explicitly reopened. Reusable behavior should move through the portable local runtime contract and web dashboard instead.
 
 ## Targets
 

--- a/docs/adrs/0005-cli-web-operator-surface.md
+++ b/docs/adrs/0005-cli-web-operator-surface.md
@@ -1,0 +1,45 @@
+# CLI And Web As The Supported Operator Surface
+
+- title: CLI and web as the supported operator surface
+- status: accepted
+- date: 2026-04-30
+
+## Context
+
+Harness briefly pursued a native macOS shell for local operation: menu bar, first-run onboarding, notifications, Launch at Login, embedded dashboard window, and DMG packaging.
+
+That direction added a second product surface and a second maintenance stack. It created work around SwiftUI, AppKit, signing, notarization, packaging, macOS permissions, and desktop lifecycle behavior. Those concerns do not strengthen Harness's core value as a verification and reliability layer.
+
+The operational loop Harness needs to support is simpler:
+
+- CLI/runtime commands for setup, status, doctor, start, stop, recovery, dry runs, and local automation
+- backend APIs as the canonical control-plane boundary
+- web dashboard for inspection, review, and verification state
+- Linear and GitHub as external work/proof systems
+- Symphony-like execution substrates beneath Harness, not inside the operator UI
+
+## Decision
+
+Harness will treat CLI + API + web dashboard as the supported operator surface.
+
+The native macOS app under `apps/macos/HarnessApp` is deprecated legacy/experimental code. It may remain in the repository temporarily, but it is not an active product direction.
+
+Do not add new native macOS app features, packaging work, signing/notarization work, notification behavior, Launch at Login behavior, or Swift onboarding flows unless this decision is explicitly reopened.
+
+## Implications
+
+- New operator flows should be expressed through `modules.local_runtime`, backend APIs, and the web dashboard.
+- Local static dashboard packaging remains useful, but it should not imply a native app requirement.
+- Setup and troubleshooting docs should lead with CLI/web, not DMG or first-run app flows.
+- Runtime contracts must stay portable and must not depend on Swift, AppKit, `.app` bundle layout, macOS notifications, or Launch at Login.
+- Existing macOS architecture notes are historical context unless a future task explicitly reactivates that surface.
+
+## Consequences
+
+This reduces maintenance burden and keeps Harness closer to its durable control-plane role.
+
+The tradeoff is less native desktop polish. That is acceptable because Harness's strategic risk is not lack of a menu-bar app; it is accidentally duplicating execution/runtime/product surfaces that stronger platform-native tools will absorb.
+
+## Follow-Up
+
+Future cleanup should remove native macOS references from active setup/release docs first, then decide whether to archive or delete `apps/macos/HarnessApp` and related scripts once no active validation depends on them.

--- a/docs/architecture/app-managed-secrets.md
+++ b/docs/architecture/app-managed-secrets.md
@@ -1,11 +1,11 @@
 # App-Managed Secrets
 
-Harness local app builds must not ask normal users to edit `.env.local`.
+Harness local CLI/web usage must not ask operators to edit `.env.local`.
 Non-secret runtime config lives in `config.json`; tokens and integration credentials live behind the app-managed secret provider.
 
 ## Secret Provider
 
-macOS v1 uses Keychain through the Harness service namespace:
+On macOS, the local runtime uses Keychain through the Harness service namespace:
 
 ```text
 com.knoxanalytics.harness.local-runtime
@@ -20,19 +20,19 @@ Current secret names:
 - `linear_api_key`: maps to `LINEAR_API_KEY`
 - `repair_callback_bearer_token`: maps to `OPENCLAW_REPAIR_BEARER_TOKEN`
 
-The `OPENCLAW_REPAIR_BEARER_TOKEN` env name remains the current concrete repair-adapter variable. It is not the product boundary. The stable local-app boundary is the named Harness secret.
+The `OPENCLAW_REPAIR_BEARER_TOKEN` env name remains the current concrete repair-adapter variable. It is not the product boundary. The stable local runtime boundary is the named Harness secret.
 
 Provider selection is platform-aware at the Python boundary:
 
 - `macos-keychain` on Darwin
 - `linux-secret-service` as the deferred Linux provider contract
-- `unsupported-<platform>` on other local-app platforms until a provider exists
+- `unsupported-<platform>` on other local platforms until a provider exists
 
 Linux Secret Service support is not implemented in this slice. The important part is that the runtime no longer hard-codes the macOS provider name into status or environment surfaces.
 
 ## CLI Contract
 
-The packaged app can call the same command surface that developers can run from a checkout:
+Future packaged CLI/web builds can call the same command surface that developers can run from a checkout:
 
 ```bash
 python3 -m modules.local_runtime --json secrets status
@@ -43,11 +43,9 @@ python3 -m modules.local_runtime --json secrets delete github_token
 
 `secrets status` never prints secret values. When a workflow requires a credential, pass `--require <name>` so missing or unavailable credentials return a setup-required exit code instead of looking like a healthy state.
 
-`secrets set` intentionally requires `--value-stdin` so users and app shells do not put tokens in shell history.
+`secrets set` intentionally requires `--value-stdin` so operators and wrapper shells do not put tokens in shell history.
 
-The future native macOS shell should prefer the Keychain APIs directly when storing user-entered tokens.
-Use the same service value above and the Harness secret name as the Keychain account.
-The Python CLI exists as a portable contract and developer fallback; the native app does not need to shell out to store secrets.
+The native macOS shell is deprecated. New credential flows should use the portable CLI/runtime contract unless a future packaging decision explicitly introduces a different shell boundary.
 
 ## Runtime Behavior
 
@@ -55,9 +53,9 @@ The Python CLI exists as a portable contract and developer fallback; the native 
 
 Existing environment variables win. This preserves developer mode:
 
-- repo-root `.env.local` remains valid for native local development
+- repo-root `.env.local` remains valid for local development
 - exported shell variables remain valid for CI and one-off debugging
-- app-managed Keychain secrets are the normal packaged-app path
+- app-managed Keychain secrets are the normal macOS local-runtime path
 
 Missing secrets do not block the local API from starting because GitHub, Linear, and executor integrations are optional until a chosen workflow needs them.
 Workflows that need a credential should call `secrets status --require <name>` or surface the integration-specific setup error.
@@ -67,7 +65,7 @@ Workflows that need a credential should call `secrets status --require <name>` o
 - Do not write token values to `config.json`.
 - Do not write token values to logs.
 - Do not return token values from CLI JSON.
-- Do not teach packaged-app users to edit `.env.local`.
+- Do not teach operators to edit `.env.local` for normal local setup.
 - Do not couple the secret model to OpenClaw or Hermes. Use Harness secret names and map them to current env vars at the runtime boundary.
 
 ## Linux Portability

--- a/docs/architecture/guided-integration-setup.md
+++ b/docs/architecture/guided-integration-setup.md
@@ -1,14 +1,14 @@
 # Guided Integration Setup
 
-`harness setup status --json` is the local app onboarding contract.
-It turns the lower-level setup doctor into user-facing setup items that a normal desktop app can render directly.
+`harness setup status --json` is the local runtime setup contract.
+It turns the lower-level setup doctor into user-facing setup items that CLI/web flows and future packaging can render directly.
 
 The setup contract is intentionally client-neutral.
 Harness can integrate with OpenClaw, Hermes, Codex, or a future desktop-agent client, but Harness must not become architecturally tied to one of them.
 
 ## Command
 
-From a packaged app, expose:
+From a future packaged CLI, expose:
 
 ```bash
 harness setup status
@@ -20,12 +20,12 @@ From a repo checkout, use:
 python3 -m modules.local_runtime --json setup status
 ```
 
-The command exits with `0` when onboarding can finish.
+The command exits with `0` when setup can finish.
 It exits with setup-required when a required item is missing for the selected workflow.
 
-## Default Onboarding
+## Default Setup
 
-Default onboarding only requires the local Harness runtime:
+Default setup only requires the local Harness runtime:
 
 - writable app data and log directories
 - app-managed runtime config
@@ -35,8 +35,8 @@ Default onboarding only requires the local Harness runtime:
 Missing GitHub, Linear, execution-substrate, and legacy ingress/executor setup appears as incomplete optional work.
 Those integrations become blockers only when the user selects a workflow that needs them.
 
-Warnings for API stopped, dashboard assets, notifications, or Launch at Login are actionable, but they do not block runtime-only onboarding.
-The app can start the API when live progress is needed, and notification/startup preferences remain user choices.
+Warnings for API stopped, dashboard assets, notifications, or launch-at-login wrapper state are actionable, but they do not block runtime-only setup.
+The CLI can start the API when live progress is needed, and notification/startup preferences remain wrapper-level choices.
 
 ## Workflow Requirements
 
@@ -54,7 +54,7 @@ Current workflow gates:
 - `linear-sync` requires Linear coordination.
 - `repair-dispatch` requires the execution substrate.
 
-Multiple `--workflow` flags can be passed when the app needs to validate a combined workflow.
+Multiple `--workflow` flags can be passed when the operator needs to validate a combined workflow.
 
 ## Setup Items
 
@@ -96,7 +96,7 @@ The top-level payload includes:
 
 GitHub and Linear credentials must be stored through the app-managed secret boundary.
 The setup contract names the secret to store and exposes the redacted validation status.
-It must not ask normal users to edit env files.
+It must not ask operators to edit env files.
 
 Current secret names:
 

--- a/docs/architecture/linux-portability-contract.md
+++ b/docs/architecture/linux-portability-contract.md
@@ -1,8 +1,8 @@
 # Linux Portability Contract
 
-`#329` is not a Linux app implementation issue. It is the guardrail issue that keeps the macOS-first work from baking macOS assumptions into Harness core.
+This document is now historical guardrail context. Harness is no longer pursuing a native macOS shell first; the supported surface is CLI + API + web dashboard.
 
-Harness is allowed to ship a native macOS shell first. It is not allowed to make the backend, SQLite store, dashboard, or CLI contract depend on Swift, AppKit, Keychain-only semantics, or `.app`-bundle assumptions.
+Harness is not allowed to make the backend, SQLite store, dashboard, or CLI contract depend on Swift, AppKit, Keychain-only semantics, or `.app`-bundle assumptions.
 
 ## Platform-Neutral Surfaces
 
@@ -15,7 +15,7 @@ These pieces must remain reusable for a future Linux package:
 - static dashboard bundle and same-origin API behavior
 - doctor/setup data model and integration semantics
 
-If one of these changes in a macOS feature branch, the change needs to be justified as a portable runtime change, not a shell convenience.
+If one of these changes in a platform packaging branch, the change needs to be justified as a portable runtime change, not a shell convenience.
 
 ## Replaceable Boundaries
 

--- a/docs/architecture/local-dashboard-packaging.md
+++ b/docs/architecture/local-dashboard-packaging.md
@@ -1,13 +1,13 @@
 # Local Dashboard Packaging
 
-The local Harness app should not ask normal users to install Node, `pnpm`, or a developer checkout just to inspect task progress.
+The local Harness dashboard path should not ask operators to install Node, `pnpm`, or keep a developer checkout just to inspect task progress.
 
-Harness packages the dashboard as static assets for local app builds and serves those assets from the local Python runtime at `/dashboard`.
+Harness can package the dashboard as static assets and serve those assets from the local Python runtime at `/dashboard`.
 The dashboard still reads canonical Harness APIs. It does not get a separate local truth store and it does not fall back to sample data when the backend is unavailable.
 
 ## Decision
 
-Use a prebuilt static dashboard bundle for the local app path.
+Use a prebuilt static dashboard bundle for local CLI/web operation.
 
 The local dashboard build:
 
@@ -19,7 +19,7 @@ The local dashboard build:
 
 The normal hosted and developer dashboard build remains a Next.js app. It keeps `app/api/harness/[...path]/route.ts` so hosted deployments can proxy dashboard reads through the web service.
 
-This split is intentional. The local app path does not need a Node server because it talks to the same-origin Python API. The hosted path still benefits from the Next proxy because Vercel owns the web/backend service boundary.
+This split is intentional. The local static-dashboard path does not need a Node server because it talks to the same-origin Python API. The hosted path still benefits from the Next proxy because Vercel owns the web/backend service boundary.
 
 ## Build Artifact
 
@@ -67,20 +67,20 @@ Expected local routes:
 
 The same process serves the canonical API routes such as `GET /tasks`, `GET /tasks/<task_id>/read-model`, and `GET /runtime/status`.
 
-## Packaged App Contract
+## Local Packaging Contract
 
-Packaged macOS and Linux shells should either:
+A future packaged CLI/web distribution should either:
 
 - place the prebuilt dashboard bundle at the configured `dashboard_assets_dir`
 - set `HARNESS_DASHBOARD_ASSETS_DIR` before starting the Harness runtime
 
-The app should open:
+The operator-facing launcher should open:
 
 ```text
 http://127.0.0.1:<runtime-port>/dashboard
 ```
 
-Closing the dashboard window must not stop the runtime. The menu-bar or tray shell remains responsible for process control.
+Closing a browser tab or optional dashboard window must not stop the runtime. Runtime control belongs to the CLI/runtime contract.
 
 ## Validation
 

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -1,7 +1,7 @@
 # Local Runtime Contract
 
-Harness local app builds control the Python backend through a stable runtime contract.
-The app shell should not import backend internals, write SQLite directly, or depend on repo-local shell exports.
+Harness local CLI/web usage controls the Python backend through a stable runtime contract.
+Any packaging or shell around this contract should not import backend internals, write SQLite directly, or depend on repo-local shell exports.
 
 ## Command Surface
 
@@ -26,7 +26,7 @@ Commands:
 - `harness secrets set <name> --value-stdin`
 - `harness secrets delete <name>`
 
-The CLI supports `--json` for app-shell consumption. JSON output is the contract the macOS menu-bar app should use, and it is also the portability boundary a future Linux shell must reuse.
+The CLI supports `--json` for automation and future packaging. JSON output is the supported local runtime contract; native shell code is no longer a product requirement.
 
 ## App-Managed Paths
 
@@ -50,7 +50,7 @@ Default Linux paths:
 
 Developer and test runs may override paths with `--data-dir`, `--log-dir`, `HARNESS_APP_DATA_DIR`,
 or `HARNESS_APP_LOG_DIR`.
-Normal app usage should rely on app-managed defaults.
+Normal local usage should rely on app-managed defaults.
 
 ## Runtime Config
 
@@ -82,7 +82,7 @@ This is what removes the need for Docker, Node, `pnpm`, or repo-local shell expo
 
 ## Secret Store
 
-macOS v1 stores local app secrets in Keychain. The stable Harness secret names are:
+On macOS, the local runtime stores secrets in Keychain. The stable Harness secret names are:
 
 - `github_token`, mapped to `GITHUB_TOKEN`
 - `linear_api_key`, mapped to `LINEAR_API_KEY`
@@ -98,7 +98,7 @@ python3 -m modules.local_runtime --json secrets delete github_token
 ```
 
 Secret status output is redacted. It reports configured, missing, unavailable, and error states without returning token values.
-Existing environment variables win over Keychain values so native developer `.env.local` workflows still work.
+Existing environment variables win over Keychain values so developer `.env.local` workflows still work.
 
 Provider selection is platform-aware. Darwin uses `macos-keychain`; Linux is reserved for the `linux-secret-service` boundary even though the Linux provider is still deferred.
 
@@ -106,11 +106,11 @@ See [app-managed-secrets.md](app-managed-secrets.md).
 
 ## Guided Setup
 
-`harness setup status --json` is the app-renderable onboarding contract.
+`harness setup status --json` is the machine-readable setup contract.
 It converts `harness doctor --json` into setup items with purpose, requirements, validation status, and next actions.
 
-Default onboarding requires only the local Harness runtime.
-Missing GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the app selects a workflow that requires one of them:
+Default setup requires only the local Harness runtime.
+Missing GitHub, Linear, and ingress/executor setup appears as incomplete optional work unless the selected workflow requires one of them:
 
 ```bash
 python3 -m modules.local_runtime --json setup status
@@ -126,15 +126,15 @@ The current workflow gates are:
 - `repair-dispatch`: requires a desktop-agent ingress/executor bridge.
 
 Setup items use the app-managed secret boundary.
-The GitHub and Linear items tell the app which named secret to store and how Harness validates it; they do not ask normal users to edit env files.
+The GitHub and Linear items tell the operator which named secret to store and how Harness validates it; they do not ask operators to edit env files.
 The ingress/executor item stays client-neutral and describes the bridge as compatible with OpenClaw, Hermes, Codex, or future desktop-agent clients.
 
 See [guided-integration-setup.md](guided-integration-setup.md).
 
 ## Dashboard Assets
 
-The local app dashboard is a prebuilt static bundle served by the Python backend.
-It is not a second server process and it is not a Node runtime embedded in the app package.
+The local static dashboard is a prebuilt bundle served by the Python backend.
+It is not a second server process and it is not a Node runtime embedded in a native app package.
 
 Developer builds produce the local bundle with:
 
@@ -142,7 +142,7 @@ Developer builds produce the local bundle with:
 pnpm build:dashboard:local
 ```
 
-Packaged builds should copy that bundle into `dashboard_assets_dir`, or set `HARNESS_DASHBOARD_ASSETS_DIR` to the installed bundle path before starting `harness serve`.
+Future packaged CLI/web builds should copy that bundle into `dashboard_assets_dir`, or set `HARNESS_DASHBOARD_ASSETS_DIR` to the installed bundle path before starting `harness serve`.
 
 When the configured directory contains `index.html`, the backend mounts it at:
 
@@ -156,10 +156,10 @@ The dashboard calls the same-origin local Harness API. If the backend is unavail
 
 ## Status And Health
 
-The backend exposes two app-shell-safe probes:
+The backend exposes two runtime-safe probes:
 
 - `GET /health`: canonical backend and storage health.
-- `GET /runtime/status`: local app runtime status envelope that includes mode, API base URL,
+- `GET /runtime/status`: local runtime status envelope that includes mode, API base URL,
   store backend, secret provider, schema readiness, and app-managed paths.
 
 `harness status --json` calls the local health endpoint and returns:
@@ -194,8 +194,8 @@ Current checks cover:
 - GitHub credential setup state
 - Linear credential setup state
 - ingress/executor bridge setup state
-- notification permission state reported by the app shell
-- Launch at Login state reported by the app shell
+- optional notification permission state reported by a wrapper shell
+- optional launch-at-login state reported by a wrapper shell
 - selected workspace folder availability
 
 The local API check is a warning when the runtime is stopped.
@@ -228,10 +228,10 @@ It is still useful for foreground debugging and for the background process launc
 `harness stop` reads the PID file and sends `SIGTERM`.
 Missing or stale PID files are treated as already stopped because the desired state is satisfied.
 
-`harness recover` is the app-facing repair action for crashed, stale, or degraded runtime state.
+`harness recover` is the runtime repair action for crashed, stale, or degraded runtime state.
 It stops an unhealthy PID-backed process when possible, clears stale PID files, starts a fresh runtime, waits for health, and reports the same user-facing JSON shape as `start`.
 
-The local API binds to loopback by default. Network exposure is out of scope for the local app v1 contract.
+The local API binds to loopback by default. Network exposure is out of scope for the local runtime contract.
 
 `harness open` should open the dashboard URL by default:
 

--- a/docs/architecture/macos-daemon-lifecycle.md
+++ b/docs/architecture/macos-daemon-lifecycle.md
@@ -1,5 +1,7 @@
 # macOS Daemon Lifecycle
 
+Status: deprecated. Harness now supports CLI/runtime control directly; this document remains historical context for the legacy Swift shell.
+
 Harness v1 uses an app-managed lifecycle, not a standalone LaunchAgent.
 
 The decision is deliberate.

--- a/docs/architecture/macos-dashboard-window.md
+++ b/docs/architecture/macos-dashboard-window.md
@@ -1,5 +1,7 @@
 # macOS Dashboard Window
 
+Status: deprecated. Harness now supports the web dashboard directly; this document remains historical context for the legacy Swift shell.
+
 The macOS dashboard window provides the full Harness inspection surface inside the native app.
 It is opened from the menu bar and embeds the same local dashboard served by the app-managed Harness runtime.
 

--- a/docs/architecture/macos-menu-bar-controller.md
+++ b/docs/architecture/macos-menu-bar-controller.md
@@ -1,5 +1,7 @@
 # macOS Menu-Bar Controller
 
+Status: deprecated. Harness now supports CLI + API + web dashboard as the operator surface; this document remains historical context for the legacy Swift shell.
+
 The macOS menu-bar controller is the first native Harness app shell.
 It gives daily operators a small status surface even when the full dashboard is closed.
 

--- a/docs/architecture/macos-onboarding-assistant.md
+++ b/docs/architecture/macos-onboarding-assistant.md
@@ -1,5 +1,7 @@
 # macOS Onboarding Assistant
 
+Status: deprecated. Harness now supports CLI + web setup/inspection as the operator path; this document remains historical context for the legacy Swift shell.
+
 The macOS onboarding assistant is the first-run path for normal users.
 It exists so a user can get to a healthy local Harness runtime without terminal commands, Docker, Python setup, Node, `pnpm`, repo cloning, or env-file editing.
 

--- a/docs/architecture/macos-packaging.md
+++ b/docs/architecture/macos-packaging.md
@@ -1,5 +1,9 @@
 # macOS Packaging
 
+Status: deprecated.
+
+Harness is no longer pursuing a native macOS app as a supported product surface. This document remains as historical context for the Swift app and DMG path, not as an active implementation target. New work should prefer the CLI/runtime contract, backend API, and web dashboard.
+
 Issue #328 is the line between a developer bundle and a distributable local Harness app.
 The goal is not "make Swift build." The goal is "ship a normal macOS app that does not depend on a repo checkout, Python install, Node install, or Docker."
 

--- a/docs/architecture/setup-doctor.md
+++ b/docs/architecture/setup-doctor.md
@@ -1,12 +1,12 @@
 # Setup Doctor Contract
 
-`harness doctor --json` is the local app setup report.
-The menu-bar app and onboarding flow should render this JSON directly instead of parsing logs or backend exception text.
+`harness doctor --json` is the local runtime setup report.
+CLI tooling and any future packaging should render this JSON directly instead of parsing logs or backend exception text.
 For user-facing onboarding steps, prefer `harness setup status --json`, which maps these checks into guided setup items and workflow-specific blockers.
 
 The doctor is intentionally broader than `/health`.
 `/health` reports whether the backend is alive.
-`doctor` explains whether the local app is set up well enough for normal users to understand what is missing and what to do next.
+`doctor` explains whether the local runtime is set up well enough for operators to understand what is missing and what to do next.
 
 ## Check Shape
 
@@ -62,14 +62,13 @@ The current doctor covers:
 - `linear_connection`: Linear credential setup state.
 - `execution_substrate`: Symphony-compatible execution-substrate availability.
 - `ingress_executor`: legacy desktop-agent bridge setup state for the current OpenClaw-shaped adapter wiring, without making OpenClaw the product boundary.
-- `notification_permission`: notification permission state reported by the app shell.
-- `launch_at_login`: launch-at-login state reported by the app shell.
+- `notification_permission`: optional notification permission state reported by a wrapper shell.
+- `launch_at_login`: optional launch-at-login state reported by a wrapper shell.
 - `workspace_folders`: configured local workspace folder availability.
 
-## App Shell Inputs
+## Optional Shell Inputs
 
-Some checks depend on facts owned by the native app shell.
-Until the Swift app owns these directly, the CLI reads these environment variables:
+Some checks can accept facts from an optional shell or wrapper. The native macOS shell is deprecated, but the CLI still reads these environment variables when present:
 
 - `HARNESS_NOTIFICATION_PERMISSION`: `authorized`, `denied`, or `not_determined`.
 - `HARNESS_LAUNCH_AT_LOGIN`: `enabled` or `disabled`.

--- a/docs/architecture/system-context.md
+++ b/docs/architecture/system-context.md
@@ -14,6 +14,7 @@ Harness sits underneath the user-facing and agent-facing work surface as the sys
 - GitHub is the source of truth for code artifacts such as pull requests and commits.
 - Executors such as Codex are workers.
 - A Symphony-like execution substrate may schedule isolated executor runs, but it is not completion truth.
+- The supported Harness operator surfaces are the CLI, backend API, and web dashboard.
 - The workflow substrate provides persistence, resumability, and coordination state for Harness itself.
 
 Stated another way:
@@ -103,6 +104,7 @@ flowchart LR
 
 - Desktop agent clients do not become the durable orchestrator.
 - Harness does not become the user interface.
+- Harness does not become a native desktop-app product; the deprecated macOS shell must not own core behavior.
 - Linear owns work coordination and structured work records, not completion enforcement semantics.
 - GitHub owns artifact evidence records, not lifecycle policy.
 - Executors do not own planning, routing, or lifecycle policy.

--- a/docs/howto/configure-harness.md
+++ b/docs/howto/configure-harness.md
@@ -1,16 +1,16 @@
 # Configure Harness
 
-Harness has two configuration paths: app-managed local configuration for the packaged app, and repo-root `.env.local` for developer and CI-style runs.
+Harness has two configuration paths: local runtime configuration for CLI/web usage, and repo-root `.env.local` for developer and CI-style runs.
 
-## App-Managed Local Configuration
+## Local Runtime Configuration
 
-The macOS app writes non-secret runtime configuration to:
+The local runtime writes non-secret runtime configuration to:
 
 ```text
 ~/Library/Application Support/Harness/config.json
 ```
 
-Secrets do not belong in that file. The app stores local credentials through the app-managed secret boundary.
+Secrets do not belong in that file. Store local credentials through the app-managed secret boundary exposed by the CLI.
 
 Stable Harness secret names:
 
@@ -56,11 +56,11 @@ The current concrete repair receiver is still OpenClaw-shaped, so some operation
 
 Those names are implementation details. Harness itself should stay client-neutral: OpenClaw, Hermes, Codex, or a future desktop agent can fill the same role if it speaks the Harness API boundaries.
 
-For hosted repair dispatch, `OPENCLAW_BASE_URL` must point at a receiver reachable from the hosted runtime. A loopback value such as `http://127.0.0.1:18789` only works for native local development.
+For hosted repair dispatch, `OPENCLAW_BASE_URL` must point at a receiver reachable from the hosted runtime. A loopback value such as `http://127.0.0.1:18789` only works for local development.
 
 ## Storage Choices
 
-Use SQLite for self-contained local app state:
+Use SQLite for self-contained local CLI/web state:
 
 ```bash
 export HARNESS_STORE_BACKEND=sqlite

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -13,10 +13,11 @@ Start here if you want to install, configure, use, and validate Harness without 
 ## Source-Of-Truth References
 
 - [Local Runtime Contract](../architecture/local-runtime-contract.md)
-- [macOS Packaging](../architecture/macos-packaging.md)
-- [Linux Portability Contract](../architecture/linux-portability-contract.md)
+- [Local Dashboard Packaging](../architecture/local-dashboard-packaging.md)
 - [Agent API Usage](../api/agent-api-usage.md)
 - [System Context](../architecture/system-context.md)
 - [Local Development](../setup/local-development.md)
 - [Vercel + Neon Deployment](../setup/vercel-neon.md)
 - [Operator Demo Walkthrough](../demo/operator-walkthrough.md)
+
+The older native macOS app and packaging notes remain in the repository as legacy context, but they are no longer the recommended Harness path.

--- a/docs/howto/local-quickstart.md
+++ b/docs/howto/local-quickstart.md
@@ -4,71 +4,9 @@
 
 Get Harness running locally, prove the runtime is healthy, and open the dashboard that shows canonical task state.
 
-## macOS App Path
+## Supported Local Path
 
-For normal users, the target install path is a signed and notarized `Harness.dmg`.
-They should not need Python, Node, Docker, `pnpm`, or a repo checkout.
-
-Until the external DMG is published, maintainers can create an internal validation package with:
-
-```bash
-./script/package_macos_app.sh
-```
-
-The build writes:
-
-- `dist/macos-release/Harness.app`
-- `dist/macos-release/Harness.dmg`
-
-The internal validation package is ad-hoc signed unless `MACOS_CODESIGN_IDENTITY` is set. External distribution still requires Developer ID signing and notarization:
-
-```bash
-export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
-export MACOS_NOTARY_PROFILE="harness-notary"
-HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
-```
-
-`HARNESS_REQUIRE_NOTARIZATION=1` is the release guardrail. It fails before build work starts if the Developer ID identity or notary profile is missing, so an official release cannot accidentally ship from an ad-hoc internal package.
-
-Check the local release prerequisites before the full build:
-
-```bash
-./script/package_macos_app.sh --check-release-prereqs
-```
-
-After installing the app, first run should guide the user through:
-
-- local runtime initialization
-- optional Launch at Login
-- optional notifications
-- optional GitHub, Linear, and desktop-agent bridge setup
-- dashboard launch
-
-The app stores runtime state under `~/Library/Application Support/Harness/` and logs under `~/Library/Logs/Harness/`.
-
-## First Run In The macOS App
-
-On a clean first launch, Harness opens the setup assistant before the dashboard.
-The default path only requires local runtime and SQLite readiness. Launch at Login, notifications, workspace folders, GitHub, Linear, and desktop-agent bridge setup are useful, but they are not required to finish core onboarding.
-
-![Harness onboarding welcome](images/macos-onboarding-welcome.png)
-
-Use **Skip Optional Items** when you only want to prove the local app path. The dashboard step stays blocked until the local runtime is initialized, running, and healthy.
-
-![Harness onboarding ready](images/macos-onboarding-ready.png)
-
-When the setup assistant shows **Ready**, choose **Finish & Open Dashboard**. The embedded dashboard should load from the local Harness runtime and show the canonical dashboard routes.
-
-![Harness embedded dashboard](images/macos-dashboard-tasks.png)
-
-What to verify:
-
-- the setup badge changes from `1 blocker` to `Ready`
-- the dashboard opens at a loopback `/dashboard/tasks/` URL
-- the dashboard renders the real Harness UI, not `{"detail":"Not Found"}`
-- the task inventory can be empty on a fresh install; that is expected
-
-## Developer Checkout Path
+The supported local operator path is CLI + web dashboard. The native macOS app is deprecated and should not be used as the normal install or validation path.
 
 Use this path when you are developing Harness or validating a PR.
 
@@ -109,18 +47,22 @@ Run one deterministic reset proof:
 python3 -m modules.reset_dryrun success
 ```
 
-For developer validation of the macOS first-run path, build the local dashboard first and launch the app through the repo script:
+For local static-dashboard validation, build the dashboard assets and serve them through the Python runtime:
 
 ```bash
 pnpm build:dashboard:local
-./script/build_and_run.sh --verify
+export HARNESS_DASHBOARD_ASSETS_DIR="$PWD/dist/local-dashboard"
+python3 -m modules.local_runtime --json init
+python3 -m modules.local_runtime --json start
+python3 -m modules.local_runtime --json status
+python3 -m modules.local_runtime --json stop
 ```
 
-The script passes `dist/local-dashboard/` to the app when those assets exist. Without packaged dashboard assets, the runtime can be healthy but the embedded dashboard cannot render the UI.
+Without packaged dashboard assets, the runtime can still be healthy, but `/dashboard` cannot render the static UI.
 
 ## What Good Looks Like
 
 - `/health` returns `status: ok`
 - the dashboard opens at `http://127.0.0.1:3000`
 - deterministic reset dry runs produce accepted or review-required results without live GitHub or Linear mutations
-- the local app runtime can start, stop, recover, and reopen the dashboard without direct SQLite edits
+- the local runtime can start, stop, recover, and serve the dashboard without direct SQLite edits

--- a/docs/howto/test-and-validate.md
+++ b/docs/howto/test-and-validate.md
@@ -33,16 +33,7 @@ python3 -m modules.local_runtime --json stop
 
 The dashboard asset export matters for checkout validation. Without it, the runtime can still be healthy, but `doctor` will warn that the embedded dashboard cannot render packaged UI assets.
 
-A packaged build should expose the same contract as `harness ...`.
-
-## Packaged macOS App
-
-```bash
-./script/package_macos_app.sh
-```
-
-The script builds dashboard assets, freezes the Python runtime, signs the bundle, smoke-tests the bundled runtime, and writes `dist/macos-release/Harness.dmg`.
-The package smoke test defaults to port `18765` so it can run even when the normal local app already owns `127.0.0.1:8765`; override it with `HARNESS_PACKAGE_VERIFY_PORT` if needed.
+A future packaged CLI should expose the same contract as `harness ...`. The native macOS app package is deprecated and is not part of the normal validation path.
 
 ## Deterministic Reset Proofs
 

--- a/docs/howto/troubleshoot.md
+++ b/docs/howto/troubleshoot.md
@@ -24,7 +24,7 @@ Check:
 
 The dashboard should report backend errors honestly. It should not silently switch to fake live data.
 
-## Local App Runtime Will Not Start
+## Local Runtime Will Not Start
 
 Run:
 
@@ -69,28 +69,6 @@ Check:
 
 Harness treats worker-reported success as advisory. If evidence is missing, stale, contradictory, or tied to the wrong run, the correct behavior is to block, retry, reconcile, or require review.
 
-## Packaged App Opens But macOS Blocks It
+## Native macOS App Issues
 
-Internal validation packages may be ad-hoc signed. External distribution requires:
-
-```bash
-export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
-export MACOS_NOTARY_PROFILE="harness-notary"
-HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
-```
-
-Then verify signing and notarization before publishing the DMG.
-
-If the command fails before building with `codesign identity not found`, inspect the available identities:
-
-```bash
-security find-identity -v -p codesigning
-```
-
-Official distribution needs a valid `Developer ID Application` certificate installed in the active keychain. An ad-hoc package is acceptable for internal validation, but it is not an official release artifact.
-
-After installing the certificate and configuring the notary profile, run the local preflight before starting a full package build:
-
-```bash
-./script/package_macos_app.sh --check-release-prereqs
-```
+The native macOS app is deprecated and is not the supported operator path. Prefer `python3 -m modules.local_runtime ...` plus the web dashboard for local operation. Do not spend debugging time on signing, notarization, Launch at Login, or notification problems unless a task explicitly reopens the native app decision.

--- a/docs/howto/use-harness.md
+++ b/docs/howto/use-harness.md
@@ -14,10 +14,10 @@ Run:
 curl -sS http://127.0.0.1:8000/health
 ```
 
-For the packaged local app, use the runtime status command instead:
+For local CLI/runtime operation, use the runtime status command:
 
 ```bash
-harness status --json
+python3 -m modules.local_runtime --json status
 ```
 
 ## Open The Dashboard
@@ -32,7 +32,7 @@ Developer dashboard:
 http://127.0.0.1:3000/tasks
 ```
 
-Packaged local app dashboard:
+Local static dashboard:
 
 ```text
 http://127.0.0.1:8765/dashboard/tasks/

--- a/docs/release/documentation-readiness-checklist.md
+++ b/docs/release/documentation-readiness-checklist.md
@@ -1,6 +1,8 @@
 # Documentation Readiness Checklist
 
-Use this checklist before calling Harness local-app documentation release-ready.
+This checklist captured the older local-app documentation release pass. The native macOS app is now deprecated; use this file as historical evidence, not as the active release checklist.
+
+Current documentation readiness should prove the CLI/runtime contract, backend API, web dashboard, deterministic dry runs, and hosted/local verification paths. Developer ID signing, notarization, DMG production, Launch at Login, and native first-run onboarding are no longer release blockers.
 
 ## Verified In This Pass
 
@@ -17,9 +19,9 @@ Use this checklist before calling Harness local-app documentation release-ready.
 - [x] Fresh macOS first-run walkthrough reaches local SQLite-backed dashboard readiness. See [macos-first-run-walkthrough-2026-04-23.md](macos-first-run-walkthrough-2026-04-23.md).
 - [x] Final onboarding screenshots are captured and referenced from the local quickstart.
 
-## Still Required Before Official Release
+## Historical macOS Release Items
 
 - [x] Run the gated live reset smoke with real GitHub and Linear dry-run targets. See [live-reset-smoke-2026-04-23.md](live-reset-smoke-2026-04-23.md).
-- [ ] Verify a Developer ID signed and notarized DMG, not only the ad-hoc internal package.
+- [ ] Verify a Developer ID signed and notarized DMG, not only the ad-hoc internal package. Deprecated with the native macOS app pivot; no longer required for the supported Harness path.
   Current local blocker: `security find-identity -v -p codesigning` reports `0 valid identities found`, so this machine cannot produce a Developer ID signed DMG yet. See [macos-notarization-readiness-2026-04-24.md](macos-notarization-readiness-2026-04-24.md).
 - [x] Re-run every reader-facing command after the final app UI and installer flow land. See [reader-command-verification-2026-04-27.md](reader-command-verification-2026-04-27.md).

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -60,7 +60,7 @@ pnpm test:frontend
 python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
 
-`backend.server` now auto-loads repo-root `.env.local` during native local startup. It also loads `config/openclaw/.env.local` when present so the current repo-owned desktop-agent config and state paths do not need to be duplicated into the shell environment.
+`backend.server` now auto-loads repo-root `.env.local` during local startup. It also loads `config/openclaw/.env.local` when present so the current repo-owned desktop-agent config and state paths do not need to be duplicated into the shell environment.
 
 For the reset verifier slice, put these in repo-root `.env.local`:
 
@@ -79,7 +79,7 @@ When `config/openclaw/.env.local` provides `OPENCLAW_CONFIG_PATH` or `OPENCLAW_S
 
 If the remote repair receiver is bearer-protected, set `OPENCLAW_REPAIR_BEARER_TOKEN`. Harness will send it as `Authorization: Bearer <token>` on the HTTP repair callback path.
 
-That loopback-style fallback is only appropriate for native local development. Do not copy `OPENCLAW_BASE_URL=http://127.0.0.1:...` into hosted Vercel environments, because the reset verifier will not be able to reach your laptop from a serverless runtime.
+That loopback-style fallback is only appropriate for local development. Do not copy `OPENCLAW_BASE_URL=http://127.0.0.1:...` into hosted Vercel environments, because the reset verifier will not be able to reach your laptop from a serverless runtime.
 
 To run the backend against SQLite local persistence:
 
@@ -89,13 +89,13 @@ export HARNESS_SQLITE_PATH="$HOME/Library/Application Support/Harness/harness.db
 python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 ```
 
-SQLite mode is the intended persistence base for the self-contained local app. It creates the database and schema automatically, enables WAL mode and foreign keys, and stores canonical tasks, evaluation records, and reset verifier contracts in one local database.
+SQLite mode is the intended persistence base for self-contained local CLI/web usage. It creates the database and schema automatically, enables WAL mode and foreign keys, and stores canonical tasks, evaluation records, and reset verifier contracts in one local database.
 
 If `HARNESS_SQLITE_PATH` is unset, Harness uses the platform local-data default: `~/Library/Application Support/Harness/harness.db` on macOS, `$XDG_DATA_HOME/harness/harness.db` on Linux, or `~/.local/share/harness/harness.db` when `XDG_DATA_HOME` is unset.
 
-### Run The Local App Runtime Contract
+### Run The Local Runtime Contract
 
-The packaged app will expose this contract as `harness`. From a repo checkout, use the module entry point:
+A future packaged CLI can expose this contract as `harness`. From a repo checkout, use the module entry point:
 
 ```bash
 python3 -m modules.local_runtime --json init
@@ -109,8 +109,8 @@ python3 -m modules.local_runtime --json recover
 python3 -m modules.local_runtime --json stop
 ```
 
-The runtime contract uses app-managed config, SQLite state, PID files, dashboard assets, and logs. A packaged app should not require Docker, Node, `pnpm`, or repo-local shell exports.
-Use `start` and `recover` for app-style background lifecycle control.
+The runtime contract uses app-managed config, SQLite state, PID files, dashboard assets, and logs. A future packaged CLI should not require Docker, Node, `pnpm`, or repo-local shell exports.
+Use `start` and `recover` for local background lifecycle control.
 Use `serve` only when you intentionally want a foreground backend for debugging.
 
 Default macOS paths:
@@ -121,7 +121,7 @@ Default macOS paths:
 - `~/Library/Application Support/Harness/runtime/harness.pid`
 - `~/Library/Logs/Harness/harness.log`
 
-Packaged app secrets use the app-managed secret store instead of `.env.local`:
+Local CLI/web secrets use the app-managed secret store instead of `.env.local`:
 
 ```bash
 printf '%s' "$GITHUB_TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin
@@ -130,9 +130,9 @@ python3 -m modules.local_runtime --json secrets status
 ```
 
 Secret status output is redacted. Use `--require <secret-name>` when a selected workflow cannot run without that credential.
-Native developer mode can still use repo-root `.env.local`.
+Developer mode can still use repo-root `.env.local`.
 
-Run setup doctor to get app-renderable setup status:
+Run setup doctor to get machine-readable setup status:
 
 ```bash
 python3 -m modules.local_runtime --json doctor
@@ -248,7 +248,7 @@ The dashboard is read-only and depends on the canonical inspection APIs:
 
 ### Build The Packaged Local Dashboard
 
-For the self-contained local app path, build static dashboard assets instead of running a Node dashboard server:
+For the self-contained local CLI/web path, build static dashboard assets instead of running a Node dashboard server:
 
 ```bash
 pnpm build:dashboard:local
@@ -278,32 +278,11 @@ http://127.0.0.1:8765/dashboard/
 
 The normal hosted/developer dashboard still uses `pnpm dev` or `pnpm build` and the Next proxy route.
 
-### Build The macOS Release Package
+### Deprecated macOS Package Path
 
-For the self-contained macOS distribution path, build the packaged app instead of the repo-root developer bundle:
+The native macOS package path is deprecated. Do not use `./script/package_macos_app.sh`, Developer ID signing, notarization, or DMG output as the normal Harness validation or release path unless a future task explicitly reopens the native app decision.
 
-```bash
-./script/package_macos_app.sh
-```
-
-That script:
-
-- builds `dist/local-dashboard/`
-- freezes `modules/local_runtime.py` into a bundled `harness` runtime
-- stages `dist/macos-release/Harness.app`
-- signs the bundle ad hoc by default, or with `MACOS_CODESIGN_IDENTITY` when set
-- creates `dist/macos-release/Harness.dmg`
-
-For external distribution, also provide:
-
-```bash
-export MACOS_CODESIGN_IDENTITY="Developer ID Application: ..."
-export MACOS_NOTARY_PROFILE="harness-notary"
-./script/package_macos_app.sh --check-release-prereqs
-HARNESS_REQUIRE_NOTARIZATION=1 ./script/package_macos_app.sh
-```
-
-See [`docs/architecture/macos-packaging.md`](../architecture/macos-packaging.md) for the packaged bundle layout, uninstall/reset notes, and notarization expectations.
+The reusable packaging work that remains relevant is the static dashboard bundle plus the local runtime contract above.
 
 ### One-Command Demo Bootstrap
 
@@ -342,7 +321,7 @@ python3 -m modules.demo_walkthrough seed \
   --output-dir demo-output/walkthrough
 ```
 
-Use native local mode when you need fast edit-run-debug loops.
+Use local mode when you need fast edit-run-debug loops.
 
 ## Docker Mode
 


### PR DESCRIPTION
## Summary
- accept CLI + API + web dashboard as the supported Harness operator surface in a new ADR
- mark the native macOS app, DMG packaging, signing/notarization, Launch at Login, notifications, and Swift onboarding as deprecated legacy context
- update README, how-to, setup, architecture, release checklist, and AGENTS guidance so future work preserves portable runtime/dashboard boundaries instead of extending the native app

## Validation
- git diff --check
- python3 -c "from pathlib import Path; paths=['docs/adrs/0005-cli-web-operator-surface.md','docs/architecture/local-runtime-contract.md','docs/architecture/local-dashboard-packaging.md','docs/architecture/setup-doctor.md','docs/architecture/macos-packaging.md','apps/macos/HarnessApp/README.md','docs/howto/local-quickstart.md','docs/howto/use-harness.md']; missing=[p for p in paths if not Path(p).is_file()]; raise SystemExit('missing: '+', '.join(missing) if missing else 0)"
- git grep -n -E "target install path|recommended Harness path|normal install|normal validation path|normal Harness validation|release blocker" -- README.md docs/howto docs/setup docs/architecture docs/release/documentation-readiness-checklist.md apps/macos/HarnessApp/README.md