### PR TITLE
feat: add Auto-build buildroom v0

### DIFF
--- a/buildroom/README.md
+++ b/buildroom/README.md
@@ -1,0 +1,47 @@
+# Auto-build Buildroom
+
+The buildroom is a filesystem-backed contract chain for approval-gated Auto-build work.
+
+It is deliberately boring in v0:
+
+- no cron
+- no unattended commits
+- no production deploys
+- no private Hermes runtime state
+- no deletion side effects
+- no live GitHub or Linear mutation
+
+The point is to prove that a candidate signal can move through evidence, idea shaping, Main approval, bounded planning, implementation receipt, independent QA, trust reporting, retention recommendation, and operator summary without blurring truth boundaries.
+
+## Contract Chain
+
+A complete local buildroom contains these ordered artifacts:
+
+1. `research_packet`
+2. `idea_contract`
+3. `intent_review`
+4. `main_review`
+5. `product_plan`
+6. `build_plan`
+7. `coder_receipt`
+8. `qa_receipt`
+9. `verification_delta`
+10. `trust_report`
+11. `retention_review`
+12. `operator_summary`
+
+## Guardrails
+
+- Dreamer/Auto-think may create an idea contract, but it cannot approve itself.
+- Main approval is required before build planning.
+- Coder must stay within the product plan's allowed paths / planned files.
+- QA must be independent from Coder.
+- Trust reporting compresses room health without hiding uncertainty.
+- Retention is recommendation-only in v0; it never deletes or moves live artifacts.
+
+## Validate
+
+```bash
+python3 scripts/validate_buildroom.py buildroom/examples/demo-room
+python3 -m unittest tests.test_buildroom_contract -v
+```

--- a/buildroom/examples/demo-room/01-research-packet.json
+++ b/buildroom/examples/demo-room/01-research-packet.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "research_packet",
+  "id": "research-demo-client-html-delivery",
+  "role": "research",
+  "summary": "Sean needs a reliable client/prospect delivery lane for generated HTML artifacts.",
+  "evidence": [
+    {
+      "source": "github_issue",
+      "ref": "sfayka/business-process-audit-studio#44",
+      "finding": "BP Audit Studio has artifact generation but needs static web bucket delivery."
+    },
+    {
+      "source": "x_article",
+      "ref": "2052796100608974848",
+      "finding": "HTML artifacts are easier to read, share, and enrich than raw Markdown."
+    }
+  ],
+  "signals": [
+    "client_delivery_gap",
+    "shareable_html_artifact",
+    "static_bucket_hosting"
+  ]
+}

--- a/buildroom/examples/demo-room/02-idea-contract.json
+++ b/buildroom/examples/demo-room/02-idea-contract.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "idea_contract",
+  "id": "idea-demo-client-html-delivery",
+  "role": "dreamer",
+  "title": "Client-facing HTML delivery lane",
+  "beneficiary": "Knox Analytics clients and prospects",
+  "why_now": "BP Audit Studio is ready to produce useful artifacts, but client delivery is still manual.",
+  "proposal": "Add a static bucket-backed publishing mechanism for generated HTML artifacts.",
+  "out_of_scope": [
+    "unattended deployment",
+    "email sending",
+    "deleting old artifacts"
+  ],
+  "verification": [
+    "artifact renders locally",
+    "publish target is configurable",
+    "client URL is copyable"
+  ],
+  "approval_authority": "main_review"
+}

--- a/buildroom/examples/demo-room/03-intent-review.json
+++ b/buildroom/examples/demo-room/03-intent-review.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "intent_review",
+  "id": "intent-demo-client-html-delivery",
+  "role": "main",
+  "decision": "ready_for_main_review",
+  "rationale": "Evidence is specific, scope is bounded, and work can be verified without live mutations."
+}

--- a/buildroom/examples/demo-room/04-main-review.json
+++ b/buildroom/examples/demo-room/04-main-review.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "main_review",
+  "id": "main-demo-client-html-delivery",
+  "role": "main",
+  "decision": "approved",
+  "approved_scope": [
+    "local buildroom template",
+    "static publishing issue linkage",
+    "guardrail validation"
+  ],
+  "blocked_scope": [
+    "cron automation",
+    "unattended commits",
+    "production deployment"
+  ]
+}

