### PR TITLE
Gate deprecated macOS app scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,11 +401,14 @@ The native macOS app shell under [`apps/macos/HarnessApp`](apps/macos/HarnessApp
 The legacy development commands still exist for compatibility, but they are not part of the recommended operator path:
 
 ```bash
+HARNESS_ENABLE_DEPRECATED_MACOS_APP=1 \
 ./script/build_and_run.sh
+
+HARNESS_ENABLE_DEPRECATED_MACOS_APP=1 \
 ./script/package_macos_app.sh
 ```
 
-No new product work should depend on those commands. Normal Harness operation should be CLI + API + web dashboard.
+Without `HARNESS_ENABLE_DEPRECATED_MACOS_APP=1`, those scripts fail fast with a deprecation message. No new product work should depend on them. Normal Harness operation should be CLI + API + web dashboard.
 
 See [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md), [`docs/architecture/local-dashboard-packaging.md`](docs/architecture/local-dashboard-packaging.md), and [`docs/architecture/setup-doctor.md`](docs/architecture/setup-doctor.md). The older macOS architecture notes remain for historical context only.
 

--- a/apps/macos/HarnessApp/README.md
+++ b/apps/macos/HarnessApp/README.md
@@ -15,6 +15,7 @@ Do not add new menu-bar, first-run onboarding, notification, Launch at Login, si
 ## Validate
 
 ```bash
+export HARNESS_ENABLE_DEPRECATED_MACOS_APP=1
 swift build
 swift run HarnessAppCoreCheck
 ```
@@ -22,7 +23,7 @@ swift run HarnessAppCoreCheck
 The repo-level launch path is:
 
 ```bash
-./script/build_and_run.sh --verify
+HARNESS_ENABLE_DEPRECATED_MACOS_APP=1 ./script/build_and_run.sh --verify
 ```
 
 When `dist/local-dashboard/index.html` exists, the repo launch script passes it to the app as `HARNESS_DASHBOARD_ASSETS_DIR`.
@@ -35,13 +36,14 @@ HARNESS_DEV_BUNDLE_ID=com.knoxanalytics.harness.local.first-run-proof \
 HARNESS_APP_DATA_DIR=/tmp/harness-first-run/data \
 HARNESS_APP_LOG_DIR=/tmp/harness-first-run/logs \
 HARNESS_RUNTIME_PORT=18767 \
+HARNESS_ENABLE_DEPRECATED_MACOS_APP=1 \
 ./script/build_and_run.sh --verify
 ```
 
 The distributable packaging path is:
 
 ```bash
-./script/package_macos_app.sh
+HARNESS_ENABLE_DEPRECATED_MACOS_APP=1 ./script/package_macos_app.sh
 ```
 
 That script stages a self-contained `Harness.app` and `Harness.dmg` under `dist/macos-release/` with a bundled `harness` runtime and prebuilt dashboard assets.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -282,6 +282,12 @@ The normal hosted/developer dashboard still uses `pnpm dev` or `pnpm build` and 
 
 The native macOS package path is deprecated. Do not use `./script/package_macos_app.sh`, Developer ID signing, notarization, or DMG output as the normal Harness validation or release path unless a future task explicitly reopens the native app decision.
 
+The legacy script now requires an explicit opt-in:
+
+```bash
+HARNESS_ENABLE_DEPRECATED_MACOS_APP=1 ./script/package_macos_app.sh
+```
+
 The reusable packaging work that remains relevant is the static dashboard bundle plus the local runtime contract above.
 
 ### One-Command Demo Bootstrap

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -16,6 +16,17 @@ APP_MACOS="$APP_CONTENTS/MacOS"
 APP_BINARY="$APP_MACOS/$APP_NAME"
 INFO_PLIST="$APP_CONTENTS/Info.plist"
 
+if [[ "${HARNESS_ENABLE_DEPRECATED_MACOS_APP:-}" != "1" ]]; then
+  cat >&2 <<'EOF'
+The native macOS app is deprecated and is no longer a supported Harness surface.
+Use the CLI/runtime contract and web dashboard instead.
+
+To run this legacy script intentionally, set:
+  HARNESS_ENABLE_DEPRECATED_MACOS_APP=1
+EOF
+  exit 2
+fi
+
 pkill -x "$APP_NAME" >/dev/null 2>&1 || true
 
 cd "$APP_DIR"

--- a/script/package_macos_app.sh
+++ b/script/package_macos_app.sh
@@ -37,6 +37,17 @@ CODESIGN_IDENTITY="${MACOS_CODESIGN_IDENTITY:-}"
 NOTARY_PROFILE="${MACOS_NOTARY_PROFILE:-}"
 REQUIRE_NOTARIZATION="${HARNESS_REQUIRE_NOTARIZATION:-0}"
 
+if [[ "${HARNESS_ENABLE_DEPRECATED_MACOS_APP:-}" != "1" ]]; then
+  cat >&2 <<'EOF'
+The native macOS app and DMG package path are deprecated and are no longer supported Harness release surfaces.
+Use the CLI/runtime contract and web dashboard instead.
+
+To run this legacy packaging script intentionally, set:
+  HARNESS_ENABLE_DEPRECATED_MACOS_APP=1
+EOF
+  exit 2
+fi
+
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || {
     echo "missing required tool: $1" >&2


### PR DESCRIPTION
## Summary
- make the legacy macOS app launch script fail fast unless HARNESS_ENABLE_DEPRECATED_MACOS_APP=1 is set
- make the legacy DMG packaging script fail fast behind the same explicit opt-in
- update docs to show the opt-in and keep CLI + API + web dashboard as the default operator path

## Validation
- ./script/build_and_run.sh --verify exits 2 with the deprecation guard before Swift work
- ./script/package_macos_app.sh --check-release-prereqs exits 2 with the deprecation guard before packaging checks
- bash -n script/build_and_run.sh
- bash -n script/package_macos_app.sh
- git diff --check