### PR TITLE
Define acceptance layer inventory and rename path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@ This file is for coding agents and automated contributors working in this reposi
 
 ## Repository Purpose
 
-Harness is a control plane and reliability layer for AI-assisted work. It evaluates whether structured work is actually complete, evidence-backed, reconciled with external systems, and safe to accept.
+Harness is the current repository name for an acceptance layer for AI-assisted work. The recommended product rename is Proofline, documented in `docs/adrs/0006-product-rename-and-acceptance-layer.md`.
+
+The system evaluates whether structured work is actually complete, evidence-backed, reconciled with external systems, and safe to accept.
 
 Work surfaces and ingress clients sit above Harness. Harness owns verification, reconciliation, lifecycle enforcement, persistence of task truth, and inspection surfaces.
 
@@ -31,6 +33,7 @@ Harness is not:
 
 - a PM tool
 - an agent runtime
+- an execution scheduler
 - a chatbot UI
 - a replacement for Linear coordination
 - a native desktop-app product
@@ -45,7 +48,33 @@ Do not casually turn this repo into:
 - a mutation-heavy dashboard app
 - a tightly coupled OpenClaw runtime extension
 - a native macOS app distribution project
+- a competing Symphony or Codex orchestration layer
 - a fake demo system that hides whether data is live or sample
+
+## Acceptance-Layer Direction
+
+Use `docs/architecture/acceptance-layer-inventory.md` as the product-scope filter.
+
+Keep work that strengthens:
+
+- canonical work contracts
+- GitHub artifact proof
+- Linear reconciliation
+- completion-claim validation
+- lifecycle enforcement
+- sticky manual review gates
+- read-model and timeline inspection
+- advisory execution-substrate boundaries
+
+Freeze or delete work that primarily builds:
+
+- custom runner daemons
+- always-on Linear polling
+- Codex workspace management
+- unbounded retry behavior
+- native desktop shell features
+- broad planner intelligence
+- mutation-heavy dashboard workflows
 
 ## Operator Surface Direction
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Harness
 
-Harness is a control plane and reliability layer for AI-assisted work.
+Harness is the current repository name for what should become an acceptance layer for AI-assisted software work.
+
+The recommended product rename is **Proofline**. The rename should happen deliberately, starting with product language and docs before package, CLI, API, or repository names change. See [`docs/adrs/0006-product-rename-and-acceptance-layer.md`](docs/adrs/0006-product-rename-and-acceptance-layer.md).
 
 It does not trust agent-reported completion on its own. It accepts or blocks lifecycle transitions only after evaluating canonical task state, evidence, reconciliation facts, and explicit review decisions.
+
+The strategic inventory for the pivot is in [`docs/architecture/acceptance-layer-inventory.md`](docs/architecture/acceptance-layer-inventory.md). The short version: keep verification, reconciliation, lifecycle enforcement, evidence policy, Linear/GitHub alignment, manual review, and inspection surfaces; wrap Symphony/Codex/Hermes/OpenClaw as advisory execution or ingress layers; freeze or delete duplicated executor/runtime/product-shell work.
 
 ## Reset Slice
 
@@ -32,13 +36,13 @@ In hosted Vercel runtimes, the reset slice is not allowed to take the whole back
 
 ## What Harness Is
 
-- A Python control-plane backend that evaluates canonical `TaskEnvelope` submissions.
+- A Python acceptance-layer backend that evaluates canonical `TaskEnvelope` submissions.
 - A read-only Next.js dashboard over canonical inspection APIs.
 - A persistence layer for task snapshots and append-only evaluation history.
 - A thin integration boundary around Linear/manual/client-specific ingress adapters and GitHub/Linear fact inputs.
 - An operational reconciliation path that can enter `reconciling`, repair missing PR artifacts, and then delegate back into canonical reevaluation.
 