--- a/buildroom/examples/demo-room/05-product-plan.json
+++ b/buildroom/examples/demo-room/05-product-plan.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "product_plan",
+  "id": "product-demo-client-html-delivery",
+  "role": "main",
+  "main_review_id": "main-demo-client-html-delivery",
+  "allowed_paths": [
+    "docs/architecture/autobuild-buildroom.md",
+    "buildroom/README.md",
+    "buildroom/schemas/buildroom-artifact.schema.json",
+    "buildroom/examples/demo-room/README.md",
+    "scripts/validate_buildroom.py",
+    "tests/test_buildroom_contract.py"
+  ],
+  "planned_files": [
+    "docs/architecture/autobuild-buildroom.md",
+    "buildroom/README.md",
+    "buildroom/schemas/buildroom-artifact.schema.json",
+    "buildroom/examples/demo-room/README.md",
+    "scripts/validate_buildroom.py",
+    "tests/test_buildroom_contract.py"
+  ],
+  "acceptance_checks": [
+    "python3 -m unittest tests.test_buildroom_contract -v",
+    "python3 scripts/validate_buildroom.py buildroom/examples/demo-room"
+  ],
+  "risk_notes": [
+    "Do not make Proofline an execution scheduler.",
+    "Do not enable live mutations in v0."
+  ]
+}

--- a/buildroom/examples/demo-room/06-build-plan.json
+++ b/buildroom/examples/demo-room/06-build-plan.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "build_plan",
+  "id": "build-demo-client-html-delivery",
+  "role": "coder",
+  "main_review_id": "main-demo-client-html-delivery",
+  "product_plan_id": "product-demo-client-html-delivery",
+  "steps": [
+    "create buildroom docs",
+    "create generic artifact schema",
+    "create demo room artifacts",
+    "create validator",
+    "add contract tests"
+  ],
+  "execution_mode": "local_filesystem_only"
+}

--- a/buildroom/examples/demo-room/07-coder-receipt.json
+++ b/buildroom/examples/demo-room/07-coder-receipt.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "coder_receipt",
+  "id": "coder-demo-client-html-delivery",
+  "role": "coder",
+  "implemented_by": "coder-agent",
+  "build_plan_id": "build-demo-client-html-delivery",
+  "changed_paths": [
+    "docs/architecture/autobuild-buildroom.md",
+    "buildroom/README.md",
+    "buildroom/schemas/buildroom-artifact.schema.json",
+    "buildroom/examples/demo-room/README.md",
+    "scripts/validate_buildroom.py",
+    "tests/test_buildroom_contract.py"
+  ],
+  "commands_run": [
+    "python3 -m unittest tests.test_buildroom_contract -v",
+    "python3 scripts/validate_buildroom.py buildroom/examples/demo-room"
+  ],
+  "claims_complete": true
+}

--- a/buildroom/examples/demo-room/08-qa-receipt.json
+++ b/buildroom/examples/demo-room/08-qa-receipt.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "qa_receipt",
+  "id": "qa-demo-client-html-delivery",
+  "role": "qa",
+  "verified_by": "qa-agent",
+  "coder_receipt_id": "coder-demo-client-html-delivery",
+  "decision": "verified",
+  "evidence_checked": [
+    "expected artifact chain exists",
+    "validator rejects changed paths outside product plan",
+    "no live mutations enabled",
+    "retention is recommendation-only"
+  ]
+}

--- a/buildroom/examples/demo-room/09-verification-delta.json
+++ b/buildroom/examples/demo-room/09-verification-delta.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "verification_delta",
+  "id": "delta-demo-client-html-delivery",
+  "role": "qa",
+  "coder_receipt_id": "coder-demo-client-html-delivery",
+  "qa_receipt_id": "qa-demo-client-html-delivery",
+  "state": "confirmed",
+  "notes": "Coder receipt and QA receipt agree on local-only artifact chain and guardrails."
+}

--- a/buildroom/examples/demo-room/10-trust-report.json
+++ b/buildroom/examples/demo-room/10-trust-report.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "trust_report",
+  "id": "trust-demo-client-html-delivery",
+  "role": "trust",
+  "state": "clean",
+  "watch_items": [
+    "Publishing backend remains unimplemented in this buildroom v0 slice."
+  ],
+  "investigate_items": []
+}

--- a/buildroom/examples/demo-room/11-retention-review.json
+++ b/buildroom/examples/demo-room/11-retention-review.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "retention_review",
+  "id": "retention-demo-client-html-delivery",
+  "role": "retention",
+  "recommendation": "keep",
+  "side_effects": "none",
+  "rationale": "Keep as a reusable demo packet and validation fixture. Retention does not delete or move live state."
+}

