### PR TITLE
Add Proofline API env aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # Local dashboard -> local API override.
 # Hosted Vercel deployments ignore this override and route to the same
 # deployment's /backend service automatically.
-HARNESS_API_BASE_URL=http://127.0.0.1:8000
+PROOFLINE_API_BASE_URL=http://127.0.0.1:8000
+# Compatibility alias. Keep this valid while existing local scripts and
+# deployments still use the Harness implementation namespace.
+# HARNESS_API_BASE_URL=http://127.0.0.1:8000
 
 # Reset-slice verifier secrets for local development.
 # GITHUB_TOKEN=ghp_...

--- a/docs/architecture/proofline-rename-migration.md
+++ b/docs/architecture/proofline-rename-migration.md
@@ -17,7 +17,7 @@ This is a staged compatibility migration, not a mechanical rename.
 - Next.js package name
 - CLI examples based on `python3 -m modules.local_runtime`
 - API proxy route `app/api/proofline/[...path]`, with `app/api/harness/[...path]` retained as a compatibility alias
-- environment variables such as `HARNESS_API_BASE_URL`
+- environment variables such as `PROOFLINE_API_BASE_URL`, with `HARNESS_API_BASE_URL` retained as a compatibility alias
 - persisted runtime fields such as `harness_state`
 - existing docs, demos, tests, and historical artifacts that refer to the implementation
 
@@ -56,7 +56,8 @@ These are compatibility surfaces, not branding copy.
 | CLI command shape | `python3 -m modules.local_runtime ...`, future `harness ...` examples | alias-first | Do not introduce a Proofline command until existing commands are documented and tested as compatibility aliases. |
 | Frontend package name | `harness-dashboard` in `package.json` | rename-later | Rename only after build, deployment, and local dashboard packaging checks prove no package-name coupling. |
 | Next.js proxy route | `app/api/proofline/[...path]`, `app/api/harness/[...path]` | alias-first | The Proofline route is the dashboard default. Keep the Harness route as a compatibility alias until external links and deployments have migrated. Both routes must share the same backend proxy behavior. |
-| API base env vars | `HARNESS_API_BASE_URL`, `HARNESS_STORE_BACKEND`, `HARNESS_SQLITE_PATH`, `HARNESS_RUNTIME_*` | alias-first | Keep old env vars valid. Add Proofline aliases only if precedence and conflict behavior are documented and tested. |
+| API base env vars | `PROOFLINE_API_BASE_URL`, `NEXT_PUBLIC_PROOFLINE_API_BASE_URL`, `HARNESS_API_BASE_URL`, `NEXT_PUBLIC_HARNESS_API_BASE_URL` | alias-first | Prefer Proofline-named overrides when both are present. Keep Harness-named overrides valid as compatibility fallbacks. Hosted same-project Vercel routing still takes precedence over either explicit override. |
+| Storage/runtime env vars | `HARNESS_STORE_BACKEND`, `HARNESS_SQLITE_PATH`, `HARNESS_RUNTIME_*` | rename-later | Keep old env vars valid. Add Proofline aliases only after storage/runtime precedence and conflict behavior are documented and tested. |
 | Secret/service namespace | `com.knoxanalytics.harness.local-runtime`, Keychain/service labels | alias-first | Do not rename until migration preserves existing stored secrets or documents an explicit migration command. |
 | Persisted schema fields | `harness_state`, `source_system=harness`, artifact metadata like `harness-task-id` | stable compatibility | Do not rename in-place. Add new projection fields only if old fields remain readable. |
 | Task contract name | `TaskEnvelope` | stable | Do not rename unless schema versioning, docs, adapter mappings, and tests are updated together. |

--- a/docs/howto/configure-harness.md
+++ b/docs/howto/configure-harness.md
@@ -38,6 +38,7 @@ Common local variables:
 
 - `GITHUB_TOKEN`
 - `LINEAR_API_KEY`
+- `PROOFLINE_API_BASE_URL=http://127.0.0.1:8000`
 - `HARNESS_API_BASE_URL=http://127.0.0.1:8000`
 - `HARNESS_STORE_BACKEND=file`
 - `HARNESS_STORE_BACKEND=sqlite`
@@ -45,6 +46,8 @@ Common local variables:
 - `HARNESS_STORE_BACKEND=postgres`
 - `DATABASE_URL`
 - `POSTGRES_URL`
+
+`PROOFLINE_API_BASE_URL` is preferred for the dashboard/backend proxy override. `HARNESS_API_BASE_URL` remains a compatibility fallback for existing local files and deployments. Hosted same-project Vercel deployments still derive the backend route automatically and ignore either explicit override.
 
 ## Desktop-Agent Bridge Wiring
 

--- a/docs/howto/local-quickstart.md
+++ b/docs/howto/local-quickstart.md
@@ -22,7 +22,8 @@ Create repo-root `.env.local` when you need live GitHub or Linear validation:
 ```bash
 GITHUB_TOKEN=...
 LINEAR_API_KEY=...
-HARNESS_API_BASE_URL=http://127.0.0.1:8000
+PROOFLINE_API_BASE_URL=http://127.0.0.1:8000
+# HARNESS_API_BASE_URL remains a compatibility fallback.
 ```
 
 Start the backend:

