### PR TITLE
Use Proofline in dashboard UI

### DIFF
--- a/app/api/harness/[...path]/route.ts
+++ b/app/api/harness/[...path]/route.ts
@@ -17,7 +17,7 @@ export async function GET(
     return NextResponse.json(
       {
         error:
-          "Harness API base URL could not be resolved. Set HARNESS_API_BASE_URL locally or deploy behind Vercel Services.",
+          "Proofline API base URL could not be resolved. Set HARNESS_API_BASE_URL locally or deploy behind Vercel Services.",
       },
       { status: 503 },
     );
@@ -45,7 +45,7 @@ export async function GET(
   } catch (error) {
     return NextResponse.json(
       {
-        error: `Harness API proxy could not reach ${upstreamUrl.origin}: ${
+        error: `Proofline API proxy could not reach ${upstreamUrl.origin}: ${
           error instanceof Error ? error.message : "unknown error"
         }`,
       },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Harness | Control Plane for AI-Assisted Work",
+  title: "Proofline | Acceptance Layer for AI-Assisted Work",
   description:
-    "The reliability layer that determines what is actually true about AI-driven work. Verification, reconciliation, and evidence-backed completion.",
+    "The acceptance layer that determines what is actually true about AI-driven work. Verification, reconciliation, and evidence-backed completion.",
 };
 
 export const viewport: Viewport = {

--- a/components/dashboard/execution-handoff-browser.tsx
+++ b/components/dashboard/execution-handoff-browser.tsx
@@ -44,7 +44,7 @@ export function ExecutionHandoffBrowser() {
         tone: "text-warning",
       },
       {
-        label: "Harness Authority",
+        label: "Proofline Authority",
         value: transportStatus?.completion_authority === "harness_verification" ? 1 : 0,
         icon: ShieldCheck,
         tone: "text-success",
@@ -99,7 +99,7 @@ export function ExecutionHandoffBrowser() {
                 </h1>
               </div>
               <p className="mt-1 text-sm text-muted-foreground">
-                Read-only preview of Symphony-compatible handoff payloads from the Harness supervision queue.
+                Read-only preview of Symphony-compatible handoff payloads from the Proofline supervision queue.
               </p>
             </div>
             <button
@@ -147,7 +147,7 @@ export function ExecutionHandoffBrowser() {
                   </div>
                   <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
                     {transportStatus?.message ||
-                      "Harness has not returned execution transport posture yet."}
+                      "Proofline has not returned execution transport posture yet."}
                   </p>
                 </div>
                 <div className="grid min-w-0 gap-3 sm:grid-cols-2 lg:min-w-[28rem]">
@@ -188,7 +188,7 @@ export function ExecutionHandoffBrowser() {
             </Card>
           ) : isLoading ? (
             <div className="rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
-              Loading execution handoffs from Harness...
+              Loading execution handoffs from Proofline...
             </div>
           ) : handoffs.length === 0 ? (
             <Card>
@@ -197,7 +197,7 @@ export function ExecutionHandoffBrowser() {
                   No execution handoffs returned
                 </p>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  Harness did not return any runner-facing handoff previews from the current supervision queue.
+                  Proofline did not return any runner-facing handoff previews from the current supervision queue.
                 </p>
               </CardContent>
             </Card>

--- a/components/dashboard/header.tsx
+++ b/components/dashboard/header.tsx
@@ -23,7 +23,7 @@ export function DashboardHeader() {
               <Activity className="h-4 w-4 text-background" />
             </div>
             <span className="text-lg font-semibold tracking-tight">
-              Harness
+              Proofline
             </span>
           </Link>
           <nav className="hidden md:flex items-center gap-1">

--- a/components/dashboard/reconciliation-card.tsx
+++ b/components/dashboard/reconciliation-card.tsx
@@ -98,7 +98,7 @@ export function ReconciliationCard({
       status: hasMismatches && systemHasMismatch("github", mismatchCategories) ? "mismatch" : inferGithubState(evidence, timeline) ? "ok" : "missing",
     },
     {
-      name: "Harness",
+      name: "Proofline",
       state: currentStatus ?? summary.harness_state,
       status: hasMismatches && systemHasMismatch("harness", mismatchCategories) ? "mismatch" : (currentStatus ?? summary.harness_state) ? "ok" : "unknown",
     },

--- a/components/dashboard/task-browser.tsx
+++ b/components/dashboard/task-browser.tsx
@@ -60,7 +60,7 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
     scopeLabel: "Inventory",
     emptyTitle: "No tasks returned",
     emptyDescription:
-      "Harness did not return any tasks from the configured backend.",
+      "Proofline did not return any tasks from the configured backend.",
     filterTask: () => true,
     sortTasks: (tasks) =>
       [...tasks].sort(
@@ -76,7 +76,7 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
     scopeLabel: "Verification Lens",
     emptyTitle: "No verification records returned",
     emptyDescription:
-      "Harness did not return any tasks with verification context yet.",
+      "Proofline did not return any tasks with verification context yet.",
     filterTask: (task) =>
       task.verification_summary !== null ||
       task.current_status === "executing" ||
@@ -166,7 +166,7 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
     scopeLabel: "Reconciliation Lens",
     emptyTitle: "No reconciliation results returned",
     emptyDescription:
-      "Harness did not return any tasks with reconciliation summaries yet.",
+      "Proofline did not return any tasks with reconciliation summaries yet.",
     filterTask: (task) => task.reconciliation_summary !== null,
     sortTasks: (tasks) =>
       [...tasks].sort((left, right) => {
@@ -240,7 +240,7 @@ const viewConfig: Record<DashboardView, ViewConfig> = {
     scopeLabel: "Manual Review Queue",
     emptyTitle: "No reviews returned",
     emptyDescription:
-      "Harness did not return any tasks with manual review activity yet.",
+      "Proofline did not return any tasks with manual review activity yet.",
     filterTask: (task) =>
       task.review_summary.status !== "none" ||
       task.review_summary.request_count > 0 ||
@@ -398,7 +398,7 @@ export function TaskBrowser({ view }: TaskBrowserProps) {
           setLoadError(
             error instanceof Error
               ? error.message
-              : "Tasks could not be loaded from Harness.",
+              : "Tasks could not be loaded from Proofline.",
           );
         }
       } finally {
@@ -479,7 +479,7 @@ export function TaskBrowser({ view }: TaskBrowserProps) {
       setLoadError(
         error instanceof Error
           ? error.message
-          : "Tasks could not be loaded from Harness.",
+          : "Tasks could not be loaded from Proofline.",
       );
     } finally {
       setIsLoadingTasks(false);
@@ -588,7 +588,7 @@ export function TaskBrowser({ view }: TaskBrowserProps) {
                     <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
                     <div className="space-y-2">
                       <p className="text-sm font-medium text-foreground">
-                        Harness data could not be loaded
+                        Proofline data could not be loaded
                       </p>
                       <p className="text-sm text-muted-foreground">{loadError}</p>
                     </div>
@@ -597,7 +597,7 @@ export function TaskBrowser({ view }: TaskBrowserProps) {
               </Card>
             ) : isLoadingTasks ? (
               <div className="rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
-                Loading tasks from Harness...
+                Loading tasks from Proofline...
               </div>
             ) : filteredTasks.length === 0 ? (
               <Card>

--- a/lib/harness-api.ts
+++ b/lib/harness-api.ts
@@ -409,7 +409,7 @@ async function fetchJson(path: string): Promise<unknown> {
   });
 
   if (!response.ok) {
-    let message = `Harness API request failed with ${response.status}`;
+    let message = `Proofline API request failed with ${response.status}`;
     try {
       const payload = (await response.json()) as { error?: string };
       if (payload.error) {

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -423,7 +423,7 @@ export const mockTasks: Task[] = [
       harness_state: "failed",
       mismatches: [
         "Linear marked done but no evidence in GitHub",
-        "Harness detected failure state",
+        "Proofline detected failure state",
       ],
       evaluated_at: "2024-01-17T10:35:00Z",
     },


### PR DESCRIPTION
## Summary
- Update visible dashboard brand, browser metadata, loading/empty/error copy, and reconciliation system labels to Proofline
- Keep compatibility identifiers such as app/api/harness, HARNESS_API_BASE_URL, and resolveHarnessApiBaseUrl unchanged
- Preserve the acceptance-layer dashboard behavior without route, API, or contract renames

## Validation
- pnpm lint
- pnpm test:frontend
- pnpm build
- git diff --check
- rg check for remaining frontend Harness text; remaining hits are compatibility identifiers only
- Local dev server render check via curl http://127.0.0.1:3000/tasks confirmed Proofline title/header/loading text

## Notes
- Browser MCP navigation to localhost was blocked by the tool safety layer, so local HTTP render verification was used instead
- Does not rename packages, API routes, CLI commands, TaskEnvelope, repo paths, or deployment identifiers
- Does not run Symphony or touch live Linear/GitHub work