### PR TITLE
Rename local app secret copy to runtime managed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ HARNESS_API_BASE_URL=http://127.0.0.1:8000
 # Hosted Vercel deployments derive the backend route automatically from
 # VERCEL_URL and the /backend service prefix.
 HARNESS_STORE_BACKEND=file
-# For the self-contained local app path, use SQLite instead:
+# For self-contained local CLI/web state, use SQLite instead:
 # HARNESS_STORE_BACKEND=sqlite
 # HARNESS_SQLITE_PATH=/Users/you/Library/Application Support/Harness/harness.db
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ See:
 - SQLite storage is implemented in [`modules/store.py`](modules/store.py) and [`modules/reset/store.py`](modules/reset/store.py). Harness creates the local database and schema automatically.
 - The default hosted deployment target is Neon-backed Postgres attached through Vercel. Harness stores canonical task and evaluation payloads as JSONB in `tasks` and `evaluation_records`.
 - The local runtime contract is implemented in [`modules/local_runtime.py`](modules/local_runtime.py) and documented in [`docs/architecture/local-runtime-contract.md`](docs/architecture/local-runtime-contract.md).
-- App-managed secret storage is implemented in [`modules/local_secrets.py`](modules/local_secrets.py) and documented in [`docs/architecture/app-managed-secrets.md`](docs/architecture/app-managed-secrets.md).
+- Runtime-managed secret storage is implemented in [`modules/local_secrets.py`](modules/local_secrets.py) and documented in [`docs/architecture/app-managed-secrets.md`](docs/architecture/app-managed-secrets.md).
 - Local dashboard packaging is documented in [`docs/architecture/local-dashboard-packaging.md`](docs/architecture/local-dashboard-packaging.md).
 - Setup doctor output is documented in [`docs/architecture/setup-doctor.md`](docs/architecture/setup-doctor.md).
 - The deprecated macOS menu-bar app remains legacy code only; supported local operation should use the CLI/runtime contract and web dashboard.
@@ -365,7 +365,7 @@ python3 -m modules.local_runtime --json recover
 python3 -m modules.local_runtime --json stop
 ```
 
-Future packaged CLI builds should expose the same contract as `harness init`, `harness start`, `harness serve`, `harness status`, `harness doctor`, `harness setup status`, `harness open`, `harness recover`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in app-managed local directories so operators do not need Docker, Node, `pnpm`, or repo-local shell exports.
+Future packaged CLI builds should expose the same contract as `harness init`, `harness start`, `harness serve`, `harness status`, `harness doctor`, `harness setup status`, `harness open`, `harness recover`, `harness stop`, and `harness secrets ...`. The runtime stores config, SQLite state, dashboard assets, PID files, and logs in runtime-managed local directories so operators do not need Docker, Node, `pnpm`, or repo-local shell exports.
 
 Build the packageable dashboard assets for the local CLI/web path:
 
@@ -375,7 +375,7 @@ pnpm build:dashboard:local
 
 The output lives in `dist/local-dashboard/`. When `HARNESS_DASHBOARD_ASSETS_DIR` points at that directory, the Python backend serves the dashboard at `/dashboard` from the same process that serves the local API.
 
-Store app-managed secrets for local CLI/web usage:
+Store runtime-managed secrets for local CLI/web usage:
 
 ```bash
 printf '%s' "$GITHUB_TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin

--- a/docs/architecture/app-managed-secrets.md
+++ b/docs/architecture/app-managed-secrets.md
@@ -1,7 +1,7 @@
-# App-Managed Secrets
+# Runtime-Managed Secrets
 
 Harness local CLI/web usage must not ask operators to edit `.env.local`.
-Non-secret runtime config lives in `config.json`; tokens and integration credentials live behind the app-managed secret provider.
+Non-secret runtime config lives in `config.json`; tokens and integration credentials live behind the runtime-managed secret provider.
 
 ## Secret Provider
 