-Harness is not a PM tool, an agent runtime, or a chatbot UI.
+Harness is not a PM tool, an agent runtime, a scheduler, an execution workbench, or a chatbot UI.
 Harness is also no longer pursuing a native macOS app as a supported product surface. The supported operator surfaces are the CLI/runtime contract, the backend API, and the web dashboard. The Swift app under `apps/macos/HarnessApp` remains legacy/experimental code while the reusable local runtime and dashboard packaging pieces are preserved. See [`docs/adrs/0005-cli-web-operator-surface.md`](docs/adrs/0005-cli-web-operator-surface.md).
 Client-specific ingress adapters are also intentionally narrow. The repo currently includes an OpenClaw-shaped ingress translator, but the same restriction applies to Hermes or any future desktop agent client: it can submit task intent, provenance, and planning-ready work into Harness, but it cannot declare `executing` or `completed`, inject executor runtime telemetry, or claim completion on initial handoff. If a client wants to hand work off as `planned`, it must provide explicit planning-grade objective fields plus a concrete `plan_summary`, and it cannot declare unresolved conditions at the same time. If it also supplies parent/dependency/capability structure, that structure must be canonical and non-self-referential before Harness will persist it. If unresolved ambiguity still exists, Harness now converts that upstream signal into canonical clarification and blocks the task instead of letting vague work look ready. Execution and completion truth must still come back through executor/reporting paths that Harness can verify.
 

--- a/docs/adrs/0006-product-rename-and-acceptance-layer.md
+++ b/docs/adrs/0006-product-rename-and-acceptance-layer.md
@@ -1,0 +1,87 @@
+# ADR 0006: Rename The Product Around Acceptance
+
+## Status
+
+Proposed
+
+## Context
+
+`Harness` has become an overloaded term in the frontier-model ecosystem. OpenAI has also used Harness language publicly, and Symphony now covers much of the executor-orchestration territory this repo originally explored.
+
+That changes the naming problem and the product problem at the same time.
+
+The product should not compete with Codex, Symphony, Hermes, or OpenClaw as an execution workbench. Those systems will keep adding scheduling, workspace, retry, and agent ergonomics. The durable product here is the acceptance boundary above them: the system that refuses to call work complete until intent, evidence, external facts, and review policy line up.
+
+## Decision
+
+Rename the product away from `Harness`.
+
+Use `Proofline` as the recommended working product name.
+
+The name fits the new positioning:
+
+- it points at proof, not execution
+- it implies a line work must cross before acceptance
+- it does not sound like an agent runtime, IDE, scheduler, or PM tool
+- it gives the product a distinct vocabulary while preserving the existing repository during migration
+
+Until the rename is executed, `Harness` remains the repository and codebase name. Product docs should start describing the system as an acceptance layer and avoid expanding the old Harness brand.
+
+## Product Boundary
+
+Proofline is:
+
+- an acceptance layer for AI-assisted software work
+- a verifier of task contracts, GitHub artifacts, Linear state, CI/review facts, and manual-review decisions
+- a reconciliation authority when intended work and artifact truth disagree
+- a source of accepted lifecycle state
+- a repair-request generator when work is incomplete or invalid
+
+Proofline is not:
+
+- an executor
+- a Codex replacement
+- a Symphony replacement
+- a desktop-agent shell
+- a PM tool
+- a general planner
+- a dashboard-first workflow manager
+
+## Naming Migration Policy
+
+Do not perform a broad mechanical rename in one PR.
+
+Rename in layers:
+
+1. Product language: README, architecture docs, AGENTS guidance, dashboard headings if applicable.
+2. Public API language where it does not break clients.
+3. Package and CLI names only after compatibility aliases exist.
+4. Repository rename last, after CI, deployment, docs, and local scripts no longer assume the old name.
+
+The current `TaskEnvelope` name should not be renamed casually. It is a contract name, not the product brand. Change it only if the schema versioning and downstream adapters can absorb the migration.
+
+## Consequences
+
+This explicitly reduces scope.
+
+Keep investing in:
+
+- task contract validation
+- completion-claim handling
+- GitHub proof validation
+- Linear reconciliation
+- manual review gates
+- read-model and timeline inspection
+- execution-substrate adapters that preserve advisory-only runner semantics
+
+Stop investing in:
+
+- custom executor scheduling
+- native macOS product shell work
+- broad planning intelligence
+- direct runner ownership
+- mutation-heavy dashboard workflows
+
+## Follow-Up
+
+Create a rename migration plan after this ADR lands. The first implementation PR should update product copy and docs only. Code/package renames should wait until the acceptance-layer inventory has removed or frozen the duplicate execution surfaces.