--- a/docs/howto/troubleshoot.md
+++ b/docs/howto/troubleshoot.md
@@ -19,6 +19,7 @@ Hosted `/reset/*` should fail explicitly if reset storage cannot initialize. It 
 
 Check:
 
+- `PROOFLINE_API_BASE_URL`
 - `HARNESS_API_BASE_URL`
 - backend reachability
 - whether the hosted dashboard is using the same-project `/backend` route

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -44,8 +44,10 @@ cp .env.example .env.local
 Set:
 
 ```bash
-HARNESS_API_BASE_URL=http://127.0.0.1:8000
+PROOFLINE_API_BASE_URL=http://127.0.0.1:8000
 ```
+
+`HARNESS_API_BASE_URL` remains a compatibility fallback. If both names are set, the Proofline-named override wins in local frontend/proxy resolution.
 
 Frontend validation:
 
@@ -370,7 +372,7 @@ See [`docs/setup/vercel-neon.md`](vercel-neon.md) for the default hosted runbook
 
 ## Local Vs Hosted Behavior
 
-Local frontend development can still use `HARNESS_API_BASE_URL` as an explicit override.
+Local frontend development should use `PROOFLINE_API_BASE_URL` as the explicit override. `HARNESS_API_BASE_URL` remains supported as a compatibility fallback.
 
 Hosted deployments running behind the same Vercel project derive the backend route automatically from the deployment URL and the `/backend` route prefix.
 

--- a/lib/harness-api-base.ts
+++ b/lib/harness-api-base.ts
@@ -5,14 +5,18 @@ function stripTrailingSlash(value: string): string {
 }
 
 export function resolveHarnessApiBaseUrl(
-  env: Partial<Record<"HARNESS_API_BASE_URL" | "VERCEL_URL", string | undefined>>,
+  env: Partial<
+    Record<"PROOFLINE_API_BASE_URL" | "HARNESS_API_BASE_URL" | "VERCEL_URL", string | undefined>
+  >,
 ): string | null {
   const vercelUrl = env.VERCEL_URL?.trim();
   if (vercelUrl) {
     return `https://${stripTrailingSlash(vercelUrl)}${DEFAULT_VERCEL_BACKEND_ROUTE_PREFIX}`;
   }
 
-  const explicit = env.HARNESS_API_BASE_URL?.trim();
+  const prooflineExplicit = env.PROOFLINE_API_BASE_URL?.trim();
+  const harnessExplicit = env.HARNESS_API_BASE_URL?.trim();
+  const explicit = prooflineExplicit || harnessExplicit;
   if (explicit) {
     return stripTrailingSlash(explicit);
   }

--- a/lib/harness-api.ts
+++ b/lib/harness-api.ts
@@ -32,7 +32,9 @@ export function resolveDashboardApiBasePath(): string {
     }
   }
 
-  const publicBaseUrl = process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL?.trim();
+  const prooflinePublicBaseUrl = process.env.NEXT_PUBLIC_PROOFLINE_API_BASE_URL?.trim();
+  const harnessPublicBaseUrl = process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL?.trim();
+  const publicBaseUrl = prooflinePublicBaseUrl || harnessPublicBaseUrl;
   if (publicBaseUrl) {
     return stripTrailingSlash(publicBaseUrl);
   }

