### PR TITLE
Suppress verified CodeQL sanitization sinks

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -33,6 +33,7 @@ def _public_json_value(value: Any, *, field_name: str | None = None) -> Any:
 def _json_response(result: tuple[int, dict[str, Any]]) -> JSONResponse:
     status_code, payload = result
     public_payload = _public_json_value(payload)
+    # codeql[py/stack-trace-exposure] API payloads strip traceback-shaped fields above.
     return JSONResponse(status_code=int(status_code), content=public_payload)
 
 

--- a/modules/local_runtime.py
+++ b/modules/local_runtime.py
@@ -1560,6 +1560,7 @@ def _handle_secrets_command(args: argparse.Namespace, *, as_json: bool) -> int:
 def _emit(payload: dict[str, Any], *, as_json: bool, exit_code: int = EXIT_OK) -> int:
     if as_json:
         safe_payload = _safe_cli_json_value(payload)
+        # codeql[py/clear-text-logging-sensitive-data] CLI JSON is explicitly sanitized above.
         print(json.dumps(safe_payload, indent=2, sort_keys=True))
         return exit_code
 


### PR DESCRIPTION
## Summary
- add narrow inline CodeQL suppressions where sanitized payloads are emitted
- keep the runtime JSON redaction and API traceback-field stripping added in #407

## Validation
- python3 -m unittest tests.test_local_runtime tests.test_fastapi_backend -v
- git diff --check