--- a/docs/architecture/acceptance-layer-inventory.md
+++ b/docs/architecture/acceptance-layer-inventory.md
@@ -1,0 +1,125 @@
+# Acceptance-Layer Inventory
+
+## Purpose
+
+Harness should now be treated as the working repository name for an acceptance layer, not as an execution product.
+
+Codex, Symphony, Hermes, OpenClaw, and adjacent agent systems are absorbing runner features quickly. That is not a reason to broaden this repo. It is the reason to narrow it. The durable product is the system that decides whether AI-assisted software work is acceptable, evidence-backed, reconciled, and safe to call complete.
+
+This inventory classifies the current repository into four buckets:
+
+- `keep`: core acceptance-layer capability.
+- `wrap`: useful only behind a boundary to an external system.
+- `freeze`: keep working for compatibility, but do not expand.
+- `delete`: remove after a separate cleanup PR proves no active path depends on it.
+
+## Decision Rule
+
+Keep a module only if it answers at least one acceptance-layer question:
+
+1. What was supposed to happen?
+2. What actually happened?
+3. What evidence proves it?
+4. What is still missing or contradictory?
+5. What repair should be requested?
+6. Can the work safely move to a terminal lifecycle state?
+
+If a module primarily polls work, launches agents, supervises workspaces, performs unbounded retries, or offers a richer operator shell, it belongs below this system and should be wrapped, frozen, or deleted.
+
+## Keep
+
+These are the product.
+
+| Area | Current Homes | Why It Stays |
+| --- | --- | --- |
+| Canonical work contract | `schemas/task_envelope.schema.json`, `modules/contracts/`, `modules/intake/`, `docs/architecture/task-envelope.md` | Defines the work and evidence contract that execution tools must satisfy. |
+| Lifecycle enforcement | `modules/evaluation.py`, `modules/contracts/task_envelope_lifecycle.py`, `modules/contracts/task_envelope_enforcement.py`, state-transition docs | Prevents worker, Linear, or dashboard claims from bypassing policy. |
+| Verification and evidence policy | `modules/contracts/task_envelope_verification.py`, `modules/contracts/task_envelope_evidence.py`, `docs/architecture/verification-and-completion-enforcement.md`, `docs/architecture/artifact-and-completion-evidence.md` | This is the acceptance boundary. |
+| Reconciliation | `modules/contracts/task_envelope_reconciliation.py`, `modules/reconciliation_runtime.py`, reset reconciliation paths | Detects mismatches across Linear, GitHub, executor claims, and stored lifecycle state. |
+| GitHub proof validation | `modules/connectors/github_artifact_validation.py`, `modules/connectors/github_facts.py`, `modules/reset/github_verifier.py` | GitHub remains the artifact truth for code-bearing work. |
+| Linear truth alignment | `modules/connectors/linear_facts.py`, `modules/connectors/linear_ingress.py`, `modules/reset/linear_client.py`, `docs/architecture/linear-harness-boundary.md` | Linear is the visible structured-work surface, but not completion truth. |
+| Manual review gates | `modules/contracts/task_envelope_review.py`, review endpoints/read-model fields | Human acceptance remains explicit and sticky. |
+| Completion-claim ingestion | completion-claim endpoint paths, execution advisory contracts, attempt validation | Worker claims are useful input only after Harness applies proof policy. |
+| Read model and timeline | `modules/read_model.py`, `GET /tasks`, `GET /tasks/<task_id>/read-model`, `GET /tasks/<task_id>/timeline` | Operators need inspectable acceptance state, not worker narrative. |
+| Reset verifier slice | `modules/reset/`, `/reset/*` routes | It is the narrowest working expression of the acceptance-layer product. |
+| Local CLI/API/web runtime | `modules/local_runtime.py`, `modules/local_setup.py`, `docs/architecture/local-runtime-contract.md` | The supported operator surfaces for inspection and local verification. Keep it portable. |
+
+## Wrap
+
+These should exist only as adapters. They should not define product truth.
+
+| Area | Current Homes | Boundary |
+| --- | --- | --- |
+| Symphony-compatible execution | `modules/adapters/symphony/`, `modules/contracts/execution_substrate.py`, `modules/execution_substrate_dryrun.py`, `docs/architecture/symphony-execution-substrate.md` | Symphony can schedule and report attempts. It cannot complete work. |
+| Codex and Codex Cloud | `modules/adapters/codex_cloud/`, Codex Cloud execution docs | Codex is an executor. It provides artifacts and summaries, not lifecycle authority. |
+| OpenClaw/Hermes-style desktop clients | `modules/adapters/openclaw/`, `modules/connectors/openclaw_*`, `docs/integration/openclaw-harness-spike.md` | Treat as ingress or repair receivers. Do not couple the product to one client. |
+| Linear mutation | Linear connector paths and reset client | Mutations must be projections of accepted Harness state or intended work setup, not agent-authored truth. |
+| GitHub sync | GitHub connector paths and `/sync/github` | GitHub facts can upgrade evidence trust only through normalized sync and verification policy. |
+| Execution substrate handoff previews | `/execution-substrate/intents`, `/execution-substrate/handoffs`, `/execution-substrate/transport-status` | Keep render-only and advisory until a separate live policy exists. |
+
+## Freeze
+
+These may stay for now, but new product work should not accumulate here.
+
+| Area | Current Homes | Freeze Rule |
+| --- | --- | --- |
+| Native macOS shell | `apps/macos/HarnessApp`, `script/build_and_run.sh`, `script/package_macos_app.sh`, macOS architecture docs | No new native features, signing, notarization, Launch at Login, notifications, or onboarding. Delete or archive later. |
+| Legacy direct dispatch paths | direct dispatch/test paths around old executor flow | Keep deterministic tests and compatibility only. New dispatch should target execution-substrate intents. |
+| Planner/decomposition experiments | `modules/goal_to_work.py`, `modules/prd_ingestion.py`, `modules/prd_breakdown.py`, planner docs | Freeze until the acceptance boundary is stronger. Linear/Codex/Symphony may cover enough of this layer. |
+| Demo/simulator surfaces | `modules/demo_*`, `modules/simulator.py`, `modules/runtime_scenario_builders.py` | Keep only when they prove acceptance semantics honestly. Do not let demos bypass canonical APIs. |
+| Evolution engine concepts | `modules/evolution/`, `docs/architecture/harness-evolution-engine.md` | Interesting later, but not core until acceptance proof is stable. |
+| Local eval harness | `docs/architecture/local-eval-harness.md` and related fixture ideas | Keep as verification support. Do not let it become a general agent benchmark product. |
+
+## Delete After Separate PR
+
+Do not delete these in the inventory PR. Deletion should be a narrow follow-up with validation.
+
+| Candidate | Reason | Required Before Delete |
+| --- | --- | --- |
+| Native macOS app tree | It is no longer a supported surface and creates validation noise. | Confirm docs, scripts, and tests no longer reference it as active. Archive historical docs or mark them clearly. |
+| macOS packaging scripts | They encode a product path that is now rejected. | Confirm no release/check script invokes them. |
+| Historical macOS architecture docs | They are stale implementation guidance. | Move to `docs/archive/` or mark historical in-place before removal. |
+| OpenClaw-specific naming in canonical docs | The role is client-neutral. | Keep concrete adapter docs, but remove OpenClaw as a default product anchor. |
+| Broad planner/runtime language in README | It suggests Harness owns too much of the lifecycle. | Replace with acceptance-layer positioning and link to this inventory. |
+
+## What Not To Build
+
+Do not add:
+
+- a competing Symphony daemon
+- a custom always-on Linear poller
+- a Codex workspace manager
+- agent retry loops outside explicit budgets
+- auto-merge as a default
+- agent-authored Linear `Done` as completion truth
+- a broad planner-intelligence surface
+- a native desktop product shell
+- a dashboard that becomes a mutation-heavy PM tool
+
+## Near-Term Architecture Target
+
+The product boundary should look like this:
+
+```text
+Linear intended work
+        |
+Acceptance contract
+        |
+Symphony/Codex/Hermes/OpenClaw execution adapters
+        |
+GitHub artifacts and runner events
+        |
+Acceptance verification, reconciliation, manual review
+        |
+Linear/GitHub/dashboard projections of accepted state
+```
+
+The layer in the middle may change every month. The acceptance boundary should not.
+
+## Immediate PR Sequence
+
+1. Land this inventory and rename ADR.
+2. Retarget README and AGENTS language from "Harness control plane" toward the acceptance-layer name once the new name is accepted.
+3. Archive or delete native macOS app code and packaging docs in a separate PR.
+4. Mark direct dispatch paths as compatibility-only in code comments and docs.
+5. Keep strengthening completion-claim, GitHub sync, Linear reconciliation, and manual-review enforcement.