@@ -49,13 +49,13 @@ The native macOS shell is deprecated. New credential flows should use the portab
 
 ## Runtime Behavior
 
-`harness start` and `harness serve` apply app-managed config, then load available app-managed secrets into process environment variables before starting the backend.
+`harness start` and `harness serve` apply runtime-managed config, then load available runtime-managed secrets into process environment variables before starting the backend.
 
 Existing environment variables win. This preserves developer mode:
 
 - repo-root `.env.local` remains valid for local development
 - exported shell variables remain valid for CI and one-off debugging
-- app-managed Keychain secrets are the normal macOS local-runtime path
+- runtime-managed Keychain secrets are the normal macOS local-runtime path
 
 Missing secrets do not block the local API from starting because GitHub, Linear, and executor integrations are optional until a chosen workflow needs them.
 Workflows that need a credential should call `secrets status --require <name>` or surface the integration-specific setup error.

--- a/docs/architecture/guided-integration-setup.md
+++ b/docs/architecture/guided-integration-setup.md
@@ -28,7 +28,7 @@ It exits with setup-required when a required item is missing for the selected wo
 Default setup only requires the local Harness runtime:
 
 - writable app data and log directories
-- app-managed runtime config
+- runtime-managed config
 - SQLite schema readiness
 - accessible selected workspace folders, if any were selected
 
@@ -94,7 +94,7 @@ The top-level payload includes:
 
 ## Integration Boundaries
 
-GitHub and Linear credentials must be stored through the app-managed secret boundary.
+GitHub and Linear credentials must be stored through the runtime-managed secret boundary.
 The setup contract names the secret to store and exposes the redacted validation status.
 It must not ask operators to edit env files.
 

--- a/docs/architecture/linux-portability-contract.md
+++ b/docs/architecture/linux-portability-contract.md
@@ -11,7 +11,7 @@ These pieces must remain reusable for a future Linux package:
 - Python runtime and backend entrypoints in `modules/local_runtime.py` and `backend.server`
 - SQLite schema, migrations, and store semantics
 - local CLI/process contract exposed as `harness ...`
-- app-managed config model and XDG-compatible data/log paths
+- runtime-managed config model and XDG-compatible data/log paths
 - static dashboard bundle and same-origin API behavior
 - doctor/setup data model and integration semantics
 
@@ -41,7 +41,7 @@ The backend and CLI should consume the same abstract outputs from these boundari
 As of the macOS packaging slice:
 
 - the runtime contract is Python, not Swift
-- app-managed paths already support macOS and Linux defaults
+- runtime-managed paths already support macOS and Linux defaults
 - the bundled dashboard is static and backend-served, not tied to a macOS web runtime
 - contract schema loading works from a repo checkout or bundled runtime
 - secret-provider selection is platform-aware in Python instead of hard-coding `macos-keychain`

--- a/docs/architecture/local-runtime-contract.md
+++ b/docs/architecture/local-runtime-contract.md
@@ -50,13 +50,13 @@ Default Linux paths:
 
 Developer and test runs may override paths with `--data-dir`, `--log-dir`, `HARNESS_APP_DATA_DIR`,
 or `HARNESS_APP_LOG_DIR`.
-Normal local usage should rely on app-managed defaults.
+Normal local usage should rely on runtime-managed defaults.
 
 ## Runtime Config
 
 `harness init` writes non-secret config to `config.json` and initializes the SQLite schema.
 Secrets do not belong in this file.
-GitHub, Linear, and ingress/executor credentials move through the app-managed secret store.
+GitHub, Linear, and ingress/executor credentials move through the runtime-managed secret store.
 
 The first schema stores:
 
@@ -76,7 +76,7 @@ The first schema stores:
 - `HARNESS_RUNTIME_PORT=8765`
 - `HARNESS_RUNTIME_BASE_URL=http://127.0.0.1:8765`
 - `HARNESS_DASHBOARD_ASSETS_DIR=<app-data>/dashboard`
