### PR TITLE
Use Proofline in architecture boundary docs

### DIFF
--- a/docs/architecture/artifact-and-completion-evidence.md
+++ b/docs/architecture/artifact-and-completion-evidence.md
@@ -4,7 +4,7 @@
 
 Define the canonical model for execution artifacts and completion evidence in Harness.
 
-Harness is a reliability/control-plane system. Executor-reported success is advisory. Completion is only trustworthy when the task's evidence policy is satisfied by verifiable artifacts.
+Proofline is a reliability/control-plane system. Executor-reported success is advisory. Completion is only trustworthy when the task's evidence policy is satisfied by verifiable artifacts.
 
 ## Design Goals
 

--- a/docs/architecture/clarification-and-missing-information.md
+++ b/docs/architecture/clarification-and-missing-information.md
@@ -4,7 +4,7 @@
 
 Define how Harness represents tasks that cannot safely proceed because required information is missing, ambiguous, or incomplete.
 
-Harness is a reliability/control-plane system. It must not silently guess when required inputs are absent or unclear.
+Proofline is a reliability/control-plane system. It must not silently guess when required inputs are absent or unclear.
 
 ## Core Rule
 

--- a/docs/architecture/completion-interception-and-artifact-validation-boundary.md
+++ b/docs/architecture/completion-interception-and-artifact-validation-boundary.md
@@ -4,7 +4,7 @@
 
 Define the control-plane boundary for executor-reported completion.
 
-This contract ensures that future executor adapters (including OpenClaw) cannot directly mark tasks complete, bypass canonical reevaluation, or relocate artifact-validation responsibility outside Harness.
+This contract ensures that future executor adapters, including OpenClaw-shaped compatibility adapters, cannot directly mark tasks complete, bypass canonical reevaluation, or relocate artifact-validation responsibility outside Proofline.
 
 ## Problem This Boundary Solves
 
@@ -16,13 +16,13 @@ Without an explicit boundary:
 - artifact references could be treated as validated evidence
 - verification/reconciliation/manual-review gates could be unintentionally bypassed
 
-Harness must intercept completion claims and re-evaluate canonical task truth before any terminal lifecycle outcome is accepted.
+Proofline must intercept completion claims and re-evaluate canonical task truth before any terminal lifecycle outcome is accepted.
 
 ## Core Boundary Rule
 
 **Completion claims from an executor are advisory execution facts, not authoritative lifecycle decisions.**
 
-Harness remains the sole authority for:
+Proofline remains the sole authority for:
 
 - lifecycle transitions
 - policy enforcement
@@ -49,9 +49,9 @@ The adapter must not:
 - resolve reconciliation mismatches
 - bypass canonical submission/reevaluation APIs
 
-### Harness Responsibilities
+### Proofline Responsibilities
 
-Harness must:
+Proofline must:
 
 - intercept every executor completion claim
 - persist claim + references as advisory facts
@@ -68,31 +68,31 @@ Artifacts split across two phases:
    - Adapter submits references to produced artifacts and related provenance.
    - These references are untrusted inputs.
 
-2. **Validation phase (Harness-side):**
-   - Harness evaluates artifact relevance/completeness under canonical policy.
-   - Harness combines artifact facts with verification/reconciliation/manual review state.
+2. **Validation phase (Proofline-side):**
+   - Proofline evaluates artifact relevance/completeness under canonical policy.
+   - Proofline combines artifact facts with verification/reconciliation/manual review state.
    - Only then can lifecycle advance to canonical completion.
 
 Therefore:
 
 - adapter **attaches** artifact references
-- Harness **validates** artifact sufficiency and completion eligibility
+- Proofline **validates** artifact sufficiency and completion eligibility
 
 ## Completion Interception Flow
 
 1. Task is in an execution-capable lifecycle state (for example `assigned`/`executing`).
 2. Executor adapter emits a completion claim with artifact + trace references.
-3. Harness records the claim as advisory execution input.
-4. Harness triggers canonical reevaluation.
+3. Proofline records the claim as advisory execution input.
+4. Proofline triggers canonical reevaluation.
 5. Reevaluation computes verification/reconciliation/evidence/manual-review outcomes.
-6. Harness enforces lifecycle transition rules from reevaluation output.
+6. Proofline enforces lifecycle transition rules from reevaluation output.
 7. Read-model and timeline expose the canonical result and audit trail.
 
 At no point does adapter-reported "success" directly become canonical `completed` state.
 
 ## Policy Invariants Preserved
 
-This boundary preserves existing Harness invariants:
+This boundary preserves existing Proofline invariants:
 
 - agent/executor success is advisory only
 - completion remains evidence-backed when policy requires evidence
@@ -103,7 +103,7 @@ This boundary preserves existing Harness invariants:
 
 ## API Surface Expectations
 
-Executor-facing integrations should continue to rely on canonical Harness paths:
+Executor-facing integrations should continue to rely on canonical Harness compatibility paths:
 
 - submission: `POST /tasks`
 - reevaluation trigger: `POST /tasks/<task_id>/reevaluate`
@@ -119,4 +119,4 @@ This boundary document complements:
 - `task-envelope-to-openclaw-mapping.md` (canonical envelope mapping boundary)
 - `codex-cloud-execution.md` (execution artifact and completion-proof requirements)
 
-Together, these documents keep execution plumbing replaceable while preserving Harness as the control-plane authority.
+Together, these documents keep execution plumbing replaceable while preserving Proofline as the control-plane authority.

--- a/docs/architecture/dispatcher-contract.md
+++ b/docs/architecture/dispatcher-contract.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-Define the canonical contract for dispatcher behavior in Harness.
+Define the canonical contract for dispatcher behavior in Proofline.
 
-Harness is a reliability/control-plane system. The dispatcher is the module that takes planned tasks, decides which worker class should handle them, records that assignment, and initiates execution through the execution gateway.
+Proofline is a reliability/control-plane system. The dispatcher is the module that takes planned tasks, decides which worker class should handle them, records that assignment, and initiates execution through the execution gateway.
 
 The dispatcher is not the planner, not the runtime, and not the verifier.
 
@@ -12,9 +12,9 @@ The dispatcher is not the planner, not the runtime, and not the verifier.
 
 The dispatcher converts planned task structure into auditable assignment decisions.
 
-Assignment truth starts here, not at ingress. New task creation and ingress adapters may declare task intent, planning state, dependencies, and clarification blockers, but they must not persist `assigned_executor` or create a task directly in `assigned`. If upstream systems want a task routed quickly, they may hand off a task as `dispatch_ready`, but Harness still owns the actual assignment decision.
+Assignment truth starts here, not at ingress. New task creation and ingress adapters may declare task intent, planning state, dependencies, and clarification blockers, but they must not persist `assigned_executor` or create a task directly in `assigned`. If upstream systems want a task routed quickly, they may hand off a task as `dispatch_ready`, but Proofline still owns the actual assignment decision.
 