--- a/buildroom/examples/demo-room/12-operator-summary.json
+++ b/buildroom/examples/demo-room/12-operator-summary.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "buildroom.v0",
+  "job_id": "demo-client-html-delivery",
+  "live_mutations_enabled": false,
+  "kind": "operator_summary",
+  "id": "operator-demo-client-html-delivery",
+  "role": "operator",
+  "headline": "Auto-build v0 local buildroom demo is clean.",
+  "status": "ready_for_review",
+  "links": [
+    "buildroom/examples/demo-room",
+    "docs/architecture/autobuild-buildroom.md"
+  ],
+  "next_actions": [
+    "Review the local contract chain.",
+    "Only then consider adding cron or dashboard surfaces."
+  ]
+}

--- a/buildroom/examples/demo-room/README.md
+++ b/buildroom/examples/demo-room/README.md
@@ -1,0 +1,13 @@
+# Demo Room: Client HTML Delivery
+
+This sanitized demo room models a Knox Auto-build v0 flow for client-facing HTML delivery.
+
+It starts from evidence that BP Audit Studio needs a better client/prospect delivery mechanism and ends with a clean operator summary. It does **not** publish, deploy, mutate GitHub/Linear, or delete anything.
+
+Run:
+
+```bash
+python3 scripts/validate_buildroom.py buildroom/examples/demo-room
+```
+
+Expected result: `valid: true`, trust state `clean`, retention recommendation `keep`.

