### PR TITLE
Clarify Proofline command compatibility

### DIFF
--- a/docs/howto/configure-harness.md
+++ b/docs/howto/configure-harness.md
@@ -1,6 +1,8 @@
-# Configure Harness
+# Configure Proofline
 
-Harness has two configuration paths: local runtime configuration for CLI/web usage, and repo-root `.env.local` for developer and CI-style runs.
+Proofline has two configuration paths: local runtime configuration for CLI/web usage, and repo-root `.env.local` for developer and CI-style runs.
+
+The active implementation still uses the Harness compatibility namespace for commands, environment variables, paths, and secret names. Keep those identifiers exactly as documented until a tested Proofline alias exists.
 
 ## Local Runtime Configuration
 
@@ -12,7 +14,7 @@ The local runtime writes non-secret runtime configuration to:
 
 Secrets do not belong in that file. Store local credentials through the runtime-managed secret boundary exposed by the CLI.
 
-Stable Harness secret names:
+Stable compatibility secret names:
 
 - `github_token`, mapped to `GITHUB_TOKEN`
 - `linear_api_key`, mapped to `LINEAR_API_KEY`
@@ -54,7 +56,7 @@ The current concrete repair receiver is still OpenClaw-shaped, so some operation
 - `OPENCLAW_CONFIG_PATH`
 - `OPENCLAW_STATE_DIR`
 
-Those names are implementation details. Harness itself should stay client-neutral: OpenClaw, Hermes, Codex, or a future desktop agent can fill the same role if it speaks the Harness API boundaries.
+Those names are implementation details. Proofline itself should stay client-neutral: OpenClaw, Hermes, Codex, or a future desktop agent can fill the same role if it speaks the canonical acceptance-layer API boundaries.
 
 For hosted repair dispatch, `OPENCLAW_BASE_URL` must point at a receiver reachable from the hosted runtime. A loopback value such as `http://127.0.0.1:18789` only works for local development.
 

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -7,10 +7,10 @@ During the staged rename, product surfaces say Proofline while commands, environ
 ## Start Here
 
 - [Local Quickstart](local-quickstart.md)
-- [Configure Harness](configure-harness.md)
-- [Use Harness](use-harness.md)
-- [Test And Validate](test-and-validate.md)
-- [Troubleshoot](troubleshoot.md)
+- [Configure Proofline](configure-harness.md)
+- [Use Proofline](use-harness.md)
+- [Test And Validate Proofline](test-and-validate.md)
+- [Troubleshoot Proofline](troubleshoot.md)
 
 ## Source-Of-Truth References
 

--- a/docs/howto/local-quickstart.md
+++ b/docs/howto/local-quickstart.md
@@ -2,13 +2,15 @@
 
 ## Goal
 
-Get Harness running locally, prove the runtime is healthy, and open the dashboard that shows canonical task state.
+Get Proofline running locally, prove the runtime is healthy, and open the dashboard that shows canonical task state.
+
+Proofline is the product name. During the staged rename, checkout commands, environment variables, runtime paths, and stored evidence still use the Harness compatibility namespace. Do not rename those local identifiers by hand.
 
 ## Supported Local Path
 
 The supported local operator path is CLI + web dashboard. The native macOS app is deprecated and should not be used as the normal install or validation path.
 
