### PR TITLE
Pin CI workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+        with:
+          version: 10
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "22"
           cache: pnpm
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-        with:
-          version: 10
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
@@ -33,16 +33,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "22"
           cache: pnpm
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           version: 10
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "24 9 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - javascript-typescript
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ed410739ba306e4ebe5e123421a6bd694e494a2b
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@ed410739ba306e4ebe5e123421a6bd694e494a2b
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@ed410739ba306e4ebe5e123421a6bd694e494a2b

--- a/tests/test_hosted_docs.py
+++ b/tests/test_hosted_docs.py
@@ -48,6 +48,7 @@ class HostedDocsTests(unittest.TestCase):
         contributing = Path("CONTRIBUTING.md").read_text(encoding="utf-8")
         security = Path("SECURITY.md").read_text(encoding="utf-8")
         ci = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        codeql = Path(".github/workflows/codeql.yml").read_text(encoding="utf-8")
         dependabot = Path(".github/dependabot.yml").read_text(encoding="utf-8")
 
         self.assertIn("Proofline is still early", contributing)
@@ -56,6 +57,8 @@ class HostedDocsTests(unittest.TestCase):
         self.assertIn("executor and agent summaries are advisory only", security)
         self.assertIn("python -m unittest discover -s tests", ci)
         self.assertIn("pnpm lint", ci)
+        self.assertIn("github/codeql-action/analyze@", codeql)
+        self.assertIn("security-events: write", codeql)
         self.assertIn("package-ecosystem: github-actions", dependabot)
         self.assertTrue(Path(".github/pull_request_template.md").exists())
         self.assertTrue(Path(".github/ISSUE_TEMPLATE/bug_report.md").exists())


### PR DESCRIPTION
## Summary
- Pin GitHub Actions workflow dependencies to full commit SHAs so the public repository can require action pinning.

## Validation
- python3 -m unittest tests.test_hosted_docs -v
- git diff --check