### PR TITLE
Disable Vercel preview deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "*": false
+    }
+  },
   "experimentalServices": {
     "web": {
       "entrypoint": ".",


### PR DESCRIPTION
## Summary
- disables automatic Vercel Git deployments for non-main branches
- keeps production deployments enabled for main
- avoids the Neon preview resource provisioning failure on PRs

## Validation
- python3 -m json.tool vercel.json
- git diff --check

## Notes
This does not change the Neon resource, database credentials, or production deployment path. The existing Vercel project-level ignored-build setting is also set to skip non-main branches, but the failed redeploy showed Neon provisioning happens before that setting is sufficient; the repo-level Git deployment rule is the durable fix.