-Use this path when you are developing Harness or validating a PR.
+Use this path when you are developing the current Harness implementation or validating a PR.
 
 ```bash
 python3 -m pip install -r requirements.txt

--- a/docs/howto/test-and-validate.md
+++ b/docs/howto/test-and-validate.md
@@ -1,6 +1,8 @@
-# Test And Validate Harness
+# Test And Validate Proofline
 
-Validation should prove three things: the service starts, the dashboard reads live Harness APIs, and completion claims are accepted only when evidence is good enough.
+Validation should prove three things: the service starts, the dashboard reads live Proofline APIs through the current Harness compatibility routes, and completion claims are accepted only when evidence is good enough.
+
+Command examples intentionally keep the Harness compatibility namespace until tested Proofline aliases exist. Do not rename `HARNESS_*` variables, runtime module paths, or stored evidence fields locally.
 
 ## Fast Local Baseline
 
@@ -33,7 +35,7 @@ python3 -m modules.local_runtime --json stop
 
 The dashboard asset export matters for checkout validation. Without it, the runtime can still be healthy, but `doctor` will warn that the embedded dashboard cannot render packaged UI assets.
 
-A future packaged CLI should expose the same contract as `harness ...`. The native macOS app package is deprecated and is not part of the normal validation path.
+A future packaged CLI should expose the same contract as a compatibility `harness ...` command and, later, a tested Proofline alias. The native macOS app package is deprecated and is not part of the normal validation path.
 
 ## Deterministic Reset Proofs
 
@@ -52,7 +54,7 @@ python3 -m modules.execution_substrate_dryrun intent-consumer
 python3 -m modules.execution_substrate_dryrun handoff
 ```
 
-These commands exercise the Symphony-compatible execution substrate boundary locally. They write JSON summaries, use disposable stores, and do not start Symphony or touch live Linear/GitHub work. The `handoff` command renders the payload Harness would hand to a Symphony-compatible runner through the disabled transport boundary while keeping `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, and `safe_to_execute_live=false`.
+These commands exercise the Symphony-compatible execution substrate boundary locally. They write JSON summaries, use disposable stores, and do not start Symphony or touch live Linear/GitHub work. The `handoff` command renders the payload Proofline would hand to a Symphony-compatible runner through the disabled transport boundary while keeping `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, and `safe_to_execute_live=false`.
 
 ## Local Live Smoke
 

--- a/docs/howto/troubleshoot.md
+++ b/docs/howto/troubleshoot.md
@@ -1,6 +1,8 @@
-# Troubleshoot Harness
+# Troubleshoot Proofline
 
 Troubleshooting should start with observable state: health response, runtime status, logs, configured paths, and the canonical task/read-model endpoints.
+
+During the staged rename, most runtime identifiers still say Harness. Treat `HARNESS_*` variables, `/api/harness` routes, local data paths, and module commands as compatibility surfaces, not stale instructions.
 
 ## Backend Starts But `/reset/*` Fails
 
@@ -41,7 +43,7 @@ Check:
 - `~/Library/Logs/Harness/harness.log`
 - whether another process owns `127.0.0.1:8765`
 
-If the PID file is stale, `recover` should clear it. If another process owns the port, Harness should report `port_conflict` with a concrete next action.
+If the PID file is stale, `recover` should clear it. If another process owns the port, Proofline should report `port_conflict` with a concrete next action.
 
 ## Reset Verifier Cannot Dispatch Repair
 
@@ -67,7 +69,7 @@ Check:
 - whether the proof belongs to the current run
 - whether a manual review gate is active
 
-Harness treats worker-reported success as advisory. If evidence is missing, stale, contradictory, or tied to the wrong run, the correct behavior is to block, retry, reconcile, or require review.
+Proofline treats worker-reported success as advisory. If evidence is missing, stale, contradictory, or tied to the wrong run, the correct behavior is to block, retry, reconcile, or require review.
 
 ## Native macOS App Issues
 

--- a/docs/howto/use-harness.md
+++ b/docs/howto/use-harness.md
@@ -1,6 +1,8 @@
-# Use Harness
+# Use Proofline
 
-This guide shows the day-one operator loop: start Harness, inspect the current task truth, and validate that the verifier is enforcing evidence instead of accepting claims on trust.
+This guide shows the day-one operator loop: start Proofline, inspect the current task truth, and validate that the verifier is enforcing evidence instead of accepting claims on trust.
+
+Current command examples still use the Harness implementation namespace. That is expected during the staged rename; the product surface is Proofline, while the runtime module, API route names, and stored evidence remain compatibility identifiers.
 
 ## Check Backend Health
 
@@ -22,7 +24,7 @@ python3 -m modules.local_runtime --json status
 
 ## Open The Dashboard
 
