### PR TITLE
Add dark-factory reference scenario

### DIFF
--- a/docs/architecture/dark-factory-acceptance-workflow.md
+++ b/docs/architecture/dark-factory-acceptance-workflow.md
@@ -147,9 +147,13 @@ Do not turn this pattern into:
 - a generic PM workflow engine
 - a dashboard that treats runner progress as accepted truth
 
-## Next Implementation Slice
+## Deterministic Reference Scenario
 
-The next issue-sized slice should be a deterministic reference scenario:
+The first deterministic reference scenario is implemented as
+`dark_factory_reference` in `modules/simulator.py` and included in the canonical
+demo runner and walkthrough packs.
+
+It uses public API paths only:
 
 1. seed a tracker-backed task through canonical submission
 2. record a runner handoff event
@@ -158,4 +162,8 @@ The next issue-sized slice should be a deterministic reference scenario:
 5. reevaluate into accepted, blocked, or in_review
 6. render the result through read-model and timeline surfaces
 
-That scenario should use public API paths and clearly labeled sample data unless it is explicitly configured for live Linear/GitHub dry-run targets.
+The sample path intentionally keeps runner output advisory. The completion claim
+initially blocks until the GitHub sync step attaches verified artifact evidence;
+Proofline then accepts completion through the ordinary read-model, timeline, and
+evaluation-history surfaces. It remains deterministic sample data, not a live
+Linear/GitHub dry-run target.