-- app-managed secrets, when present, mapped to their backend environment variables
+- runtime-managed secrets, when present, mapped to their backend environment variables
 
 This is what removes the need for Docker, Node, `pnpm`, or repo-local shell exports for the backend runtime.
 
@@ -125,7 +125,7 @@ The current workflow gates are:
 - `linear-sync`: requires Linear coordination.
 - `repair-dispatch`: requires a desktop-agent ingress/executor bridge.
 
-Setup items use the app-managed secret boundary.
+Setup items use the runtime-managed secret boundary.
 The GitHub and Linear items tell the operator which named secret to store and how Harness validates it; they do not ask operators to edit env files.
 The ingress/executor item stays client-neutral and describes the bridge as compatible with OpenClaw, Hermes, Codex, or future desktop-agent clients.
 
@@ -160,7 +160,7 @@ The backend exposes two runtime-safe probes:
 
 - `GET /health`: canonical backend and storage health.
 - `GET /runtime/status`: local runtime status envelope that includes mode, API base URL,
-  store backend, secret provider, schema readiness, and app-managed paths.
+  store backend, secret provider, schema readiness, and runtime-managed paths.
 
 `harness status --json` calls the local health endpoint and returns:
 
@@ -216,8 +216,8 @@ All CLI failures should produce operator-readable messages. Stack traces are not
 
 ## Process Lifecycle
 
-`harness start` is the app-facing lifecycle command.
-It initializes the runtime if needed, starts `harness serve` as an app-managed background process, waits for `/health`, and then returns JSON the app can render.
+`harness start` is the local lifecycle command.
+It initializes the runtime if needed, starts `harness serve` as a runtime-managed background process, waits for `/health`, and then returns JSON the CLI or wrapper can render.
 If the runtime is already healthy, `start` exits successfully without launching a duplicate process.
 If the PID file is stale, `start` removes it and starts a fresh runtime.
 If the configured port is already owned by a non-Harness process, `start` fails with `status=port_conflict` and an explicit next action.

--- a/docs/architecture/setup-doctor.md
+++ b/docs/architecture/setup-doctor.md
@@ -54,7 +54,7 @@ The current doctor covers:
 
 - `app_data_dir`: app data directory writability.
 - `log_dir`: log directory writability.
-- `config`: app-managed config presence and readability.
+- `config`: runtime-managed config presence and readability.
 - `sqlite`: SQLite database availability and schema readiness.
 - `api_health`: local API availability.
 - `dashboard`: packaged dashboard asset availability and dashboard HTTP route reachability when the API is running.

--- a/docs/howto/configure-harness.md
+++ b/docs/howto/configure-harness.md
@@ -10,7 +10,7 @@ The local runtime writes non-secret runtime configuration to:
 ~/Library/Application Support/Harness/config.json
 ```
 
-Secrets do not belong in that file. Store local credentials through the app-managed secret boundary exposed by the CLI.
+Secrets do not belong in that file. Store local credentials through the runtime-managed secret boundary exposed by the CLI.
 
 Stable Harness secret names:
 

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -109,7 +109,7 @@ python3 -m modules.local_runtime --json recover
 python3 -m modules.local_runtime --json stop
 ```
 
-The runtime contract uses app-managed config, SQLite state, PID files, dashboard assets, and logs. A future packaged CLI should not require Docker, Node, `pnpm`, or repo-local shell exports.
+The runtime contract uses runtime-managed config, SQLite state, PID files, dashboard assets, and logs. A future packaged CLI should not require Docker, Node, `pnpm`, or repo-local shell exports.
 Use `start` and `recover` for local background lifecycle control.
 Use `serve` only when you intentionally want a foreground backend for debugging.
 
@@ -121,7 +121,7 @@ Default macOS paths:
 - `~/Library/Application Support/Harness/runtime/harness.pid`
 - `~/Library/Logs/Harness/harness.log`
 
