### PR TITLE
Retarget local setup copy to CLI web

### DIFF
--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -188,7 +188,7 @@ def resolve_runtime_paths(
     platform_name: str | None = None,
     home: str | Path | None = None,
 ) -> RuntimePaths:
-    """Resolve app-managed local runtime paths."""
+    """Resolve managed local runtime paths."""
 
     current_platform = platform_name or sys.platform
     home_path = Path(home).expanduser() if home is not None else Path.home()
@@ -578,8 +578,8 @@ def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
                 code="config",
                 status="fail",
                 message=str(error),
-                impact="Harness cannot start reliably until app-managed config exists and is readable.",
-                next_action="Run `harness init` from the app bundle or CLI.",
+                impact="Harness cannot start reliably until local runtime config exists and is readable.",
+                next_action="Run `harness init` from the CLI.",
             )
         )
     else:
@@ -640,14 +640,14 @@ def run_doctor(paths: RuntimePaths) -> tuple[int, dict[str, Any]]:
                 status="pass" if api_running else "warn",
                 message="Local API is healthy." if api_running else "Local API is not running.",
                 impact=(
-                    "The menu-bar app and dashboard can read Harness state."
+                    "The CLI and dashboard can read Harness state."
                     if api_running
-                    else "The app can still run setup checks, but live task status and the dashboard are unavailable."
+                    else "Setup checks can still run, but live task status and the dashboard are unavailable."
                 ),
                 next_action=(
                     "No action needed."
                     if api_running
-                    else "Start Harness from the app or run `harness serve`."
+                    else "Run `harness start` or `harness serve`."
                 ),
                 details={
                     "api_base_url": config.base_url,
@@ -976,9 +976,9 @@ def _check_notification_permission() -> RuntimeCheck:
     return RuntimeCheck(
         code="notification_permission",
         status="warn",
-        message="Notification permission has not been reported by the app shell.",
-        impact="Harness can run, but the app has not confirmed whether attention alerts can be delivered.",
-        next_action="Open the Harness app and complete the notifications setup step.",
+        message="Notification permission has not been reported by a wrapper shell.",
+        impact="Harness can run, but no wrapper has confirmed whether attention alerts can be delivered.",
+        next_action="No action needed unless a wrapper shell is responsible for local notifications.",
         details={"permission": permission},
     )
 
@@ -1000,15 +1000,15 @@ def _check_launch_at_login() -> RuntimeCheck:
             status="warn",
             message="Launch at Login is disabled.",
             impact="Harness will only run after the user starts it manually.",
-            next_action="Enable Launch at Login from the Harness app if you want background supervision after login.",
+            next_action="No action needed unless a wrapper shell is responsible for startup after login.",
             details={"state": state},
         )
     return RuntimeCheck(
         code="launch_at_login",
         status="warn",
-        message="Launch at Login state has not been reported by the app shell.",
+        message="Launch at Login state has not been reported by a wrapper shell.",
         impact="Harness can run, but automatic startup has not been confirmed.",
-        next_action="Open the Harness app and complete the Launch at Login setup step.",
+        next_action="No action needed for CLI/web usage.",
         details={"state": state},
     )
 
@@ -1039,7 +1039,7 @@ def _check_workspace_folders() -> RuntimeCheck:
             status="fail",
             message="One or more configured workspace folders are unavailable.",
             impact="Workflows that need local repository or artifact inspection may fail.",