--- a/buildroom/schemas/buildroom-artifact.schema.json
+++ b/buildroom/schemas/buildroom-artifact.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://proofline.local/schemas/buildroom-artifact.schema.json",
+  "title": "Proofline Auto-build v0 Buildroom Artifact",
+  "type": "object",
+  "required": ["schema_version", "kind", "id", "job_id", "role", "live_mutations_enabled"],
+  "properties": {
+    "schema_version": {
+      "const": "buildroom.v0"
+    },
+    "kind": {
+      "enum": [
+        "research_packet",
+        "idea_contract",
+        "intent_review",
+        "main_review",
+        "product_plan",
+        "build_plan",
+        "coder_receipt",
+        "qa_receipt",
+        "verification_delta",
+        "trust_report",
+        "retention_review",
+        "operator_summary"
+      ]
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "job_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "role": {
+      "enum": ["research", "dreamer", "main", "coder", "qa", "trust", "retention", "operator"]
+    },
+    "live_mutations_enabled": {
+      "const": false
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/architecture/autobuild-buildroom.md
+++ b/docs/architecture/autobuild-buildroom.md
@@ -1,0 +1,84 @@
+# Auto-build Buildroom Architecture
+
+Auto-build v0 is a local, approval-gated contract chain. It is not a scheduler, runtime, PM tool, or permission slip for agents to build whatever they notice.
+
+## Why This Exists
+
+Research and agents can surface more candidate work than Sean should manually track. The useful capability is not automatic output volume; it is compounding judgment with receipts.
+
+The buildroom turns a signal into reviewable work only when the handoff is explicit:
+
+```text
+research packet
+  -> idea contract
+  -> intent review
+  -> Main review
+  -> product plan
+  -> build plan
+  -> coder receipt
+  -> QA receipt
+  -> verification delta
+  -> trust report
+  -> retention review
+  -> operator summary
+```
+
+## Role Boundaries
+
+- **Research** gathers evidence.
+- **Dreamer / Auto-think** shapes signals into candidate idea contracts.
+- **Main** decides whether a candidate is worth building and writes the bounded product plan.
+- **Coder** implements only the approved, bounded plan.
+- **QA** independently verifies the implementation and evidence.
+- **Trust** summarizes room health as `clean`, `watch`, or `investigate`.
+- **Retention** recommends `keep`, `improve`, `park`, or `prune` without side effects.
+- **Operator** sees the compressed status and next actions.
+
+## v0 Constraints
+
+The first useful version is intentionally local:
+
+- no cron
+- no live GitHub/Linear mutation
+- no unattended commits
+- no production deploys
+- no deletion or pruning side effects
+- no private runtime path dependency
+- no expansion of Proofline into an execution scheduler
+
+## Acceptance Boundary
+
+Proofline remains the acceptance authority. Coder receipts are evidence, not truth. QA receipts are independent evidence, not automatic acceptance. Trust reports compress state, but they must not hide uncertainty.
+
+The buildroom strengthens existing Proofline boundaries by making the planning-to-build handoff explicit and auditable.
+
+## Validation
+
+Use:
+
+```bash
+python3 scripts/validate_buildroom.py buildroom/examples/demo-room
+python3 -m unittest tests.test_buildroom_contract -v
+```
+
+The validator checks:
+
+- required ordered artifacts exist
+- all artifacts share one `job_id`
+- Dreamer cannot approve itself
+- Main approval precedes build planning
+- Coder changed paths stay within the product plan
+- QA is independent from Coder
+- verification delta is confirmed
+- retention is recommendation-only
+- live mutations are disabled
+
+## Future Work
+
+Only after the local chain proves useful:
+
+1. render operator summaries in the dashboard
+2. add more schemas and fixtures
+3. connect approved product plans to existing Proofline task envelopes
+4. add optional cron-generated candidate packets
+5. add live execution hooks behind explicit operator approval

--- a/scripts/validate_buildroom.py
+++ b/scripts/validate_buildroom.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+EXPECTED_CHAIN = [
+    ("01-research-packet.json", "research_packet"),
+    ("02-idea-contract.json", "idea_contract"),
+    ("03-intent-review.json", "intent_review"),
+    ("04-main-review.json", "main_review"),
+    ("05-product-plan.json", "product_plan"),
+    ("06-build-plan.json", "build_plan"),
+    ("07-coder-receipt.json", "coder_receipt"),
+    ("08-qa-receipt.json", "qa_receipt"),
+    ("09-verification-delta.json", "verification_delta"),
+    ("10-trust-report.json", "trust_report"),
+    ("11-retention-review.json", "retention_review"),
+    ("12-operator-summary.json", "operator_summary"),
+]
+
+
+def _read_json(path: Path, errors: list[str]) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        errors.append(f"missing_required_artifact: {path.name}")
+        return {}
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid_json: {path.name}: {exc}")
+        return {}
+    if not isinstance(data, dict):
+        errors.append(f"artifact_not_object: {path.name}")
+        return {}
+    return data
+
+
+def validate_buildroom(room_path: str | Path) -> dict[str, Any]:
+    """Validate a local Auto-build v0 buildroom contract chain.
+
+    The validator is intentionally deterministic and filesystem-only. It does
+    not call GitHub, Linear, cron, an agent runtime, or any live service.
+    """
+    room = Path(room_path)
+    errors: list[str] = []
+    artifacts: list[dict[str, Any]] = []
+
+    for filename, expected_kind in EXPECTED_CHAIN:
+        artifact = _read_json(room / filename, errors)
+        if not artifact:
+            continue
+        if artifact.get("schema_version") != "buildroom.v0":
+            errors.append(f"unsupported_schema_version: {filename}")
+        if artifact.get("kind") != expected_kind:
+            errors.append(f"unexpected_kind: {filename}: {artifact.get('kind')} != {expected_kind}")
+        artifacts.append(artifact)
+
+    job_ids = {artifact.get("job_id") for artifact in artifacts if artifact.get("job_id")}
+    if len(job_ids) != 1:
+        errors.append(f"job_id_mismatch: {sorted(job_ids)}")
+    job_id = next(iter(job_ids), None) if job_ids else None
+
+    by_kind = {artifact.get("kind"): artifact for artifact in artifacts}
+    idea = by_kind.get("idea_contract", {})
+    intent = by_kind.get("intent_review", {})
+    main = by_kind.get("main_review", {})
+    product = by_kind.get("product_plan", {})
+    build = by_kind.get("build_plan", {})
+    coder = by_kind.get("coder_receipt", {})
+    qa = by_kind.get("qa_receipt", {})
+    delta = by_kind.get("verification_delta", {})
+    trust = by_kind.get("trust_report", {})
+    retention = by_kind.get("retention_review", {})
+
+    if idea.get("approval_authority") != "main_review":
+        errors.append("idea_contract_must_not_self_approve")
+    if intent.get("decision") != "ready_for_main_review":
+        errors.append("intent_review_not_ready")
+    if main.get("decision") != "approved":
+        errors.append("main_review_not_approved")
+    if build.get("main_review_id") != main.get("id"):
+        errors.append("build_plan_missing_main_review_link")
+
+    allowed_paths = set(product.get("allowed_paths", []))
+    planned_files = set(product.get("planned_files", []))
+    changed_paths = set(coder.get("changed_paths", []))
+    for changed_path in sorted(changed_paths):
+        if changed_path not in allowed_paths and changed_path not in planned_files:
+            errors.append(f"coder_changed_path_outside_allowed_paths: {changed_path}")
+
+    if coder.get("claims_complete") is not True:
+        errors.append("coder_receipt_missing_completion_claim")
+    if qa.get("verified_by") == coder.get("implemented_by"):
+        errors.append("qa_not_independent")
+    if qa.get("decision") != "verified":
+        errors.append("qa_not_verified")
+    if delta.get("state") != "confirmed":
+        errors.append("verification_delta_not_confirmed")
+    if retention.get("side_effects") != "none":
+        errors.append("retention_must_be_recommendation_only")
+
+    guardrails = {
+        "dreamer_cannot_approve": idea.get("approval_authority") == "main_review",
+        "main_approved_before_build": main.get("decision") == "approved" and build.get("main_review_id") == main.get("id"),
+        "coder_paths_within_product_plan": not any(
+            changed_path not in allowed_paths and changed_path not in planned_files
+            for changed_path in changed_paths
+        ),
+        "qa_independent_from_coder": bool(qa.get("verified_by")) and qa.get("verified_by") != coder.get("implemented_by"),
+        "retention_recommendation_only": retention.get("side_effects") == "none",
+    }
+
+    return {
+        "valid": not errors,
+        "errors": errors,
+        "job_id": job_id,
+        "artifact_kinds": [artifact.get("kind") for artifact in artifacts],
+        "guardrails": guardrails,
+        "trust_state": trust.get("state"),
+        "retention_recommendation": retention.get("recommendation"),
+        "live_mutations_enabled": any(bool(artifact.get("live_mutations_enabled")) for artifact in artifacts),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    room = Path(argv[0]) if argv else Path("buildroom/examples/demo-room")
+    result = validate_buildroom(room)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_buildroom_contract.py
+++ b/tests/test_buildroom_contract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.validate_buildroom import validate_buildroom
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO_ROOM = REPO_ROOT / "buildroom" / "examples" / "demo-room"
+
+
+class BuildroomContractTests(unittest.TestCase):
+    def test_demo_room_has_complete_ordered_contract_chain(self) -> None:
+        result = validate_buildroom(DEMO_ROOM)
+
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["job_id"], "demo-client-html-delivery")
+        self.assertEqual(
+            result["artifact_kinds"],
+            [
+                "research_packet",
+                "idea_contract",
+                "intent_review",
+                "main_review",
+                "product_plan",
+                "build_plan",
+                "coder_receipt",
+                "qa_receipt",
+                "verification_delta",
+                "trust_report",
+                "retention_review",
+                "operator_summary",
+            ],
+        )
+        self.assertEqual(result["trust_state"], "clean")
+        self.assertEqual(result["retention_recommendation"], "keep")
+
+    def test_demo_room_preserves_autobuild_guardrails(self) -> None:
+        result = validate_buildroom(DEMO_ROOM)
+
+        self.assertTrue(result["guardrails"]["dreamer_cannot_approve"])
+        self.assertTrue(result["guardrails"]["main_approved_before_build"])
+        self.assertTrue(result["guardrails"]["coder_paths_within_product_plan"])
+        self.assertTrue(result["guardrails"]["qa_independent_from_coder"])
+        self.assertTrue(result["guardrails"]["retention_recommendation_only"])
+        self.assertFalse(result["live_mutations_enabled"])
+
+    def test_rejects_coder_receipt_that_expands_outside_allowed_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            room = Path(tmp)
+            for source in sorted(DEMO_ROOM.glob("*.json")):
+                target = room / source.name
+                target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+            coder_path = room / "07-coder-receipt.json"
+            coder_receipt = json.loads(coder_path.read_text(encoding="utf-8"))
+            coder_receipt["changed_paths"].append("modules/evaluation.py")
+            coder_path.write_text(json.dumps(coder_receipt, indent=2) + "\n", encoding="utf-8")
+
+            result = validate_buildroom(room)
+
+        self.assertFalse(result["valid"])
+        self.assertIn("coder_changed_path_outside_allowed_paths: modules/evaluation.py", result["errors"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a local `buildroom/` Auto-build v0 contract chain with a sanitized demo room.
- Adds `scripts/validate_buildroom.py` to verify ordered artifacts and guardrails.
- Adds tests that prove the demo room is complete and rejects Coder path expansion outside the Main-approved product plan.
- Documents the architecture and strict non-goals: no cron, no unattended commits, no live mutation, no deletion side effects.

## Verification
- `python3 -m unittest tests.test_buildroom_contract -v`
- `python3 scripts/validate_buildroom.py buildroom/examples/demo-room`
- `python3 -m unittest tests.test_buildroom_contract tests.test_autonomous_dryrun tests.test_goal_to_work -v`

Closes #415