-Local CLI/web secrets use the app-managed secret store instead of `.env.local`:
+Local CLI/web secrets use the runtime-managed secret store instead of `.env.local`:
 
 ```bash
 printf '%s' "$GITHUB_TOKEN" | python3 -m modules.local_runtime --json secrets set github_token --value-stdin

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -24,7 +24,7 @@ from modules.local_secrets import (
     LocalSecretError,
     SecretStatus,
     collect_secret_statuses,
-    load_app_managed_secrets_into_environment,
+    load_runtime_managed_secrets_into_environment,
     secret_status_payload,
 )
 from modules.local_setup import (
@@ -278,7 +278,7 @@ def init_runtime(
     port: int = DEFAULT_API_PORT,
     force: bool = False,
 ) -> tuple[RuntimeConfig, bool]:
-    """Create app-managed runtime directories, config, log file, and SQLite schema."""
+    """Create runtime-managed directories, config, log file, and SQLite schema."""
 
     paths.data_dir.mkdir(parents=True, exist_ok=True)
     paths.log_dir.mkdir(parents=True, exist_ok=True)
@@ -305,7 +305,7 @@ def init_runtime(
 
 
 def apply_runtime_environment(config: RuntimeConfig, *, config_path: Path) -> None:
-    """Apply app-managed runtime environment for backend startup."""
+    """Apply runtime-managed environment for backend startup."""
 
     secret_store = create_secret_store()
     os.environ["HARNESS_STORE_BACKEND"] = "sqlite"
@@ -318,10 +318,10 @@ def apply_runtime_environment(config: RuntimeConfig, *, config_path: Path) -> No
     os.environ[ENV_RUNTIME_PORT] = str(config.port)
     os.environ[ENV_RUNTIME_BASE_URL] = config.base_url
     os.environ.setdefault(ENV_DASHBOARD_ASSETS_DIR, str(config.dashboard_assets_dir))
-    load_app_managed_secrets_into_environment(store=secret_store)
+    load_runtime_managed_secrets_into_environment(store=secret_store)
     os.environ.setdefault(
         ENV_SECRET_PROVIDER,
-        str(getattr(secret_store, "provider_name", "app-managed-secret-store")),
+        str(getattr(secret_store, "provider_name", "runtime-managed-secret-store")),
     )
 
 
@@ -444,7 +444,7 @@ def start_runtime(
     timeout_seconds: float = 10.0,
     force_restart: bool = False,
 ) -> tuple[int, dict[str, Any]]:
-    """Start the local runtime as an app-managed background process."""
+    """Start the local runtime as a runtime-managed background process."""
 
     config, _ = init_runtime(paths, host=host or DEFAULT_API_HOST, port=port or DEFAULT_API_PORT)
     if host or port:
@@ -538,7 +538,7 @@ def recover_runtime(
     *,
     timeout_seconds: float = 10.0,
 ) -> tuple[int, dict[str, Any]]:
-    """Recover the app-managed runtime after stale PID, crash, or degraded health."""
+    """Recover the runtime-managed process after stale PID, crash, or degraded health."""
 
     return start_runtime(paths, timeout_seconds=timeout_seconds, force_restart=True)
 
@@ -1217,8 +1217,8 @@ def build_parser() -> argparse.ArgumentParser:
         prog="harness",
         description="Control the local Harness runtime.",
     )
-    parser.add_argument("--data-dir", help="Override the app-managed data directory")
-    parser.add_argument("--log-dir", help="Override the app-managed log directory")
+    parser.add_argument("--data-dir", help="Override the runtime-managed data directory")
+    parser.add_argument("--log-dir", help="Override the runtime-managed log directory")
     parser.add_argument("--json", action="store_true", dest="as_json", help="Emit machine-readable JSON output")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -1234,7 +1234,7 @@ def build_parser() -> argparse.ArgumentParser:
     serve_parser.add_argument("--host", help="Temporary host override for this process")
     serve_parser.add_argument("--port", type=int, help="Temporary port override for this process")
 
-    start_parser = subparsers.add_parser("start", help="Start the local Harness API as an app-managed process")
+    start_parser = subparsers.add_parser("start", help="Start the local Harness API as a runtime-managed process")
     start_parser.add_argument("--host", help="Temporary host override for this process")
     start_parser.add_argument("--port", type=int, help="Temporary port override for this process")
     start_parser.add_argument("--timeout", default=10.0, type=float, help="Startup timeout in seconds")
@@ -1278,12 +1278,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Treat integrations for the selected workflow as required",
     )
 
-    secrets_parser = subparsers.add_parser("secrets", help="Manage app-managed Harness secrets")
+    secrets_parser = subparsers.add_parser("secrets", help="Manage runtime-managed Harness secrets")
     secrets_subparsers = secrets_parser.add_subparsers(dest="secret_command", required=True)
 
     secrets_status_parser = secrets_subparsers.add_parser(
         "status",
-        help="Report configured and missing app-managed secrets without printing values",
+        help="Report configured and missing runtime-managed secrets without printing values",
     )
     secrets_status_parser.add_argument(
         "--require",
@@ -1294,7 +1294,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     secrets_set_parser = secrets_subparsers.add_parser(
         "set",
-        help="Store a secret in the app-managed secret provider",
+        help="Store a secret in the runtime-managed secret provider",
     )
     secrets_set_parser.add_argument("name", help="Secret name")
     secrets_set_parser.add_argument(
@@ -1305,7 +1305,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     secrets_delete_parser = secrets_subparsers.add_parser(
         "delete",
-        help="Delete a stored app-managed secret",
+        help="Delete a stored runtime-managed secret",
     )
     secrets_delete_parser.add_argument("name", help="Secret name")
 
@@ -1415,7 +1415,7 @@ def _handle_secrets_command(args: argparse.Namespace, *, as_json: bool) -> int:
             {
                 "status": "stored",
                 "secret": args.name,
-                "message": "Secret stored in the app-managed secret provider.",
+                "message": "Secret stored in the runtime-managed secret provider.",
             },
             as_json=as_json,
         )

--- a/modules/local_secrets.py
+++ b/modules/local_secrets.py
@@ -100,7 +100,7 @@ def get_secret_definition(name: str) -> SecretDefinition:
 
 
 class MacOSKeychainSecretStore:
-    """Store local app secrets in macOS Keychain through the `security` command."""
+    """Store local runtime secrets in macOS Keychain through the `security` command."""
 
     def __init__(
         self,
@@ -237,21 +237,21 @@ class UnsupportedPlatformSecretStore:
     def get_secret(self, name: str) -> str:
         definition = get_secret_definition(name)
         raise SecretProviderUnavailableError(
-            f"{definition.label} is unavailable because Harness does not have an app-managed secret provider "
+            f"{definition.label} is unavailable because Harness does not have a runtime-managed secret provider "
             f"for {self._platform_name}."
         )
 
     def set_secret(self, name: str, value: str) -> None:
         definition = get_secret_definition(name)
         raise SecretProviderUnavailableError(
-            f"{definition.label} cannot be stored because Harness does not have an app-managed secret provider "
+            f"{definition.label} cannot be stored because Harness does not have a runtime-managed secret provider "
             f"for {self._platform_name}."
         )
 
     def delete_secret(self, name: str) -> bool:
         get_secret_definition(name)
         raise SecretProviderUnavailableError(
-            f"Harness does not have an app-managed secret provider for {self._platform_name}."
+            f"Harness does not have a runtime-managed secret provider for {self._platform_name}."
         )
 
 
@@ -290,12 +290,12 @@ def create_secret_store(*, platform_name: str | None = None) -> SecretStore:
     return UnsupportedPlatformSecretStore(platform_name=resolved_platform)
 
 
-def load_app_managed_secrets_into_environment(
+def load_runtime_managed_secrets_into_environment(
     *,
     store: SecretStore | None = None,
     overwrite: bool = False,
 ) -> list[SecretStatus]:
-    """Populate missing runtime env vars from app-managed secrets.
+    """Populate missing runtime env vars from runtime-managed secrets.
 
     Existing environment variables win by default so developer env-file mode and
     explicitly exported variables keep working.
@@ -320,6 +320,16 @@ def load_app_managed_secrets_into_environment(
             os.environ[definition.env_var] = value
             statuses.append(_configured_status(definition, source=_provider_name(secret_store), required=False))
     return statuses
+
+
+def load_app_managed_secrets_into_environment(
+    *,
+    store: SecretStore | None = None,
+    overwrite: bool = False,
+) -> list[SecretStatus]:
+    """Backward-compatible alias for the pre-CLI/web naming."""
+
+    return load_runtime_managed_secrets_into_environment(store=store, overwrite=overwrite)
 
 
 def collect_secret_statuses(
@@ -364,7 +374,7 @@ def secret_status_payload(statuses: list[SecretStatus]) -> dict[str, object]:
         status = "ok"
     return {
         "status": status,
-        "provider": "app-managed-secret-store",
+        "provider": "runtime-managed-secret-store",
         "missing_required": missing_required,
         "secrets": [status_item.asdict() for status_item in statuses],
     }
@@ -414,7 +424,7 @@ def _unavailable_status(definition: SecretDefinition, message: str, *, required:
         source=None,
         required=required,
         message=message,
-        next_action="Use developer env-file mode or install a supported local app secret provider.",
+        next_action="Use developer env-file mode or install a supported local runtime secret provider.",
     )
 
 

--- a/modules/local_setup.py
+++ b/modules/local_setup.py
@@ -110,7 +110,7 @@ SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
             SetupAction(
                 kind="runtime",
                 label="Initialize local runtime",
-                description="Create app-managed config, logs, and the SQLite database.",
+                description="Create runtime-managed config, logs, and the SQLite database.",
                 command="harness init",
             ),
             SetupAction(
@@ -146,7 +146,7 @@ SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
             SetupAction(
                 kind="secret",
                 label="Connect GitHub",
-                description="Store the GitHub credential through the app-managed secret boundary.",
+                description="Store the GitHub credential through the runtime-managed secret boundary.",
                 command="harness secrets set github_token --value-stdin",
                 secret_name="github_token",
                 stores_secret=True,
@@ -175,7 +175,7 @@ SETUP_ITEM_DEFINITIONS: tuple[SetupItemDefinition, ...] = (
             SetupAction(
                 kind="secret",
                 label="Connect Linear",
-                description="Store the Linear credential through the app-managed secret boundary.",
+                description="Store the Linear credential through the runtime-managed secret boundary.",
                 command="harness secrets set linear_api_key --value-stdin",
                 secret_name="linear_api_key",
                 stores_secret=True,

--- a/modules/store.py
+++ b/modules/store.py
@@ -305,7 +305,7 @@ def resolve_sqlite_database_path(
     platform_name: str | None = None,
     home: str | Path | None = None,
 ) -> Path:
-    """Resolve the SQLite DB path used by local app persistence."""
+    """Resolve the SQLite DB path used by local runtime persistence."""
 
     if database_path is not None and str(database_path).strip():
         return Path(database_path).expanduser()

--- a/tests/test_local_runtime.py
+++ b/tests/test_local_runtime.py
@@ -55,7 +55,7 @@ class LocalRuntimeCliTests(unittest.TestCase):
             )
         return exit_code, json.loads(stdout.getvalue())
 
-    def test_init_creates_app_managed_config_sqlite_database_and_log(self) -> None:
+    def test_init_creates_runtime_managed_config_sqlite_database_and_log(self) -> None:
         exit_code, payload = self._run_cli("init")
 
         config_path = self.data_path / "config.json"
@@ -499,7 +499,7 @@ class LocalRuntimeProcessTests(unittest.TestCase):
 
 
 class LocalRuntimeContractTests(unittest.TestCase):
-    def test_resolves_macos_app_managed_paths(self) -> None:
+    def test_resolves_macos_runtime_managed_paths(self) -> None:
         paths = resolve_runtime_paths(platform_name="darwin", home="/Users/sean")
 
         self.assertEqual(paths.data_dir, Path("/Users/sean/Library/Application Support/Harness"))
@@ -508,7 +508,7 @@ class LocalRuntimeContractTests(unittest.TestCase):
         self.assertEqual(paths.database_path, paths.data_dir / "harness.db")
         self.assertEqual(paths.dashboard_assets_dir, paths.data_dir / "dashboard")
 
-    def test_resolves_linux_app_managed_paths(self) -> None:
+    def test_resolves_linux_runtime_managed_paths(self) -> None:
         with patch.dict(
             os.environ,
             {"XDG_DATA_HOME": "/tmp/xdg-data", "XDG_STATE_HOME": "/tmp/xdg-state"},

--- a/tests/test_local_secrets.py
+++ b/tests/test_local_secrets.py
@@ -14,7 +14,7 @@ from modules.local_secrets import (
     SecretProviderUnavailableError,
     UnsupportedPlatformSecretStore,
     collect_secret_statuses,
-    load_app_managed_secrets_into_environment,
+    load_runtime_managed_secrets_into_environment,
     secret_status_payload,
 )
 
@@ -110,7 +110,7 @@ class LocalSecretStatusTests(unittest.TestCase):
         with self.assertRaises(SecretProviderUnavailableError):
             store.get_secret("github_token")
 
-    def test_loads_app_managed_secrets_into_missing_environment_vars(self) -> None:
+    def test_loads_runtime_managed_secrets_into_missing_environment_vars(self) -> None:
         store = InMemorySecretStore(
             {
                 "github_token": "ghp_secret",
@@ -119,7 +119,7 @@ class LocalSecretStatusTests(unittest.TestCase):
         )
 
         with patch.dict(os.environ, {}, clear=True):
-            statuses = load_app_managed_secrets_into_environment(store=store)
+            statuses = load_runtime_managed_secrets_into_environment(store=store)
 
             self.assertEqual(os.environ["GITHUB_TOKEN"], "ghp_secret")
             self.assertEqual(os.environ["LINEAR_API_KEY"], "lin_secret")
@@ -129,11 +129,11 @@ class LocalSecretStatusTests(unittest.TestCase):
         self.assertEqual(status_by_name["github_token"].source, "memory")
         self.assertEqual(status_by_name["repair_callback_bearer_token"].status, "missing")
 
-    def test_existing_environment_vars_win_over_app_managed_secrets(self) -> None:
+    def test_existing_environment_vars_win_over_runtime_managed_secrets(self) -> None:
         store = InMemorySecretStore({"github_token": "keychain-secret"})
 
         with patch.dict(os.environ, {"GITHUB_TOKEN": "env-secret"}, clear=True):
-            load_app_managed_secrets_into_environment(store=store)
+            load_runtime_managed_secrets_into_environment(store=store)
 
             self.assertEqual(os.environ["GITHUB_TOKEN"], "env-secret")
 


### PR DESCRIPTION
## Summary
- Retarget active CLI/runtime copy from app-managed/local-app wording to runtime-managed wording
- Rename the active secret-loading helper to load_runtime_managed_secrets_into_environment while keeping a compatibility alias for the old name
- Update local setup docs, runtime contract docs, CLI help text, tests, and env example to match the CLI/web pivot

## Validation
- python3 -m unittest tests.test_local_secrets tests.test_local_setup tests.test_local_runtime
- python3 -m py_compile modules/local_secrets.py modules/local_runtime.py modules/local_setup.py modules/store.py
- python3 -m modules.local_runtime --help
- python3 -m modules.local_runtime secrets --help
- git diff --check
- python3 -m unittest discover -s tests