-Symphony changes the implementation target for dispatch. Harness should make policy and assignment decisions, then hand execution scheduling to a Symphony-compatible substrate. Harness should not grow an always-on runner that duplicates Symphony's polling, workspace, session, and retry responsibilities.
+Symphony changes the implementation target for dispatch. Proofline should make policy and assignment decisions, then hand execution scheduling to a Symphony-compatible substrate. Proofline should not grow an always-on runner that duplicates Symphony's polling, workspace, session, and retry responsibilities.
 
 It is responsible for:
 
@@ -88,7 +88,7 @@ The dispatcher must not begin normal dispatch from:
 - `failed`
 - `canceled`
 
-Automatic post-ingestion dispatch follows the same rule. A task that is merely `planned` is not dispatchable just because it looks non-terminal; planning and clarification gates must be cleared and the task must enter `dispatch_ready` first. While Harness still exposes legacy direct dispatch for compatibility, API responses now describe that follow-up under `execution_continuation`; the older `automatic_dispatch` field is a compatibility alias, not the preferred execution-substrate contract.
+Automatic post-ingestion dispatch follows the same rule. A task that is merely `planned` is not dispatchable just because it looks non-terminal; planning and clarification gates must be cleared and the task must enter `dispatch_ready` first. While Proofline still exposes legacy direct dispatch for compatibility, API responses now describe that follow-up under `execution_continuation`; the older `automatic_dispatch` field is a compatibility alias, not the preferred execution-substrate contract.
 
 ### Clarification Preconditions
 
@@ -136,7 +136,7 @@ The dispatcher must not override verification or reconciliation policy by starti
 The dispatcher receives:
 
 - one canonical `TaskEnvelope` that is ready for dispatch
-- optional dispatch policy directives supplied by Harness core
+- optional dispatch policy directives supplied by Proofline core
 - executor inventory or worker capability facts supplied by integration layers
 
 ### Required TaskEnvelope Inputs
@@ -165,7 +165,7 @@ The dispatcher must not require executor-native request shapes as canonical inpu
 
 ### Optional Dispatch Directives
 
-Harness core may provide directives such as:
+Proofline core may provide directives such as:
 
 - permitted executor classes
 - forbidden executor classes
@@ -431,7 +431,7 @@ Redispatch may choose:
 - the same worker instance
 - a different worker instance
 
-Policy for when redispatch is allowed belongs to Harness core.
+Policy for when redispatch is allowed belongs to Proofline core.
 
 The dispatcher applies that policy. It does not invent it.
 

--- a/docs/architecture/linear-harness-boundary.md
+++ b/docs/architecture/linear-harness-boundary.md
@@ -1,23 +1,23 @@
-# Linear And Harness Boundary
+# Linear And Proofline Boundary
 
 ## Purpose
 
-Clarify how Linear and Harness fit together so Harness is positioned as complementary to Linear rather than competitive with it.
+Clarify how Linear and Proofline fit together so Proofline is positioned as complementary to Linear rather than competitive with it.
 
 ## Boundary Summary
 
 - Linear is the AI-native work surface and system of record for structured work.
-- Harness is the control plane and reliability layer underneath that work surface.
+- Proofline is the control plane and reliability layer underneath that work surface.
 
 Linear is where humans and agents coordinate work.
 
-Harness is where the system decides whether work is actually verified, reconciled, and acceptable as complete.
+Proofline is where the system decides whether work is actually verified, reconciled, and acceptable as complete.
 
 ## System Of Record Model
 
 - Linear is the source of truth for intended work.
 - GitHub is the source of truth for executed artifacts.
-- Harness is the source of truth for verified state and lifecycle correctness.
+- Proofline is the source of truth for verified state and lifecycle correctness.
 
 ## Linear Owns
 
@@ -27,11 +27,11 @@ Harness is where the system decides whether work is actually verified, reconcile
 - collaboration around task planning and progress
 - structured-work records that represent what should be happening
 
-## Harness Owns
+## Proofline Owns
 
 - canonical control-plane contracts such as `TaskEnvelope`
 - artifact-backed completion enforcement
-- reconciliation between Harness state, GitHub facts, and Linear facts
+- reconciliation between Proofline state, GitHub facts, and Linear facts
 - auditable lifecycle and state-transition enforcement
 - verification and manual-review policy
 - decisions about whether completion should be accepted, blocked, reversed, or escalated
@@ -45,25 +45,25 @@ Harness is where the system decides whether work is actually verified, reconcile
 - which issue, project, or workflow does it belong to?
 - what do humans and agents currently believe is happening?
 
-### Harness Answers
+### Proofline Answers
 
 - did the work actually happen?
 - is completion supported by evidence?
-- do GitHub, Linear, and Harness agree?
+- do GitHub, Linear, and Proofline agree?
 - should completion be accepted, blocked, reversed, failed, or sent to manual review?
 
 ## Interaction Model
 
 1. Work is initiated through an ingress surface such as OpenClaw or directly inside a work surface such as Linear.
 2. Linear remains the visible system of record for work coordination.
-3. Harness consumes relevant task state and normalizes it into canonical control-plane contracts.
-4. Harness delegates execution to workers and gathers execution evidence.
-5. Harness reconciles its own state against GitHub and Linear.
-6. Harness reports verified outcomes back so Linear reflects trusted state rather than unverified claims.
+3. Proofline consumes relevant task state and normalizes it into canonical control-plane contracts.
+4. Proofline delegates execution to workers and gathers execution evidence.
+5. Proofline reconciles its own state against GitHub and Linear.
+6. Proofline reports verified outcomes back so Linear reflects trusted state rather than unverified claims.
 
 ## Contract Boundary
 
-### Linear -> Harness
+### Linear -> Proofline
 
 Linear sends:
 
@@ -73,18 +73,18 @@ Linear sends:
 - `labels` and `priority` when present
 - linked artifacts when present
 
-### Harness Derives
+### Proofline Derives
 
-Harness derives:
+Proofline derives:
 
 - canonical `TaskEnvelope`
 - required artifacts
 - verification expectations
 - reconciliation expectations against GitHub and Linear state
 
-### Harness -> Linear
+### Proofline -> Linear
 
-Harness returns:
+Proofline returns:
 
 - control-plane outcome: `completed`, `blocked`, `in_review`, or `failed`
 - evidence validation result
@@ -93,7 +93,7 @@ Harness returns:
 
 ## Linear Facts Contract
 
-When Harness receives normalized `linear_facts` through the public API:
+When Proofline receives normalized `linear_facts` through the public API:
 
 - `record_found=false` means the Linear record is unresolved, and `workflow` must be `null` or omitted
 - `record_found=true` means the record is resolved, and `workflow` must be an object containing:
@@ -108,24 +108,24 @@ This keeps review-required cases explicit: unresolved Linear identity is represe
 2. An executor such as Codex performs the work.
 3. A pull request is opened in GitHub.
 4. Linear is marked done by a human or agent.