--- a/docs/architecture/canonical-vocabulary.md
+++ b/docs/architecture/canonical-vocabulary.md
@@ -14,11 +14,21 @@ For this architecture, a desktop agent client such as OpenClaw, Hermes, or a fut
 
 ### Harness
 
-The control plane and reliability layer responsible for normalizing work, delegating execution, verifying completion, and enforcing lifecycle correctness.
+The current repository and codebase name for the acceptance layer.
+
+`Harness` should no longer be treated as the long-term product name. Use it when referring to current code, APIs, historical docs, or repository paths. Product positioning should move toward the acceptance-layer name selected in ADR 0006.
+
+### Proofline
+
+The recommended working product name for the acceptance layer.
+
+Proofline is responsible for deciding whether AI-assisted software work has crossed the evidence and reconciliation line required for acceptance. It wraps execution tools, but it is not an executor.
 
 ### Control Plane
 
 The part of the system that decides what work exists, who owns it, what state it is in, and what should happen next.
+
+Use carefully. The durable product direction is narrower than a broad control plane: acceptance, verification, reconciliation, and lifecycle enforcement.
 
 ### Structured Work
 
@@ -120,6 +130,12 @@ The policy-driven decision about whether a claimed completed state should be acc
 
 Harness owns completion enforcement. Linear may display the result, but it does not replace that policy function.
 