-            next_action="Reconnect the missing folders from the Harness app or remove stale workspace folder entries.",
+            next_action="Reconnect the missing folders through your wrapper shell or remove stale workspace folder entries.",
             details=details,
         )
     return RuntimeCheck(
@@ -1174,7 +1174,7 @@ def _open_url(url: str) -> None:
 
 
 def build_runtime_status_payload(health_payload: dict[str, Any]) -> dict[str, Any]:
-    """Build the stable backend endpoint payload used by the app shell."""
+    """Build the stable backend endpoint payload used by local runtime clients."""
 
     base_url = os.environ.get(ENV_RUNTIME_BASE_URL)
     if not base_url:
@@ -1263,12 +1263,12 @@ def build_parser() -> argparse.ArgumentParser:
     recover_parser = subparsers.add_parser("recover", help="Recover a stale, crashed, or degraded local runtime")
     recover_parser.add_argument("--timeout", default=10.0, type=float, help="Recovery startup timeout in seconds")
 
-    setup_parser = subparsers.add_parser("setup", help="Guide local onboarding and optional integration setup")
+    setup_parser = subparsers.add_parser("setup", help="Guide local runtime and optional integration setup")
     setup_subparsers = setup_parser.add_subparsers(dest="setup_command", required=True)
 
     setup_status_parser = setup_subparsers.add_parser(
         "status",
-        help="Report guided setup state for the local app onboarding flow",
+        help="Report guided setup state for CLI/web setup flows",
     )
     setup_status_parser.add_argument(
         "--workflow",

--- a/modules/local_setup.py
+++ b/modules/local_setup.py
@@ -1,4 +1,4 @@
-"""Guided setup contract for the local Harness app."""
+"""Guided setup contract for the local Harness runtime."""
 
 from __future__ import annotations
 
@@ -82,17 +82,17 @@ SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
         title="Local Harness runtime",
         category="core",
         purpose=(
-            "Runs Harness locally with app-managed config, SQLite persistence, local logs, "
+            "Runs Harness locally with managed config, SQLite persistence, local logs, "
             "and the dashboard/API served from the local backend."
         ),
         what_user_needs=(
-            "Writable app data and log folders.",
-            "Initialized app-managed config and SQLite database.",
-            "A running local API when the menu-bar summary or dashboard needs live progress.",
+            "Writable local data and log folders.",
+            "Initialized managed config and SQLite database.",
+            "A running local API when CLI/web inspection needs live progress.",
         ),
         how_harness_validates=(
             "Harness checks writable app folders, config readability, SQLite schema readiness, "
-            "API health, dashboard assets, app-reported permissions, and selected workspace folders."
+            "API health, dashboard assets, optional wrapper-reported permissions, and selected workspace folders."
         ),
         doctor_check_codes=(
             "app_data_dir",
@@ -121,8 +121,8 @@ SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
             ),
         ),
         notes=(
-            "API and dashboard warnings do not block onboarding; the app can start the runtime when needed.",
-            "Notifications and Launch at Login are encouraged app-shell choices, not hard requirements.",
+            "API and dashboard warnings do not block setup; the CLI can start the runtime when needed.",
+            "Notifications and Launch at Login are optional wrapper-shell choices, not Harness requirements.",
         ),
     ),
     SetupItemDefinition(
@@ -135,10 +135,10 @@ SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
         ),
         what_user_needs=(
             "A GitHub account or token with access to the repositories Harness should verify.",
-            "The packaged app should store the credential through its app-managed secret provider.",
+            "Store the credential through the managed secret provider.",
         ),
         how_harness_validates=(
-            "Harness checks the redacted status of the app-managed `github_token` secret through the setup doctor."
+            "Harness checks the redacted status of the managed `github_token` secret through the setup doctor."
         ),
         doctor_check_codes=("github_connection",),
         completion_check_codes=("github_connection",),
@@ -164,10 +164,10 @@ SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
         ),
         what_user_needs=(
             "A Linear API key or app authorization for the workspace Harness should coordinate with.",
-            "The packaged app should store the credential through its app-managed secret provider.",
+            "Store the credential through the managed secret provider.",
         ),
         how_harness_validates=(
-            "Harness checks the redacted status of the app-managed `linear_api_key` secret through the setup doctor."
+            "Harness checks the redacted status of the managed `linear_api_key` secret through the setup doctor."
         ),
         doctor_check_codes=("linear_connection",),
         completion_check_codes=("linear_connection",),