-5. Harness evaluates the completion claim:
+5. Proofline evaluates the completion claim:
    - verifies the pull request exists
    - checks repository and branch correctness
    - validates artifact completeness
-6. Harness returns a control-plane decision:
+6. Proofline returns a control-plane decision:
    - `accepted_completion` when the evidence and external facts align
    - `blocked` when required evidence is missing or incomplete
-   - `external_mismatch` when GitHub, Linear, and Harness facts do not agree
+   - `external_mismatch` when GitHub, Linear, and Proofline facts do not agree
 
 ## Boundary Note
 
-`review_required` should be understood as the decision outcome that moves Harness into the explicit `in_review` lifecycle state.
+`review_required` should be understood as the decision outcome that moves Proofline into the explicit `in_review` lifecycle state.
 
-Linear does not need to share the same internal enum, but Harness must not keep the underlying task in `completed` once review is required.
+Linear does not need to share the same internal enum, but Proofline must not keep the underlying task in `completed` once review is required.
 
 ## Non-Goals
 
-Harness should not become:
+Proofline should not become:
 
 - a replacement for Linear's issue/project coordination UX
 - a generic agent coordination product
@@ -134,7 +134,7 @@ Harness should not become:
 
 ## Product Implication
 
-The moat for Harness is not better work coordination UX.
+The moat for Proofline is not better work coordination UX.
 
 The moat is reliable completion enforcement beneath AI-driven work:
 

--- a/docs/architecture/openclaw-executor-adapter.md
+++ b/docs/architecture/openclaw-executor-adapter.md
@@ -27,7 +27,7 @@ A future executor adapter is a different concern:
 
 Keeping those concerns separate protects the core design:
 
-- Harness remains the control plane
+- Proofline remains the control plane
 - the desktop agent client remains replaceable
 - completion remains evidence-backed instead of executor-declared
 

--- a/docs/architecture/operator-and-manual-review.md
+++ b/docs/architecture/operator-and-manual-review.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-Define the canonical operator and manual review contract for Harness.
+Define the canonical operator and manual review contract for Proofline.
 
-Harness is a reliability/control-plane system. Human intervention is allowed, but it must occur through explicit, auditable control-plane surfaces rather than informal overrides.
+Proofline is a reliability/control-plane system. Human intervention is allowed, but it must occur through explicit, auditable control-plane surfaces rather than informal overrides.
 
 Manual review is therefore a governed decision path, not an escape hatch.
 

--- a/docs/architecture/planner-contract.md
+++ b/docs/architecture/planner-contract.md
@@ -4,7 +4,7 @@
 
 Define the canonical contract for planner behavior in Harness.
 
-Harness is a reliability/control-plane system. The planner is not a freeform reasoning agent. It is a bounded module that transforms sufficiently defined task contracts into a structured, reviewable execution plan.
+Proofline is a reliability/control-plane system. The planner is not a freeform reasoning agent. It is a bounded module that transforms sufficiently defined task contracts into a structured, reviewable execution plan.
 
 ## Planner Role
 

--- a/docs/architecture/reconciliation-rules.md
+++ b/docs/architecture/reconciliation-rules.md
@@ -4,7 +4,7 @@
 
 Define how Harness reconciles internal task state with external systems of record and artifact systems.
 
-Harness is a reliability/control-plane system. A task is not trustworthy merely because an executor reported success or because one external system looks consistent in isolation. Harness must compare internal lifecycle state, evidence state, and external system state and then represent any mismatch explicitly.
+Proofline is a reliability/control-plane system. A task is not trustworthy merely because an executor reported success or because one external system looks consistent in isolation. Proofline must compare internal lifecycle state, evidence state, and external system state and then represent any mismatch explicitly.
 
 Completion is provisional until reconciliation passes.
 

--- a/docs/architecture/runtime-execution-contract.md
+++ b/docs/architecture/runtime-execution-contract.md
@@ -2,13 +2,13 @@
 
 ## Purpose
 
-Define the canonical runtime execution contract for Harness.
+Define the canonical runtime execution contract for Proofline.
 
-Harness is a reliability/control-plane system. The runtime coordinates execution after dispatch, preserves durable in-flight state, records execution events, and feeds normalized execution facts back into the control plane.
+Proofline is a reliability/control-plane system. The runtime coordinates execution after dispatch, preserves durable in-flight state, records execution events, and feeds normalized execution facts back into the control plane.
 
 The runtime is not the planner, not the dispatcher, and not the verifier.
 
-A Symphony-like runner is one possible runtime or execution-substrate implementation. It may poll eligible work, create isolated workspaces, launch Codex sessions, detect stalls, and report handoffs. It still emits advisory execution facts only. Harness remains responsible for verification, reconciliation, manual review, and lifecycle acceptance.
+A Symphony-like runner is one possible runtime or execution-substrate implementation. It may poll eligible work, create isolated workspaces, launch Codex sessions, detect stalls, and report handoffs. It still emits advisory execution facts only. Proofline remains responsible for verification, reconciliation, manual review, and lifecycle acceptance.
 
 ## Runtime Role
 
@@ -368,14 +368,14 @@ Each retry should remain traceable through:
 
 ## Invalid Execution Attempts
 
-Harness distinguishes a failed execution attempt from an invalid execution attempt.
+Proofline distinguishes a failed execution attempt from an invalid execution attempt.
 
 - failed attempt: the executor actually ran and reported an unsuccessful terminal outcome
 - invalid execution attempt: the executor claimed success, but the current run did not produce the minimum proof needed to trust that claim as a real code-bearing attempt
 
 For the current implemented policy, a code-bearing successful attempt must provide coherent current-run repository and branch context, plus commit context unless that commit can be recovered safely during governed reconciliation.
 
-Some failures in that gate are stricter than a generic invalid attempt. Harness treats them as executor-side contract violations rather than as retryable malformed output:
+Some failures in that gate are stricter than a generic invalid attempt. Proofline treats them as executor-side contract violations rather than as retryable malformed output:
 
 - reserved shared branches such as `work`
 - missing branch identity for a delegated code-bearing run
@@ -389,25 +389,25 @@ These do not authorize reconciliation. They are rejected before reconciliation b
 Examples of `invalid_execution_attempt`:
 
 - no repository/branch/commit context for the current run
-- repository or branch context is missing, so Harness cannot recover commit identity later
+- repository or branch context is missing, so Proofline cannot recover commit identity later
 - conflicting repo/branch/commit values inside the attempt payload
 - malformed success-shaped output that cannot identify the current execution attempt coherently
 