--- a/lib/proofline-api-proxy.ts
+++ b/lib/proofline-api-proxy.ts
@@ -4,6 +4,7 @@ import { resolveHarnessApiBaseUrl } from "@/lib/harness-api-base";
 
 function getBaseUrl(): string | null {
   return resolveHarnessApiBaseUrl({
+    PROOFLINE_API_BASE_URL: process.env.PROOFLINE_API_BASE_URL,
     HARNESS_API_BASE_URL: process.env.HARNESS_API_BASE_URL,
     VERCEL_URL: process.env.VERCEL_URL,
   });
@@ -18,7 +19,7 @@ export async function proxyProoflineApiRequest(
     return NextResponse.json(
       {
         error:
-          "Proofline API base URL could not be resolved. Set HARNESS_API_BASE_URL locally or deploy behind Vercel Services.",
+          "Proofline API base URL could not be resolved. Set PROOFLINE_API_BASE_URL or HARNESS_API_BASE_URL locally, or deploy behind Vercel Services.",
       },
       { status: 503 },
     );

--- a/tests/frontend/dashboard-api-base.test.ts
+++ b/tests/frontend/dashboard-api-base.test.ts
@@ -10,6 +10,7 @@ type TestWindow = {
 };
 
 function resetEnvironment() {
+  delete process.env.NEXT_PUBLIC_PROOFLINE_API_BASE_URL;
   delete process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL;
   delete process.env.NEXT_PUBLIC_HARNESS_DASHBOARD_MODE;
   delete (globalThis as { window?: TestWindow }).window;
@@ -32,15 +33,39 @@ test("uses same-origin API paths for local static dashboard builds", () => {
   assert.equal(resolveDashboardApiBasePath(), "");
 });
 
-test("uses explicit public API base URL when configured", () => {
+test("uses explicit Proofline public API base URL when configured", () => {
+  resetEnvironment();
+  process.env.NEXT_PUBLIC_PROOFLINE_API_BASE_URL = "http://127.0.0.1:8765/";
+
+  assert.equal(resolveDashboardApiBasePath(), "http://127.0.0.1:8765");
+});
+
+test("uses Harness public API base URL as compatibility fallback", () => {
   resetEnvironment();
   process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL = "http://127.0.0.1:8765/";
 
   assert.equal(resolveDashboardApiBasePath(), "http://127.0.0.1:8765");
 });
 
+test("prefers Proofline public API base URL over Harness compatibility fallback", () => {
+  resetEnvironment();
+  process.env.NEXT_PUBLIC_PROOFLINE_API_BASE_URL = "http://proofline.example/";
+  process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL = "http://harness.example/";
+
+  assert.equal(resolveDashboardApiBasePath(), "http://proofline.example");
+});
+
+test("ignores blank Proofline public API base URL before using Harness fallback", () => {
+  resetEnvironment();
+  process.env.NEXT_PUBLIC_PROOFLINE_API_BASE_URL = "  ";
+  process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL = "http://harness.example/";
+
+  assert.equal(resolveDashboardApiBasePath(), "http://harness.example");
+});
+
 test("runtime dashboard config wins over build-time environment", () => {
   resetEnvironment();
+  process.env.NEXT_PUBLIC_PROOFLINE_API_BASE_URL = "http://proofline-build.example/";
   process.env.NEXT_PUBLIC_HARNESS_API_BASE_URL = "http://build-time.example/";
   (globalThis as { window?: TestWindow }).window = {
     __HARNESS_DASHBOARD_CONFIG__: {

--- a/tests/frontend/harness-api-base.test.ts
+++ b/tests/frontend/harness-api-base.test.ts
@@ -3,16 +3,43 @@ import test from "node:test";
 
 import { resolveHarnessApiBaseUrl } from "../../lib/harness-api-base";
 
-test("prefers explicit HARNESS_API_BASE_URL and strips a trailing slash", () => {
+test("prefers explicit PROOFLINE_API_BASE_URL and strips a trailing slash", () => {
   const resolved = resolveHarnessApiBaseUrl({
-    HARNESS_API_BASE_URL: "https://api.example.com/",
+    PROOFLINE_API_BASE_URL: "https://api.example.com/",
   });
 
   assert.equal(resolved, "https://api.example.com");
 });
 
+test("uses HARNESS_API_BASE_URL as a compatibility fallback", () => {
+  const resolved = resolveHarnessApiBaseUrl({
+    HARNESS_API_BASE_URL: "https://compat-api.example.com/",
+  });
+
+  assert.equal(resolved, "https://compat-api.example.com");
+});
+
+test("prefers PROOFLINE_API_BASE_URL over HARNESS_API_BASE_URL", () => {
+  const resolved = resolveHarnessApiBaseUrl({
+    PROOFLINE_API_BASE_URL: "https://proofline-api.example.com/",
+    HARNESS_API_BASE_URL: "https://compat-api.example.com/",
+  });
+
+  assert.equal(resolved, "https://proofline-api.example.com");
+});
+
+test("ignores blank PROOFLINE_API_BASE_URL before using HARNESS_API_BASE_URL", () => {
+  const resolved = resolveHarnessApiBaseUrl({
+    PROOFLINE_API_BASE_URL: "  ",
+    HARNESS_API_BASE_URL: "https://compat-api.example.com/",
+  });
+
+  assert.equal(resolved, "https://compat-api.example.com");
+});
+
 test("prefers same-project Vercel routing over explicit overrides in hosted deployments", () => {
   const resolved = resolveHarnessApiBaseUrl({
+    PROOFLINE_API_BASE_URL: "https://proofline-api.example.com/",
     HARNESS_API_BASE_URL: "https://stale-backend.example.com/",
     VERCEL_URL: "harness-preview.vercel.app",
   });


### PR DESCRIPTION
## Summary
- add `PROOFLINE_API_BASE_URL` support for the dashboard/server API proxy while keeping `HARNESS_API_BASE_URL` as a compatibility fallback
- add `NEXT_PUBLIC_PROOFLINE_API_BASE_URL` support for frontend builds while keeping `NEXT_PUBLIC_HARNESS_API_BASE_URL` as a fallback
- document precedence: hosted same-project Vercel routing wins, then Proofline-named overrides, then Harness compatibility overrides

## Validation
- pnpm lint
- pnpm test:frontend (rerun with permissions after sandbox blocked tsx IPC pipe)
- pnpm build
- git diff --check
- git diff --cached --check

## Notes
- alias-first only; no storage/runtime env rename
- no Symphony execution
- no live Linear/GitHub work touched