+### Acceptance Layer
+
+The product role above execution tools that determines whether intended work, artifact evidence, external facts, and review policy line up.
+
+The acceptance layer can request repair or retry work. It does not perform the worker execution itself.
+
 ## Terms To Avoid Or Use Carefully
 
 ### Agent
@@ -144,5 +160,6 @@ Avoid as a system-wide architecture term. Use `structured work state`, `workflow
 - Name modules by responsibility, not by vendor.
 - Separate business state from runtime state in naming.
 - Use `executor` as the abstraction and `Codex` as one implementation.
+- Use `acceptance layer`, `verification`, `evidence`, and `reconciliation` for product language instead of broad executor-orchestration language.
 - Use `verification` or `evidence` instead of vague claims like `done` when artifact checks are required.
 - Use `Linear` when referring to the work surface or structured-work system of record, not as a synonym for the Harness control plane.


### PR DESCRIPTION
## Summary
- Add an acceptance-layer inventory that classifies current Harness areas as keep, wrap, freeze, or delete
- Add ADR 0006 recommending Proofline as the working product rename and defining a staged rename policy
- Update README, AGENTS, and canonical vocabulary so future work narrows around acceptance instead of execution

## Validation
- Verified new doc paths exist
- rg check for Proofline, ADR, and inventory references
- git diff --check

## Notes
- Docs/design only; no Symphony, Linear, GitHub issue, executor, or live-work execution changes
- Does not perform a code/package/repo rename yet