-A narrow exception exists for `missing_pr_after_execution`: if repository and branch identity are present but commit SHA is still absent, Harness may allow the completion claim to enter reconciliation so the handler can resolve the current branch head SHA before PR lookup. That exception does not relax the requirement for repository and branch identity, and it does not authorize terminal success on its own.
+A narrow exception exists for `missing_pr_after_execution`: if repository and branch identity are present but commit SHA is still absent, Proofline may allow the completion claim to enter reconciliation so the handler can resolve the current branch head SHA before PR lookup. That exception does not relax the requirement for repository and branch identity, and it does not authorize terminal success on its own.
 
 This is intentionally earlier than reconciliation.
 
-- invalid execution attempt means Harness does not yet trust that a real current-run execution exists
-- reconciliation means Harness trusts the run happened and is now trying to recover or validate missing external artifacts for that run
+- invalid execution attempt means Proofline does not yet trust that a real current-run execution exists
+- reconciliation means Proofline trusts the run happened and is now trying to recover or validate missing external artifacts for that run
 
 The control-plane policy is:
 
 1. execution completes and reports success
-2. Harness validates the execution attempt shape
-3. if the attempt violates the execution contract, Harness fails it explicitly without treating it as flaky progress
+2. Proofline validates the execution attempt shape
+3. if the attempt violates the execution contract, Proofline fails it explicitly without treating it as flaky progress
 4. if valid, the claim can proceed to completion handling and, if needed, reconciliation
-5. if invalid and retry budget remains, Harness schedules a fresh execution attempt
-6. if invalid attempts exhaust the retry budget, Harness transitions the task to `failed`
+5. if invalid and retry budget remains, Proofline schedules a fresh execution attempt
+6. if invalid attempts exhaust the retry budget, Proofline transitions the task to `failed`
 
 This keeps routine executor misses out of manual review while preserving truthful completion boundaries.
 
@@ -415,7 +415,7 @@ This keeps routine executor misses out of manual review while preserving truthfu
 
 Represents runtime cancellation of an in-flight attempt under control-plane direction or policy.
 
-Cancellation of an attempt does not automatically imply top-level task `canceled`; Harness core still applies lifecycle policy.
+Cancellation of an attempt does not automatically imply top-level task `canceled`; Proofline core still applies lifecycle policy.
 
 ## Progress Reporting
 
@@ -453,7 +453,7 @@ Failure reporting should preserve:
 
 The runtime reports failure facts.
 
-Harness core decides whether the task becomes `failed`, `blocked`, reassigned, or retried.
+Proofline core decides whether the task becomes `failed`, `blocked`, reassigned, or retried.
 
 ## Retry Semantics
 
@@ -468,9 +468,9 @@ Retries should be represented through:
 
 Retry policy is not invented by the runtime.
 
-The runtime applies the policy given by Harness core or higher-level orchestration rules.
+The runtime applies the policy given by Proofline core or higher-level orchestration rules.
 
-When the runtime is backed by a Symphony-like daemon, retry state must still obey Harness budgets. A daemon loop may keep work moving only while a task, project, repository, and executor all remain within explicit retry, wall-clock, idle-time, and spend limits. Budget exhaustion must stop automatic continuation rather than letting the runner relaunch work forever.
+When the runtime is backed by a Symphony-like daemon, retry state must still obey Proofline budgets. A daemon loop may keep work moving only while a task, project, repository, and executor all remain within explicit retry, wall-clock, idle-time, and spend limits. Budget exhaustion must stop automatic continuation rather than letting the runner relaunch work forever.
 
 ## Budget Governance
 
@@ -509,7 +509,7 @@ Possible next actions include:
 
 The runtime may detect the issue.
 
-Harness core and dispatcher policy determine the correct consequence.
+Proofline core and dispatcher policy determine the correct consequence.
 
 ## Attachment Of Outputs And Artifacts
 

--- a/docs/architecture/state-transition-enforcement.md
+++ b/docs/architecture/state-transition-enforcement.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-Define the canonical state transition enforcement rules for Harness.
+Define the canonical state transition enforcement rules for Proofline.
 
-Harness is a reliability/control-plane system. Lifecycle states are enforced control-plane states, not informational labels or worker hints.
+Proofline is a reliability/control-plane system. Lifecycle states are enforced control-plane states, not informational labels or worker hints.
 
 A state transition is valid only when:
 

--- a/docs/architecture/symphony-execution-substrate.md
+++ b/docs/architecture/symphony-execution-substrate.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-Define how Harness should respond to OpenAI's Symphony project without weakening Harness's source-of-truth boundary.
+Define how Proofline should respond to OpenAI's Symphony project without weakening the acceptance-layer source-of-truth boundary.
 
-Symphony validates the need for a daemonized execution substrate that keeps Codex working on structured tasks. It does not replace Harness. Harness remains the control plane, verification layer, and lifecycle authority. A Symphony-like service may run work, retry work, preserve per-issue workspaces, and report execution facts. It must not decide whether work is complete.
+Symphony validates the need for a daemonized execution substrate that keeps Codex working on structured tasks. It does not replace Proofline. Proofline remains the control plane, verification layer, and lifecycle authority. A Symphony-like service may run work, retry work, preserve per-issue workspaces, and report execution facts. It must not decide whether work is complete.
 
 References:
 
@@ -16,13 +16,13 @@ References:
 
 ## Decision
 
-Harness should wrap a Symphony-like runner as an execution substrate.
+Proofline should wrap a Symphony-like runner as an execution substrate.
 
-Harness should not build a duplicate low-level daemon whose only purpose is to poll Linear, create workspaces, launch Codex, and keep attempts moving. Symphony's public spec is now the right shape for that lower layer.
+Proofline should not build a duplicate low-level daemon whose only purpose is to poll Linear, create workspaces, launch Codex, and keep attempts moving. Symphony's public spec is now the right shape for that lower layer.
 
 Local setup now reflects that decision. The `repair-dispatch` workflow requires an `execution_substrate` setup item, with Symphony as the preferred runner. The old `ingress_executor` setup item remains as a compatibility bridge for older OpenClaw/Hermes/Codex repair paths, but it is no longer the primary execution-scheduling requirement.
 
-Harness should also not collapse into Symphony. Symphony is a runner and tracker reader. Harness is the source of verified lifecycle truth.
+Proofline should also not collapse into Symphony. Symphony is a runner and tracker reader. Proofline is the source of verified lifecycle truth.
 
 The intended stack is:
 
@@ -31,11 +31,11 @@ Ambiguous product or software idea
         |
 Clarification and PRD/spec generation
         |
-Harness planning and decomposition
+Proofline planning and decomposition
         |
 Linear project, issue, and dependency graph
         |
-Harness dispatch policy and execution budgets
+Proofline dispatch policy and execution budgets
         |
 Symphony-like execution substrate
         |
@@ -43,7 +43,7 @@ Codex / Codex Cloud / future workers
         |
 GitHub commits, pull requests, CI, reviews, artifacts
         |