@@ -246,7 +246,7 @@ SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
                 kind="connection",
                 label="Connect desktop-agent bridge",
                 description=(
-                    "Connect OpenClaw, Hermes, Codex, or another compatible client through the app setup flow."
+                    "Connect OpenClaw, Hermes, Codex, or another compatible client through CLI/web setup."
                 ),
             ),
             SetupAction(
@@ -278,7 +278,7 @@ def build_guided_setup_status(
     *,
     selected_workflows: Iterable[str] = (),
 ) -> dict[str, Any]:
-    """Build the app-renderable guided onboarding status from doctor output."""
+    """Build the guided setup status from doctor output."""
 
     workflows = _normalize_workflows(selected_workflows)
     required_item_ids = {"local_runtime"}
@@ -457,7 +457,7 @@ def _next_action(
 ) -> str:
     if status == "complete":
         if definition.id == "local_runtime":
-            return "No setup action is required to finish onboarding. Start Harness when live progress is needed."
+            return "No setup action is required. Start Harness when live progress is needed."
         return "No action needed."
 
     failing_check = next((check for check in checks if check.get("status") == "fail"), None)
@@ -473,9 +473,9 @@ def _next_action(
     if definition.setup_actions:
         action = definition.setup_actions[0]
         if action.command:
-            return f"Run `{action.command}` or complete the equivalent app setup step."
+            return f"Run `{action.command}` or complete the equivalent setup step."
         return action.description
-    return "Open Harness setup and complete this item."
+    return "Complete this item through the CLI or configured operator surface."
 
 
 def _summarize_check(check: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -167,6 +167,8 @@ class LocalRuntimeCliTests(unittest.TestCase):
         self.assertEqual(checks["launch_at_login"]["status"], "pass")
         self.assertEqual(checks["workspace_folders"]["status"], "pass")
         self.assertIn("harness serve", checks["api_health"]["next_action"])
+        self.assertNotIn("Harness app", json.dumps(payload))
+        self.assertNotIn("menu-bar", json.dumps(payload))
         self.assertTrue(all(check.get("impact") for check in payload["checks"]))
         self.assertTrue(all(check.get("next_action") for check in payload["checks"]))
 

--- a/tests/test_local_setup.py
+++ b/tests/test_local_setup.py
@@ -20,10 +20,14 @@ def healthy_runtime_doctor_payload(
         check("log_dir", "pass"),
         check("config", "pass"),
         check("sqlite", "pass"),
-        check("api_health", "warn", next_action="Start Harness from the app or run `harness serve`."),
+        check("api_health", "warn", next_action="Run `harness start` or `harness serve`."),
         check("dashboard", "warn", next_action="Install packaged dashboard assets."),
-        check("notification_permission", "warn", next_action="Complete the notifications setup step."),
-        check("launch_at_login", "warn", next_action="Complete the Launch at Login setup step."),
+        check(
+            "notification_permission",
+            "warn",
+            next_action="No action needed unless a wrapper shell is responsible for local notifications.",
+        ),
+        check("launch_at_login", "warn", next_action="No action needed for CLI/web usage."),
         check("workspace_folders", "pass"),
         check(
             "github_connection",
@@ -95,6 +99,9 @@ class GuidedSetupStatusTests(unittest.TestCase):
         self.assertFalse(items["linear"]["required"])
         self.assertFalse(items["execution_substrate"]["required"])
         self.assertFalse(items["ingress_executor"]["required"])
+        runtime_text = str(items["local_runtime"])
+        self.assertNotIn("Harness app", runtime_text)
+        self.assertNotIn("menu-bar", runtime_text)
 
     def test_selected_workflow_makes_integration_setup_required(self) -> None:
         payload = build_guided_setup_status(


### PR DESCRIPTION
## Summary
- remove deprecated native-app wording from local runtime doctor/setup JSON copy
- retarget setup guidance to CLI/web and wrapper-neutral language
- add focused assertions that local runtime/setup payloads do not point operators back to the Harness app or menu bar

## Validation
- python3 -m unittest tests.test_local_setup tests.test_local_runtime
- python3 -m py_compile modules/local_runtime.py modules/local_setup.py
- python3 -m unittest discover -s tests
- git diff --check