### PR TITLE
Point Codex run action at local runtime

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -3,9 +3,9 @@ version = 1
 name = "Harness"
 
 [setup]
-script = ""
+script = "python3 -m modules.local_runtime --json init"
 
 [[actions]]
 name = "Run"
 icon = "run"
-command = "./script/build_and_run.sh"
+command = "python3 -m modules.local_runtime --json start"


### PR DESCRIPTION
## Summary
- update the Codex environment setup action to initialize Harness through the local runtime CLI
- update the Codex Run action to start Harness through {
  "api_base_url": "http://127.0.0.1:8765",
  "message": "Harness runtime started.",
  "paths": {
    "config_path": "/Users/ssbob/Library/Application Support/Harness/config.json",
    "dashboard_assets_dir": "/Users/ssbob/Library/Application Support/Harness/dashboard",
    "data_dir": "/Users/ssbob/Library/Application Support/Harness",
    "database_path": "/Users/ssbob/Library/Application Support/Harness/harness.db",
    "log_dir": "/Users/ssbob/Library/Logs/Harness",
    "log_path": "/Users/ssbob/Library/Logs/Harness/harness.log",
    "pid_path": "/Users/ssbob/Library/Application Support/Harness/runtime/harness.pid",
    "runtime_dir": "/Users/ssbob/Library/Application Support/Harness/runtime"
  },
  "pid": 87894,
  "recovered": true,
  "status": "running"
}
- remove the last active Codex run hook to the deprecated native macOS launch script

## Validation
- python3 -c "import tomllib; from pathlib import Path; payload=tomllib.loads(Path('.codex/environments/environment.toml').read_text()); assert payload['setup']['script'] == 'python3 -m modules.local_runtime --json init'; assert payload['actions'][0]['command'] == 'python3 -m modules.local_runtime --json start'"
- python3 -m modules.local_runtime --data-dir /private/tmp/harness-codex-run-action-data --log-dir /private/tmp/harness-codex-run-action-logs --json init
- python3 -m modules.local_runtime --data-dir /private/tmp/harness-codex-run-action-data --log-dir /private/tmp/harness-codex-run-action-logs --json start --port 18782 --timeout 5
- python3 -m modules.local_runtime --data-dir /private/tmp/harness-codex-run-action-data --log-dir /private/tmp/harness-codex-run-action-logs --json stop
- git diff --check