-Harness verification, reconciliation, manual review, completion authority
+Proofline verification, reconciliation, manual review, completion authority
 ```
 
 This preserves the current source-of-truth model:
@@ -52,11 +52,11 @@ This preserves the current source-of-truth model:
 - GitHub is the source of truth for executed code artifacts.
 - Executors are replaceable workers.
 - A Symphony-like runner is an execution scheduler.
-- Harness is the source of truth for verified lifecycle state.
+- Proofline is the source of truth for verified lifecycle state.
 
 ## What Symphony Validates
 
-Symphony validates the parts of the Harness thesis that were most likely to become operational bottlenecks:
+Symphony validates the parts of the Proofline thesis that were most likely to become operational bottlenecks:
 
 - Work should be represented in a structured work surface before agents execute it.
 - Long-running agent execution should be daemonized instead of driven by manual terminal supervision.
@@ -65,17 +65,17 @@ Symphony validates the parts of the Harness thesis that were most likely to beco
 - Multiple agent runs require bounded concurrency, retry state, and operator-visible runtime status.
 - Execution summaries are not enough; systems need artifacts, logs, and handoff states.
 
-The important strategic implication is that Harness should spend less effort on bespoke executor scheduling and more effort on the things Symphony intentionally does not own: clarification, decomposition, verification, reconciliation, lifecycle policy, manual review, and project-level completion.
+The important strategic implication is that Proofline should spend less effort on bespoke executor scheduling and more effort on the things Symphony intentionally does not own: clarification, decomposition, verification, reconciliation, lifecycle policy, manual review, and project-level completion.
 
-## What Harness Should Borrow
+## What Proofline Should Borrow
 
-Harness should adopt these Symphony concepts either directly or through compatible abstractions:
+Proofline should adopt these Symphony concepts either directly or through compatible abstractions:
 
-- Repo-owned execution workflow contract, initially `WORKFLOW.md` or a Harness-specific profile that can generate one.
+- Repo-owned execution workflow contract, initially `WORKFLOW.md` or a Proofline-specific profile that can generate one.
 - Per-issue or per-task deterministic workspace roots.
 - Bounded concurrency by repository, project, executor class, and risk level.
 - Poll/reconcile loop for eligible Linear issues.
-- Stop active runs when Linear state, dependency state, or Harness policy makes the issue ineligible.
+- Stop active runs when Linear state, dependency state, or Proofline policy makes the issue ineligible.
 - Retry queue with attempt count, retry reason, due time, and exponential backoff.
 - Stall and timeout detection based on heartbeats and progress facts.
 - Runtime snapshot with running sessions, retrying sessions, rate-limit state, token usage, and seconds running.
@@ -83,40 +83,40 @@ Harness should adopt these Symphony concepts either directly or through compatib
 - Dynamic tool exposure for privileged integrations so worker sessions do not receive raw broad-scope tokens.
 - Workflow prompt construction that receives issue context, attempt context, and prior handoff context.
 
-These are execution-substrate concerns. They should feed Harness with advisory events and artifact references, not canonical lifecycle decisions.
+These are execution-substrate concerns. They should feed Proofline with advisory events and artifact references, not canonical lifecycle decisions.
 
-## What Harness Must Not Copy
+## What Proofline Must Not Copy
 
-Harness must not copy the parts of a high-trust Symphony deployment that assume the runner and agents can mutate truth safely.
+Proofline must not copy the parts of a high-trust Symphony deployment that assume the runner and agents can mutate truth safely.
 
 Do not copy:
 
 - Agent-authored Linear state as completion truth.
-- Agent-authored acceptance criteria changes after PRD/spec approval without Harness or human review.
+- Agent-authored acceptance criteria changes after PRD/spec approval without Proofline or human review.
 - Automatic move to `Done` as a runner success state.
 - Auto-merge as a default behavior.
 - Unbounded retry loops.
-- In-memory runner state as durable Harness truth.
-- Broad raw Linear or GitHub mutation tools inside worker sessions without Harness-owned audit and policy boundaries.
+- In-memory runner state as durable Proofline truth.
+- Broad raw Linear or GitHub mutation tools inside worker sessions without Proofline-owned audit and policy boundaries.
 - Runner success summaries as completion evidence.
 - Silent recovery from external mismatches.
 
-The safe rule is simple: the runner may reach a handoff state; Harness decides whether the handoff is acceptable.
+The safe rule is simple: the runner may reach a handoff state; Proofline decides whether the handoff is acceptable.
 
 ## Boundary Model
 
 ### Symphony-Like Runner Owns
 
-- Polling for eligible work when delegated by Harness policy.
+- Polling for eligible work when delegated by Proofline policy.
 - Creating or reusing isolated workspaces.
 - Launching Codex or another selected executor.
 - Passing workflow prompts and attempt context.
 - Observing heartbeats, stalls, timeouts, and worker exits.
-- Scheduling execution-level retries within Harness-provided budgets.
+- Scheduling execution-level retries within Proofline-provided budgets.
 - Emitting normalized execution events and artifact references.
 - Cleaning up or preserving workspaces according to configured policy.
 
-### Harness Owns
+### Proofline Owns
 
 - Clarification interviews and missing-information handling.
 - PRD or PRD-like spec approval state.
@@ -143,17 +143,17 @@ Linear does not decide whether artifact-backed completion should be trusted.
 
 - Branches, commits, pull requests, changed files, CI status, reviews, and merge state.
 
-GitHub stores artifact facts. It does not decide Harness lifecycle state.
+GitHub stores artifact facts. It does not decide Proofline lifecycle state.
 
 ## Runner Event Contract
 
-The runner integration should emit advisory events into Harness. These events should be append-only and attempt-scoped.
+The runner integration should emit advisory events into Proofline. These events should be append-only and attempt-scoped.
 
 The first in-code contract lives in [`modules/contracts/execution_substrate.py`](../../modules/contracts/execution_substrate.py). It intentionally models runner events as advisory input, not as lifecycle authority.
 
-Harness accepts these events through `POST /tasks/<task_id>/execution-substrate-events`. That endpoint appends validated runner events to `observability.execution_metadata.execution_substrate_events` and projects them into the read-model and timeline. It does not run verification, mutate Linear or GitHub, or authorize a lifecycle transition.
+Proofline accepts these events through the current Harness compatibility route `POST /tasks/<task_id>/execution-substrate-events`. That endpoint appends validated runner events to `observability.execution_metadata.execution_substrate_events` and projects them into the read-model and timeline. It does not run verification, mutate Linear or GitHub, or authorize a lifecycle transition.
 
-The deterministic local dry run lives in [`modules/execution_substrate_dryrun.py`](../../modules/execution_substrate_dryrun.py). It simulates a Symphony-style event stream against a disposable local task and proves that runner handoff remains advisory until Harness verification runs. It also includes an intent-consumer dry run that creates a local retryable task, polls the execution-substrate intent queue, and records advisory runner events without starting Symphony or touching live work.
+The deterministic local dry run lives in [`modules/execution_substrate_dryrun.py`](../../modules/execution_substrate_dryrun.py). It simulates a Symphony-style event stream against a disposable local task and proves that runner handoff remains advisory until Proofline verification runs. It also includes an intent-consumer dry run that creates a local retryable task, polls the execution-substrate intent queue, and records advisory runner events without starting Symphony or touching live work.
 
 Run the two local substrate dry runs with:
 
@@ -163,17 +163,17 @@ python3 -m modules.execution_substrate_dryrun intent-consumer
 python3 -m modules.execution_substrate_dryrun handoff
 ```
 