--- a/modules/demo_runner.py
+++ b/modules/demo_runner.py
@@ -24,6 +24,7 @@ class DemoScenarioSpec:
 
 
 CANONICAL_DEMO_SCENARIOS: tuple[DemoScenarioSpec, ...] = (
+    DemoScenarioSpec("dark_factory_reference", "Dark-Factory Reference", "A tracker-backed task moves through runner handoff, completion claim, GitHub sync, and Proofline acceptance."),
     DemoScenarioSpec("successful_completion", "Accepted Completion", "A task is submitted with aligned evidence and accepted immediately."),
     DemoScenarioSpec("missing_evidence_then_completed", "Blocked To Completed", "A task is blocked for insufficient evidence, then resolved with additional artifacts."),
     DemoScenarioSpec("wrong_target_corrected", "Wrong Target Corrected", "A task starts blocked while target facts are being corrected, then is reevaluated with aligned facts and accepted."),
@@ -49,9 +50,36 @@ def _extract_updates(step: SimulationStepResult) -> list[str]:
     request = step.request_payload or {}
     request_body = request.get("request") if isinstance(request, dict) else None
     if not isinstance(request_body, dict):
-        return []
+        updates: list[str] = []
+        event = request.get("event") if isinstance(request, dict) else None
+        if isinstance(event, dict):
+            if event.get("event_type"):
+                updates.append(f"runner_event={event['event_type']}")
+            artifacts = event.get("artifact_references") or []
+            if artifacts:
+                updates.append(f"runner_artifacts={len(artifacts)}")
+        github = request.get("github") if isinstance(request, dict) else None
+        if isinstance(github, dict):
+            branch = github.get("branch") if isinstance(github.get("branch"), dict) else {}
+            pull_request = github.get("pull_request") if isinstance(github.get("pull_request"), dict) else {}
+            files = github.get("files") if isinstance(github.get("files"), list) else []
+            if branch.get("name"):
+                updates.append(f"github_branch={branch['name']}")
+            if pull_request.get("number"):
+                updates.append(f"github_pr={pull_request['number']}")
+            if files:
+                updates.append(f"github_files={len(files)}")
+        return updates
 
     updates: list[str] = []
+    if "completion_claim" in request_body:
+        claim = request_body.get("completion_claim") or {}
+        if claim.get("claim_id"):
+            updates.append(f"completion_claim={claim['claim_id']}")
+    if "execution_attempt" in request_body:
+        attempt = request_body.get("execution_attempt") or {}
+        if attempt.get("attempt_id"):
+            updates.append(f"execution_attempt={attempt['attempt_id']}")
     if "new_artifacts" in request_body:
         artifacts = request_body.get("new_artifacts") or []
         artifact_types = [artifact.get("type", "unknown") for artifact in artifacts if isinstance(artifact, dict)]

--- a/modules/demo_walkthrough.py
+++ b/modules/demo_walkthrough.py
@@ -49,6 +49,12 @@ class DemoWalkthroughResult:
 
 CANONICAL_WALKTHROUGH: tuple[DemoWalkthroughScenario, ...] = (
     DemoWalkthroughScenario(
+        "dark_factory_reference",
+        "Dark-Factory Reference",
+        "Show the tracker to runner to GitHub loop while keeping Proofline as the acceptance authority.",
+        "Open the timeline and read-model to show runner handoff, completion claim, GitHub sync, then accepted completion.",
+    ),
+    DemoWalkthroughScenario(
         "successful_completion",
         "Accepted Completion",
         "Explain how aligned evidence and reconciliation allow Harness to preserve completed.",

--- a/modules/simulator.py
+++ b/modules/simulator.py
@@ -299,6 +299,8 @@ class SimulationResult:
     evaluation_history: tuple[dict[str, Any], ...]
     supervision_queue_status: int | None
     supervision_entry: dict[str, Any] | None
+    read_model: dict[str, Any] | None = None
+    timeline: tuple[dict[str, Any], ...] = ()
 
 
 class HarnessSimulatorClient:
@@ -330,8 +332,23 @@ class HarnessSimulatorClient:
     def reevaluate_task(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         return self._request_json("POST", f"/tasks/{task_id}/reevaluate", payload)
 
+    def submit_completion_claim(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", f"/tasks/{task_id}/completion-claims", payload)
+
+    def submit_execution_substrate_event(self, task_id: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", f"/tasks/{task_id}/execution-substrate-events", payload)
+
+    def submit_github_sync(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        return self._request_json("POST", "/sync/github", payload)
+
     def get_task(self, task_id: str) -> tuple[int, dict[str, Any]]:
         return self._request_json("GET", f"/tasks/{task_id}")
+
+    def get_task_read_model(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/tasks/{task_id}/read-model")
+
+    def get_task_timeline(self, task_id: str) -> tuple[int, dict[str, Any]]:
+        return self._request_json("GET", f"/tasks/{task_id}/timeline")
 
     def get_evaluation_history(self, task_id: str) -> tuple[int, dict[str, Any]]:
         return self._request_json("GET", f"/tasks/{task_id}/evaluations")
@@ -455,6 +472,63 @@ def _reevaluate_step(
     )
 
 
+def _completion_claim_step(
+    client: HarnessSimulatorClient,
+    context: _ScenarioContext,
+    name: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    if context.task_id is None:
+        raise ValueError("task_id is required before completion claim submission")
+    path = f"/tasks/{context.task_id}/completion-claims"
+    status, response_payload = client.submit_completion_claim(context.task_id, payload)
+    return context.record(
+        name=name,
+        method="POST",
+        path=path,
+        http_status=status,
+        request_payload=payload,
+        payload=response_payload,
+    )
+
+
+def _execution_substrate_step(
+    client: HarnessSimulatorClient,
+    context: _ScenarioContext,
+    name: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    if context.task_id is None:
+        raise ValueError("task_id is required before execution-substrate event submission")
+    path = f"/tasks/{context.task_id}/execution-substrate-events"
+    status, response_payload = client.submit_execution_substrate_event(context.task_id, payload)
+    return context.record(
+        name=name,
+        method="POST",
+        path=path,
+        http_status=status,
+        request_payload=payload,
+        payload=response_payload,
+    )
+
+
+def _github_sync_step(
+    client: HarnessSimulatorClient,
+    context: _ScenarioContext,
+    name: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    status, response_payload = client.submit_github_sync(payload)
+    return context.record(
+        name=name,
+        method="POST",
+        path="/sync/github",
+        http_status=status,
+        request_payload=payload,
+        payload=response_payload,
+    )
+
+
 def _fetch_final_state(
     client: HarnessSimulatorClient,
     context: _ScenarioContext,
@@ -475,6 +549,19 @@ def _fetch_final_state(
         None,
     )
     return task_payload.get("task"), tuple(history_payload.get("evaluations", ())), queue_status, supervision_entry
+
+
+def _fetch_read_model_and_timeline(
+    client: HarnessSimulatorClient,
+    context: _ScenarioContext,
+) -> tuple[dict[str, Any] | None, tuple[dict[str, Any], ...]]:
+    if context.task_id is None:
+        return None, ()
+
+    _, read_model_payload = client.get_task_read_model(context.task_id)
+    _, timeline_payload = client.get_task_timeline(context.task_id)
+    timeline = timeline_payload.get("timeline") if isinstance(timeline_payload.get("timeline"), list) else []
+    return read_model_payload.get("task"), tuple(timeline)
 
 
 def _review_request_payload(task_id: str) -> dict[str, Any]:
@@ -519,6 +606,187 @@ def _review_decision_payload(task_id: str) -> dict[str, Any]:
     return _to_jsonable(decision)
 
 
+def _dark_factory_task_payload() -> dict[str, Any]:
+    task_envelope = create_task_envelope(
+        {
+            "id": "task-dark-factory-reference-1",
+            "title": "Dark-factory reference acceptance scenario",
+            "description": (
+                "Deterministic tracker-to-runner-to-GitHub scenario used to "
+                "verify Proofline's acceptance boundary."
+            ),
+            "origin": {
+                "source_system": "linear",
+                "source_type": "synchronization",
+                "source_id": "KNO-DARK-1",
+                "ingress_name": "Linear",
+            },
+            "objective": {
+                "summary": "Accept a runner-completed code change only after GitHub evidence is verified.",
+                "deliverable_type": "code_change",
+                "success_signal": "Read-model and timeline show the completion was accepted by Proofline.",
+            },
+            "acceptance_criteria": [
+                {
+                    "id": "ac-dark-1",
+                    "description": (
+                        "Runner completion remains advisory until a verified pull request "
+                        "and commit satisfy the task evidence policy."
+                    ),
+                    "required": True,
+                }
+            ],
+        },
+        now="2026-04-01T09:00:00Z",
+    )
+    return {"request": {"task_envelope": task_envelope}}
+
+
+def _dark_factory_handoff_event_payload(task_id: str) -> dict[str, Any]:
+    return {
+        "event": {
+            "event_id": "dark-factory-handoff-1",
+            "task_id": task_id,
+            "attempt_id": "attempt-dark-factory-1",
+            "runner_kind": "symphony",
+            "runner_session_id": "runner-session-dark-factory-1",
+            "executor_kind": "codex_app_server",
+            "workspace_id": "workspace/dark-factory-reference",
+            "event_type": "handoff_reported",
+            "occurred_at": "2026-04-01T09:05:00Z",
+            "provenance": {
+                "source_system": "symphony",
+                "source_type": "runner_event",
+                "source_id": "runner-session-dark-factory-1:handoff-1",
+                "captured_by": "dark-factory-reference-scenario",
+            },
+            "payload": {
+                "handoff_state": "ready_for_verification",
+                "summary": "Runner reports Codex has produced artifacts for Proofline verification.",
+                "budget_outcome": "within_policy",
+            },
+            "artifact_references": [
+                {
+                    "artifact_type": "pull_request",
+                    "repository": "sfayka/Harness",
+                    "branch": "codex/demo",
+                    "pr_url": "https://github.com/sfayka/Harness/pull/300",
+                    "reported_by": "symphony",
+                    "reported_at": "2026-04-01T09:05:00Z",
+                    "source_attempt_id": "attempt-dark-factory-1",
+                }
+            ],
+        }
+    }
+
+
+def _dark_factory_completion_claim_payload(context: _ScenarioContext) -> dict[str, Any]:
+    return {
+        "request": {
+            "completion_claim": {
+                "claim_id": "claim-dark-factory-1",
+                "reported_at": "2026-04-01T09:10:00Z",
+                "reported_by": "codex_app_server",
+                "reason": "Executor reports the dark-factory task is complete.",
+                "metadata": {"attempt_id": "attempt-dark-factory-1"},
+            },
+            "execution_attempt": {
+                "attempt_id": "attempt-dark-factory-1",
+                "recorded_at": "2026-04-01T09:10:05Z",
+                "status": "succeeded",
+                "reported_by": "codex_app_server",
+                "artifact_references": [
+                    {
+                        "reference_id": "attempt-dark-factory-1:pr",
+                        "artifact_type": "pull_request",
+                        "location": "https://github.com/sfayka/Harness/pull/300",
+                        "metadata": {
+                            "repository_host": "github.com",
+                            "repository_owner": "sfayka",
+                            "repository_name": "Harness",
+                            "branch_name": "codex/demo",
+                            "pull_request_number": 300,
+                            "pull_request_state": "open",
+                            "merged": False,
+                        },
+                    },
+                    {
+                        "reference_id": "attempt-dark-factory-1:commit",
+                        "artifact_type": "commit",
+                        "location": "https://github.com/sfayka/Harness/commit/abcdef1234567890",
+                        "commit_sha": "abcdef1234567890",
+                        "metadata": {
+                            "repository_host": "github.com",
+                            "repository_owner": "sfayka",
+                            "repository_name": "Harness",
+                            "branch_name": "codex/demo",
+                            "commit_sha": "abcdef1234567890",
+                        },
+                    },
+                ],
+                "metadata": {
+                    "runner_kind": "symphony",
+                    "runner_session_id": "runner-session-dark-factory-1",
+                    "handoff_event_id": "dark-factory-handoff-1",
+                },
+            },
+            "acceptance_criteria_satisfied": True,
+            "runtime_facts": {
+                "executor_reported_success": True,
+                "attempt_count": 1,
+            },
+        }
+    }
+
+
+def _dark_factory_github_sync_payload(task_id: str) -> dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "captured_at": "2026-04-01T09:12:00Z",
+        "captured_by": "dark-factory-reference-scenario",
+        "expected_code_context": {
+            "repository_host": "github.com",
+            "repository_owner": "sfayka",
+            "repository_name": "Harness",
+            "branch_name": "codex/demo",
+            "base_branch": "main",
+        },
+        "github": {
+            "repository": {
+                "host": "github.com",
+                "owner": "sfayka",
+                "name": "Harness",
+                "node_id": "repo-123",
+            },
+            "branch": {
+                "name": "codex/demo",
+                "baseRefName": "main",
+                "target": {"oid": "abcdef1234567890"},
+            },
+            "commit": {
+                "sha": "abcdef1234567890",
+                "html_url": "https://github.com/sfayka/Harness/commit/abcdef1234567890",
+                "commit": {"message": "Complete dark-factory reference task"},
+            },
+            "pull_request": {
+                "number": 300,
+                "state": "open",
+                "reviewDecision": "approved",
+                "html_url": "https://github.com/sfayka/Harness/pull/300",
+                "merged": False,
+            },
+            "files": [
+                {
+                    "filename": "modules/api.py",
+                    "status": "modified",
+                    "additions": 12,
+                    "deletions": 1,
+                }
+            ],
+        },
+    }
+
+
 def _scenario_successful_completion(
     client: HarnessSimulatorClient,
     *,
@@ -548,6 +816,61 @@ def _scenario_successful_completion(
         history,
         queue_status,
         supervision_entry,
+    )
+
+
+def _scenario_dark_factory_reference(
+    client: HarnessSimulatorClient,
+    *,
+    task_id_override: str | None = None,
+    task_title_override: str | None = None,
+    origin_source_id_override: str | None = None,
+) -> SimulationResult:
+    context = _ScenarioContext(
+        task_id_override=task_id_override,
+        task_title_override=task_title_override,
+        origin_source_id_override=origin_source_id_override,
+    )
+    submission_payload = _dark_factory_task_payload()
+    if task_id_override is not None:
+        submission_payload["request"]["task_envelope"]["id"] = task_id_override
+    if task_title_override is not None:
+        submission_payload["request"]["task_envelope"]["title"] = task_title_override
+    if origin_source_id_override is not None:
+        submission_payload["request"]["task_envelope"]["origin"]["source_id"] = origin_source_id_override
+
+    _submit_step(client, context, "seed_tracker_task", submission_payload)
+    _execution_substrate_step(
+        client,
+        context,
+        "record_runner_handoff",
+        _dark_factory_handoff_event_payload(context.task_id or "task-dark-factory-reference-1"),
+    )
+    _completion_claim_step(
+        client,
+        context,
+        "submit_executor_completion_claim",
+        _dark_factory_completion_claim_payload(context),
+    )
+    _github_sync_step(
+        client,
+        context,
+        "attach_github_artifact_evidence",
+        _dark_factory_github_sync_payload(context.task_id or "task-dark-factory-reference-1"),
+    )
+    task_snapshot, history, queue_status, supervision_entry = _fetch_final_state(client, context)
+    read_model, timeline = _fetch_read_model_and_timeline(client, context)
+    return SimulationResult(
+        "dark_factory_reference",
+        context.task_id,
+        task_snapshot.get("status") if task_snapshot else None,
+        tuple(context.steps),
+        task_snapshot,
+        history,
+        queue_status,
+        supervision_entry,
+        read_model,
+        timeline,
     )
 
 
@@ -928,6 +1251,7 @@ def _scenario_long_running_handoff(
 
 
 _SCENARIOS = {
+    "dark_factory_reference": _scenario_dark_factory_reference,
     "successful_completion": _scenario_successful_completion,
     "missing_evidence_then_completed": _scenario_missing_evidence_then_completed,
     "wrong_target_corrected": _scenario_wrong_target_corrected,

--- a/tests/test_demo_bootstrap.py
+++ b/tests/test_demo_bootstrap.py
@@ -55,12 +55,13 @@ class DemoBootstrapTests(unittest.TestCase):
             try:
                 self.assertEqual(result.dashboard_url, f"http://127.0.0.1:{dashboard_port}")
                 self.assertEqual(result.api_base_url, f"http://127.0.0.1:{api_port}")
-                self.assertEqual(len(result.walkthrough.scenarios), 5)
+                self.assertEqual(len(result.walkthrough.scenarios), 6)
                 self.assertTrue((output_dir / "walkthrough.txt").exists())
 
                 store = FileBackedHarnessStore(str(store_root))
                 tasks = store.list_tasks()
                 task_ids = {task["id"] for task in tasks}
+                self.assertIn("demo-dark-factory-reference", task_ids)
                 self.assertIn("demo-successful-completion", task_ids)
                 self.assertIn("demo-long-running-handoff", task_ids)
             finally:

--- a/tests/test_demo_runner.py
+++ b/tests/test_demo_runner.py
@@ -33,6 +33,7 @@ class HarnessDemoRunnerTests(unittest.TestCase):
             self.assertTrue((output_path / "index.json").exists())
 
             expected_final_states = {
+                "dark_factory_reference": "completed",
                 "successful_completion": "completed",
                 "missing_evidence_then_completed": "completed",
                 "wrong_target_corrected": "completed",
@@ -60,6 +61,20 @@ class HarnessDemoRunnerTests(unittest.TestCase):
         self.assertIn("reconciliation:", timeline)
         self.assertIn("lifecycle:", timeline)
         self.assertIn("new_artifacts=changed_file", timeline)
+        self.assertIn("Final Task State: completed", timeline)
+
+    def test_console_timeline_includes_dark_factory_flow_details(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = run_demo_pack(
+                scenario_names=("dark_factory_reference",),
+                output_dir=temp_dir,
+            )[0]
+            timeline = render_console_timeline(result)
+
+        self.assertIn("record_runner_handoff", timeline)
+        self.assertIn("runner_event=handoff_reported", timeline)
+        self.assertIn("completion_claim=claim-dark-factory-1", timeline)
+        self.assertIn("attach_github_artifact_evidence", timeline)
         self.assertIn("Final Task State: completed", timeline)
 
     def test_mermaid_trace_includes_transitions_and_final_state(self) -> None:

--- a/tests/test_demo_walkthrough.py
+++ b/tests/test_demo_walkthrough.py
@@ -46,8 +46,9 @@ class DemoWalkthroughTests(unittest.TestCase):
         tasks = store.list_tasks()
         task_ids = {task["id"] for task in tasks}
 
-        self.assertEqual(len(result.scenarios), 5)
-        self.assertEqual(len(tasks), 5)
+        self.assertEqual(len(result.scenarios), 6)
+        self.assertEqual(len(tasks), 6)
+        self.assertIn("demo-dark-factory-reference", task_ids)
         self.assertIn("demo-successful-completion", task_ids)
         self.assertIn("demo-review-required-then-completed", task_ids)
         self.assertTrue((self.output_dir / "walkthrough.txt").exists())

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -34,6 +34,7 @@ class HarnessSimulatorTests(unittest.TestCase):
     def test_lists_supported_scenarios(self) -> None:
         scenarios = list_scenarios()
 
+        self.assertIn("dark_factory_reference", scenarios)
         self.assertIn("successful_completion", scenarios)
         self.assertIn("missing_evidence_then_completed", scenarios)
         self.assertIn("review_required_pending", scenarios)
@@ -101,6 +102,36 @@ class HarnessSimulatorTests(unittest.TestCase):
         self.assertIn("progress_artifact", artifact_types)
         self.assertIn("handoff_artifact", artifact_types)
         self.assertEqual(len(result.evaluation_history), 5)
+
+    def test_runs_dark_factory_reference_through_public_acceptance_surfaces(self) -> None:
+        result = run_scenario("dark_factory_reference", base_url=self.base_url)
+
+        self.assertEqual(result.final_task_status, "completed")
+        self.assertEqual(
+            [step.name for step in result.steps],
+            [
+                "seed_tracker_task",
+                "record_runner_handoff",
+                "submit_executor_completion_claim",
+                "attach_github_artifact_evidence",
+            ],
+        )
+        self.assertEqual([step.http_status for step in result.steps], [200, 200, 200, 200])
+        self.assertEqual(result.steps[1].action, "execution_substrate_event_recorded")
+        self.assertEqual(result.steps[2].task_status, "blocked")
+        self.assertEqual(result.steps[3].task_status, "completed")
+        self.assertEqual(len(result.evaluation_history), 3)
+        self.assertIsNotNone(result.read_model)
+        assert result.read_model is not None
+        self.assertEqual(result.read_model["execution_summary"]["substrate_event_count"], 1)
+        self.assertTrue(result.read_model["completion_validation_summary"]["completion_accepted"])
+        self.assertEqual(result.read_model["completion_validation_summary"]["intent_status"], "matched")
+        self.assertTrue(
+            any(event["event_type"] == "execution_substrate_event_recorded" for event in result.timeline)
+        )
+        self.assertTrue(
+            any(event["event_type"] == "execution_attempt_recorded" for event in result.timeline)
+        )
 
     def test_can_run_scenario_with_deterministic_task_identity(self) -> None:
         result = run_scenario(


### PR DESCRIPTION
Implements the remaining documented dark-factory backlog slice from docs/architecture/dark-factory-acceptance-workflow.md.

Changes:
- add a deterministic dark_factory_reference simulator scenario using public API paths only: POST /tasks, POST /tasks/:id/execution-substrate-events, POST /tasks/:id/completion-claims, POST /sync/github, then read-model/timeline inspection
- include the scenario in the canonical demo runner and walkthrough packs
- update the architecture doc from next-slice language to the implemented reference scenario
- add tests for the scenario, demo output, walkthrough/bootstrap counts, and read-model/timeline surfaces

Validation:
- git diff --check
- python3 -m unittest tests.test_simulator tests.test_demo_runner tests.test_demo_walkthrough tests.test_demo_bootstrap -v
- python3 -m unittest tests.connectors.test_github_sync tests.test_execution_substrate_ingestion -v
- python3 -m unittest discover -s tests