-The dashboard reads canonical Harness APIs. It should show real backend errors when the API is unavailable, not sample data pretending to be live.
+The dashboard reads canonical Proofline APIs through the current Harness compatibility routes. It should show real backend errors when the API is unavailable, not sample data pretending to be live.
 
 ![Local dashboard task list](images/local-dashboard-tasks.png)
 
@@ -44,7 +46,7 @@ Open a task detail panel and check the verification, reconciliation, evidence, a
 
 ![Local dashboard task detail](images/local-dashboard-task-detail.png)
 
-The important question is not whether an agent said the work was complete. The important question is whether Harness has enough current evidence to accept that claim.
+The important question is not whether an agent said the work was complete. The important question is whether Proofline has enough current evidence to accept that claim.
 
 ## Watch Review Surfaces
 

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -1,8 +1,10 @@
 # Local Development
 
-This guide covers the practical local and container runbook for Harness.
+This guide covers the practical local and container runbook for the current Harness implementation of Proofline.
 
-For a reader-facing install and validation path, start with [Local Quickstart](../howto/local-quickstart.md), [Use Harness](../howto/use-harness.md), and [Test And Validate Harness](../howto/test-and-validate.md).
+For a reader-facing install and validation path, start with [Local Quickstart](../howto/local-quickstart.md), [Use Proofline](../howto/use-harness.md), and [Test And Validate Proofline](../howto/test-and-validate.md).
+
+Proofline is the product name. The local development surface still uses Harness compatibility identifiers for Python modules, environment variables, runtime paths, API proxy routes, and persisted state. Keep those identifiers stable unless a change adds tested aliases and a rollback path.
 
 ## Prerequisites
 
@@ -91,11 +93,11 @@ python3 -m uvicorn backend.server:app --host 127.0.0.1 --port 8000
 
 SQLite mode is the intended persistence base for self-contained local CLI/web usage. It creates the database and schema automatically, enables WAL mode and foreign keys, and stores canonical tasks, evaluation records, and reset verifier contracts in one local database.
 
-If `HARNESS_SQLITE_PATH` is unset, Harness uses the platform local-data default: `~/Library/Application Support/Harness/harness.db` on macOS, `$XDG_DATA_HOME/harness/harness.db` on Linux, or `~/.local/share/harness/harness.db` when `XDG_DATA_HOME` is unset.
+If `HARNESS_SQLITE_PATH` is unset, the runtime uses the platform local-data default: `~/Library/Application Support/Harness/harness.db` on macOS, `$XDG_DATA_HOME/harness/harness.db` on Linux, or `~/.local/share/harness/harness.db` when `XDG_DATA_HOME` is unset.
 
 ### Run The Local Runtime Contract
 
-A future packaged CLI can expose this contract as `harness`. From a repo checkout, use the module entry point:
+A future packaged CLI can expose this contract as a compatibility `harness` command and, later, a Proofline alias. From a repo checkout, use the module entry point:
 
 ```bash
 python3 -m modules.local_runtime --json init
@@ -280,7 +282,7 @@ The normal hosted/developer dashboard still uses `pnpm dev` or `pnpm build` and 
 
 ### Removed macOS Package Path
 
-The native macOS package path has been removed from the active tree. Do not use Developer ID signing, notarization, DMG output, or a Swift app shell as the normal Harness validation or release path unless a future task explicitly reopens the native app decision.
+The native macOS package path has been removed from the active tree. Do not use Developer ID signing, notarization, DMG output, or a Swift app shell as the normal Proofline validation or release path unless a future task explicitly reopens the native app decision.
 
 The reusable packaging work that remains relevant is the static dashboard bundle plus the local runtime contract above.
 


### PR DESCRIPTION
## Summary
- retitle active how-to docs around Proofline while preserving Harness implementation identifiers
- add explicit compatibility notes for commands, env vars, runtime paths, API routes, and stored evidence
- update the how-to index and local development links to use Proofline-facing labels

## Validation
- git diff --check
- git diff --cached --check
- tracked-doc heading check via git ls-files + rg

## Notes
- docs-only change
- did not run Symphony or touch live Linear/GitHub work