-These commands write a JSON summary to stdout. They use disposable local stores, do not start Symphony, do not read live Linear or GitHub state, and do not authorize task completion. The `handoff` command renders the Symphony-compatible payload through the disabled transport boundary and marks `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, and `safe_to_execute_live=false`. They exist to make the execution-substrate boundary testable before Harness connects a real Symphony runner.
+These commands write a JSON summary to stdout. They use disposable local stores, do not start Symphony, do not read live Linear or GitHub state, and do not authorize task completion. The `handoff` command renders the Symphony-compatible payload through the disabled transport boundary and marks `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, and `safe_to_execute_live=false`. They exist to make the execution-substrate boundary testable before Proofline connects a real Symphony runner.
 
-The supervision queue now also exposes `execution_substrate_intent` for attention items that should be continued by a Symphony-compatible runner. This is the replacement for Harness pretending to be the runner in the normal path. A supervisor can submit that intent to Symphony, and Symphony reports back through `POST /tasks/<task_id>/execution-substrate-events`. Harness also exposes `GET /execution-substrate/intents` as a runner-facing filtered projection of those intents. The old direct `/tasks/<task_id>/dispatch` behavior remains only as a compatibility and deterministic-test path.
+The supervision queue now also exposes `execution_substrate_intent` for attention items that should be continued by a Symphony-compatible runner. This is the replacement for Proofline pretending to be the runner in the normal path. A supervisor can submit that intent to Symphony, and Symphony reports back through `POST /tasks/<task_id>/execution-substrate-events`. Proofline also exposes `GET /execution-substrate/intents` as a runner-facing filtered projection of those intents. The old direct `/tasks/<task_id>/dispatch` behavior remains only as a compatibility and deterministic-test path.
 
-Runner-facing intents are also part of the in-code execution-substrate contract. Supervision builds them through `build_execution_substrate_intent` rather than hand-writing arbitrary queue payloads. A valid intent must remain advisory, must preserve `completion_authority=harness_verification`, and must explicitly prohibit marking Harness complete, moving Linear to Done as truth, or auto-merging without policy. This gives a Symphony adapter a stable handoff shape while keeping Harness above the runner as the verification boundary.
+Runner-facing intents are also part of the in-code execution-substrate contract. Supervision builds them through `build_execution_substrate_intent` rather than hand-writing arbitrary queue payloads. A valid intent must remain advisory, must preserve `completion_authority=harness_verification`, and must explicitly prohibit marking Proofline complete, moving Linear to Done as truth, or auto-merging without policy. This gives a Symphony adapter a stable handoff shape while keeping Proofline above the runner as the verification boundary.
 
-The first Symphony adapter lives in [`modules/adapters/symphony`](../../modules/adapters/symphony). It only renders a validated intent into an inert Symphony-compatible handoff payload. It does not start Symphony, poll Linear, launch Codex, mutate GitHub, or consume live work. Its purpose is to pin the Harness-to-runner payload shape before adding any daemon transport. The same package exposes `DisabledSymphonyExecutionTransport` as the explicit live-transport boundary: it can preview the handoff, but `dispatch()` raises until Harness has a separate live execution policy.
+The first Symphony adapter lives in [`modules/adapters/symphony`](../../modules/adapters/symphony). It only renders a validated intent into an inert Symphony-compatible handoff payload. It does not start Symphony, poll Linear, launch Codex, mutate GitHub, or consume live work. Its purpose is to pin the Proofline-to-runner payload shape before adding any daemon transport. The same package exposes `DisabledSymphonyExecutionTransport` as the explicit live-transport boundary: it can preview the handoff, but `dispatch()` raises until Proofline has a separate live execution policy.
 
-Harness exposes `GET /execution-substrate/handoffs` as a read-only preview of those rendered handoffs. The endpoint renders from the current supervision intent queue, marks `dispatch_enabled=false`, and does not start or contact Symphony. It exists so operators and future runners can inspect the exact payload shape before any live execution transport is enabled.
+Proofline exposes `GET /execution-substrate/handoffs` as a read-only preview of those rendered handoffs. The endpoint renders from the current supervision intent queue, marks `dispatch_enabled=false`, and does not start or contact Symphony. It exists so operators and future runners can inspect the exact payload shape before any live execution transport is enabled.
 
-That preview surface is protected by the execution-substrate contract validator. A valid preview must remain `advisory_only=true`, `dispatch_enabled=false`, `completion_authority=harness_verification`, `mode=render_only`, `runner_completion_is_truth=false`, and `safe_to_execute_live=false`. It must also carry the required runner prohibitions: no marking Harness complete, no treating Linear Done as truth, and no auto-merge without policy. Future live Symphony transport should add a separate execution path rather than weakening this read-only preview contract.
+That preview surface is protected by the execution-substrate contract validator. A valid preview must remain `advisory_only=true`, `dispatch_enabled=false`, `completion_authority=harness_verification`, `mode=render_only`, `runner_completion_is_truth=false`, and `safe_to_execute_live=false`. It must also carry the required runner prohibitions: no marking Proofline complete, no treating Linear Done as truth, and no auto-merge without policy. Future live Symphony transport should add a separate execution path rather than weakening this read-only preview contract.
 
 The disabled live-transport posture is also an explicit contract. `modules/contracts/execution_substrate.py` owns the canonical disabled Symphony-compatible policy used by `GET /execution-substrate/transport-status`: `transport_status=disabled`, `dispatch_enabled=false`, `live_dispatch_enabled=false`, `completion_authority=harness_verification`, `runner_completion_is_truth=false`, and `safe_to_execute_live=false`. New live transport work must introduce a separate policy-gated path rather than changing these guardrail fields opportunistically.
 
@@ -195,7 +195,7 @@ Initial event family:
 - `run_cancelled`
 - `run_completed_by_executor`
 
-These names are intentionally execution-facing. None of them mean Harness has accepted completion.
+These names are intentionally execution-facing. None of them mean Proofline has accepted completion.
 
 Required event fields:
 
@@ -223,11 +223,11 @@ Required artifact reference fields when the runner reports artifacts:
 - `reported_at`
 - `verification_status`
 
-Runner-reported artifact references start as unverified unless they come from a separate trusted sync path, such as Harness-controlled GitHub API readback.
+Runner-reported artifact references start as unverified unless they come from a separate trusted sync path, such as Proofline-controlled GitHub API readback.
 
 ## TaskEnvelope Impact
 
