### PR TITLE
Treat wrapper checks as optional for CLI web

### DIFF
--- a/docs/architecture/guided-integration-setup.md
+++ b/docs/architecture/guided-integration-setup.md
@@ -35,8 +35,8 @@ Default setup only requires the local Harness runtime:
 Missing GitHub, Linear, execution-substrate, and legacy ingress/executor setup appears as incomplete optional work.
 Those integrations become blockers only when the user selects a workflow that needs them.
 
-Warnings for API stopped, dashboard assets, notifications, or launch-at-login wrapper state are actionable, but they do not block runtime-only setup.
-The CLI can start the API when live progress is needed, and notification/startup preferences remain wrapper-level choices.
+Warnings for API stopped or missing dashboard assets are actionable, but they do not block runtime-only setup.
+The CLI can start the API when live progress is needed. Notification and startup-after-login preferences are wrapper-level choices and do not create default setup warnings.
 
 ## Workflow Requirements
 

--- a/docs/architecture/setup-doctor.md
+++ b/docs/architecture/setup-doctor.md
@@ -62,8 +62,8 @@ The current doctor covers:
 - `linear_connection`: Linear credential setup state.
 - `execution_substrate`: Symphony-compatible execution-substrate availability.
 - `ingress_executor`: legacy desktop-agent bridge setup state for the current OpenClaw-shaped adapter wiring, without making OpenClaw the product boundary.
-- `notification_permission`: optional notification permission state reported by a wrapper shell.
-- `launch_at_login`: optional launch-at-login state reported by a wrapper shell.
+- `notification_permission`: optional notification delivery state reported by a wrapper shell; unknown or disabled states are healthy for CLI/web usage.
+- `launch_at_login`: optional startup-after-login state reported by a wrapper shell; unknown or disabled states are healthy for CLI/web usage.
 - `workspace_folders`: configured local workspace folder availability.
 
 ## Optional Shell Inputs

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -967,18 +967,18 @@ def _check_notification_permission() -> RuntimeCheck:
     if permission in {"denied", "disabled"}:
         return RuntimeCheck(
             code="notification_permission",
-            status="warn",
-            message="Notification permission is denied.",
-            impact="Harness can still run, but attention events will not appear as local notifications.",
-            next_action="Enable Harness notifications in system settings if you want attention alerts.",
+            status="pass",
+            message="Wrapper notification delivery is disabled.",
+            impact="Harness can run normally through CLI/web surfaces without local notifications.",
+            next_action="No action needed.",
             details={"permission": permission},
         )
     return RuntimeCheck(
         code="notification_permission",
-        status="warn",
-        message="Notification permission has not been reported by a wrapper shell.",
-        impact="Harness can run, but no wrapper has confirmed whether attention alerts can be delivered.",
-        next_action="No action needed unless a wrapper shell is responsible for local notifications.",
+        status="pass",
+        message="No wrapper notification delivery is configured.",
+        impact="Harness can run normally through CLI/web surfaces without local notifications.",
+        next_action="No action needed.",
         details={"permission": permission},
     )
 
@@ -997,18 +997,18 @@ def _check_launch_at_login() -> RuntimeCheck:
     if state in {"disabled", "false", "0", "no"}:
         return RuntimeCheck(
             code="launch_at_login",
-            status="warn",
-            message="Launch at Login is disabled.",
-            impact="Harness will only run after the user starts it manually.",
-            next_action="No action needed unless a wrapper shell is responsible for startup after login.",
+            status="pass",
+            message="Wrapper startup after login is disabled.",
+            impact="Harness can run normally through explicit CLI/web startup.",
+            next_action="No action needed.",
             details={"state": state},
         )
     return RuntimeCheck(
         code="launch_at_login",
-        status="warn",
-        message="Launch at Login state has not been reported by a wrapper shell.",
-        impact="Harness can run, but automatic startup has not been confirmed.",
-        next_action="No action needed for CLI/web usage.",
+        status="pass",
+        message="No wrapper startup after login is configured.",
+        impact="Harness can run normally through explicit CLI/web startup.",
+        next_action="No action needed.",
         details={"state": state},
     )
 

--- a/tests/test_local_setup.py
+++ b/tests/test_local_setup.py
@@ -24,10 +24,10 @@ def healthy_runtime_doctor_payload(
         check("dashboard", "warn", next_action="Install packaged dashboard assets."),
         check(
             "notification_permission",
-            "warn",
-            next_action="No action needed unless a wrapper shell is responsible for local notifications.",
+            "pass",
+            next_action="No action needed.",
         ),
-        check("launch_at_login", "warn", next_action="No action needed for CLI/web usage."),
+        check("launch_at_login", "pass", next_action="No action needed."),
         check("workspace_folders", "pass"),
         check(
             "github_connection",


### PR DESCRIPTION
## Summary
- Treat disabled or unreported wrapper notification delivery as healthy for CLI/web usage
- Treat disabled or unreported wrapper startup-after-login as healthy for explicit CLI/web startup
- Update setup doctor docs and setup guidance so wrapper-only preferences do not create default setup warnings

## Validation
- python3 -m unittest tests.test_local_setup tests.test_local_runtime
- python3 -m py_compile modules/local_runtime.py modules/local_setup.py
- git diff --check
- python3 -m modules.local_runtime --data-dir /private/tmp/harness-wrapper-checks-data --log-dir /private/tmp/harness-wrapper-checks-logs --json init
- python3 -m modules.local_runtime --data-dir /private/tmp/harness-wrapper-checks-data --log-dir /private/tmp/harness-wrapper-checks-logs --json doctor
- python3 -m unittest discover -s tests