-Harness should add a canonical execution-substrate surface to `TaskEnvelope`, or formalize the same shape under existing observability fields before schema expansion.
+Proofline should add a canonical execution-substrate surface to `TaskEnvelope`, or formalize the same shape under existing observability fields before schema expansion.
 
 Proposed `execution` section:
 
@@ -268,23 +268,23 @@ Do not add this schema field casually before Phase 1 proves the minimum data nee
 
 ## Linear Integration Impact
 
-Harness should treat Symphony's Linear usage as scheduling input, not lifecycle authority.
+Proofline should treat Symphony's Linear usage as scheduling input, not lifecycle authority.
 
 Recommended Linear model:
 
-- Harness-created or Harness-approved issues are executable.
+- Proofline-created or Proofline-approved issues are executable.
 - Agent-created follow-up issues enter `proposed` or `needs_triage` until accepted.
 - Runner may move issues to a handoff state such as `Human Review`.
 - Runner may add PR links and progress comments.
-- Runner may not mark work as Harness-verified complete.
+- Runner may not mark work as Proofline-verified complete.
 - Runner may not rewrite accepted acceptance criteria without review.
-- Harness writes back verification status separately, either as labels, comments, custom fields, or a dedicated status convention.
+- Proofline writes back verification status separately, either as labels, comments, custom fields, or a dedicated status convention.
 
-Linear dependencies should gate runner dispatch. A runner should not start a dependent issue simply because it appears active if Harness or Linear blockers are unresolved.
+Linear dependencies should gate runner dispatch. A runner should not start a dependent issue simply because it appears active if Proofline or Linear blockers are unresolved.
 
 ## Retry Model Impact
 
-Harness should split retry causes instead of treating all continuation as the same loop.
+Proofline should split retry causes instead of treating all continuation as the same loop.
 
 Retry classes:
 
@@ -292,7 +292,7 @@ Retry classes:
 - `repair_retry`: missing PR, missing commit, stale branch readback, CI status unavailable.
 - `spec_retry`: unclear task, missing acceptance criteria, contradictory scope.
 - `verification_retry`: GitHub, Linear, CI, or review facts unavailable.
-- `policy_retry`: allowed redispatch after manual review or Harness recovery.
+- `policy_retry`: allowed redispatch after manual review or Proofline recovery.
 
 Each class needs separate budgets:
 
@@ -320,7 +320,7 @@ Add an execution-substrate section or view that shows:
 - current Linear state
 - reported artifacts
 - GitHub verification state
-- Harness lifecycle state
+- Proofline lifecycle state
 - blocking mismatch reasons
 - budget consumption
 
@@ -328,7 +328,7 @@ The UI copy and read-model contract should preserve this distinction:
 
 - `Executor says done` means advisory handoff.
 - `Artifacts verified` means GitHub/CI/review facts satisfy the relevant evidence contract.
-- `Harness complete` means lifecycle acceptance passed verification and reconciliation.
+- `Proofline complete` means lifecycle acceptance passed verification and reconciliation.
 
 No dashboard surface should display a runner handoff as final project completion.
 
@@ -336,7 +336,7 @@ No dashboard surface should display a runner handoff as final project completion
 
 Runner handoff should trigger reevaluation. It should not complete work.
 
-For code-bearing work, Harness must independently fetch and validate:
+For code-bearing work, Proofline must independently fetch and validate:
 
 - repository
 - branch
@@ -355,7 +355,7 @@ Completion can be accepted only when:
 - required artifacts are present and coherent
 - required checks pass
 - manual review gates are resolved
-- Linear state and Harness state do not have a blocking mismatch
+- Linear state and Proofline state do not have a blocking mismatch
 - dependency and project rollup gates are satisfied
 
 Project-level `done` is stricter than task-level completion. A project may report done only when all required child tasks, validation tasks, dependencies, and review gates are complete.
@@ -368,11 +368,11 @@ These rules apply before any live Symphony-style runner is enabled against real 
 2. No automatic merge in Phase 1 or Phase 2.
 3. No agent-written Linear completion truth.
 4. No unbounded retries.
-5. No runner state as Harness canonical state.
+5. No runner state as Proofline canonical state.
 6. No broad raw mutation tokens inside worker sessions unless mediated, scoped, and audited.
 7. No silent mock or fallback data in dashboard execution state.
 8. No acceptance criteria rewrites after approval without explicit review.
-9. No worker-created issues entering the executable DAG without Harness or human acceptance.
+9. No worker-created issues entering the executable DAG without Proofline or human acceptance.
 10. No executor summary accepted without independent artifact verification.
 
 ## Phase 0: Documentation And Design Only
@@ -401,24 +401,24 @@ Exit criteria:
 
 - The architecture boundary is documented.
 - The next disposable-repo trial is specified.
-- Future implementation agents can tell which code belongs in Harness and which belongs in the runner layer.
+- Future implementation agents can tell which code belongs in Proofline and which belongs in the runner layer.
 
 ## Phase 1: Local Dry Run / Disposable Repo Trial
 
-Goal: prove the runner/Harness boundary without operational risk.
+Goal: prove the runner/Proofline boundary without operational risk.
 
 Scope:
 
 - Use a disposable repository.
 - Use fake Linear data or a non-production test project.
 - Run a Symphony-like loop locally or simulate its event stream.
-- Capture runner events into Harness as advisory execution facts.
+- Capture runner events into Proofline as advisory execution facts.
 - Exercise workspace creation, session start, heartbeat, handoff, stall, timeout, and retry events.
-- Verify that Harness refuses to convert runner success into completion without GitHub artifact readback.
+- Verify that Proofline refuses to convert runner success into completion without GitHub artifact readback.
 
 Required proof:
 
-- A runner handoff triggers Harness reevaluation.
+- A runner handoff triggers Proofline reevaluation.
 - Missing artifacts block completion.
 - Valid GitHub readback can satisfy evidence policy.
 - Retry budget exhaustion stops automatic continuation.
@@ -438,11 +438,11 @@ Scope:
 
 - One selected repository.
 - One selected Linear project or label.
-- Harness-approved executable issues only.
+- Proofline-approved executable issues only.
 - Runner may move issues to a handoff state, not `Done`.
 - Runner may attach PR links and progress comments.
-- Harness independently reads GitHub artifacts.
-- Harness writes verified status back to Linear.
+- Proofline independently reads GitHub artifacts.
+- Proofline writes verified status back to Linear.
 - Manual approval required before merge.
 
 Required controls:
@@ -457,18 +457,18 @@ Required controls:
 Exit criteria:
 
 - Real Linear issue can be executed into a PR handoff.
-- Harness blocks completion when proof is missing or contradictory.
-- Harness accepts completion only after evidence and reconciliation pass.
-- No runner path can mark Harness task `completed` directly.
+- Proofline blocks completion when proof is missing or contradictory.
+- Proofline accepts completion only after evidence and reconciliation pass.
+- No runner path can mark a Proofline task `completed` directly.
 
-## Phase 3: Productionized Harness Execution Substrate
+## Phase 3: Productionized Proofline Execution Substrate
 
-Goal: make Symphony-like execution a replaceable substrate under Harness.
+Goal: make Symphony-like execution a replaceable substrate under Proofline.
 
 Scope:
 
 - Hardened runner adapter.
-- Persisted dispatch, attempt, retry, and event state in Harness.
+- Persisted dispatch, attempt, retry, and event state in Proofline.
 - Project-level DAG orchestration from approved specs into Linear.
 - Repair dispatch when verification fails.
 - Operator controls for pause, resume, cancel, redispatch, and quarantine.
@@ -476,16 +476,16 @@ Scope:
 
 Possible future auto-merge:
 
-Auto-merge should remain off by default. It may become a policy-gated capability only for explicitly low-risk work after Harness proves:
+Auto-merge should remain off by default. It may become a policy-gated capability only for explicitly low-risk work after Proofline proves:
 
 - required CI checks pass
 - review requirements pass or are waived by policy
 - PR branch and commit match the current execution attempt
-- no blocking Linear/GitHub/Harness mismatch exists
+- no blocking Linear/GitHub/Proofline mismatch exists
 - rollback or repair path is defined
 - audit trail records the reason merge was allowed
 
-## Duplicative Harness Areas To Revisit
+## Duplicative Proofline Areas To Revisit
 
 After Phase 0 is merged, review these areas for code that should wrap a Symphony-like substrate instead of duplicating one:
 
@@ -496,7 +496,7 @@ After Phase 0 is merged, review these areas for code that should wrap a Symphony
 - stale supervision loops that only keep workers busy
 - dashboard runtime status that lacks runner/session semantics
 
-Do not remove verification, reconciliation, completion-claim interception, manual review, TaskEnvelope validation, or GitHub artifact validation. Those are Harness core.
+Do not remove verification, reconciliation, completion-claim interception, manual review, TaskEnvelope validation, or GitHub artifact validation. Those are Proofline core.
 
 ## Recommended Next Implementation PR
 
@@ -509,4 +509,4 @@ After this design PR merges, the next PR should be a dry-run runner-event ingest
 - Do not run Symphony against live work.
 - Do not mutate Linear or GitHub.
 
-That PR moves Harness toward a Symphony-compatible architecture without creating operational risk.
+That PR moves Proofline toward a Symphony-compatible architecture without creating operational risk.

--- a/docs/architecture/verification-and-completion-enforcement.md
+++ b/docs/architecture/verification-and-completion-enforcement.md
@@ -2,15 +2,15 @@
 
 ## Purpose
 
-Define the canonical verification and completion enforcement contract for Harness.
+Define the canonical verification and completion enforcement contract for Proofline.
 
-Harness is a reliability/control-plane system. Completion is not accepted because an executor reported success. Completion is a control-plane decision made by evaluating runtime facts, artifact evidence, acceptance criteria, and reconciliation results.
+Proofline is a reliability/control-plane system. Completion is not accepted because an executor reported success. Completion is a control-plane decision made by evaluating runtime facts, artifact evidence, acceptance criteria, and reconciliation results.
 
 Verification is therefore the policy layer that decides whether a task outcome is trustworthy enough to remain completed.
 
 ## Verification Role
 
-Verification consumes the facts produced by other modules and applies Harness completion policy to them.
+Verification consumes the facts produced by other modules and applies Proofline completion policy to them.
 
 It is responsible for:
 
@@ -76,11 +76,11 @@ Verification consumes:
 
 These records determine whether completion has the required evidentiary support.
 
-Caller-submitted evidence is not allowed to self-attest final trust. In particular, a completion claim cannot force a repository-backed PR artifact into `verification_status=verified` and then rely on that same caller-set state to satisfy completion policy. Harness must either verify the artifact through reconciliation or leave it unverified.
+Caller-submitted evidence is not allowed to self-attest final trust. In particular, a completion claim cannot force a repository-backed PR artifact into `verification_status=verified` and then rely on that same caller-set state to satisfy completion policy. Proofline must either verify the artifact through reconciliation or leave it unverified.
 
 ### Reconciliation Results
 
-Verification consumes reconciliation results that compare Harness state to external systems.
+Verification consumes reconciliation results that compare Proofline state to external systems.
 
 Initial scope includes:
 
@@ -98,7 +98,7 @@ These criteria define what the task must satisfy in system terms.
 
 Artifacts and reconciliation support completion, but they do not replace task-specific acceptance criteria.
 
-Required acceptance criteria must also be concrete enough for automatic completion. Criteria such as "it works", "done", or other generic quality claims are not strong enough on their own to justify a terminal success decision. Harness may allow such tasks to exist, but verification should escalate them to explicit human review rather than auto-completing on vague criteria.
+Required acceptance criteria must also be concrete enough for automatic completion. Criteria such as "it works", "done", or other generic quality claims are not strong enough on their own to justify a terminal success decision. Proofline may allow such tasks to exist, but verification should escalate them to explicit human review rather than auto-completing on vague criteria.
 
 Reevaluation also must not preload terminal evidence state as a side channel. If a request is not itself a claimed completion, it may not set `completion_evidence.status=satisfied`, inject validated artifact IDs, or otherwise present completion evidence as already settled.
 
@@ -297,7 +297,7 @@ This distinction must remain explicit.
 - reconciliation is non-blocking
 - verification policy accepts the result
 
-If these collapse into one concept, Harness stops being a reliability layer.
+If these collapse into one concept, Proofline stops being a reliability layer.
 
 ## Insufficient Evidence Versus External Mismatch
 
@@ -428,7 +428,7 @@ The boundary between runtime and verification must remain strict.
 
 Runtime may say "the worker says it finished."
 
-Verification decides whether Harness believes that should count.
+Verification decides whether Proofline believes that should count.
 
 ## Reconciliation Versus Verification
 
@@ -436,7 +436,7 @@ Reconciliation and verification are related but not identical.
 
 ### Reconciliation Owns
 
-- comparing Harness records against GitHub and Linear facts
+- comparing Proofline records against GitHub and Linear facts
 - classifying mismatch conditions
 - reporting whether blocking contradictions exist
 


### PR DESCRIPTION
## Summary
- update active architecture boundary docs to use Proofline for the product/control-plane role
- keep Harness only where it refers to compatibility paths, implementation identifiers, or the OpenAI article title
- align Symphony, runtime, dispatch, Linear, verification, reconciliation, and completion-interception docs with the staged rename

## Validation
- git diff --check
- git diff --cached --check
- rg check for stale strategic Harness boundary phrases

## Notes
- docs-only change
- no Symphony execution
- no live Linear/GitHub work touched